### PR TITLE
minor: make AuthMechanism non-exhaustive

### DIFF
--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -81,7 +81,8 @@ pub enum AuthMechanism {
     /// Assume Role request, or temporary AWS IAM credentials assigned to an EC2 instance or ECS
     /// task.
     ///
-    /// Note: This mechanism is not currently only supported with the tokio runtime.
+    /// Note: Only server versions 4.4+ suppport AWS authentication. Additionally, the driver only
+    /// supports AWS authentication with the tokio runtime.
     #[cfg(feature = "tokio-runtime")]
     MongoDbAws,
 }

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -81,7 +81,7 @@ pub enum AuthMechanism {
     /// Assume Role request, or temporary AWS IAM credentials assigned to an EC2 instance or ECS
     /// task.
     ///
-    /// Note: Only server versions 4.4+ suppport AWS authentication. Additionally, the driver only
+    /// Note: Only server versions 4.4+ support AWS authentication. Additionally, the driver only
     /// supports AWS authentication with the tokio runtime.
     #[cfg(feature = "tokio-runtime")]
     MongoDbAws,

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -35,6 +35,7 @@ const PLAIN_STR: &str = "PLAIN";
 ///
 /// Note: not all of these mechanisms are currently supported by the driver.
 #[derive(Clone, Deserialize, PartialEq, Debug)]
+#[non_exhaustive]
 pub enum AuthMechanism {
     /// MongoDB Challenge Response nonce and MD5 based authentication system. It is currently
     /// deprecated and will never be supported by this driver.
@@ -75,6 +76,12 @@ pub enum AuthMechanism {
     /// Note: This mechanism is not currently supported by this driver but will be in the future.
     Plain,
 
+    /// MONGODB-AWS authenticates using AWS IAM credentials (an access key ID and a secret access
+    /// key), temporary AWS IAM credentials obtained from an AWS Security Token Service (STS)
+    /// Assume Role request, or temporary AWS IAM credentials assigned to an EC2 instance or ECS
+    /// task.
+    ///
+    /// Note: This mechanism is not currently only supported with the tokio runtime.
     #[cfg(feature = "tokio-runtime")]
     MongoDbAws,
 }


### PR DESCRIPTION
I realized right after merging RUST-359 that I forgot to make the change that was the whole reason we delayed merging it in the first place, so here it is