### PR TITLE
Default on ReplaceOptions.hint is missing

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -233,6 +233,7 @@ pub struct ReplaceOptions {
     ///
     /// Only available in MongoDB 4.2+. See the official MongoDB
     /// [documentation](https://docs.mongodb.com/manual/reference/command/update/#ex-update-command-hint) for examples.
+    #[builder(default)]
     pub hint: Option<Hint>,
 
     /// The write concern for the operation.


### PR DESCRIPTION
So it'll throw a not very helpful error at you:

> error[E0599]: no method named `build` found for type `mongodb::coll::options::TypedBuilder_BuilderFor_ReplaceOptions<(), (std::option::Option<bool>,), (), (), ()>` in the current scope