### PR TITLE
minor: remove dev dependency on assert_matches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ features = ["dangerous_configuration"]
 
 [dev-dependencies]
 approx = "0.3.2"
-assert_matches = "1.3.0"
 derive_more = "0.15.0"
 function_name = "0.2.0"
 pretty_assertions = "0.6.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 
 ## Installation
 ### Requirements
- - Rust 1.42+
+| Driver Version | Required Rust Version |
+|:--------------:|:---------------------:|
+| master         | 1.42+                 |
+| 0.9.x          | 1.39+                 |
 - MongoDB 3.6+
 
 ### Importing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 
 ## Installation
 ### Requirements
- - Rust 1.39+
+ - Rust 1.42+
 - MongoDB 3.6+
 
 ### Importing

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -1,4 +1,3 @@
-use assert_matches::assert_matches;
 use bson::{bson, doc};
 
 use crate::{
@@ -119,9 +118,11 @@ async fn not_master_keep_pool() {
             .unwrap();
 
         let result = coll.insert_one(doc! { "test": 1 }, None);
-        assert_matches!(
-            result.as_ref().map_err(|e| e.as_ref()),
-            Err(ErrorKind::CommandError(CommandError { code: 10107, .. })),
+        assert!(
+            matches!(
+                result.as_ref().map_err(|e| e.as_ref()),
+                Err(ErrorKind::CommandError(CommandError { code: 10107, .. }))
+            ),
             "insert should have failed"
         );
 
@@ -160,9 +161,11 @@ async fn not_master_reset_pool() {
             .unwrap();
 
         let result = coll.insert_one(doc! { "test": 1 }, None);
-        assert_matches!(
-            result.as_ref().map_err(|e| e.as_ref()),
-            Err(ErrorKind::CommandError(CommandError { code: 10107, .. })),
+        assert!(
+            matches!(
+                result.as_ref().map_err(|e| e.as_ref()),
+                Err(ErrorKind::CommandError(CommandError { code: 10107, .. }))
+            ),
             "insert should have failed"
         );
 
@@ -200,9 +203,11 @@ async fn shutdown_in_progress() {
             .unwrap();
 
         let result = coll.insert_one(doc! { "test": 1 }, None);
-        assert_matches!(
-            result.as_ref().map_err(|e| e.as_ref()),
-            Err(ErrorKind::CommandError(CommandError { code: 91, .. })),
+        assert!(
+            matches!(
+                result.as_ref().map_err(|e| e.as_ref()),
+                Err(ErrorKind::CommandError(CommandError { code: 91, .. }))
+            ),
             "insert should have failed"
         );
 
@@ -240,9 +245,11 @@ async fn interrupted_at_shutdown() {
             .unwrap();
 
         let result = coll.insert_one(doc! { "test": 1 }, None);
-        assert_matches!(
-            result.as_ref().map_err(|e| e.as_ref()),
-            Err(ErrorKind::CommandError(CommandError { code: 11600, .. })),
+        assert!(
+            matches!(
+                result.as_ref().map_err(|e| e.as_ref()),
+                Err(ErrorKind::CommandError(CommandError { code: 11600, .. }))
+            ),
             "insert should have failed"
         );
 

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -1,4 +1,3 @@
-use assert_matches::assert_matches;
 use serde::Deserialize;
 
 use crate::{options::ClientOptions, test::run_spec_test};
@@ -38,11 +37,11 @@ async fn run() {
         let result = ClientOptions::parse(&test_file.uri);
 
         if let Some(true) = test_file.error {
-            assert_matches!(result, Err(_));
+            assert!(matches!(result, Err(_)));
             return;
         }
 
-        assert_matches!(result, Ok(_));
+        assert!(matches!(result, Ok(_)));
 
         let options = result.unwrap();
 


### PR DESCRIPTION
This PR removes the dependency on the third party `assert_matches` crate in favor of using the newly introduced `matches!` in Rust 1.42