### PR TITLE
minor: acquire concurrency lock in update one spec tests

### DIFF
--- a/tests/spec/crud/update_one.rs
+++ b/tests/spec/crud/update_one.rs
@@ -3,7 +3,7 @@ use mongodb::options::{Collation, UpdateOptions};
 use serde::Deserialize;
 
 use super::{Outcome, TestFile};
-use crate::CLIENT;
+use crate::{CLIENT, LOCK};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +32,8 @@ fn run_update_one_test(test_file: TestFile) {
         if test_case.operation.name != "updateOne" {
             continue;
         }
+
+        let _guard = LOCK.run_concurrently();
 
         test_case.description = test_case.description.replace('$', "%");
 


### PR DESCRIPTION
I missed a spot to acquire the test lock, and the test failed in the waterfall. Hopefully this is a sign that if we forget to lock somewhere in the tests, they'll fail quickly so we can notice.