### PR TITLE
minor: remove unused variables

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -119,7 +119,7 @@ impl Client {
 
         let server = match self.select_server(op.selection_criteria()).await {
             Ok(server) => server,
-            Err(err) => {
+            Err(_) => {
                 return Err(first_error);
             }
         };

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -400,7 +400,7 @@ async fn implicit_session_returned_after_exhaust_by_get_more() {
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
-    for i in 0..5 {
+    for _ in 0..5 {
         coll.insert_one(doc! {}, None)
             .await
             .expect("insert should succeed");
@@ -416,7 +416,7 @@ async fn implicit_session_returned_after_exhaust_by_get_more() {
         .await
         .expect("find should succeed");
 
-    for i in 0..4 {
+    for _ in 0..4 {
         assert!(matches!(cursor.next().await, Some(Ok(_))));
     }
 
@@ -456,7 +456,7 @@ async fn find_and_getmore_share_session() {
     let options = InsertOneOptions::builder()
         .write_concern(WriteConcern::builder().w(Acknowledgment::Majority).build())
         .build();
-    for i in 0..3 {
+    for _ in 0..3 {
         coll.insert_one(doc! {}, options.clone())
             .await
             .expect("insert should succeed");
@@ -489,7 +489,7 @@ async fn find_and_getmore_share_session() {
             .await
             .expect("find should succeed");
 
-        for i in 0..3 {
+        for _ in 0..3 {
             assert!(matches!(cursor.next().await, Some(Ok(_))));
         }
 

--- a/src/cmap/background.rs
+++ b/src/cmap/background.rs
@@ -61,7 +61,7 @@ impl ConnectionPool {
                         Ok(connection) => {
                             connection_manager.checked_in_connections.push(connection)
                         }
-                        e @ Err(_) => {
+                        Err(_) => {
                             // Since we encountered an error, we return early from this function and
                             // put the background thread back to sleep. Next time it wakes up, any
                             // stale connections will be closed, and the thread can try to create

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -151,8 +151,8 @@ impl Handshaker {
 
             if let Some(ref mut platform) = metadata.platform {
                 if let Some(ref driver_info_platform) = driver_info.platform {
-                    metadata.driver.version.push('|');
-                    metadata.driver.version.push_str(driver_info_platform);
+                    platform.push('|');
+                    platform.push_str(driver_info_platform);
                 }
             }
         }

--- a/src/event/cmap.rs
+++ b/src/event/cmap.rs
@@ -230,41 +230,41 @@ pub struct ConnectionCheckedInEvent {
 pub trait CmapEventHandler: Send + Sync {
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection pool is created.
-    fn handle_pool_created_event(&self, event: PoolCreatedEvent) {}
+    fn handle_pool_created_event(&self, _event: PoolCreatedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection pool is cleared.
-    fn handle_pool_cleared_event(&self, event: PoolClearedEvent) {}
+    fn handle_pool_cleared_event(&self, _event: PoolClearedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection pool is cleared.
-    fn handle_pool_closed_event(&self, event: PoolClosedEvent) {}
+    fn handle_pool_closed_event(&self, _event: PoolClosedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection is created.
-    fn handle_connection_created_event(&self, event: ConnectionCreatedEvent) {}
+    fn handle_connection_created_event(&self, _event: ConnectionCreatedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection is ready to be used.
-    fn handle_connection_ready_event(&self, event: ConnectionReadyEvent) {}
+    fn handle_connection_ready_event(&self, _event: ConnectionReadyEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection is closed.
-    fn handle_connection_closed_event(&self, event: ConnectionClosedEvent) {}
+    fn handle_connection_closed_event(&self, _event: ConnectionClosedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a thread begins checking out a connection to use for an operation.
-    fn handle_connection_checkout_started_event(&self, event: ConnectionCheckoutStartedEvent) {}
+    fn handle_connection_checkout_started_event(&self, _event: ConnectionCheckoutStartedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a thread is unable to check out a connection.
-    fn handle_connection_checkout_failed_event(&self, event: ConnectionCheckoutFailedEvent) {}
+    fn handle_connection_checkout_failed_event(&self, _event: ConnectionCheckoutFailedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection is successfully checked out.
-    fn handle_connection_checked_out_event(&self, event: ConnectionCheckedOutEvent) {}
+    fn handle_connection_checked_out_event(&self, _event: ConnectionCheckedOutEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a connection is checked back into a connection pool.
-    fn handle_connection_checked_in_event(&self, event: ConnectionCheckedInEvent) {}
+    fn handle_connection_checked_in_event(&self, _event: ConnectionCheckedInEvent) {}
 }

--- a/src/event/command.rs
+++ b/src/event/command.rs
@@ -113,13 +113,13 @@ pub struct CommandFailedEvent {
 pub trait CommandEventHandler: Send + Sync {
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a database command is initiated.
-    fn handle_command_started_event(&self, event: CommandStartedEvent) {}
+    fn handle_command_started_event(&self, _event: CommandStartedEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a database command successfully completes.
-    fn handle_command_succeeded_event(&self, event: CommandSucceededEvent) {}
+    fn handle_command_succeeded_event(&self, _event: CommandSucceededEvent) {}
 
     /// A [`Client`](../../struct.Client.html) will call this method on each registered handler
     /// whenever a database command fails to complete successfully.
-    fn handle_command_failed_event(&self, event: CommandFailedEvent) {}
+    fn handle_command_failed_event(&self, _event: CommandFailedEvent) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@
 //! # }
 //! ```
 
-#![allow(unused_variables)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -42,7 +42,7 @@ impl Operation for Aggregate {
     type O = CursorSpecification;
     const NAME: &'static str = "aggregate";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.target.to_bson(),
             "pipeline": bson_util::to_bson_array(&self.pipeline),

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -38,7 +38,7 @@ impl Operation for Count {
     type O = i64;
     const NAME: &'static str = "count";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body: Document = doc! {
             Self::NAME: self.ns.coll.clone(),
         };

--- a/src/operation/create/mod.rs
+++ b/src/operation/create/mod.rs
@@ -37,7 +37,7 @@ impl Operation for Create {
     type O = ();
     const NAME: &'static str = "create";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.ns.coll.clone(),
         };

--- a/src/operation/delete/mod.rs
+++ b/src/operation/delete/mod.rs
@@ -55,7 +55,7 @@ impl Operation for Delete {
     type O = DeleteResult;
     const NAME: &'static str = "delete";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut delete = doc! {
             "q": self.filter.clone(),
             "limit": self.limit,

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -52,7 +52,7 @@ impl Operation for Distinct {
     type O = Vec<Bson>;
     const NAME: &'static str = "distinct";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body: Document = doc! {
             Self::NAME: self.ns.coll.clone(),
             "key": self.field_name.clone(),

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -37,7 +37,7 @@ impl Operation for DropCollection {
     type O = ();
     const NAME: &'static str = "drop";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.ns.coll.clone(),
         };

--- a/src/operation/drop_database/mod.rs
+++ b/src/operation/drop_database/mod.rs
@@ -30,7 +30,7 @@ impl Operation for DropDatabase {
     type O = ();
     const NAME: &'static str = "dropDatabase";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: 1,
         };

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -48,7 +48,7 @@ impl Operation for Find {
     type O = CursorSpecification;
     const NAME: &'static str = "find";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.ns.coll.clone(),
         };

--- a/src/operation/find_and_modify/mod.rs
+++ b/src/operation/find_and_modify/mod.rs
@@ -75,7 +75,7 @@ impl Operation for FindAndModify {
     type O = Option<Document>;
     const NAME: &'static str = "findAndModify";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body: Document = doc! {
             Self::NAME: self.ns.coll.clone(),
             "query": self.query.clone(),

--- a/src/operation/find_and_modify/test.rs
+++ b/src/operation/find_and_modify/test.rs
@@ -34,7 +34,6 @@ async fn build_with_delete_no_options() {
         coll: "test_coll".to_string(),
     };
     let filter = doc! { "x": { "$gt": 1 } };
-    let max_time = Duration::from_millis(2u64);
 
     let op = FindAndModify::with_delete(ns, filter.clone(), None);
 

--- a/src/operation/get_more/mod.rs
+++ b/src/operation/get_more/mod.rs
@@ -41,7 +41,7 @@ impl Operation for GetMore {
     type O = GetMoreResult;
     const NAME: &'static str = "getMore";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.cursor_id,
             "collection": self.ns.coll.clone(),

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -48,7 +48,7 @@ impl Operation for Insert {
     type O = InsertManyResult;
     const NAME: &'static str = "insert";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.ns.coll.clone(),
             "documents": bson_util::to_bson_array(&self.documents),

--- a/src/operation/list_collections/mod.rs
+++ b/src/operation/list_collections/mod.rs
@@ -43,7 +43,7 @@ impl Operation for ListCollections {
     type O = CursorSpecification;
     const NAME: &'static str = "listCollections";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: 1,
         };

--- a/src/operation/list_databases/mod.rs
+++ b/src/operation/list_databases/mod.rs
@@ -46,7 +46,7 @@ impl Operation for ListDatabases {
     type O = Vec<Document>;
     const NAME: &'static str = "listDatabases";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body: Document = doc! {
             Self::NAME: 1,
             "nameOnly": self.name_only

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -50,7 +50,7 @@ impl Operation for RunCommand {
     // that should fail loudly if accidentally passed to the server.
     const NAME: &'static str = "$genericRunCommand";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let command_name = self
             .command_name()
             .ok_or_else(|| ErrorKind::ArgumentError {

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -59,7 +59,7 @@ impl Operation for Update {
     type O = UpdateResult;
     const NAME: &'static str = "update";
 
-    fn build(&self, description: &StreamDescription) -> Result<Command> {
+    fn build(&self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.ns.coll.clone(),
         };

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, Weak},
-    time::Duration,
-};
+use std::{sync::Weak, time::Duration};
 
 use time::PreciseTime;
 
@@ -55,13 +52,13 @@ impl Monitor {
             .heartbeat_freq
             .unwrap_or(DEFAULT_HEARTBEAT_FREQUENCY);
 
-        while let Some(server) = self.server.upgrade() {
+        while let Some(_server) = self.server.upgrade() {
             let topology = match self.topology.upgrade() {
                 Some(topology) => topology,
                 None => break,
             };
 
-            if self.check_if_topology_changed(server, &topology).await {
+            if self.check_if_topology_changed(&topology).await {
                 topology.notify_topology_changed();
             }
 
@@ -77,11 +74,7 @@ impl Monitor {
     /// connection will replaced with a new one.
     ///
     /// Returns true if the topology has changed and false otherwise.
-    async fn check_if_topology_changed(
-        &mut self,
-        server: Arc<Server>,
-        topology: &Topology,
-    ) -> bool {
+    async fn check_if_topology_changed(&mut self, topology: &Topology) -> bool {
         // Send an isMaster to the server.
         let server_description = self.check_server().await;
         self.server_type = server_description.server_type;

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -254,8 +254,6 @@ impl Topology {
         // references to the same instances though, since each is wrapped in an `Arc`.
         let mut state_clone = self.state.read().await.clone();
 
-        let old_description = state_clone.description.clone();
-
         // TODO RUST-232: Theoretically, `TopologyDescription::update` can return an error. However,
         // this can only happen if we try to access a field from the isMaster response when an error
         // occurred during the check. In practice, this can't happen, because the SDAM algorithm

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -71,9 +71,7 @@ async fn tailable_cursor() {
     let delay = RUNTIME.delay_for(await_time);
 
     match futures::future::select(Box::pin(delay), Box::pin(next_doc)).await {
-        Either::Left((_, next_doc)) => {
-            panic!("should have gotten next document, but instead timed")
-        }
+        Either::Left((..)) => panic!("should have gotten next document, but instead timed"),
         Either::Right((next_doc, _)) => {
             assert_eq!(next_doc.transpose().unwrap(), Some(doc! { "_id": 5 }))
         }

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -61,7 +61,7 @@ async fn run_test<F: Future>(name: &str, test: impl Fn(EventClient, Database, Co
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn get_more() {
-    async fn get_more_test(client: EventClient, db: Database, coll: Collection) {
+    async fn get_more_test(client: EventClient, _db: Database, coll: Collection) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
             return;
@@ -108,7 +108,7 @@ async fn get_more() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn not_master_keep_pool() {
-    async fn not_master_keep_pool_test(client: EventClient, db: Database, coll: Collection) {
+    async fn not_master_keep_pool_test(client: EventClient, _db: Database, coll: Collection) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
             return;
@@ -153,7 +153,7 @@ async fn not_master_keep_pool() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn not_master_reset_pool() {
-    async fn not_master_reset_pool_test(client: EventClient, db: Database, coll: Collection) {
+    async fn not_master_reset_pool_test(client: EventClient, _db: Database, coll: Collection) {
         // This test must only run on 4.0 servers.
         if !client.server_version_eq(4, 0) {
             return;
@@ -198,7 +198,7 @@ async fn not_master_reset_pool() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn shutdown_in_progress() {
-    async fn shutdown_in_progress_test(client: EventClient, db: Database, coll: Collection) {
+    async fn shutdown_in_progress_test(client: EventClient, _db: Database, coll: Collection) {
         if client.server_version_lt(4, 0) {
             return;
         }
@@ -242,7 +242,7 @@ async fn shutdown_in_progress() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn interrupted_at_shutdown() {
-    async fn interrupted_at_shutdown_test(client: EventClient, db: Database, coll: Collection) {
+    async fn interrupted_at_shutdown_test(client: EventClient, _db: Database, coll: Collection) {
         if client.server_version_lt(4, 0) {
             return;
         }

--- a/src/test/spec/runner/operation.rs
+++ b/src/test/spec/runner/operation.rs
@@ -143,11 +143,11 @@ impl TestOperation for DeleteMany {
         Ok(Some(result))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -169,11 +169,11 @@ impl TestOperation for DeleteOne {
         Ok(Some(result))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -253,11 +253,11 @@ impl TestOperation for Find {
         Ok(Some(Bson::from(result)))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -283,11 +283,11 @@ impl TestOperation for InsertMany {
         Ok(Some(result))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -309,11 +309,11 @@ impl TestOperation for InsertOne {
         Ok(Some(result))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -338,11 +338,11 @@ impl TestOperation for UpdateMany {
         Ok(Some(result))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -373,11 +373,11 @@ impl TestOperation for UpdateOne {
         Ok(Some(result))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -399,11 +399,11 @@ impl TestOperation for Aggregate {
         Ok(Some(Bson::from(result)))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -429,11 +429,11 @@ impl TestOperation for Distinct {
         Ok(Some(Bson::Array(result)))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -456,11 +456,11 @@ impl TestOperation for CountDocuments {
         Ok(Some(Bson::from(result)))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -479,11 +479,11 @@ impl TestOperation for EstimatedDocumentCount {
         Ok(Some(Bson::from(result)))
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -507,11 +507,11 @@ impl TestOperation for FindOne {
         }
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -525,7 +525,7 @@ impl TestOperation for ListDatabases {
         &["listDatabases"]
     }
 
-    async fn execute_on_collection(&self, collection: &Collection) -> Result<Option<Bson>> {
+    async fn execute_on_collection(&self, _collection: &Collection) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
@@ -535,7 +535,7 @@ impl TestOperation for ListDatabases {
         Ok(Some(Bson::Array(result)))
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -549,7 +549,7 @@ impl TestOperation for ListDatabaseNames {
         &["listDatabases"]
     }
 
-    async fn execute_on_collection(&self, collection: &Collection) -> Result<Option<Bson>> {
+    async fn execute_on_collection(&self, _collection: &Collection) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
@@ -559,7 +559,7 @@ impl TestOperation for ListDatabaseNames {
         Ok(Some(Bson::Array(result)))
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }
@@ -573,11 +573,11 @@ impl TestOperation for ListCollections {
         &["listCollections"]
     }
 
-    async fn execute_on_collection(&self, collection: &Collection) -> Result<Option<Bson>> {
+    async fn execute_on_collection(&self, _collection: &Collection) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
@@ -597,11 +597,11 @@ impl TestOperation for ListCollectionNames {
         &["listCollections"]
     }
 
-    async fn execute_on_collection(&self, collection: &Collection) -> Result<Option<Bson>> {
+    async fn execute_on_collection(&self, _collection: &Collection) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
@@ -621,15 +621,15 @@ impl TestOperation for UnimplementedOperation {
         unimplemented!()
     }
 
-    async fn execute_on_collection(&self, collection: &Collection) -> Result<Option<Bson>> {
+    async fn execute_on_collection(&self, _collection: &Collection) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_client(&self, client: &EventClient) -> Result<Option<Bson>> {
+    async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {
         unimplemented!()
     }
 
-    async fn execute_on_database(&self, database: &Database) -> Result<Option<Bson>> {
+    async fn execute_on_database(&self, _database: &Database) -> Result<Option<Bson>> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
It appears that we accidentally never removed the project-wide annotation to suppress unused variable warnings, so I removed it and fixed all the issues. Fortunately, almost all of these were not indicators of bugs; the one exception was a very minor bug in handshake metadata logic for libraries wrapping the driver, where we accidentally appended the platform name to the driver's version string instead of the platform string (but with the proper delimiter, so this likely didn't break anything).