### PR TITLE
minor: limit evergreen to four test threads

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -3,4 +3,4 @@
 set -o errexit
 
 . ~/.cargo/env
-cargo test
+cargo test -- --test-threads=4


### PR DESCRIPTION
We've been having some issues with r2d2 with higher thread counts, so we're going to experiment it to being limited to 4 to see if that makes the tests more consistent.