### PR TITLE
Derive Clone for DatabaseOptions

### DIFF
--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// These are the valid options for creating a [`Database`](../struct.Database.html) with
 /// [`Client::database_with_options`](../struct.Client.html#method.database_with_options).
-#[derive(Debug, Default, TypedBuilder)]
+#[derive(Clone, Debug, Default, TypedBuilder)]
 pub struct DatabaseOptions {
     /// The default read preference for operations.
     #[builder(default)]


### PR DESCRIPTION
I am trying to port r2d2-mongodb to use this new mongodb driver and it would be very nice if DatabaseOptions could be cloned.