### PR TITLE
RUST-243 Fix background thread closing of perished connections

### DIFF
--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -112,8 +112,17 @@ impl Connection {
 
     /// Helper to mark the time that the connection was checked into the pool for the purpose of
     /// detecting when it becomes idle.
-    pub(super) fn mark_as_ready_and_available(&mut self) {
+    pub(super) fn mark_checked_in(&mut self) {
+        self.pool.take();
         self.ready_and_available_time = Some(Instant::now());
+    }
+
+    /// Helper to mark that the connection has been checked out of the pool. This ensures that the
+    /// connection is not marked as idle based on the time that it's checked out and that it has a
+    /// reference to the pool.
+    pub(super) fn mark_checked_out(&mut self, pool: Weak<ConnectionPoolInner>) {
+        self.pool = Some(pool);
+        self.ready_and_available_time.take();
     }
 
     /// Checks if the connection is idle.


### PR DESCRIPTION
The flaky test that would occasionally fail was the CMAP test "pool-checkout-no-idle", which checked that checking out a connection, checking it back in, waiting beyond maxIdleTimeMS, and then checking out a connection again gave a new connection due to the first connection being closed due to idleness. This test would usually pass because our CMAP background threads slept for a fairly long time between iterations, so the thread would usually not wake up in time to clean up the connection itself, and the checkout algorithm would close the idle connection on its own and then create a new connection. However, this test would fail whenever the background thread woke up in time to clean up the connection itself because the background thread was not using the pool's `close_connection` helper, which meant that no ConnectionClosed event was being emitted.

Now that this is fixed, we can also reduce the sleep between iterations to 10 ms as described in RUST-207, as the test referenced in that ticket was the same one! Setting the duration to 10 ms essentially makes it guaranteed that the background thread will clean up the connection, so it would cause this test to fail every time.