### PR TITLE
 Added "Bson" in the scope of " Finding documents in a collection" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ collection.insert_many(docs, None)?;
 ```
 ### Finding documents in a collection
 ```rust
-use bson::{doc, bson};
+use bson::{doc, bson, Bson};
 use mongodb::options::FindOptions;
 ```
 ```rust


### PR DESCRIPTION
It is necessary as it is using afterwards