### PR TITLE
RUST-392 Suppress "ns not found" errors

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -209,7 +209,7 @@ impl Client {
                     }
                 }
 
-                Err(error)
+                op.handle_error(error)
             }
             Ok(response) => {
                 self.emit_command_event(|handler| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,7 +58,15 @@ impl Error {
                 let error: Error = other_error_kind.into();
                 std::io::Error::new(std::io::ErrorKind::Other, Box::new(error))
             }
-            Err(e) => std::io::Error::new(std::io::ErrorKind::Other, Box::new(Error { kind: e }))
+            Err(e) => std::io::Error::new(std::io::ErrorKind::Other, Box::new(Error { kind: e })),
+        }
+    }
+
+    /// Whether this error is an "ns not found" error or not.
+    pub(crate) fn is_ns_not_found(&self) -> bool {
+        match self.kind.as_ref() {
+            ErrorKind::CommandError(err) if err.code == 26 => true,
+            _ => false,
         }
     }
 }

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -5,7 +5,7 @@ use bson::doc;
 
 use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
-    error::Result,
+    error::{Error, Result},
     operation::{append_options, Operation, WriteConcernOnlyBody},
     options::{DropCollectionOptions, WriteConcern},
     Namespace,
@@ -54,6 +54,14 @@ impl Operation for DropCollection {
 
     fn handle_response(&self, response: CommandResponse) -> Result<Self::O> {
         response.body::<WriteConcernOnlyBody>()?.validate()
+    }
+
+    fn handle_error(&self, error: Error) -> Result<Self::O> {
+        if error.is_ns_not_found() {
+            Ok(())
+        } else {
+            Err(error)
+        }
     }
 
     fn write_concern(&self) -> Option<&WriteConcern> {

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -21,7 +21,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     cmap::{Command, CommandResponse, StreamDescription},
-    error::{BulkWriteError, BulkWriteFailure, ErrorKind, Result, WriteConcernError, WriteFailure},
+    error::{
+        BulkWriteError,
+        BulkWriteFailure,
+        Error,
+        ErrorKind,
+        Result,
+        WriteConcernError,
+        WriteFailure,
+    },
     options::WriteConcern,
     selection_criteria::SelectionCriteria,
     Namespace,
@@ -56,6 +64,12 @@ pub(crate) trait Operation {
 
     /// Interprets the server response to the command.
     fn handle_response(&self, response: CommandResponse) -> Result<Self::O>;
+
+    /// Interpret an error encountered while sending the built command to the server, potentially
+    /// recovering.
+    fn handle_error(&self, error: Error) -> Result<Self::O> {
+        Err(error)
+    }
 
     /// Criteria to use for selecting the server that this operation will be executed on.
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -533,3 +533,15 @@ async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>)
     assert_eq!(allow_disk_use, expected_value);
     assert_eq!(iter.count(), 0);
 }
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn ns_not_found_suppression() {
+    let _guard = LOCK.run_concurrently().await;
+
+    let client = TestClient::new().await;
+    let coll = client.get_coll(function_name!(), function_name!());
+    coll.drop(None).await.expect("drop should not fail");
+    coll.drop(None).await.expect("drop should not fail");
+}


### PR DESCRIPTION
[RUST-392](https://jira.mongodb.org/browse/RUST-392)

This PR updates `Collection::drop` to ignore errors returned from the server when dropping a nonexistent collection.