### PR TITLE
Read preference and write concern changes from implicit sessions PR

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -93,6 +93,10 @@ impl Client {
         op: &T,
         connection: &mut Connection,
     ) -> Result<T::O> {
+        if let Some(wc) = op.write_concern() {
+            wc.validate()?;
+        }
+
         let mut cmd = op.build(connection.stream_description()?)?;
         self.inner
             .topology

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -1,0 +1,124 @@
+use std::time::Duration;
+
+use bson::{doc, Bson};
+
+use crate::{
+    error::ErrorKind,
+    options::{Acknowledgment, InsertOneOptions, WriteConcern},
+    test::{TestClient, LOCK},
+};
+
+#[test]
+fn write_concern_is_acknowledged() {
+    let w_1 = WriteConcern::builder()
+        .w(Acknowledgment::Nodes(1))
+        .journal(false)
+        .build();
+    assert!(w_1.is_acknowledged());
+
+    let w_majority = WriteConcern::builder()
+        .w(Acknowledgment::Majority)
+        .journal(false)
+        .build();
+    assert!(w_majority.is_acknowledged());
+
+    let w_0 = WriteConcern::builder()
+        .w(Acknowledgment::Nodes(0))
+        .journal(false)
+        .build();
+    assert!(!w_0.is_acknowledged());
+
+    let w_0 = WriteConcern::builder().w(Acknowledgment::Nodes(0)).build();
+    assert!(!w_0.is_acknowledged());
+
+    let empty = WriteConcern::builder().build();
+    assert!(empty.is_acknowledged());
+
+    let empty = WriteConcern::builder().journal(false).build();
+    assert!(empty.is_acknowledged());
+
+    let empty = WriteConcern::builder().journal(true).build();
+    assert!(empty.is_acknowledged());
+}
+
+#[test]
+fn write_concern_deserialize() {
+    let w_1 = doc! { "w": 1 };
+    let wc: WriteConcern = bson::from_bson(Bson::Document(w_1)).unwrap();
+    assert_eq!(
+        wc,
+        WriteConcern {
+            w: Acknowledgment::Nodes(1).into(),
+            w_timeout: None,
+            journal: None
+        }
+    );
+
+    let w_majority = doc! { "w": "majority" };
+    let wc: WriteConcern = bson::from_bson(Bson::Document(w_majority)).unwrap();
+    assert_eq!(
+        wc,
+        WriteConcern {
+            w: Acknowledgment::Majority.into(),
+            w_timeout: None,
+            journal: None
+        }
+    );
+
+    let w_timeout = doc! { "w": "majority", "wtimeout": 100 };
+    let wc: WriteConcern = bson::from_bson(Bson::Document(w_timeout)).unwrap();
+    assert_eq!(
+        wc,
+        WriteConcern {
+            w: Acknowledgment::Majority.into(),
+            w_timeout: Duration::from_millis(100).into(),
+            journal: None
+        }
+    );
+
+    let journal = doc! { "w": "majority", "j": true };
+    let wc: WriteConcern = bson::from_bson(Bson::Document(journal)).unwrap();
+    assert_eq!(
+        wc,
+        WriteConcern {
+            w: Acknowledgment::Majority.into(),
+            w_timeout: None,
+            journal: true.into()
+        }
+    );
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn inconsistent_write_concern_rejected() {
+    let _guard = LOCK.run_concurrently().await;
+
+    let client = TestClient::new().await;
+    let db = client.database(function_name!());
+    let error = db
+        .run_command(
+            doc! {
+                "insert": function_name!(),
+                "documents": [ {} ],
+                "writeConcern": { "w": 0, "j": true }
+            },
+            None,
+        )
+        .await
+        .expect_err("insert should fail");
+    assert!(matches!(error.kind.as_ref(), ErrorKind::ArgumentError { .. }));
+
+    let coll = db.collection(function_name!());
+    let wc = WriteConcern {
+        w: Acknowledgment::Nodes(0).into(),
+        journal: true.into(),
+        w_timeout: None,
+    };
+    let options = InsertOneOptions::builder().write_concern(wc).build();
+    let error = coll
+        .insert_one(doc! {}, options)
+        .await
+        .expect_err("insert should fail");
+    assert!(matches!(error.kind.as_ref(), ErrorKind::ArgumentError { .. }));
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -231,7 +231,7 @@ impl Database {
         command: Document,
         selection_criteria: impl Into<Option<SelectionCriteria>>,
     ) -> Result<Document> {
-        let operation = RunCommand::new(self.name().into(), command, selection_criteria.into());
+        let operation = RunCommand::new(self.name().into(), command, selection_criteria.into())?;
         self.client().execute_operation(&operation, None).await
     }
 

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     cursor::CursorSpecification,
     error::Result,
     operation::{append_options, CursorBody, Operation, WriteConcernOnlyBody},
-    options::{AggregateOptions, SelectionCriteria},
+    options::{AggregateOptions, SelectionCriteria, WriteConcern},
     Namespace,
 };
 
@@ -86,6 +86,12 @@ impl Operation for Aggregate {
         self.options
             .as_ref()
             .and_then(|opts| opts.selection_criteria.as_ref())
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }
 

--- a/src/operation/create/mod.rs
+++ b/src/operation/create/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, WriteConcernOnlyBody},
-    options::CreateCollectionOptions,
+    options::{CreateCollectionOptions, WriteConcern},
     Namespace,
 };
 
@@ -53,5 +53,11 @@ impl Operation for Create {
 
     fn handle_response(&self, response: CommandResponse) -> Result<Self::O> {
         response.body::<WriteConcernOnlyBody>()?.validate()
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }

--- a/src/operation/delete/mod.rs
+++ b/src/operation/delete/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     collation::Collation,
     error::{convert_bulk_errors, Result},
     operation::{append_options, Operation, WriteResponseBody},
-    options::DeleteOptions,
+    options::{DeleteOptions, WriteConcern},
     results::DeleteResult,
 };
 
@@ -87,5 +87,11 @@ impl Operation for Delete {
         Ok(DeleteResult {
             deleted_count: body.n,
         })
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, WriteConcernOnlyBody},
-    options::DropCollectionOptions,
+    options::{DropCollectionOptions, WriteConcern},
     Namespace,
 };
 
@@ -54,5 +54,11 @@ impl Operation for DropCollection {
 
     fn handle_response(&self, response: CommandResponse) -> Result<Self::O> {
         response.body::<WriteConcernOnlyBody>()?.validate()
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }

--- a/src/operation/drop_database/mod.rs
+++ b/src/operation/drop_database/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, WriteConcernOnlyBody},
-    options::DropDatabaseOptions,
+    options::{DropDatabaseOptions, WriteConcern},
 };
 
 #[derive(Debug)]
@@ -47,5 +47,11 @@ impl Operation for DropDatabase {
 
     fn handle_response(&self, response: CommandResponse) -> Result<Self::O> {
         response.body::<WriteConcernOnlyBody>()?.validate()
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }

--- a/src/operation/find_and_modify/mod.rs
+++ b/src/operation/find_and_modify/mod.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     error::{ErrorKind, Result},
     operation::{append_options, Operation},
+    options::WriteConcern,
 };
 
 pub(crate) struct FindAndModify {
@@ -88,6 +89,7 @@ impl Operation for FindAndModify {
             body,
         ))
     }
+
     fn handle_response(&self, response: CommandResponse) -> Result<Self::O> {
         let body: ResponseBody = response.body()?;
         match body.value {
@@ -102,6 +104,10 @@ impl Operation for FindAndModify {
             }
             .into()),
         }
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options.write_concern.as_ref()
     }
 }
 

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
     error::{ErrorKind, Result},
     operation::{append_options, Operation, WriteResponseBody},
-    options::InsertManyOptions,
+    options::{InsertManyOptions, WriteConcern},
     results::InsertManyResult,
     Namespace,
 };
@@ -83,5 +83,11 @@ impl Operation for Insert {
             );
         }
         Ok(InsertManyResult { inserted_ids: map })
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
     error::{BulkWriteError, BulkWriteFailure, ErrorKind, Result, WriteConcernError, WriteFailure},
+    options::WriteConcern,
     selection_criteria::SelectionCriteria,
     Namespace,
 };
@@ -58,6 +59,18 @@ pub(crate) trait Operation {
 
     /// Criteria to use for selecting the server that this operation will be executed on.
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {
+        None
+    }
+
+    /// Whether or not this operation will request acknowledgment from the server.
+    fn is_acknowledged(&self) -> bool {
+        self.write_concern()
+            .map(WriteConcern::is_acknowledged)
+            .unwrap_or(true)
+    }
+
+    /// The write concern to use for this operation, if any.
+    fn write_concern(&self) -> Option<&WriteConcern> {
         None
     }
 

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -9,7 +9,7 @@ use crate::{
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn build() {
-    let op = RunCommand::new("foo".into(), doc! { "isMaster": 1 }, None);
+    let op = RunCommand::new("foo".into(), doc! { "isMaster": 1 }, None).unwrap();
     assert!(op.selection_criteria().is_none());
 
     let command = op.build(&StreamDescription::new_testing()).unwrap();
@@ -29,7 +29,7 @@ async fn build() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn no_error_ok_0() {
-    let op = RunCommand::new("foo".into(), doc! { "isMaster": 1 }, None);
+    let op = RunCommand::new("foo".into(), doc! { "isMaster": 1 }, None).unwrap();
     assert!(op.selection_criteria().is_none());
 
     let command_response = CommandResponse::with_document(doc! {

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
     error::{convert_bulk_errors, Result},
     operation::{Operation, WriteResponseBody},
-    options::{UpdateModifications, UpdateOptions},
+    options::{UpdateModifications, UpdateOptions, WriteConcern},
     results::UpdateResult,
     Namespace,
 };
@@ -128,6 +128,12 @@ impl Operation for Update {
             modified_count,
             upserted_id,
         })
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.options
+            .as_ref()
+            .and_then(|opts| opts.write_concern.as_ref())
     }
 }
 

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -188,7 +188,18 @@ impl TopologyDescription {
 
                 command.read_pref = Some(resolved_read_pref);
             }
-            _ => {}
+            _ => {
+                command.read_pref = match criteria {
+                    Some(SelectionCriteria::ReadPreference(rp)) => Some(rp.clone()),
+                    Some(SelectionCriteria::Predicate(_)) => {
+                        Some(ReadPreference::PrimaryPreferred {
+                            max_staleness: None,
+                            tag_sets: None,
+                        })
+                    }
+                    None => Some(ReadPreference::Primary),
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This breaks off some changes from the implicit sessions PR to reduce the size of the diff. This PR adds support for determining if an operation is acknowledged (RUST-289) and fixes a bug where $readPreference wasn't being set against certain topologies (RUST-397).