### PR TITLE
RUST-479 / RUST-502 Improve authSource handling

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -944,6 +944,13 @@ impl ClientOptionsParser {
             }
         }
 
+        if options.auth_source.as_deref() == Some("") {
+            return Err(ErrorKind::ArgumentError {
+                message: "empty authSource provided".to_string(),
+            }
+            .into());
+        }
+
         let db_str = db.as_deref();
 
         match options.auth_mechanism {
@@ -992,13 +999,6 @@ impl ClientOptionsParser {
                     return Err(ErrorKind::ArgumentError {
                         message: "username and mechanism both not provided, but authentication \
                                   was requested"
-                            .to_string(),
-                    }
-                    .into());
-                } else if options.auth_source.is_some() {
-                    return Err(ErrorKind::ArgumentError {
-                        message: "username and mechanism both not provided, but authSource was \
-                                  specified"
                             .to_string(),
                     }
                     .into());

--- a/src/test/spec/auth.rs
+++ b/src/test/spec/auth.rs
@@ -50,7 +50,13 @@ async fn run_auth_test(test_file: TestFile) {
     for mut test_case in test_file.tests {
         test_case.description = test_case.description.replace('$', "%");
 
-        let skipped_mechanisms = ["GSSAPI", "MONGODB-X509", "PLAIN", "MONGODB-CR"];
+        let skipped_mechanisms = [
+            "GSSAPI",
+            "MONGODB-X509",
+            "PLAIN",
+            "MONGODB-CR",
+            "MONGODB-AWS",
+        ];
 
         // TODO: X509 (RUST-147)
         // TODO: GSSAPI (RUST-196)

--- a/src/test/spec/json/auth/connection-string.json
+++ b/src/test/spec/json/auth/connection-string.json
@@ -108,6 +108,16 @@
       }
     },
     {
+      "description": "must raise an error when the authSource is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=",
+      "valid": false
+    },
+    {
+      "description": "must raise an error when the authSource is empty without credentials",
+      "uri": "mongodb://localhost/admin?authSource=",
+      "valid": false
+    },
+    {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo",
       "valid": false
@@ -197,6 +207,18 @@
     {
       "description": "should recognize the mechanism with no username (MONGODB-X509)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-X509",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-X509",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external",
       "valid": true,
       "credential": {
         "username": null,
@@ -352,9 +374,10 @@
       "credential": null
     },
     {
-      "description": "authSource without username is invalid (default mechanism)",
+      "description": "authSource without username doesn't create credential (default mechanism)",
       "uri": "mongodb://localhost/?authSource=foo",
-      "valid": false
+      "valid": true,
+      "credential": null
     },
     {
       "description": "should throw an exception if no username provided (userinfo implies default mechanism)",
@@ -365,6 +388,62 @@
       "description": "should throw an exception if no username/password provided (userinfo implies default mechanism)",
       "uri": "mongodb://:@localhost.com/",
       "valid": false
+    },
+    {
+      "description": "should recognise the mechanism (MONGODB-AWS)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external",
+      "valid": true,
+      "credential": {
+        "username": null,
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should throw an exception if username and no password (MONGODB-AWS)",
+      "uri": "mongodb://user@localhost/?authMechanism=MONGODB-AWS",
+      "valid": false,
+      "credential": null
+    },
+    {
+      "description": "should use username and password if specified (MONGODB-AWS)",
+      "uri": "mongodb://user%21%40%23%24%25%5E%26%2A%28%29_%2B:pass%21%40%23%24%25%5E%26%2A%28%29_%2B@localhost/?authMechanism=MONGODB-AWS",
+      "valid": true,
+      "credential": {
+        "username": "user!@#$%^&*()_+",
+        "password": "pass!@#$%^&*()_+",
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should use username, password and session token if specified (MONGODB-AWS)",
+      "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token%21%40%23%24%25%5E%26%2A%28%29_%2B",
+      "valid": true,
+      "credential": {
+        "username": "user",
+        "password": "password",
+        "source": "$external",
+        "mechanism": "MONGODB-AWS",
+        "mechanism_properties": {
+          "AWS_SESSION_TOKEN": "token!@#$%^&*()_+"
+        }
+      }
     }
   ]
 }

--- a/src/test/spec/json/auth/connection-string.yml
+++ b/src/test/spec/json/auth/connection-string.yml
@@ -86,6 +86,14 @@ tests:
             mechanism_properties:
                 SERVICE_NAME: "mongodb"
     -
+        description: "must raise an error when the authSource is empty"
+        uri: "mongodb://user:password@localhost/foo?authSource="
+        valid: false
+    -
+        description: "must raise an error when the authSource is empty without credentials"
+        uri: "mongodb://localhost/admin?authSource="
+        valid: false
+    -
         description: "should throw an exception if authSource is invalid (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo"
         valid: false
@@ -160,6 +168,16 @@ tests:
     -
         description: "should recognize the mechanism with no username (MONGODB-X509)"
         uri: "mongodb://localhost/?authMechanism=MONGODB-X509"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-X509"
+            mechanism_properties: ~
+    -
+        description: "should recognize the mechanism with no username when auth source is explicitly specified (MONGODB-X509)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-X509&authSource=$external"
         valid: true
         credential:
             username: ~
@@ -288,9 +306,10 @@ tests:
         valid: true
         credential: ~
     -
-        description: "authSource without username is invalid (default mechanism)"
+        description: "authSource without username doesn't create credential (default mechanism)"
         uri: "mongodb://localhost/?authSource=foo"
-        valid: false
+        valid: true
+        credential: ~
     -
         description: "should throw an exception if no username provided (userinfo implies default mechanism)"
         uri: "mongodb://@localhost.com/"
@@ -299,3 +318,49 @@ tests:
         description: "should throw an exception if no username/password provided (userinfo implies default mechanism)"
         uri: "mongodb://:@localhost.com/"
         valid: false
+    -
+        description: "should recognise the mechanism (MONGODB-AWS)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-AWS"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-AWS"
+            mechanism_properties: ~
+    -
+        description: "should recognise the mechanism when auth source is explicitly specified (MONGODB-AWS)"
+        uri: "mongodb://localhost/?authMechanism=MONGODB-AWS&authSource=$external"
+        valid: true
+        credential:
+            username: ~
+            password: ~
+            source: "$external"
+            mechanism: "MONGODB-AWS"
+            mechanism_properties: ~
+    -
+        description: "should throw an exception if username and no password (MONGODB-AWS)"
+        uri: "mongodb://user@localhost/?authMechanism=MONGODB-AWS"
+        valid: false
+        credential: ~
+    -
+      description: "should use username and password if specified (MONGODB-AWS)"
+      uri: "mongodb://user%21%40%23%24%25%5E%26%2A%28%29_%2B:pass%21%40%23%24%25%5E%26%2A%28%29_%2B@localhost/?authMechanism=MONGODB-AWS"
+      valid: true
+      credential:
+          username: "user!@#$%^&*()_+"
+          password: "pass!@#$%^&*()_+"
+          source: "$external"
+          mechanism: "MONGODB-AWS"
+          mechanism_properties: ~
+    -
+      description: "should use username, password and session token if specified (MONGODB-AWS)"
+      uri: "mongodb://user:password@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:token%21%40%23%24%25%5E%26%2A%28%29_%2B"
+      valid: true
+      credential:
+          username: "user"
+          password: "password"
+          source: "$external"
+          mechanism: "MONGODB-AWS"
+          mechanism_properties:
+              AWS_SESSION_TOKEN: "token!@#$%^&*()_+"

--- a/src/test/spec/json/auth/mongodb-aws.rst
+++ b/src/test/spec/json/auth/mongodb-aws.rst
@@ -1,0 +1,94 @@
+===========
+MongoDB AWS
+===========
+
+There are 5 scenarios drivers MUST test:
+
+#. ``Regular Credentials``: Auth via an ``ACCESS_KEY_ID`` and ``SECRET_ACCESS_KEY`` pair
+#. ``EC2 Credentials``: Auth from an EC2 instance via temporary credentials assigned to the machine
+#. ``ECS Credentials``: Auth from an ECS instance via temporary credentials assigned to the task
+#. ``Assume Role``: Auth via temporary credentials obtained from an STS AssumeRole request
+#. ``AWS Lambda``: Auth via environment variables ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and ``AWS_SESSION_TOKEN``.
+
+For brevity, this section gives the values ``<AccessKeyId>``, ``<SecretAccessKey>`` and ``<Token>`` in place of a valid access key ID, secret access key and session token (also known as a security token). Note that if these values are passed into the URI they MUST be URL encoded. Sample values are below.
+
+.. code-block:: 
+
+  AccessKeyId=AKIAI44QH8DHBEXAMPLE
+  SecretAccessKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  Token=AQoDYXdzEJr...<remainder of security token>
+|
+.. sectnum::
+
+Regular credentials
+======================
+
+Drivers MUST be able to authenticate by providing a valid access key id and secret access key pair as the username and password, respectively, in the MongoDB URI. An example of a valid URI would be:
+
+.. code-block:: 
+
+  mongodb://<AccessKeyId>:<SecretAccessKey>@localhost/?authMechanism=MONGODB-AWS
+|
+EC2 Credentials
+===============
+
+Drivers MUST be able to authenticate from an EC2 instance via temporary credentials assigned to the machine. A sample URI on an EC2 machine would be:
+
+.. code-block::
+  
+  mongodb://localhost/?authMechanism=MONGODB-AWS
+|
+.. note:: No username, password or session token is passed into the URI. Drivers MUST query the EC2 instance endpoint to obtain these credentials. 
+
+ECS instance
+============
+
+Drivers MUST be able to authenticate from an ECS container via temporary credentials. A sample URI in an ECS container would be:
+
+.. code-block::
+
+  mongodb://localhost/?authMechanism=MONGODB-AWS
+|
+.. note:: No username, password or session token is passed into the URI. Drivers MUST query the ECS container endpoint to obtain these credentials. 
+
+AssumeRole
+==========
+
+Drivers MUST be able to authenticate using temporary credentials returned from an assume role request. These temporary credentials consist of an access key ID, a secret access key, and a security token passed into the URI. A sample URI would be: 
+
+.. code-block::
+
+  mongodb://<AccessKeyId>:<SecretAccessKey>@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:<Token>
+|
+AWS Lambda
+==========
+
+Drivers MUST be able to authenticate via an access key ID, secret access key and optional session token taken from the environment variables, respectively: 
+
+.. code-block::
+
+  AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY 
+  AWS_SESSION_TOKEN
+|
+
+Sample URIs both with and without optional session tokens set are shown below. Drivers MUST test both cases.
+
+.. code-block:: bash
+
+  # without a session token
+  export AWS_ACCESS_KEY_ID="<AccessKeyId>"
+  export AWS_SECRET_ACCESS_KEY="<SecretAccessKey>"
+
+  URI="mongodb://localhost/?authMechanism=MONGODB-AWS"
+|
+.. code-block:: bash
+
+  # with a session token
+  export AWS_ACCESS_KEY_ID="<AccessKeyId>"
+  export AWS_SECRET_ACCESS_KEY="<SecretAccessKey>"
+  export AWS_SESSION_TOKEN="<Token>"
+
+  URI="mongodb://localhost/?authMechanism=MONGODB-AWS"
+|
+.. note:: No username, password or session token is passed into the URI. Drivers MUST check the environment variables listed above for these values. If the session token is set Drivers MUST use it.


### PR DESCRIPTION
[RUST-479](https://jira.mongodb.org/browse/RUST-479)

This was the original ticket I planned on completing. It relaxes the connection string parsing logic to allow authSource to be specified without attempting to authenticate.

[RUST-502](https://jira.mongodb.org/browse/RUST-502)

This was another ticket dealing with authSource whose tests I pulled in while syncing. It was easier to just implement this behavior rather than adding logic to skip it, so I included it as part of this PR.

I also included the sync commits in this PR, because otherwise the waterfall would start being red until I merged this PR.