### PR TITLE
RUST-362 Add hint option to findAndModify operations

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -356,6 +356,11 @@ pub struct FindOneAndReplaceOptions {
     /// information on how to use this option.
     #[builder(default)]
     pub collation: Option<Collation>,
+
+    /// The index to use for the operation.
+    /// Only available in MongoDB 4.4+.
+    #[builder(default)]
+    pub hint: Option<Hint>,
 }
 
 /// Specifies the options to a
@@ -408,6 +413,11 @@ pub struct FindOneAndUpdateOptions {
     /// information on how to use this option.
     #[builder(default)]
     pub collation: Option<Collation>,
+
+    /// The index to use for the operation.
+    /// Only available in MongoDB 4.4+.
+    #[builder(default)]
+    pub hint: Option<Hint>,
 }
 
 /// Specifies the options to a [`Collection::aggregate`](../struct.Collection.html#method.aggregate)

--- a/src/operation/find_and_modify/options.rs
+++ b/src/operation/find_and_modify/options.rs
@@ -103,6 +103,7 @@ impl FindAndModifyOptions {
             .sort(opts.sort)
             .upsert(opts.upsert)
             .write_concern(opts.write_concern)
+            .hint(opts.hint)
             .build()
     }
 
@@ -121,6 +122,7 @@ impl FindAndModifyOptions {
             .sort(opts.sort)
             .upsert(opts.upsert)
             .write_concern(opts.write_concern)
+            .hint(opts.hint)
             .build()
     }
 }


### PR DESCRIPTION
Added a hint option to findAndModify operation (similar to the find operation) and tested its use in the delete, replace and update operations