### PR TITLE
RUST-268 Improve server selection timeout error messages

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -213,7 +213,13 @@ impl Client {
         }
 
         Err(ErrorKind::ServerSelectionError {
-            message: "timed out while trying to select server".into(),
+            message: self
+                .inner
+                .topology
+                .read()
+                .unwrap()
+                .description
+                .server_selection_timeout_error_message(&criteria),
         }
         .into())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,7 +149,7 @@ pub enum ErrorKind {
     ResponseError { message: String },
 
     /// The Client was not able to select a server for the operation.
-    #[error(display = ": {}", message)]
+    #[error(display = "{}", message)]
     ServerSelectionError { message: String },
 
     /// An error occurred during SRV record lookup.

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -1,4 +1,4 @@
-use std::{fmt, time::Duration};
+use std::time::Duration;
 
 use bson::{oid::ObjectId, UtcDateTime};
 use chrono::offset::Utc;
@@ -80,21 +80,6 @@ impl PartialEq for ServerDescription {
             }
             _ => false,
         }
-    }
-}
-
-impl fmt::Display for ServerDescription {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{ Address: {}, Type: {:?}, Average RTT: {:?}, LastError: ",
-            self.address, self.server_type, self.average_round_trip_time
-        )?;
-        match self.reply.as_ref().err() {
-            Some(e) => write!(f, "{}", e)?,
-            None => write!(f, "None")?,
-        }
-        write!(f, " }}")
     }
 }
 

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -27,13 +27,13 @@ impl TopologyDescription {
     ) -> String {
         if self.has_available_servers() {
             format!(
-                "Server selection timeout: No servers suitable for criteria {:?}. Current \
-                 topology: {}",
+                "Server selection timeout: None of the available servers suitable for criteria \
+                 {:?}. Topology: {}",
                 criteria, self
             )
         } else {
             format!(
-                "Server selection timeout: No available servers. Current topology: {}",
+                "Server selection timeout: No available servers. Topology: {}",
                 self
             )
         }
@@ -315,8 +315,8 @@ impl TopologyDescription {
 impl fmt::Display for TopologyDescription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{ Type: {:?}, Servers: [ ", self.topology_type)?;
-        for server in self.servers.values() {
-            write!(f, "{}, ", server)?;
+        for server_info in self.servers.values().map(ServerInfo::new) {
+            write!(f, "{}, ", server_info)?;
         }
         write!(f, "] }}")
     }

--- a/src/sdam/public.rs
+++ b/src/sdam/public.rs
@@ -92,32 +92,43 @@ impl<'a> fmt::Display for ServerInfo<'a> {
             self.server_type()
         )?;
 
-        if let Some(avg_rtt) = self.average_round_trip_time() {
-            write!(f, ", Average RTT: {:?}", avg_rtt)?;
-        }
+        match self.description.reply {
+            Ok(_) => {
+                if let Some(avg_rtt) = self.average_round_trip_time() {
+                    write!(f, ", Average RTT: {:?}", avg_rtt)?;
+                }
 
-        if let Some(last_update_time) = self.last_update_time() {
-            write!(f, ", Last Update Time: {:?}", last_update_time)?;
-        }
+                if let Some(last_update_time) = self.last_update_time() {
+                    write!(f, ", Last Update Time: {:?}", last_update_time)?;
+                }
 
-        if let Some(max_wire_version) = self.max_wire_version() {
-            write!(f, ", Max Wire Version: {}", max_wire_version)?;
-        }
+                if let Some(max_wire_version) = self.max_wire_version() {
+                    write!(f, ", Max Wire Version: {}", max_wire_version)?;
+                }
 
-        if let Some(min_wire_version) = self.min_wire_version() {
-            write!(f, ", Min Wire Version: {}", min_wire_version)?;
-        }
+                if let Some(min_wire_version) = self.min_wire_version() {
+                    write!(f, ", Min Wire Version: {}", min_wire_version)?;
+                }
 
-        if let Some(rs_name) = self.replica_set_name() {
-            write!(f, ", Replica Set Name: {}", rs_name)?;
-        }
+                if let Some(rs_name) = self.replica_set_name() {
+                    write!(f, ", Replica Set Name: {}", rs_name)?;
+                }
 
-        if let Some(rs_version) = self.replica_set_version() {
-            write!(f, ", Replica Set Version: {}", rs_version)?;
-        }
+                if let Some(rs_version) = self.replica_set_version() {
+                    write!(f, ", Replica Set Version: {}", rs_version)?;
+                }
 
-        if let Some(tags) = self.tags() {
-            write!(f, ", Tags: {:?}", tags)?;
+                if let Some(tags) = self.tags() {
+                    write!(f, ", Tags: {:?}", tags)?;
+                }
+
+                if let Some(compatibility_error) = self.description.compatibility_error_message() {
+                    write!(f, ", Compatiblity Error: {}", compatibility_error)?;
+                }
+            }
+            Err(ref e) => {
+                write!(f, ", Error: {}", e)?;
+            }
         }
 
         write!(f, " }}")

--- a/src/sdam/public.rs
+++ b/src/sdam/public.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use bson::UtcDateTime;
 
@@ -80,5 +80,46 @@ impl<'a> ServerInfo<'a> {
     /// Gets the tags associated with the server.
     pub fn tags(&self) -> Option<&TagSet> {
         self.command_response_getter(|r| r.tags.as_ref())
+    }
+}
+
+impl<'a> fmt::Display for ServerInfo<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
+        write!(
+            f,
+            "{{ Address: {}, Type: {:?}",
+            self.address(),
+            self.server_type()
+        )?;
+
+        if let Some(avg_rtt) = self.average_round_trip_time() {
+            write!(f, ", Average RTT: {:?}", avg_rtt)?;
+        }
+
+        if let Some(last_update_time) = self.last_update_time() {
+            write!(f, ", Last Update Time: {:?}", last_update_time)?;
+        }
+
+        if let Some(max_wire_version) = self.max_wire_version() {
+            write!(f, ", Max Wire Version: {}", max_wire_version)?;
+        }
+
+        if let Some(min_wire_version) = self.min_wire_version() {
+            write!(f, ", Min Wire Version: {}", min_wire_version)?;
+        }
+
+        if let Some(rs_name) = self.replica_set_name() {
+            write!(f, ", Replica Set Name: {}", rs_name)?;
+        }
+
+        if let Some(rs_version) = self.replica_set_version() {
+            write!(f, ", Replica Set Version: {}", rs_version)?;
+        }
+
+        if let Some(tags) = self.tags() {
+            write!(f, ", Tags: {:?}", tags)?;
+        }
+
+        write!(f, " }}")
     }
 }

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -112,6 +112,10 @@ impl TestClient {
         self.options.credential.is_some()
     }
 
+    pub fn is_replica_set(&self) -> bool {
+        self.server_info.is_replica_set == Some(true) || self.server_info.hosts.is_some()
+    }
+
     #[allow(dead_code)]
     pub fn server_version_eq(&self, major: u64, minor: u64) -> bool {
         self.server_version.major == major && self.server_version.minor == minor

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -113,7 +113,7 @@ impl TestClient {
     }
 
     pub fn is_replica_set(&self) -> bool {
-        self.server_info.is_replica_set == Some(true) || self.server_info.hosts.is_some()
+        self.options.repl_set_name.is_some()
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
[RUST-268](https://jira.mongodb.org/browse/RUST-268)

This PR improves the server selection timeout error messages by mentioning why the timeout ocurred as well as the state of the topology. It's loosely based off of the [error message psuedocode in the server selection spec](https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#server-selection-errors). 

The formatting and content are also inspired by similar error messages in the [go driver](https://github.com/mongodb/mongo-go-driver/pull/148):
```
Error { kind: ServerSelectionError { message: "Server selection timeout: No servers suitable for criteria ReadPreference(Secondary { tag_sets: Some([{\"asdfasdf\": \"asdfadsf\"}]), max_staleness: None }). Current topology: { Type: Unknown, Servers: [ { Address: localhost:27019, Type: RSArbiter, Average RTT: Some(653.756µs), LastError: None }, { Address: localhost:27018, Type: RSSecondary, Average RTT: Some(517.942µs), LastError: None }, { Address: localhost:27017, Type: Unknown, Average RTT: None, LastError: None }, ] }" } }
```