### PR TITLE
Added optional bson u2i feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ default = ["tokio-runtime"]
 tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "reqwest", "serde_bytes"]
 async-std-runtime = ["async-std", "async-std/attributes", "async-std-resolver", "tokio-util/compat"]
 sync = ["async-std-runtime"]
+# The bson/u2i feature enables automatic conversion from unsigned to signed types during
+# serialization. This feature is intended for use when serializing data types in third-party crates
+# whose implementation cannot be changed; otherwise, it is preferred to use the helper functions
+# provided in the bson::serde_helpers module.
 bson-u2i = ["bson/u2i"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default = ["tokio-runtime"]
 tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "reqwest", "serde_bytes"]
 async-std-runtime = ["async-std", "async-std/attributes", "async-std-resolver", "tokio-util/compat"]
 sync = ["async-std-runtime"]
+bson-u2i = ["bson/u2i"]
 
 [dependencies]
 async-trait = "0.1.42"


### PR DESCRIPTION
The BSON crate offered the "unsigned integer to integer (u2i)" auto conversion feature. Since the crate is now reexported, it would be nice to still be able to use this.