### PR TITLE
Add common read concern, write concern, and selection criteria tests

### DIFF
--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test;
 
-use std::time::Duration;
+use std::{rc::Rc, time::Duration};
 
 use derivative::Derivative;
 use rand::seq::IteratorRandom;
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// Describes which servers are suitable for a given operation.
-#[derive(Derivative)]
+#[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub(crate) enum SelectionCriteria {
     /// A read preference that describes the suitable servers based on the server type, max
@@ -22,7 +22,7 @@ pub(crate) enum SelectionCriteria {
 
     /// A predicate used to filter servers that are considered suitable. A `server` will be
     /// considered suitable by a `predicate` if `predicate(server)` returns true.
-    Predicate(#[derivative(Debug = "ignore")] Box<dyn Fn(&ServerDescription) -> bool>),
+    Predicate(#[derivative(Debug = "ignore")] Rc<dyn Fn(&ServerDescription) -> bool>),
 }
 
 impl SelectionCriteria {


### PR DESCRIPTION
This PR adds tests that can be used by all operations that get certain options from both the struct and the object that executes the operation (e.g. read concern on a find).

Here's an example of how they would be used:
```rust
#[test]
fn build_read_concern() {
    test::build_read_concern(|coll_rc, opts_rc| {
        let opts = opts_rc.map(|rc| FindOptions::builder().read_concern(rc).build());
        Find::new(Namespace::empty(), Document::new(), None, coll_rc, opts)
    });
}

#[test]
fn op_selection_criteria() {
    test::op_selection_criteria(|coll_rp, opts_sc| {
        let opts = opts_sc.map(|sc| FindOptions::builder().selection_criteria(sc).build());
        Find::new(Namespace::empty(), Document::new(), coll_rp, None, opts)
    });
}
```