### PR TITLE
SDAM state machine implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.16.0"
 features = ["dangerous_configuration"]
 
 [dependencies.serde]
-version = "1.0.94"
+version = "1.0.98"
 features = ["derive"]
 
 [dev-dependencies]

--- a/src/is_master.rs
+++ b/src/is_master.rs
@@ -1,8 +1,95 @@
+use bson::{oid::ObjectId, TimeStamp, UtcDateTime};
 use serde::Deserialize;
 
-#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+use crate::{read_preference::TagSet, sdam::ServerType};
+
+#[derive(Debug, Clone)]
+pub(crate) struct IsMasterReply {
+    pub command_response: IsMasterCommandResponse,
+    pub round_trip_time: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct IsMasterCommandResponse {
     #[serde(rename = "ismaster")]
     pub is_master: Option<bool>,
+    pub ok: Option<f32>,
+    pub hosts: Option<Vec<String>>,
+    pub passives: Option<Vec<String>>,
+    pub arbiters: Option<Vec<String>>,
+    pub msg: Option<String>,
+    pub me: Option<String>,
+    pub set_version: Option<i32>,
+    pub set_name: Option<String>,
+    pub hidden: Option<bool>,
+    pub secondary: Option<bool>,
+    pub arbiter_only: Option<bool>,
+    #[serde(rename = "isreplicaset")]
+    pub is_replica_set: Option<bool>,
+    pub logical_session_timeout_minutes: Option<i64>,
+    pub last_write: Option<LastWrite>,
+    pub min_wire_version: Option<i32>,
+    pub max_wire_version: Option<i32>,
+    pub tags: Option<TagSet>,
+    pub election_id: Option<ObjectId>,
+    pub primary: Option<String>,
+    pub sasl_supported_mechs: Option<Vec<String>>,
+}
+
+impl PartialEq for IsMasterCommandResponse {
+    fn eq(&self, other: &Self) -> bool {
+        self.server_type() == other.server_type()
+            && self.min_wire_version == other.min_wire_version
+            && self.max_wire_version == other.max_wire_version
+            && self.me == other.me
+            && self.hosts == other.hosts
+            && self.passives == other.passives
+            && self.arbiters == other.arbiters
+            && self.tags == other.tags
+            && self.set_name == other.set_name
+            && self.set_version == other.set_version
+            && self.election_id == other.election_id
+            && self.primary == other.primary
+            && self.logical_session_timeout_minutes == other.logical_session_timeout_minutes
+    }
+}
+
+impl IsMasterCommandResponse {
+    pub(crate) fn server_type(&self) -> ServerType {
+        if self.ok != Some(1.0) {
+            ServerType::Unknown
+        } else if self.msg.as_ref().map(String::as_str) == Some("isdbgrid") {
+            ServerType::Mongos
+        } else if self.set_name.is_some() {
+            if let Some(true) = self.is_master {
+                ServerType::RSPrimary
+            } else if let Some(true) = self.hidden {
+                ServerType::RSOther
+            } else if let Some(true) = self.secondary {
+                ServerType::RSSecondary
+            } else if let Some(true) = self.arbiter_only {
+                ServerType::RSArbiter
+            } else {
+                ServerType::RSOther
+            }
+        } else if let Some(true) = self.is_replica_set {
+            ServerType::RSGhost
+        } else {
+            ServerType::Standalone
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LastWrite {
+    pub op_time: OpTime,
+    pub last_write_date: UtcDateTime,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub(crate) struct OpTime {
+    ts: TimeStamp,
+    t: i32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,13 @@ mod is_master;
 pub mod options;
 mod read_preference;
 pub mod results;
+#[allow(dead_code)]
+mod sdam;
+#[cfg(test)]
+mod test;
 
 #[cfg(test)]
 #[macro_use]
 extern crate derive_more;
-#[cfg(test)]
-mod test;
 
 pub use crate::{client::Client, coll::Collection, cursor::Cursor, db::Database};

--- a/src/sdam/description/mod.rs
+++ b/src/sdam/description/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod server;
+pub(crate) mod topology;

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -1,0 +1,225 @@
+use bson::{oid::ObjectId, UtcDateTime};
+
+use crate::{error::Result, is_master::IsMasterReply, options::StreamAddress};
+
+const DRIVER_MIN_DB_VERSION: &str = "3.6";
+const DRIVER_MIN_WIRE_VERSION: i32 = 6;
+const DRIVER_MAX_WIRE_VERSION: i32 = 7;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ServerType {
+    Standalone,
+    Mongos,
+    RSPrimary,
+    RSSecondary,
+    RSArbiter,
+    RSOther,
+    RSGhost,
+    Unknown,
+}
+
+impl Default for ServerType {
+    fn default() -> Self {
+        ServerType::Unknown
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ServerDescription {
+    pub(crate) address: StreamAddress,
+    pub(crate) server_type: ServerType,
+    pub(crate) last_update_time: Option<UtcDateTime>,
+
+    // The SDAM spec indicates that a ServerDescription needs to contain an error message if an
+    // error occurred when trying to send an isMaster for the server's heartbeat. Additionally,
+    // we need to be able to create a server description that doesn't contain either an isMaster
+    // reply or an error, since there's a gap between when a server is newly added to the topology
+    // and when the first heartbeat occurs.
+    //
+    // In order to represent all these states, we store a Result directly in the ServerDescription,
+    // which either contains the aforementioned error message or an Option<IsMasterResult>. This
+    // allows us to ensure that only valid states are possible (e.g. preventing that both an error
+    // and a reply are present) while still making it easy to define helper methods on
+    // ServerDescription for information we need from the isMaster reply by propagating with `?`.
+    reply: std::result::Result<Option<IsMasterReply>, String>,
+}
+
+impl PartialEq for ServerDescription {
+    fn eq(&self, other: &Self) -> bool {
+        if self.address == other.address && self.server_type == other.server_type {
+            return false;
+        }
+
+        let self_reply = self
+            .reply
+            .as_ref()
+            .map(|reply| reply.as_ref().map(|r| &r.command_response));
+        let other_reply = other
+            .reply
+            .as_ref()
+            .map(|reply| reply.as_ref().map(|r| &r.command_response));
+
+        self_reply == other_reply
+    }
+}
+
+impl ServerDescription {
+    pub(crate) fn new(
+        mut address: StreamAddress,
+        is_master_reply: Option<Result<IsMasterReply>>,
+    ) -> Self {
+        address.hostname = address.hostname.to_lowercase();
+
+        let mut description = Self {
+            address,
+            server_type: Default::default(),
+            last_update_time: None,
+            reply: is_master_reply.transpose().map_err(|e| e.to_string()),
+        };
+
+        if let Ok(Some(ref mut reply)) = description.reply {
+            // Infer the server type from the isMaster response.
+            description.server_type = reply.command_response.server_type();
+
+            // If the server type is unknown, we don't want to take into account the round trip time
+            // when checking the latency during server selection.
+            if let ServerType::Unknown = description.server_type {
+                reply.round_trip_time.take();
+            }
+
+            // Normalize all instances of hostnames to lowercase.
+            if let Some(ref mut hosts) = reply.command_response.hosts {
+                let normalized_hostnames = hosts
+                    .drain(..)
+                    .map(|hostname| hostname.to_lowercase())
+                    .collect();
+
+                std::mem::replace(hosts, normalized_hostnames);
+            }
+
+            if let Some(ref mut passives) = reply.command_response.passives {
+                let normalized_hostnames = passives
+                    .drain(..)
+                    .map(|hostname| hostname.to_lowercase())
+                    .collect();
+
+                std::mem::replace(passives, normalized_hostnames);
+            }
+
+            if let Some(ref mut arbiters) = reply.command_response.arbiters {
+                let normalized_hostnames = arbiters
+                    .drain(..)
+                    .map(|hostname| hostname.to_lowercase())
+                    .collect();
+
+                std::mem::replace(arbiters, normalized_hostnames);
+            }
+
+            if let Some(ref mut me) = reply.command_response.me {
+                std::mem::replace(me, me.to_lowercase());
+            }
+        }
+
+        description
+    }
+
+    pub(crate) fn compatibility_error_message(&self) -> Option<String> {
+        if let Ok(Some(ref reply)) = self.reply {
+            let is_master_min_wire_version = reply.command_response.min_wire_version.unwrap_or(0);
+
+            if is_master_min_wire_version > DRIVER_MAX_WIRE_VERSION {
+                return Some(format!(
+                    "Server at {} requires wire version {}, but this version of the MongoDB Rust \
+                     driver only supports up to {}",
+                    self.address, is_master_min_wire_version, DRIVER_MAX_WIRE_VERSION,
+                ));
+            }
+
+            let is_master_max_wire_version = reply.command_response.max_wire_version.unwrap_or(0);
+
+            if is_master_max_wire_version < DRIVER_MIN_WIRE_VERSION {
+                return Some(format!(
+                    "Server at {} reports wire version {}, but this version of the MongoDB Rust \
+                     driver requires at least {} (MongoDB {}).",
+                    self.address,
+                    is_master_max_wire_version,
+                    DRIVER_MIN_WIRE_VERSION,
+                    DRIVER_MIN_DB_VERSION
+                ));
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn set_name(&self) -> std::result::Result<Option<String>, String> {
+        let set_name = self
+            .reply
+            .as_ref()?
+            .as_ref()
+            .and_then(|reply| reply.command_response.set_name.clone());
+        Ok(set_name)
+    }
+
+    pub(crate) fn known_hosts(&self) -> std::result::Result<impl Iterator<Item = &String>, String> {
+        let known_hosts = self.reply.as_ref()?.as_ref().map(|reply| {
+            let hosts = reply.command_response.hosts.as_ref();
+            let passives = reply.command_response.passives.as_ref();
+            let arbiters = reply.command_response.arbiters.as_ref();
+
+            hosts
+                .into_iter()
+                .flatten()
+                .chain(passives.into_iter().flatten())
+                .chain(arbiters.into_iter().flatten())
+        });
+
+        Ok(known_hosts.into_iter().flatten())
+    }
+
+    pub(crate) fn invalid_me(&self) -> std::result::Result<bool, String> {
+        if let Some(ref reply) = self.reply.as_ref()? {
+            if let Some(ref me) = reply.command_response.me {
+                return Ok(&self.address.to_string() != me);
+            }
+        }
+
+        Ok(false)
+    }
+
+    pub(crate) fn set_version(&self) -> std::result::Result<Option<i32>, String> {
+        let me = self
+            .reply
+            .as_ref()?
+            .as_ref()
+            .and_then(|reply| reply.command_response.set_version);
+        Ok(me)
+    }
+
+    pub(crate) fn election_id(&self) -> std::result::Result<Option<ObjectId>, String> {
+        let me = self
+            .reply
+            .as_ref()?
+            .as_ref()
+            .and_then(|reply| reply.command_response.election_id.clone());
+        Ok(me)
+    }
+
+    pub(crate) fn min_wire_version(&self) -> std::result::Result<Option<i32>, String> {
+        let me = self
+            .reply
+            .as_ref()?
+            .as_ref()
+            .and_then(|reply| reply.command_response.min_wire_version);
+        Ok(me)
+    }
+
+    pub(crate) fn max_wire_version(&self) -> std::result::Result<Option<i32>, String> {
+        let me = self
+            .reply
+            .as_ref()?
+            .as_ref()
+            .and_then(|reply| reply.command_response.max_wire_version);
+        Ok(me)
+    }
+}

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -1,0 +1,367 @@
+#[cfg(test)]
+mod test;
+
+use std::collections::{HashMap, HashSet};
+
+use bson::oid::ObjectId;
+use serde::Deserialize;
+
+use crate::{
+    error::Result,
+    options::{ClientOptions, StreamAddress},
+    sdam::description::server::{ServerDescription, ServerType},
+};
+
+/// The TopologyType type, as described by the SDAM spec.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]
+pub(crate) enum TopologyType {
+    Single,
+    ReplicaSetNoPrimary,
+    ReplicaSetWithPrimary,
+    Sharded,
+    Unknown,
+}
+
+impl Default for TopologyType {
+    fn default() -> Self {
+        TopologyType::Unknown
+    }
+}
+
+/// The TopologyDescription type, as described by the SDAM spec.
+#[derive(Debug, Clone)]
+struct TopologyDescription {
+    /// Whether or not the topology was initialized with a single seed.
+    single_seed: bool,
+
+    /// The current type of the topology.
+    topology_type: TopologyType,
+
+    /// The replica set name of the topology.
+    set_name: Option<String>,
+
+    /// The highest replica set version the driver has seen by a member of the topology.
+    max_set_version: Option<i32>,
+
+    /// The highest replica set election id the driver has seen by a member of the topology.
+    max_election_id: Option<ObjectId>,
+
+    /// Describes the compatibility issue between the driver and server with regards to the
+    /// respective supported wire versions.
+    compatibility_error: Option<String>,
+
+    // TODO RUST-149: Session support.
+    logical_session_timeout_minutes: Option<u32>,
+
+    /// The server descriptions of each member of the topology.
+    servers: HashMap<StreamAddress, ServerDescription>,
+}
+
+impl TopologyDescription {
+    fn new(options: ClientOptions) -> Self {
+        let topology_type = if options.repl_set_name.is_some() {
+            TopologyType::ReplicaSetNoPrimary
+        } else if let Some(true) = options.direct_connection {
+            TopologyType::Single
+        } else {
+            TopologyType::Unknown
+        };
+
+        let servers: HashMap<_, _> = options
+            .hosts
+            .into_iter()
+            .map(|address| {
+                let description = ServerDescription::new(address.clone(), None);
+
+                (address, description)
+            })
+            .collect();
+
+        Self {
+            single_seed: servers.len() == 1,
+            topology_type,
+            set_name: options.repl_set_name,
+            max_set_version: None,
+            max_election_id: None,
+            compatibility_error: None,
+            logical_session_timeout_minutes: None,
+            servers,
+        }
+    }
+
+    /// Check the cluster for a compatibility error, and record the error message if one is found.
+    fn check_compatibility(&mut self) {
+        for server in self.servers.values() {
+            let error_message = server.compatibility_error_message();
+
+            if error_message.is_some() {
+                self.compatibility_error = error_message;
+                return;
+            }
+        }
+    }
+
+    /// Update the topology based on the new information about the topology contained by the
+    /// ServerDescription.
+    fn update(&mut self, server_description: ServerDescription) -> Result<()> {
+        // Ignore updates from servers not currently in the cluster.
+        if !self.servers.contains_key(&server_description.address) {
+            return Ok(());
+        }
+
+        // Replace the old info about the server with the new info.
+        self.servers.insert(
+            server_description.address.clone(),
+            server_description.clone(),
+        );
+
+        // Update the topology description based on the current topology type.
+        match self.topology_type {
+            TopologyType::Single => {}
+            TopologyType::Unknown => self.update_unknown_topology(server_description)?,
+            TopologyType::Sharded => self.update_sharded_topology(server_description),
+            TopologyType::ReplicaSetNoPrimary => {
+                self.update_replica_set_no_primary_topology(server_description)?
+            }
+            TopologyType::ReplicaSetWithPrimary => {
+                self.update_replica_set_with_primary_topology(server_description)?;
+            }
+        }
+
+        // Record any compatibility error.
+        self.check_compatibility();
+
+        Ok(())
+    }
+
+    /// Update the Unknown topology description based on the server description.
+    fn update_unknown_topology(&mut self, server_description: ServerDescription) -> Result<()> {
+        match server_description.server_type {
+            ServerType::Unknown | ServerType::RSGhost => {}
+            ServerType::Standalone => {
+                self.update_unknown_with_standalone_server(server_description)
+            }
+            ServerType::Mongos => self.topology_type = TopologyType::Sharded,
+            ServerType::RSPrimary => {
+                self.update_rs_from_primary_server(server_description)?;
+            }
+            ServerType::RSSecondary | ServerType::RSArbiter | ServerType::RSOther => {
+                self.update_rs_without_primary_server(server_description)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Update the Sharded topology description based on the server description.
+    fn update_sharded_topology(&mut self, server_description: ServerDescription) {
+        match server_description.server_type {
+            ServerType::Unknown | ServerType::Mongos => {}
+            _ => {
+                self.servers.remove(&server_description.address);
+            }
+        }
+    }
+
+    /// Update the ReplicaSetNoPrimary topology description based on the server description.
+    fn update_replica_set_no_primary_topology(
+        &mut self,
+        server_description: ServerDescription,
+    ) -> Result<()> {
+        match server_description.server_type {
+            ServerType::Unknown | ServerType::RSGhost => {}
+            ServerType::Standalone | ServerType::Mongos => {
+                self.servers.remove(&server_description.address);
+            }
+            ServerType::RSPrimary => self.update_rs_from_primary_server(server_description)?,
+            ServerType::RSSecondary | ServerType::RSArbiter | ServerType::RSOther => {
+                self.update_rs_without_primary_server(server_description)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Update the ReplicaSetWithPrimary topology description based on the server description.
+    fn update_replica_set_with_primary_topology(
+        &mut self,
+        server_description: ServerDescription,
+    ) -> Result<()> {
+        match server_description.server_type {
+            ServerType::Unknown | ServerType::RSGhost => {
+                self.record_primary_state();
+            }
+            ServerType::Standalone | ServerType::Mongos => {
+                self.servers.remove(&server_description.address);
+                self.record_primary_state();
+            }
+            ServerType::RSPrimary => self.update_rs_from_primary_server(server_description)?,
+            ServerType::RSSecondary | ServerType::RSArbiter | ServerType::RSOther => {
+                self.update_rs_with_primary_from_member(server_description)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Update the Unknown topology description based on the Standalone server description.
+    fn update_unknown_with_standalone_server(&mut self, server_description: ServerDescription) {
+        if self.single_seed {
+            self.topology_type = TopologyType::Single;
+        } else {
+            self.servers.remove(&server_description.address);
+        }
+    }
+
+    /// Update the ReplicaSetNoPrimary topology description based on the non-primary server
+    /// description.
+    fn update_rs_without_primary_server(
+        &mut self,
+        server_description: ServerDescription,
+    ) -> Result<()> {
+        if self.set_name.is_none() {
+            self.set_name = server_description.set_name()?;
+        } else if self.set_name != server_description.set_name()? {
+            self.servers.remove(&server_description.address);
+
+            return Ok(());
+        }
+
+        self.add_new_servers(server_description.known_hosts()?)?;
+
+        if server_description.invalid_me()? {
+            self.servers.remove(&server_description.address);
+        }
+
+        Ok(())
+    }
+
+    /// Update the ReplicaSetWithPrimary topology description based on the non-primary server
+    /// description.
+    fn update_rs_with_primary_from_member(
+        &mut self,
+        server_description: ServerDescription,
+    ) -> Result<()> {
+        if self.set_name != server_description.set_name()? {
+            self.servers.remove(&server_description.address);
+            self.record_primary_state();
+
+            return Ok(());
+        }
+
+        if server_description.invalid_me()? {
+            self.servers.remove(&server_description.address);
+            self.record_primary_state();
+
+            return Ok(());
+        }
+
+        Ok(())
+    }
+
+    /// Update the replica set topology description based on the RSPrimary server description.
+    fn update_rs_from_primary_server(
+        &mut self,
+        server_description: ServerDescription,
+    ) -> Result<()> {
+        if self.set_name.is_none() {
+            self.set_name = server_description.set_name()?;
+        } else if self.set_name != server_description.set_name()? {
+            self.servers.remove(&server_description.address);
+            self.record_primary_state();
+
+            return Ok(());
+        }
+
+        if let Some(server_set_version) = server_description.set_version()? {
+            if let Some(server_election_id) = server_description.election_id()? {
+                if let Some(topology_max_set_version) = self.max_set_version {
+                    if let Some(ref topology_max_election_id) = self.max_election_id {
+                        if topology_max_set_version > server_set_version
+                            || (topology_max_set_version == server_set_version
+                                && *topology_max_election_id > server_election_id)
+                        {
+                            self.servers.insert(
+                                server_description.address.clone(),
+                                ServerDescription::new(server_description.address, None),
+                            );
+                            self.record_primary_state();
+                            return Ok(());
+                        }
+                    }
+                }
+
+                self.max_election_id = Some(server_election_id);
+            }
+        }
+
+        if let Some(server_set_version) = server_description.set_version()? {
+            if self
+                .max_set_version
+                .as_ref()
+                .map(|topology_max_set_version| server_set_version > *topology_max_set_version)
+                .unwrap_or(true)
+            {
+                self.max_set_version = Some(server_set_version);
+            }
+        }
+
+        let addresses: Vec<_> = self.servers.keys().cloned().collect();
+
+        // If any other servers are RSPrimary, replace them with an unknown server decscription,
+        // which will cause them to be updated by a new isMaster.
+        for address in addresses.clone() {
+            if address == server_description.address {
+                continue;
+            }
+
+            if let ServerType::RSPrimary = self.servers.get(&address).unwrap().server_type {
+                self.servers
+                    .insert(address.clone(), ServerDescription::new(address, None));
+            }
+        }
+
+        self.add_new_servers(server_description.known_hosts()?)?;
+        let known_hosts: HashSet<_> = server_description.known_hosts()?.collect();
+
+        for address in addresses {
+            if !known_hosts.contains(&address.to_string()) {
+                self.servers.remove(&address);
+            }
+        }
+
+        self.record_primary_state();
+
+        Ok(())
+    }
+
+    /// Inspect the topology for a primary server, and update the topology type to
+    /// ReplicaSetNoPrimary if none is found.
+    ///
+    /// This should only be called on a replica set topology.
+    fn record_primary_state(&mut self) {
+        self.topology_type = if self
+            .servers
+            .values()
+            .any(|server| server.server_type == ServerType::RSPrimary)
+        {
+            TopologyType::ReplicaSetWithPrimary
+        } else {
+            TopologyType::ReplicaSetNoPrimary
+        };
+    }
+
+    /// Create a new ServerDescription for each address and add it to the topology.
+    fn add_new_servers<'a>(&'a mut self, servers: impl Iterator<Item = &'a String>) -> Result<()> {
+        for server in servers {
+            let server = StreamAddress::parse(&server)?;
+
+            if !self.servers.contains_key(&server) {
+                self.servers
+                    .insert(server.clone(), ServerDescription::new(server, None));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/sdam/description/topology/test.rs
+++ b/src/sdam/description/topology/test.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+
+use bson::oid::ObjectId;
+use serde::Deserialize;
+
+use crate::{
+    error::ErrorKind,
+    is_master::{IsMasterCommandResponse, IsMasterReply},
+    options::{ClientOptions, StreamAddress},
+    sdam::description::{
+        server::{ServerDescription, ServerType},
+        topology::{TopologyDescription, TopologyType},
+    },
+};
+
+#[derive(Debug, Deserialize)]
+pub struct TestFile {
+    description: String,
+    uri: String,
+    phases: Vec<Phase>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Phase {
+    responses: Vec<Response>,
+    outcome: Outcome,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Response(String, IsMasterCommandResponse);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Outcome {
+    topology_type: TopologyType,
+    set_name: Option<String>,
+    servers: HashMap<String, Server>,
+    logical_session_timeout_minutes: Option<i32>,
+    compatible: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Server {
+    #[serde(rename = "type")]
+    server_type: String,
+    set_name: Option<String>,
+    set_version: Option<i32>,
+    election_id: Option<ObjectId>,
+    logical_session_timeout_minutes: Option<i32>,
+    min_wire_version: Option<i32>,
+    max_wire_version: Option<i32>,
+}
+
+fn server_type_from_str(s: &str) -> Option<ServerType> {
+    let t = match s {
+        "Standalone" => ServerType::Standalone,
+        "Mongos" => ServerType::Mongos,
+        "RSPrimary" => ServerType::RSPrimary,
+        "RSSecondary" => ServerType::RSSecondary,
+        "RSArbiter" => ServerType::RSArbiter,
+        "RSOther" => ServerType::RSOther,
+        "RSGhost" => ServerType::RSGhost,
+        "Unknown" | "PossiblePrimary" => ServerType::Unknown,
+        _ => return None,
+    };
+
+    Some(t)
+}
+
+fn run_test(test_file: TestFile) {
+    let mut options = ClientOptions::parse(&test_file.uri).expect(&test_file.description);
+
+    if options.hosts.len() == 1 {
+        options.direct_connection = Some(true);
+    }
+
+    let mut topology_description = TopologyDescription::new(options);
+
+    for (i, phase) in test_file.phases.into_iter().enumerate() {
+        for Response(address, command_response) in phase.responses {
+            let is_master_reply = if command_response == Default::default() {
+                Err(ErrorKind::OperationError("dummy error".to_string()).into())
+            } else {
+                Ok(IsMasterReply {
+                    command_response,
+                    round_trip_time: Some(1234), // Doesn't matter for tests.
+                })
+            };
+
+            topology_description
+                .update(ServerDescription::new(
+                    StreamAddress::parse(&address).unwrap(),
+                    Some(is_master_reply),
+                ))
+                .unwrap();
+        }
+
+        assert_eq!(
+            topology_description.topology_type, phase.outcome.topology_type,
+            "{}: {}",
+            &test_file.description, i,
+        );
+
+        assert_eq!(
+            topology_description.set_name, phase.outcome.set_name,
+            "{}: {}",
+            &test_file.description, i,
+        );
+
+        // TODO: Test for proper logicalSessionTimeoutMinutes value once sessions spec
+        // is implemented.
+
+        if let Some(compatible) = phase.outcome.compatible {
+            assert_eq!(
+                topology_description.compatibility_error.is_none(),
+                compatible,
+                "{}: {}",
+                &test_file.description,
+                i,
+            );
+        }
+
+        assert_eq!(
+            topology_description.servers.len(),
+            phase.outcome.servers.len(),
+            "{}: {}",
+            &test_file.description,
+            i
+        );
+
+        let description = &test_file.description;
+
+        for (address, server) in phase.outcome.servers {
+            let actual_server = dbg!(&topology_description.servers)
+                .get(&dbg!(StreamAddress::parse(&address)).unwrap())
+                .unwrap_or_else(|| panic!("{} (phase {})", description, i));
+
+            let server_type = server_type_from_str(&server.server_type)
+                .unwrap_or_else(|| panic!("{} (phase {})", description, i));
+
+            assert_eq!(
+                actual_server.server_type, server_type,
+                "{} (phase {})",
+                &test_file.description, i
+            );
+
+            assert_eq!(
+                actual_server.set_name().unwrap_or(None),
+                server.set_name,
+                "{} (phase {})",
+                &test_file.description,
+                i
+            );
+
+            assert_eq!(
+                actual_server.set_version().unwrap_or(None),
+                server.set_version,
+                "{} (phase {})",
+                &test_file.description,
+                i
+            );
+
+            assert_eq!(
+                actual_server.election_id().unwrap_or(None),
+                server.election_id,
+                "{} (phase {})",
+                &test_file.description,
+                i
+            );
+
+            // TODO: Test for proper logicalSessionTimeoutMinutes value once sessions spec
+            // is implemented.
+
+            if let Some(min_wire_version) = server.min_wire_version {
+                assert_eq!(
+                    actual_server.min_wire_version().unwrap(),
+                    Some(min_wire_version),
+                    "{} (phase {})",
+                    &test_file.description,
+                    i
+                );
+            }
+
+            if let Some(max_wire_version) = server.max_wire_version {
+                assert_eq!(
+                    actual_server.max_wire_version().unwrap(),
+                    Some(max_wire_version),
+                    "{} (phase {})",
+                    &test_file.description,
+                    i
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn single() {
+    crate::test::run(&["server-discovery-and-monitoring", "single"], run_test);
+}
+
+#[test]
+fn rs() {
+    crate::test::run(&["server-discovery-and-monitoring", "rs"], run_test);
+}
+
+#[test]
+fn sharded() {
+    crate::test::run(&["server-discovery-and-monitoring", "sharded"], run_test);
+}

--- a/src/sdam/mod.rs
+++ b/src/sdam/mod.rs
@@ -1,0 +1,3 @@
+mod description;
+
+pub(crate) use self::description::server::ServerType;


### PR DESCRIPTION
I suggest when viewing to quickly look over the stuff before 93ca739 and then focus on reviewing that commit forward separately; the previous two commits are taken from `unreviewed-impl`, namely moving `src/client.rs` to `src/client/mod.rs` and the `ClientOptions` API.