### PR TITLE
RUST-408 Generate API documentation for the sync API on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ function_name = "0.2.0"
 pretty_assertions = "0.6.1"
 serde_json = "1.0.40"
 semver = "0.9.0"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ define_if_single_runtime_enabled! {
     mod sdam;
     mod selection_criteria;
     mod srv;
-    #[cfg(feature = "sync")]
+    #[cfg(any(feature = "sync", docsrs))]
     pub mod sync;
     #[cfg(test)]
     mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
         clippy::float_cmp
     )
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 macro_rules! define_if_single_runtime_enabled {
     ( $( $def:item )+ ) => {
@@ -114,6 +115,7 @@ define_if_single_runtime_enabled! {
     mod selection_criteria;
     mod srv;
     #[cfg(any(feature = "sync", docsrs))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
     pub mod sync;
     #[cfg(test)]
     mod test;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,3 +1,5 @@
+//! Contains the sync API. This is only available when the `sync` feature is enabled.
+
 mod client;
 mod coll;
 mod cursor;


### PR DESCRIPTION
With a bit of work, I was able to spin up a [local instance of docs.rs](https://github.com/rust-lang/docs.rs/blob/master/README.md#cli) to verify that this generates the sync API documentation. To see the generated documentation locally without needing to set up a docs.rs instance, you can run `cargo rustdoc -p mongodb --open -- --cfg docsrs`.