### PR TITLE
minor: fix 1.40 clippy failures

### DIFF
--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -160,7 +160,7 @@ impl FromStr for AuthMechanism {
             GSSAPI_STR => Ok(AuthMechanism::Gssapi),
             PLAIN_STR => Ok(AuthMechanism::Plain),
             _ => Err(ErrorKind::ArgumentError {
-                message: format!("invalid mechanism string: {}", str).to_string(),
+                message: format!("invalid mechanism string: {}", str),
             }
             .into()),
         }

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -150,7 +150,7 @@ impl Client {
             Err(error) => {
                 let command_failed_event = CommandFailedEvent {
                     duration,
-                    command_name: cmd.name.clone(),
+                    command_name: cmd.name,
                     failure: error.clone(),
                     request_id,
                     connection: connection_info,

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -631,7 +631,7 @@ fn percent_decode(s: &str, err_message: &str) -> Result<String> {
 fn validate_userinfo(s: &str, userinfo_type: &str) -> Result<()> {
     if s.chars().any(|c| USERINFO_RESERVED_CHARACTERS.contains(&c)) {
         return Err(ErrorKind::ArgumentError {
-            message: format!("{} must be URL encoded", userinfo_type).to_string(),
+            message: format!("{} must be URL encoded", userinfo_type),
         }
         .into());
     }

--- a/src/cmap/establish/handshake.rs
+++ b/src/cmap/establish/handshake.rs
@@ -60,8 +60,8 @@ impl Handshaker {
     pub(super) fn new(options: Option<&ConnectionPoolOptions>) -> Self {
         let mut document = BASE_HANDSHAKE_DOCUMENT.clone();
 
-        if let Some(ref app_name) = options.as_ref().and_then(|opts| opts.app_name.as_ref()) {
-            document.insert("application", doc! { "name": *app_name });
+        if let Some(app_name) = options.as_ref().and_then(|opts| opts.app_name.as_ref()) {
+            document.insert("application", doc! { "name": app_name });
         }
 
         let mut db = "admin";

--- a/src/cmap/establish/handshake.rs
+++ b/src/cmap/establish/handshake.rs
@@ -61,7 +61,7 @@ impl Handshaker {
         let mut document = BASE_HANDSHAKE_DOCUMENT.clone();
 
         if let Some(ref app_name) = options.as_ref().and_then(|opts| opts.app_name.as_ref()) {
-            document.insert("application", doc! { "name": app_name.to_string() });
+            document.insert("application", doc! { "name": *app_name });
         }
 
         let mut db = "admin";

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -164,7 +164,7 @@ impl Collection {
             [read_concern, write_concern, selection_criteria]
         );
 
-        let aggregate = Aggregate::new(self.namespace().clone(), pipeline, options);
+        let aggregate = Aggregate::new(self.namespace(), pipeline, options);
         let client = self.client();
         client
             .execute_operation(&aggregate, None)
@@ -536,7 +536,7 @@ impl<'de> Deserialize<'de> for Namespace {
         match (db, coll) {
             (Some(db), coll) if !coll.is_empty() => Ok(Self {
                 db: db.to_string(),
-                coll: coll.to_string(),
+                coll,
             }),
             _ => Err(D::Error::custom("Missing one or more fields in namespace")),
         }

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -21,7 +21,7 @@ fn build_test(
 ) {
     let target = target.into();
 
-    let aggregate = Aggregate::new(target.clone(), pipeline.clone(), options);
+    let aggregate = Aggregate::new(target.clone(), pipeline, options);
 
     let mut cmd = aggregate.build(&StreamDescription::new_testing()).unwrap();
 
@@ -94,7 +94,7 @@ fn build_batch_size() {
     expected_body.insert("cursor", doc! { "batchSize": 5 });
     build_test(
         ns.clone(),
-        pipeline.clone(),
+        pipeline,
         Some(batch_size_options.clone()),
         expected_body.clone(),
     );
@@ -211,7 +211,7 @@ fn handle_success() {
     );
 
     let aggregate = Aggregate::new(
-        ns.clone(),
+        ns,
         Vec::new(),
         Some(
             AggregateOptions::builder()

--- a/src/operation/distinct/test.rs
+++ b/src/operation/distinct/test.rs
@@ -24,7 +24,7 @@ fn build() {
         distinct_command.body,
         doc! {
             "distinct": "test_coll",
-            "key": field_name.clone()
+            "key": field_name
         }
     );
     assert_eq!(distinct_command.target_db, "test_db");
@@ -47,8 +47,8 @@ fn build_with_query() {
         distinct_command.body,
         doc! {
             "distinct": "test_coll",
-            "key": field_name.clone(),
-            "query": Bson::Document(query.clone())
+            "key": field_name,
+            "query": Bson::Document(query)
         }
     );
     assert_eq!(distinct_command.target_db, "test_db");
@@ -73,7 +73,7 @@ fn build_with_options() {
         distinct_command.body,
         doc! {
             "distinct": "test_coll",
-            "key": field_name.clone(),
+            "key": field_name,
             "maxTimeMS": max_time.as_millis() as i64
         }
     );

--- a/src/operation/find/test.rs
+++ b/src/operation/find/test.rs
@@ -110,12 +110,7 @@ fn build_cursor_type() {
         "awaitData": true,
     };
 
-    build_test(
-        ns.clone(),
-        None,
-        Some(tailable_await_options),
-        tailable_await_body,
-    );
+    build_test(ns, None, Some(tailable_await_options), tailable_await_body);
 }
 
 #[test]
@@ -135,7 +130,7 @@ fn build_max_await_time() {
         "maxTimeMS": 10 as i64
     };
 
-    build_test(ns.clone(), None, Some(options), body);
+    build_test(ns, None, Some(options), body);
 }
 
 #[test]
@@ -162,7 +157,7 @@ fn build_limit() {
         "singleBatch": true
     };
 
-    build_test(ns.clone(), None, Some(negative_options), negative_body);
+    build_test(ns, None, Some(negative_options), negative_body);
 }
 
 #[test]
@@ -233,7 +228,7 @@ fn handle_success() {
     );
 
     let find = Find::new(
-        ns.clone(),
+        ns,
         None,
         Some(FindOptions::builder().batch_size(123).build()),
     );

--- a/src/operation/find_and_modify/test.rs
+++ b/src/operation/find_and_modify/test.rs
@@ -24,7 +24,7 @@ fn empty_delete() -> FindAndModify {
         coll: "test_coll".to_string(),
     };
     let filter = doc! {};
-    FindAndModify::with_delete(ns, filter.clone(), None)
+    FindAndModify::with_delete(ns, filter, None)
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn empty_replace() -> FindAndModify {
     };
     let filter = doc! {};
     let replacement = doc! { "x": { "inc": 1 } };
-    FindAndModify::with_replace(ns, filter.clone(), replacement.clone(), None).unwrap()
+    FindAndModify::with_replace(ns, filter, replacement, None).unwrap()
 }
 
 #[test]
@@ -221,7 +221,7 @@ fn empty_update() -> FindAndModify {
     };
     let filter = doc! {};
     let update = UpdateModifications::Document(doc! { "$x": { "$inc": 1 } });
-    FindAndModify::with_update(ns, filter.clone(), update.clone(), None).unwrap()
+    FindAndModify::with_update(ns, filter, update, None).unwrap()
 }
 
 #[test]

--- a/src/operation/get_more/test.rs
+++ b/src/operation/get_more/test.rs
@@ -19,7 +19,7 @@ fn build_test(
     max_time: Option<Duration>,
     mut expected_body: Document,
 ) {
-    let get_more = GetMore::new(ns.clone(), cursor_id, address.clone(), batch_size, max_time);
+    let get_more = GetMore::new(ns.clone(), cursor_id, address, batch_size, max_time);
 
     let build_result = get_more.build(&StreamDescription::new_testing());
     assert!(build_result.is_ok());
@@ -58,7 +58,7 @@ fn build() {
     build_test(
         ns,
         cursor_id,
-        address.clone(),
+        address,
         Some(batch_size),
         Some(max_time),
         expected_body,
@@ -97,7 +97,7 @@ fn build_batch_size() {
         None,
         doc! {
             "getMore": cursor_id,
-            "collection": ns.coll.clone(),
+            "collection": ns.coll,
             "batchSize": 123,
         },
     );

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -58,7 +58,7 @@ fn build_with_filter() {
         doc! {
             "listDatabases": 1,
             "nameOnly": false,
-            "filter": Bson::Document(filter.clone())
+            "filter": Bson::Document(filter)
         }
     );
     assert_eq!(list_databases_command.target_db, "admin");

--- a/src/options.rs
+++ b/src/options.rs
@@ -9,12 +9,10 @@
 //! ```rust
 //! # use mongodb::options::FindOptions;
 //! #
-//! # fn main() {
-//! let options = FindOptions::builder()
-//!                   .limit(20)
-//!                   .batch_size(5)
-//!                   .build();
-//! # }
+//! # let options = FindOptions::builder()
+//! #                   .limit(20)
+//! #                   .batch_size(5)
+//! #                   .build();
 //! ```
 
 pub use crate::{

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -133,7 +133,7 @@ impl Topology {
             address.clone(),
             &options,
         ));
-        self.servers.insert(address.clone(), server.clone());
+        self.servers.insert(address, server.clone());
 
         let conn = Connection::new(
             0,

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -196,7 +196,7 @@ impl ReadPreference {
     }
 
     pub(crate) fn into_document(self) -> Document {
-        let (mode, tag_sets, max_staleness) = match self.clone() {
+        let (mode, tag_sets, max_staleness) = match self {
             ReadPreference::Primary => ("primary", None, None),
             ReadPreference::PrimaryPreferred {
                 tag_sets,

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -41,7 +41,7 @@ fn run_test(name: &str, test: impl Fn(EventClient, Database, Collection)) {
         &name,
         Some(
             CreateCollectionOptions::builder()
-                .write_concern(wc_majority.clone())
+                .write_concern(wc_majority)
                 .build(),
         ),
     )

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -91,7 +91,7 @@ fn run() {
         }
 
         if let Some(mut parsed_options) = test_file.parsed_options {
-            parsed_options.db = resolved_db.clone();
+            parsed_options.db = resolved_db;
 
             let actual_options = options
                 .credential


### PR DESCRIPTION
clippy got an update in rust 1.40 and started failing on the codebase, and this PR fixes those failures.