### PR TITLE
RUST-524 mark structs non_exhaustive

### DIFF
--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -221,6 +221,7 @@ impl FromStr for AuthMechanism {
 /// Some fields (mechanism and source) may be omitted and will either be negotiated or assigned a
 /// default value, depending on the values of other fields in the credential.
 #[derive(Clone, Debug, Default, Deserialize, TypedBuilder, PartialEq)]
+#[non_exhaustive]
 pub struct Credential {
     /// The username to authenticate with. This applies to all mechanisms but may be omitted when
     /// authenticating via MONGODB-X509.

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -7,6 +7,7 @@ use typed_builder::TypedBuilder;
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Collation {
     /// The ICU locale.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// cloned.
 #[derive(Clone, Debug, Error)]
 #[error(display = "{}", kind)]
+#[non_exhaustive]
 pub struct Error {
     /// The type of error that occurred.
     pub kind: Arc<ErrorKind>,

--- a/src/results.rs
+++ b/src/results.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 /// operation.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct InsertOneResult {
     /// The `_id` field of the document inserted.
     pub inserted_id: Bson,
@@ -31,6 +32,7 @@ impl InsertOneResult {
 /// operation.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct InsertManyResult {
     /// The `_id` field of the documents inserted.
     pub inserted_ids: HashMap<usize, Bson>,
@@ -48,6 +50,7 @@ impl InsertManyResult {
 /// [`Collection::update_many`](../struct.Collection.html#method.update_many) operation.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct UpdateResult {
     /// The number of documents that matched the filter.
     pub matched_count: i64,
@@ -61,6 +64,7 @@ pub struct UpdateResult {
 /// [`Collection::delete_many`](../struct.Collection.html#method.delete_many) operation.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct DeleteResult {
     /// The number of documents deleted by the operation.
     pub deleted_count: i64,


### PR DESCRIPTION
https://jira.mongodb.org/browse/RUST-524

This PR marks structs to which we anticipate adding fields as `non_exhaustive`.
