### PR TITLE
minor: fix macOS evergreen failures

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -3,6 +3,6 @@
 rm -rf ~/.rustup
 curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
 
-echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ~/.cargo/env
+echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ~/.cargo/env
 . ~/.cargo/env
 rustup toolchain install nightly -c rustfmt

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -3,5 +3,6 @@
 rm -rf ~/.rustup
 curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path
 
+echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ~/.cargo/env
 . ~/.cargo/env
 rustup toolchain install nightly -c rustfmt

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -3,4 +3,4 @@
 set -o errexit
 
 . ~/.cargo/env
-RUST_BACKTRACE=1 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test
+RUST_BACKTRACE=1 cargo test

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -3,4 +3,4 @@
 set -o errexit
 
 . ~/.cargo/env
-RUST_BACKTRACE=1 cargo test
+RUST_BACKTRACE=1 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test


### PR DESCRIPTION
This PR updates our evergreen config to use a [cargo option](https://github.com/rust-lang/cargo/issues/2078#issuecomment-434388584) (via an environment variable) which forces cargo to use the git cli to fetch the crates index rather than libgit2, allowing us to sidestep the issues we were having with the ssh-agent on macOS. 