### PR TITLE
RUST-300 Update StreamAddress resolution to be async

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -7,7 +7,6 @@ use std::{
     fs::File,
     hash::{Hash, Hasher},
     io::{BufReader, Seek, SeekFrom},
-    net::{SocketAddr, ToSocketAddrs},
     str::FromStr,
     sync::Arc,
     time::Duration,
@@ -87,14 +86,6 @@ impl Hash for StreamAddress {
     {
         self.hostname.hash(state);
         self.port.unwrap_or(27017).hash(state);
-    }
-}
-
-impl ToSocketAddrs for StreamAddress {
-    type Iter = std::vec::IntoIter<SocketAddr>;
-
-    fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
-        (self.hostname.as_str(), self.port.unwrap_or(27017)).to_socket_addrs()
     }
 }
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{SocketAddr, ToSocketAddrs},
+    net::SocketAddr,
     ops::DerefMut,
     pin::Pin,
     sync::Arc,
@@ -16,6 +16,7 @@ use crate::{
     cmap::options::StreamOptions,
     error::{ErrorKind, Result},
     options::StreamAddress,
+    RUNTIME,
 };
 
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -105,7 +106,7 @@ impl AsyncTcpStream {
     async fn connect(address: &StreamAddress, connect_timeout: Option<Duration>) -> Result<Self> {
         let timeout = connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT);
 
-        let mut socket_addrs: Vec<_> = address.to_socket_addrs()?.collect();
+        let mut socket_addrs: Vec<_> = RUNTIME.resolve_address(address).await?.collect();
 
         if socket_addrs.is_empty() {
             return Err(ErrorKind::NoDnsResults(address.clone()).into());


### PR DESCRIPTION
This is a follow up PR for [RUST-300](https://jira.mongodb.org/browse/RUST-300)

This previous PR (#149) only updated the SRV/TXT DNS resolution to be async. This PR updates the regular DNS resolution to also be async by replacing the usage of `std::net::ToSocketAddrs` with the async-std/tokio equivalents.