### PR TITLE
RUST-370 Ensuring that the WriteConcernError errInfo object is propagated

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use serde::Deserialize;
 use time::OutOfRangeError;
 
-use crate::options::StreamAddress;
+use crate::{bson::Document, options::StreamAddress};
 
 lazy_static! {
     static ref RECOVERING_CODES: Vec<i32> = vec![11600, 11602, 13436, 189, 91];
@@ -381,6 +381,10 @@ pub struct WriteConcernError {
     /// A description of the error that occurred.
     #[serde(rename = "errmsg")]
     pub message: String,
+
+    /// A document identifying the write concern setting related to the error.
+    #[serde(rename = "errInfo")]
+    pub details: Option<Document>,
 }
 
 /// An error that occurred during a write operation that wasn't due to being unable to satisfy a

--- a/src/operation/delete/test.rs
+++ b/src/operation/delete/test.rs
@@ -167,7 +167,14 @@ async fn handle_write_concern_failure() {
         "writeConcernError": {
             "code": 456,
             "codeName": "wcError",
-            "errmsg": "some message"
+            "errmsg": "some message",
+            "errInfo": {
+                "writeConcern": {
+                    "w": 2,
+                    "wtimeout": 0,
+                    "provenance": "clientSupplied"
+                }
+            }
         }
     });
 
@@ -180,6 +187,11 @@ async fn handle_write_concern_failure() {
                 code: 456,
                 code_name: "wcError".to_string(),
                 message: "some message".to_string(),
+                details: Some(doc! { "writeConcern": {
+                    "w": 2,
+                    "wtimeout": 0,
+                    "provenance": "clientSupplied"
+                } }),
             };
             assert_eq!(wc_error, &expected_wc_err);
         }

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -179,7 +179,14 @@ async fn handle_write_failure() {
         "writeConcernError": {
             "code": 123,
             "codeName": "woohoo",
-            "errmsg": "error message"
+            "errmsg": "error message",
+            "errInfo": {
+                "writeConcern": {
+                    "w": 2,
+                    "wtimeout": 0,
+                    "provenance": "clientSupplied"
+                }
+            }
         }
     });
 
@@ -203,6 +210,11 @@ async fn handle_write_failure() {
                 code: 123,
                 code_name: "woohoo".to_string(),
                 message: "error message".to_string(),
+                details: Some(doc! { "writeConcern": {
+                    "w": 2,
+                    "wtimeout": 0,
+                    "provenance": "clientSupplied"
+                } }),
             };
             assert_eq!(write_concern_error, expected_wc_err);
         }

--- a/src/operation/update/test.rs
+++ b/src/operation/update/test.rs
@@ -252,7 +252,14 @@ async fn handle_write_concern_failure() {
         "writeConcernError": {
             "code": 456,
             "codeName": "wcError",
-            "errmsg": "some message"
+            "errmsg": "some message",
+            "errInfo": {
+                "writeConcern": {
+                    "w": 2,
+                    "wtimeout": 0,
+                    "provenance": "clientSupplied"
+                }
+            }
         }
     });
 
@@ -265,6 +272,11 @@ async fn handle_write_concern_failure() {
                 code: 456,
                 code_name: "wcError".to_string(),
                 message: "some message".to_string(),
+                details: Some(doc! { "writeConcern": {
+                    "w": 2,
+                    "wtimeout": 0,
+                    "provenance": "clientSupplied"
+                } }),
             };
             assert_eq!(wc_error, &expected_wc_err);
         }


### PR DESCRIPTION
This PR introduces a new field errInfo in WriteConcernError and tests verifies that the provenance field is propagated from the server to the client