### PR TITLE
RUST-396 Parse responses with command errors into Errors in run_command

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -181,12 +181,7 @@ impl Client {
                         session.advance_cluster_time(cluster_time)
                     }
                 }
-
-                if !op.handles_command_errors() {
-                    response.validate().map(|_| response)
-                } else {
-                    Ok(response)
-                }
+                response.validate().map(|_| response)
             }
             err => err,
         };

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -62,12 +62,6 @@ pub(crate) trait Operation {
         None
     }
 
-    /// Whether or not the operation has special handling for command errors, or whether they should
-    /// just be propogated to the user immediately.
-    fn handles_command_errors(&self) -> bool {
-        false
-    }
-
     /// Whether or not this operation will request acknowledgment from the server.
     fn is_acknowledged(&self) -> bool {
         self.write_concern()

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -69,10 +69,6 @@ impl Operation for RunCommand {
         Ok(response.raw_response)
     }
 
-    fn handles_command_errors(&self) -> bool {
-        true
-    }
-
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {
         self.selection_criteria.as_ref()
     }

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -7,8 +7,7 @@ use crate::{
     error::{Error, ErrorKind},
     options::{
         auth::{AuthMechanism, Credential},
-        ClientOptions,
-        ListDatabasesOptions,
+        ClientOptions, ListDatabasesOptions,
     },
     selection_criteria::{ReadPreference, SelectionCriteria},
     test::{util::TestClient, CLIENT_OPTIONS, LOCK},
@@ -467,7 +466,7 @@ async fn scram_missing_user_options() {
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn saslprep_options() {
+async fn saslprep() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
@@ -497,35 +496,6 @@ async fn saslprep_options() {
     auth_test_options("IX", "I\u{00AD}X", None, true).await;
     auth_test_options("\u{2168}", "IV", None, true).await;
     auth_test_options("\u{2168}", "I\u{00AD}V", None, true).await;
-}
-
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn saslprep_uri() {
-    let client = TestClient::new().await;
-
-    if client.server_version_lt(4, 0) || !client.auth_enabled() {
-        return;
-    }
-
-    client
-        .create_user(
-            "IX",
-            "IX",
-            &[Bson::from("root")],
-            &[AuthMechanism::ScramSha256],
-        )
-        .await
-        .unwrap();
-    client
-        .create_user(
-            "\u{2168}",
-            "\u{2163}",
-            &[Bson::from("root")],
-            &[AuthMechanism::ScramSha256],
-        )
-        .await
-        .unwrap();
 
     auth_test_uri("IX", "IX", None, true).await;
     auth_test_uri("IX", "I%C2%ADX", None, true).await;

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -7,7 +7,8 @@ use crate::{
     error::{Error, ErrorKind},
     options::{
         auth::{AuthMechanism, Credential},
-        ClientOptions, ListDatabasesOptions,
+        ClientOptions,
+        ListDatabasesOptions,
     },
     selection_criteria::{ReadPreference, SelectionCriteria},
     test::{util::TestClient, CLIENT_OPTIONS, LOCK},


### PR DESCRIPTION
[RUST-396](https://jira.mongodb.org/browse/RUST-396)

This PR updates `run_command` to parse command errors from server responses and return them as `Error` rather than as part of the command response.

e.g.
```rust
// before
db.run_command(doc! { "asdfaf": true }, None).await; // Ok(Document({ "ok": 0, ... })

// after
db.run_command(doc! { "asdfaf": true }, None).await; // Err(ErrorKind::CommandError { ... })
```
Without this logic, it can be easy to ignore errors unintentionally, as is seen in the test fix included in this PR.

For completeness, I redid my survey of the other drivers, and there does not appear to be a consensus on this behavior:
- libmongoc - validates
- CXX - validates
- Swift - validates
- PHP - validates
- Ruby - result that can be validated by user
- Go - result that is implicitly validated in all its methods
- Java - no validation
- Python - optional validation, on by default
- C# - no validation
- Node - validates

So tallying that up, it seems 2 drivers do no validation, 2 do it optionally, and the rest validate.
I think that if we wanted to preserve the no-validation behavior, adding it as an option to `run_command` that is off by default would be reasonable.