### PR TITLE
RUST-246 Batch large inserts

### DIFF
--- a/src/bson_util.rs
+++ b/src/bson_util.rs
@@ -107,3 +107,146 @@ pub(crate) fn serialize_batch_size<S: Serializer>(
         )),
     }
 }
+
+pub fn doc_size_bytes(doc: &Document) -> usize {
+    // 
+    // * i32 length prefix (4 bytes)
+    // * for each element:
+    //   * type (1 byte)
+    //   * number of UTF-8 bytes in key
+    //   * null terminator for the key (1 byte)
+    //   * size of the value
+    // * null terminator (1 byte)
+    4 + doc
+        .into_iter()
+        .map(|(key, val)| 1 + key.len() + 1 + size_bytes(val))
+        .sum::<usize>()
+        + 1
+}
+
+pub fn size_bytes(val: &Bson) -> usize {
+    match val {
+        Bson::FloatingPoint(_) => 8,
+        // 
+        // * length prefix (4 bytes)
+        // * number of UTF-8 bytes
+        // * null terminator (1 byte)
+        Bson::String(s) => 4 + s.len() + 1,
+        // An array is serialized as a document with the keys "0", "1", "2", etc., so the size of
+        // an array is:
+        //
+        // * length prefix (4 bytes)
+        // * for each element:
+        //   * type (1 byte)
+        //   * number of decimal digits in key
+        //   * null terminator for the key (1 byte)
+        //   * size of value
+        // * null terminator (1 byte)
+        Bson::Array(arr) => {
+            4 + arr
+                .iter()
+                .enumerate()
+                .map(|(i, val)| 1 + num_decimal_digits(i) + 1 + size_bytes(val))
+                .sum::<usize>()
+                + 1
+        }
+        Bson::Document(doc) => doc_size_bytes(doc),
+        Bson::Boolean(_) => 1,
+        Bson::Null => 0,
+        // for $pattern and $opts:
+        //   * number of UTF-8 bytes
+        //   * null terminator (1 byte)
+        Bson::RegExp(pattern, opts) => pattern.len() + 1 + opts.len() + 1,
+        // 
+        // * length prefix (4 bytes)
+        // * number of UTF-8 bytes
+        // * null terminator (1 byte)
+        Bson::JavaScriptCode(code) => 4 + code.len() + 1,
+        // 
+        // * i32 length prefix (4 bytes)
+        // * i32 length prefix for code (4 bytes)
+        // * number of UTF-8 bytes in code
+        // * null terminator for code (1 byte)
+        // * length of document
+        Bson::JavaScriptCodeWithScope(code, scope) => {
+            4 + 4 + code.len() + 1 + doc_size_bytes(scope)
+        }
+        Bson::I32(_) => 4,
+        Bson::I64(_) => 8,
+        Bson::TimeStamp(_) => 8,
+        // 
+        // * i32 length prefix (4 bytes)
+        // * subtype (1 byte)
+        // * number of bytes
+        Bson::Binary(_, bytes) => 4 + 1 + bytes.len(),
+        Bson::ObjectId(_) => 12,
+        Bson::UtcDatetime(_) => 8,
+        // 
+        // * i32 length prefix (4 bytes)
+        // * subtype (1 byte)
+        // * number of UTF-8 bytes
+        Bson::Symbol(s) => 4 + 1 + s.len(),
+    }
+}
+
+fn num_decimal_digits(n: usize) -> usize {
+    let mut digits = 1;
+    let mut curr = 10;
+
+    while curr < n {
+        curr = match curr.checked_mul(10) {
+            Some(val) => val,
+            None => break,
+        };
+
+        digits += 1;
+    }
+
+    digits
+}
+
+#[cfg(test)]
+mod test {
+    use bson::{oid::ObjectId, spec::BinarySubtype, Bson};
+    use chrono::{DateTime, NaiveDateTime, Utc};
+
+    use super::doc_size_bytes;
+
+    #[test]
+    fn doc_size_bytes_eq_serialized_size_bytes() {
+        let doc = doc! {
+            "double": -12.3,
+            "string": "foo",
+            "array": ["foobar", -7, Bson::Null, Bson::TimeStamp(1278), false],
+            "document": {
+                "x": 1,
+                "yyz": "Rush is one of the greatest bands of all time",
+            },
+            "bool": true,
+            "null": Bson::Null,
+            "regex": Bson::RegExp("foobar".into(), "i".into()),
+            "code": Bson::JavaScriptCode("foo(x) { return x + 1; }".into()),
+            "code with scope": Bson::JavaScriptCodeWithScope(
+                "foo(x) { return x + y; }".into(),
+                doc! { "y": -17 },
+            ),
+            "i32": 12i32,
+            "i64": -126i64,
+            "timestamp": Bson::TimeStamp(1223334444),
+            "binary": Bson::Binary(BinarySubtype::Generic, vec![3, 222, 11]),
+            "objectid": ObjectId::with_bytes([1; 12]),
+            "datetime": DateTime::from_utc(
+                NaiveDateTime::from_timestamp(4444333221, 0),
+                Utc,
+            ),
+            "symbol": Bson::Symbol("foobar".into()),
+        };
+
+        let size_bytes = doc_size_bytes(&doc);
+
+        let mut serialized_bytes = Vec::new();
+        bson::encode_document(&mut serialized_bytes, &doc).unwrap();
+
+        assert_eq!(size_bytes, serialized_bytes.len());
+    }
+}

--- a/src/bson_util.rs
+++ b/src/bson_util.rs
@@ -207,7 +207,7 @@ fn num_decimal_digits(n: usize) -> usize {
 
 #[cfg(test)]
 mod test {
-    use bson::{oid::ObjectId, spec::BinarySubtype, Bson};
+    use bson::{bson, doc, oid::ObjectId, spec::BinarySubtype, Bson};
     use chrono::{DateTime, NaiveDateTime, Utc};
 
     use super::doc_size_bytes;

--- a/src/coll/batch.rs
+++ b/src/coll/batch.rs
@@ -1,0 +1,78 @@
+// Splits off elements from `all` so that the sum of sizes in `all` is not greater than
+// `max_batch_size`. Any remaining elements will be returned in a separate vector.
+pub(crate) fn split_off_batch<T>(
+    all: &mut Vec<T>,
+    max_batch_size: usize,
+    get_size: impl Fn(&T) -> usize,
+) -> Option<Vec<T>> {
+    if all.is_empty() {
+        return None;
+    }
+
+    let mut batch_size = get_size(&all[0]);
+
+    for i in 1..all.len() {
+        let elem_size = get_size(&all[i]);
+
+        if batch_size + elem_size > max_batch_size {
+            return Some(all.split_off(i));
+        }
+
+        batch_size += elem_size;
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::split_off_batch;
+
+    #[test]
+    fn split_empty_batch() {
+        let mut all: Vec<i32> = Vec::new();
+
+        assert!(split_off_batch(&mut all, 10, |_| 1).is_none());
+    }
+
+    #[test]
+    fn split_single_batch() {
+        let mut all = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        assert!(split_off_batch(&mut all, 10, |_| 1).is_none());
+    }
+
+    #[test]
+    fn split_multi_batch() {
+        let mut all = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let rest = split_off_batch(&mut all, 3, |_| 1);
+
+        assert_eq!(all, vec![1, 2, 3]);
+        assert_eq!(rest, Some(vec![4, 5, 6, 7, 8, 9, 10]));
+    }
+
+    #[test]
+    fn split_batches_until_none() {
+        let mut batches = Vec::new();
+        let mut all = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        while let Some(batch) = split_off_batch(&mut all, 3, |_| 1) {
+            batches.push(std::mem::replace(&mut all, batch));
+        }
+
+        assert_eq!(all, vec![10]);
+        assert_eq!(batches.len(), 3);
+        assert_eq!(batches[0], vec![1, 2, 3]);
+        assert_eq!(batches[1], vec![4, 5, 6]);
+        assert_eq!(batches[2], vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn split_batch_with_too_large_element() {
+        let mut all = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let rest = split_off_batch(&mut all, 3, |_| 5);
+
+        assert_eq!(all, vec![1]);
+        assert_eq!(rest, Some(vec![2, 3, 4, 5, 6, 7, 8, 9, 10]));
+    }
+}

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -390,6 +390,13 @@ impl Collection {
 
         let mut docs: Vec<Document> = docs.into_iter().collect();
 
+        if docs.is_empty() {
+            return Err(ErrorKind::ArgumentError {
+                message: "No documents provided to insert_many".to_string(),
+            }
+            .into());
+        }
+
         let ordered = options.as_ref().and_then(|o| o.ordered).unwrap_or(true);
 
         let mut cumulative_failure: Option<BulkWriteFailure> = None;

--- a/src/error.rs
+++ b/src/error.rs
@@ -305,7 +305,7 @@ pub struct WriteError {
 #[derive(Debug, PartialEq, Clone, Deserialize)]
 pub struct BulkWriteError {
     /// Index into the list of operations that this error corresponds to.
-    pub index: i32,
+    pub index: usize,
 
     /// Identifies the type of write concern error.
     pub code: i32,
@@ -330,6 +330,15 @@ pub struct BulkWriteFailure {
 
     /// The error that ocurred on account of write concern failure.
     pub write_concern_error: Option<WriteConcernError>,
+}
+
+impl BulkWriteFailure {
+    pub(crate) fn new() -> Self {
+        BulkWriteFailure {
+            write_errors: None,
+            write_concern_error: None,
+        }
+    }
 }
 
 /// An error that occurred when trying to execute a write operation.

--- a/src/results.rs
+++ b/src/results.rs
@@ -32,6 +32,14 @@ pub struct InsertManyResult {
     pub inserted_ids: HashMap<usize, Bson>,
 }
 
+impl InsertManyResult {
+    pub(crate) fn new() -> Self {
+        InsertManyResult {
+            inserted_ids: HashMap::new(),
+        }
+    }
+}
+
 /// The result of a [`Collection::update_one`](../struct.Collection.html#method.update_one) or
 /// [`Collection::update_many`](../struct.Collection.html#method.update_many) operation.
 #[derive(Debug)]

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -1,8 +1,10 @@
-use bson::{bson, doc, Bson};
+use bson::{bson, doc, Bson, Document};
+use lazy_static::lazy_static;
 
 use crate::{
+    error::ErrorKind,
     event::command::CommandStartedEvent,
-    options::{AggregateOptions, FindOptions, UpdateOptions},
+    options::{AggregateOptions, FindOptions, InsertManyOptions, UpdateOptions},
     test::{
         util::{drop_collection, CommandEvent, EventClient},
         CLIENT,
@@ -218,4 +220,159 @@ fn no_kill_cursors_on_exhausted() {
     std::mem::drop(cursor);
 
     assert!(!kill_cursors_sent(&event_client));
+}
+
+lazy_static! {
+    #[allow(clippy::unreadable_literal)]
+    static ref LARGE_DOC: Document = doc! {
+        "text": "the quick brown fox jumped over the lazy sheep dog",
+        "in_reply_to_status_id": 22213321312i64,
+        "retweet_count": Bson::Null,
+        "contributors": Bson::Null,
+        "created_at": ";lkasdf;lkasdfl;kasdfl;kasdkl;ffasdkl;fsadkl;fsad;lfk",
+        "geo": Bson::Null,
+        "source": "web",
+        "coordinates": Bson::Null,
+        "in_reply_to_screen_name": "sdafsdafsdaffsdafasdfasdfasdfasdfsadf",
+        "truncated": false,
+        "entities": {
+            "user_mentions": [
+                {
+                    "indices": [
+                        0,
+                        9
+                    ],
+                    "screen_name": "sdafsdaff",
+                    "name": "sadfsdaffsadf",
+                    "id": 1
+                }
+            ],
+            "urls": [],
+            "hashtags": []
+        },
+        "retweeted": false,
+        "place": Bson::Null,
+        "user": {
+            "friends_count": 123,
+            "profile_sidebar_fill_color": "7a7a7a",
+            "location": "sdafffsadfsdaf sdaf asdf asdf sdfsdfsdafsdaf asdfff sadf",
+            "verified": false,
+            "follow_request_sent": Bson::Null,
+            "favourites_count": 0,
+            "profile_sidebar_border_color": "a3a3a3",
+            "profile_image_url": "sadfkljajsdlkffajlksdfjklasdfjlkasdljkf asdjklffjlksadfjlksadfjlksdafjlksdaf",
+            "geo_enabled": false,
+            "created_at": "sadffasdffsdaf",
+            "description": "sdffasdfasdfasdfasdf",
+            "time_zone": "Mountain Time (US & Canada)",
+            "url": "sadfsdafsadf fsdaljk asjdklf lkjasdf lksadklfffsjdklafjlksdfljksadfjlk",
+            "screen_name": "adsfffasdf sdlk;fjjdsakfasljkddfjklasdflkjasdlkfjldskjafjlksadf",
+            "notifications": Bson::Null,
+            "profile_background_color": "303030",
+            "listed_count": 1,
+            "lang": "en"
+        }
+    };
+}
+
+#[test]
+#[function_name::named]
+fn large_insert() {
+    let _guard = LOCK.run_concurrently();
+
+    let docs = vec![LARGE_DOC.clone(); 35000];
+
+    let coll = CLIENT.init_db_and_coll(function_name!(), function_name!());
+    assert_eq!(
+        coll.insert_many(docs, None).unwrap().inserted_ids.len(),
+        35000
+    );
+}
+
+/// Returns a vector of documents that cannot be sent in one batch (35000 documents).
+/// Includes duplicate _id's across different batches.
+fn multibatch_documents_with_duplicate_keys() -> Vec<Document> {
+    let large_doc = LARGE_DOC.clone();
+
+    let mut docs: Vec<Document> = Vec::new();
+    docs.extend(vec![large_doc.clone(); 7498]);
+
+    docs.push(doc! { "_id": 1 });
+    docs.push(doc! { "_id": 1 }); // error in first batch, index 7499
+
+    docs.extend(vec![large_doc.clone(); 14999]);
+    docs.push(doc! { "_id": 1 }); // error in second batch, index 22499
+
+    docs.extend(vec![large_doc.clone(); 9999]);
+    docs.push(doc! { "_id": 1 }); // error in third batch, index 32499
+
+    docs.extend(vec![large_doc; 2500]);
+
+    assert_eq!(docs.len(), 35000);
+    docs
+}
+
+#[test]
+#[function_name::named]
+fn large_insert_unordered_with_errors() {
+    let _guard = LOCK.run_concurrently();
+
+    let docs = multibatch_documents_with_duplicate_keys();
+
+    let coll = CLIENT.init_db_and_coll(function_name!(), function_name!());
+    let options = InsertManyOptions::builder().ordered(false).build();
+
+    match coll
+        .insert_many(docs, options)
+        .expect_err("should get error")
+        .kind
+        .as_ref()
+    {
+        ErrorKind::BulkWriteError(ref failure) => {
+            let mut write_errors = failure
+                .write_errors
+                .clone()
+                .expect("should have write errors");
+            assert_eq!(write_errors.len(), 3);
+            write_errors.sort_by(|lhs, rhs| lhs.index.cmp(&rhs.index));
+
+            assert_eq!(write_errors[0].index, 7499);
+            assert_eq!(write_errors[1].index, 22499);
+            assert_eq!(write_errors[2].index, 32499);
+        }
+        e => panic!("expected bulk write error, got {:?} instead", e),
+    }
+}
+
+#[test]
+#[function_name::named]
+fn large_insert_ordered_with_errors() {
+    let _guard = LOCK.run_concurrently();
+
+    let docs = multibatch_documents_with_duplicate_keys();
+
+    let coll = CLIENT.init_db_and_coll(function_name!(), function_name!());
+    let options = InsertManyOptions::builder().ordered(true).build();
+
+    match coll
+        .insert_many(docs, options)
+        .expect_err("should get error")
+        .kind
+        .as_ref()
+    {
+        ErrorKind::BulkWriteError(ref failure) => {
+            let write_errors = failure
+                .write_errors
+                .clone()
+                .expect("should have write errors");
+            assert_eq!(write_errors.len(), 1);
+            assert_eq!(write_errors[0].index, 7499);
+            assert_eq!(
+                coll.count_documents(None, None)
+                    .expect("count should succeed"),
+                7499
+            );
+        }
+        e => panic!("expected bulk write error, got {:?} instead", e),
+    }
 }

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -376,3 +376,22 @@ fn large_insert_ordered_with_errors() {
         e => panic!("expected bulk write error, got {:?} instead", e),
     }
 }
+
+#[test]
+#[function_name::named]
+fn empty_insert() {
+    let _guard = LOCK.run_concurrently();
+
+    let coll = CLIENT
+        .database(function_name!())
+        .collection(function_name!());
+    match coll
+        .insert_many(Vec::new(), None)
+        .expect_err("should get error")
+        .kind
+        .as_ref()
+    {
+        ErrorKind::ArgumentError { .. } => {}
+        e => panic!("expected argument error, got {:?}", e),
+    };
+}


### PR DESCRIPTION
[RUST-246](https://jira.mongodb.org/browse/RUST-246)

This PR adds batching to `insert_many`, which breaks up inserts that would be too large for a single command into several, combining their errors and results as they come back from the server.

This was originally #105 , but due to some GitHub sync issues with my fork once this repo became public, I had to re-open.