### PR TITLE
RUST-483 Allow alternate DNS resolver configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository contains the officially supported MongoDB Rust driver, a client 
         - [Inserting documents into a collection](#inserting-documents-into-a-collection)
         - [Finding documents in a collection](#finding-documents-in-a-collection)
     - [Using the sync API](#using-the-sync-api)
+- [Atlas note](#atlas-note)
+- [Windows DNS note](#windows-dns-note)
 - [Bug Reporting / Feature Requests](#bug-reporting--feature-requests)
 - [Contributing](#contributing)
 - [Running the tests](#running-the-tests)
@@ -181,6 +183,21 @@ for result in cursor {
 ## Atlas note
 
 Currently, the driver has issues connecting to Atlas tiers above M2 unless the server version is at least 4.2. We're working on fixing this, but in the meantime, a workaround is to upgrade your cluster to 4.2. The driver has no known issues with either M0 or M2 instances.
+
+## Windows DNS note
+
+On Windows, there is a known issue in the `trust-dns-resolver` crate, which the driver uses to perform DNS lookups, that causes severe performance degradation in resolvers that use the system configuration. Since the driver uses the system configuration by default, users are recommended to specify an alternate resolver configuration on Windows until that issue is resolved. This is only has an effect when connecting to deployments using a `mongodb+srv` connection string.
+
+e.g.
+
+``` rust
+let options = ClientOptions::parse_with_resolver_config(
+    "mongodb+srv://my.host.com",
+    ResolverConfig::cloudflare(),
+)
+.await?;
+let client = Client::with_options(options)?;
+```
 
 ## Bug Reporting / Feature Requests
 To file a bug report or submit a feature request, please open a ticket on our [Jira project](https://jira.mongodb.org/browse/RUST):

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Currently, the driver has issues connecting to Atlas tiers above M2 unless the s
 
 ## Windows DNS note
 
-On Windows, there is a known issue in the `trust-dns-resolver` crate, which the driver uses to perform DNS lookups, that causes severe performance degradation in resolvers that use the system configuration. Since the driver uses the system configuration by default, users are recommended to specify an alternate resolver configuration on Windows until that issue is resolved. This is only has an effect when connecting to deployments using a `mongodb+srv` connection string.
+On Windows, there is a known issue in the `trust-dns-resolver` crate, which the driver uses to perform DNS lookups, that causes severe performance degradation in resolvers that use the system configuration. Since the driver uses the system configuration by default, users are recommended to specify an alternate resolver configuration on Windows until that issue is resolved. This only has an effect when connecting to deployments using a `mongodb+srv` connection string.
 
 e.g.
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -24,6 +24,7 @@ use rustls::{
 };
 use serde::Deserialize;
 use strsim::jaro_winkler;
+use trust_dns_resolver::config::ResolverConfig;
 use typed_builder::TypedBuilder;
 use webpki_roots::TLS_SERVER_ROOTS;
 
@@ -309,6 +310,15 @@ pub struct ClientOptions {
     #[builder(default)]
     pub repl_set_name: Option<String>,
 
+    /// Configuration of the trust-dns resolver used for SRV and TXT lookups.
+    /// By default, the host system's resolver configuration will be used.
+    ///
+    /// On Windows, there is a known performance issue in trust-dns with using the default system
+    /// configuration, so a custom configuration is reccommended.
+    #[builder(default)]
+    #[serde(skip)]
+    pub resolver_config: Option<ResolverConfig>,
+
     /// Whether or not the client should retry a read operation if the operation fails.
     ///
     /// The default value is true.
@@ -574,6 +584,7 @@ impl From<ClientOptionsParser> for ClientOptions {
             command_event_handler: None,
             original_srv_hostname: None,
             original_uri: Some(parser.original_uri),
+            resolver_config: None,
         }
     }
 }
@@ -639,13 +650,37 @@ impl ClientOptions {
     ///   * `wTimeoutMS`: maps to the `w_timeout` field of the `write_concern` field
     ///   * `zlibCompressionLevel`: not yet implemented
     pub async fn parse(s: &str) -> Result<Self> {
-        let parser = ClientOptionsParser::parse(s)?;
+        Self::parse_uri(s, None).await
+    }
+
+    /// Parses a MongoDB connection string into a `ClientOptions` struct.
+    /// If the string is malformed or one of the options has an invalid value, an error will be
+    /// returned.
+    ///
+    /// In the case that "mongodb+srv" is used, SRV and TXT record lookups will be done using the
+    /// provided `ResolverConfig` as part of this method.
+    ///
+    /// The format of a MongoDB connection string is described [here](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-formats).
+    ///
+    /// See the docstring on `ClientOptions::parse` for information on how the various URI options
+    /// map to fields on `ClientOptions`.
+    pub async fn parse_with_resolver_config(
+        uri: &str,
+        resolver_config: ResolverConfig,
+    ) -> Result<Self> {
+        Self::parse_uri(uri, Some(resolver_config)).await
+    }
+
+    /// Populate this `ClientOptions` from the given URI, optionally using the resolver config for
+    /// DNS lookups.
+    async fn parse_uri(uri: &str, resolver_config: Option<ResolverConfig>) -> Result<Self> {
+        let parser = ClientOptionsParser::parse(uri)?;
         let srv = parser.srv;
         let auth_source_present = parser.auth_source.is_some();
         let mut options: Self = parser.into();
 
         if srv {
-            let mut resolver = SrvResolver::new().await?;
+            let mut resolver = SrvResolver::new(resolver_config.clone()).await?;
             let mut config = resolver
                 .resolve_client_options(&options.hosts[0].hostname)
                 .await?;

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -314,7 +314,7 @@ pub struct ClientOptions {
     /// By default, the host system's resolver configuration will be used.
     ///
     /// On Windows, there is a known performance issue in trust-dns with using the default system
-    /// configuration, so a custom configuration is reccommended.
+    /// configuration, so a custom configuration is recommended.
     #[builder(default)]
     #[serde(skip)]
     pub resolver_config: Option<ResolverConfig>,

--- a/src/runtime/resolver.rs
+++ b/src/runtime/resolver.rs
@@ -3,6 +3,7 @@ use std::{future::Future, net::SocketAddr, time::Duration};
 use async_trait::async_trait;
 use trust_dns_proto::error::ProtoError;
 use trust_dns_resolver::{
+    config::ResolverConfig,
     lookup::{SrvLookup, TxtLookup},
     name_server::{GenericConnection, GenericConnectionProvider},
     IntoName,
@@ -26,8 +27,13 @@ pub(crate) struct AsyncResolver {
 }
 
 impl AsyncResolver {
-    pub(crate) async fn new() -> Result<Self> {
-        let resolver = TrustDnsResolver::from_system_conf(crate::RUNTIME).await?;
+    pub(crate) async fn new(config: Option<ResolverConfig>) -> Result<Self> {
+        let resolver = match config {
+            Some(config) => {
+                TrustDnsResolver::new(config, Default::default(), crate::RUNTIME).await?
+            }
+            None => TrustDnsResolver::from_system_conf(crate::RUNTIME).await?,
+        };
         Ok(Self { resolver })
     }
 }

--- a/src/sdam/srv_polling/mod.rs
+++ b/src/sdam/srv_polling/mod.rs
@@ -128,7 +128,7 @@ impl SrvPollingMonitor {
             return Ok(resolver);
         }
 
-        let resolver = SrvResolver::new().await?;
+        let resolver = SrvResolver::new(self.client_options.resolver_config.clone()).await?;
 
         // Since the connection was not `Some` above, this will always insert the new connection and
         // return a reference to it.

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -1,4 +1,4 @@
-use trust_dns_resolver::error::ResolveErrorKind;
+use trust_dns_resolver::{config::ResolverConfig, error::ResolveErrorKind};
 
 use crate::{
     error::{Error, ErrorKind, Result},
@@ -19,8 +19,8 @@ pub(crate) struct ResolvedConfig {
 }
 
 impl SrvResolver {
-    pub(crate) async fn new() -> Result<Self> {
-        let resolver = AsyncResolver::new().await?;
+    pub(crate) async fn new(config: Option<ResolverConfig>) -> Result<Self> {
+        let resolver = AsyncResolver::new(config).await?;
 
         Ok(Self {
             resolver,


### PR DESCRIPTION
RUST-483

This PR allows users to resolve `mongodb+srv` connection strings using alternate DNS resolver configurations. This helps users avoid the [known performance issue in trust-dns-resolver on Windows](https://github.com/bluejekyll/trust-dns#resolver) when using the system configuration (issue seen in RUST-467).

I opted to only include a helper on `ClientOptions` and not one on `Client` itself since this seemed like a very specific issue that was strictly configuration related.