### PR TITLE
RUST-434 Rewrite ReadConcern as struct

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     concern::{Acknowledgment, ReadConcern, WriteConcern},
     error::{ErrorKind, Result},
     event::{cmap::CmapEventHandler, command::CommandEventHandler},
+    options::ReadConcernLevel,
     sdam::MIN_HEARTBEAT_FREQUENCY,
     selection_criteria::{ReadPreference, SelectionCriteria, TagSet},
     srv::SrvResolver,
@@ -1231,7 +1232,7 @@ impl ClientOptionsParser {
                 self.max_pool_size = Some(get_u32!(value, k));
             }
             "readconcernlevel" => {
-                self.read_concern = Some(ReadConcern::Custom(value.to_string()));
+                self.read_concern = Some(ReadConcernLevel::from_str(value).into());
             }
             "readpreference" => {
                 self.read_preference = Some(match &value.to_lowercase()[..] {
@@ -1482,7 +1483,7 @@ mod tests {
 
     use super::{ClientOptions, StreamAddress};
     use crate::{
-        concern::{Acknowledgment, ReadConcern, WriteConcern},
+        concern::{Acknowledgment, ReadConcernLevel, WriteConcern},
         selection_criteria::ReadPreference,
     };
 
@@ -1620,7 +1621,7 @@ mod tests {
                     hostname: "localhost".to_string(),
                     port: Some(27017),
                 }],
-                read_concern: Some(ReadConcern::Custom("foo".to_string())),
+                read_concern: Some(ReadConcernLevel::Custom("foo".to_string()).into()),
                 original_uri: Some(uri.into()),
                 ..Default::default()
             }
@@ -1820,7 +1821,7 @@ mod tests {
                     }
                     .into()
                 ),
-                read_concern: Some(ReadConcern::Majority),
+                read_concern: Some(ReadConcernLevel::Majority.into()),
                 write_concern: Some(write_concern),
                 repl_set_name: Some("foo".to_string()),
                 heartbeat_freq: Some(Duration::from_millis(1000)),

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -167,7 +167,7 @@ fn document_from_client_options(mut options: ClientOptions) -> Document {
     }
 
     if let Some(s) = options.read_concern.take() {
-        doc.insert("readconcernlevel", s.as_str());
+        doc.insert("readconcernlevel", s.level.as_str());
     }
 
     if let Some(i_or_s) = options

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -6,7 +6,7 @@ use super::AggregateTarget;
 use crate::{
     bson_util,
     cmap::{CommandResponse, StreamDescription},
-    concern::ReadConcern,
+    concern::{ReadConcern, ReadConcernLevel},
     error::{ErrorKind, WriteFailure},
     operation::{test, Aggregate, Operation},
     options::{AggregateOptions, Hint, StreamAddress},
@@ -47,7 +47,7 @@ async fn build() {
     let options = AggregateOptions::builder()
         .hint(Hint::Keys(doc! { "x": 1, "y": 2 }))
         .bypass_document_validation(true)
-        .read_concern(ReadConcern::Available)
+        .read_concern(ReadConcern::from(ReadConcernLevel::Available))
         .build();
 
     let expected_body = doc! {

--- a/src/operation/count/test.rs
+++ b/src/operation/count/test.rs
@@ -8,6 +8,7 @@ use crate::{
     concern::ReadConcern,
     error::ErrorKind,
     operation::{test, Count, Operation},
+    options::ReadConcernLevel,
 };
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -34,7 +35,7 @@ async fn build() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn build_with_options() {
-    let read_concern = ReadConcern::Local;
+    let read_concern: ReadConcern = ReadConcernLevel::Local.into();
     let max_time = Duration::from_millis(2 as u64);
     let options: EstimatedDocumentCountOptions = EstimatedDocumentCountOptions::builder()
         .max_time(max_time)
@@ -54,7 +55,7 @@ async fn build_with_options() {
         doc! {
             "count": "test_coll",
             "maxTimeMS": max_time.as_millis() as i64,
-            "readConcern": doc!{"level": read_concern.as_str().to_string()}
+            "readConcern": doc!{"level": read_concern.level.as_str().to_string()}
         }
     );
     assert_eq!(count_command.target_db, "test_db");

--- a/src/operation/find/test.rs
+++ b/src/operation/find/test.rs
@@ -6,7 +6,7 @@ use crate::{
     bson_util,
     cmap::{CommandResponse, StreamDescription},
     operation::{test, Find, Operation},
-    options::{CursorType, FindOptions, Hint, ReadConcern, StreamAddress},
+    options::{CursorType, FindOptions, Hint, ReadConcern, ReadConcernLevel, StreamAddress},
     Namespace,
 };
 
@@ -46,7 +46,7 @@ async fn build() {
         .hint(Hint::Keys(doc! { "x": 1, "y": 2 }))
         .projection(doc! { "x": 0 })
         .allow_partial_results(true)
-        .read_concern(ReadConcern::Available)
+        .read_concern(ReadConcern::from(ReadConcernLevel::Available))
         .build();
 
     let expected_body = doc! {

--- a/src/test/spec/read_write_concern/connection_string.rs
+++ b/src/test/spec/read_write_concern/connection_string.rs
@@ -44,7 +44,7 @@ async fn run_connection_string_test(test_file: TestFile) {
                     let mut actual_read_concern = Document::new();
 
                     if let Some(client_read_concern) = options.read_concern {
-                        actual_read_concern.insert("level", client_read_concern.as_str());
+                        actual_read_concern.insert("level", client_read_concern.level.as_str());
                     }
 
                     assert_eq!(


### PR DESCRIPTION
[RUST-434](https://jira.mongodb.org/browse/RUST-434)

This PR reimplements a read concern as a struct (`ReadConcern`) with a single field `level` (`ReadConcernLevel` enum) both to better match with the spec and to allow for future compatibility. It also fixes a bug where every read concern parsed from a URI was being initialized as a `ReadConcernLevel::Custom`.