### PR TITLE
RUST-511 Remove unnecessary usage of Deserialize<'de>

### DIFF
--- a/src/client/auth/aws.rs
+++ b/src/client/auth/aws.rs
@@ -39,7 +39,7 @@ pub(super) async fn authenticate_stream(
     let nonce = auth::generate_nonce_bytes();
 
     let client_first_payload = doc! {
-        "r": Binary { subtype: BinarySubtype::Generic, bytes: nonce.clone().into() },
+        "r": Binary { subtype: BinarySubtype::Generic, bytes: nonce.clone().to_vec() },
         // `110` is ASCII for the character `n`, which is required by the spec to indicate that
         // channel binding is not supported.
         "p": 110i32,

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -25,16 +25,16 @@ pub use self::runner::{
     TestFile,
 };
 
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::bson::Bson;
 
-pub(crate) async fn run_spec_test<'a, T, F, G>(spec: &[&str], run_test_file: F)
+pub(crate) async fn run_spec_test<T, F, G>(spec: &[&str], run_test_file: F)
 where
     F: Fn(T) -> G,
     G: Future<Output = ()>,
-    T: Deserialize<'a>,
+    T: DeserializeOwned,
 {
     let base_path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "src", "test", "spec", "json"]
         .iter()


### PR DESCRIPTION
To prevent the changes in RUST-511 from breaking the tests, this PR updates the constraint in `run_spec_test` to use `DeserializedOwned`.

This also fixes a compilation issue with the driver in older versions of Rust.