### PR TITLE
minor: fix documentation about user retention when dropping databases…

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -152,7 +152,7 @@ impl Collection {
         self.inner.write_concern.as_ref()
     }
 
-    /// Drops the collection, deleting all data, users, and indexes stored in it.
+    /// Drops the collection, deleting all data and indexes stored in it.
     pub async fn drop(&self, options: impl Into<Option<DropCollectionOptions>>) -> Result<()> {
         let mut options = options.into();
         resolve_options!(self, options, [write_concern]);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -145,7 +145,7 @@ impl Database {
         Collection::new(self.clone(), name, Some(options))
     }
 
-    /// Drops the database, deleting all data, collections, users, and indexes stored in it.
+    /// Drops the database, deleting all data, collections, and indexes stored in it.
     pub async fn drop(&self, options: impl Into<Option<DropDatabaseOptions>>) -> Result<()> {
         let mut options = options.into();
         resolve_options!(self, options, [write_concern]);


### PR DESCRIPTION
… and collections

While writing tests for X.509 authentication, I discovered that dropping a database [doesn't actually delete the users in that database](https://docs.mongodb.com/manual/reference/command/dropDatabase/#user-management). Somehow, I remembered that the docstring I wrote for `Database::drop` indicated the opposite, hence this pull request to fix it. Additionally, I realized there's no reason to mention users on `Collection::drop`, as users are only associated with databases, not collections. 