### PR TITLE
RUST-527 - Implementation of gridfs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = ["tokio-runtime"]
 tokio-runtime = ["tokio/dns", "tokio/macros", "tokio/rt-core", "tokio/tcp", "tokio/rt-threaded", "tokio/time", "reqwest", "serde_bytes"]
 async-std-runtime = ["async-std", "async-std/attributes"]
 sync = ["async-std-runtime"]
+gridfs = []
 
 [dependencies]
 async-trait = "0.1.24"

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -10,7 +10,7 @@ use crate::{
         deserialize_duration_from_u64_millis,
         serialize_batch_size,
         serialize_duration_as_int_millis,
-        serialize_u32_as_i32,
+        serialize_option_u32_as_i32,
     },
     concern::{ReadConcern, WriteConcern},
     options::Collation,
@@ -651,7 +651,7 @@ pub struct FindOptions {
     /// number of round trips needed to return the entire set of documents returned by the
     /// query.
     #[builder(default)]
-    #[serde(serialize_with = "serialize_u32_as_i32")]
+    #[serde(serialize_with = "serialize_option_u32_as_i32")]
     pub batch_size: Option<u32>,
 
     /// Tags the query with an arbitrary string to help trace the operation through the database

--- a/src/gridfs/mod.rs
+++ b/src/gridfs/mod.rs
@@ -1,0 +1,58 @@
+/// This follow officiel [specification](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst)
+/// If you found bug according to the specification, please report bug
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    bson::{oid::ObjectId, DateTime, Document},
+    bson_util::{serialize_u32_as_i32, serialize_u64_as_i64},
+};
+
+/// This represent a chunk of a file
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Chunk {
+    /// a unique ID for this document of type BSON ObjectId
+    #[serde(rename = "_id")]
+    id: ObjectId,
+    /// the id for this file (the _id from the files collection document). This field takes the
+    /// type of the corresponding _id in the files collection.
+    files_id: ObjectId,
+    /// the index number of this chunk, zero-based.
+    #[serde(serialize_with = "serialize_u32_as_i32")]
+    n: u32,
+    /// a chunk of data from the user file
+    #[serde(with = "serde_bytes")]
+    data: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MetaChunk {
+    /// a unique ID for this document. Usually this will be of type ObjectId, but a custom _id
+    /// value provided by the application may be of any type.
+    #[serde(rename = "_id")]
+    id: ObjectId,
+    /// the length of this stored file, in bytes
+    #[serde(serialize_with = "serialize_u64_as_i64")]
+    length: u64,
+    /// the size, in bytes, of each data chunk of this file. This value is configurable by file.
+    /// The default is 255 KiB.
+    chunk_size: u32,
+    /// the date and time this file was added to GridFS, stored as a BSON datetime value.
+    /// The value of this field MUST be the datetime when the upload completed, not the datetime
+    /// when it was begun.
+    upload_date: DateTime,
+    /// DEPRECATED, a hash of the contents of the stored file
+    #[deprecated]
+    md5: String,
+    /// the name of this stored file; this does not need to be unique
+    filename: String,
+    /// DEPRECATED, any MIME type, for application use only
+    #[deprecated]
+    content_type: String,
+    /// DEPRECATED, for application use only
+    #[deprecated]
+    aliases: Vec<String>,
+    /// any additional application data the user wishes to store
+    metadata: Document,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,3 +173,6 @@ pub(crate) static RUNTIME: runtime::AsyncRuntime = runtime::AsyncRuntime::Tokio;
 
 #[cfg(all(not(feature = "tokio-runtime"), feature = "async-std-runtime"))]
 pub(crate) static RUNTIME: runtime::AsyncRuntime = runtime::AsyncRuntime::AsyncStd;
+
+#[cfg(feature = "gridfs")]
+mod gridfs;


### PR DESCRIPTION
This is a work in progress implementation of [gridfs](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst). The jira ticket [RUST-527](https://jira.mongodb.org/browse/RUST-527). Any help/remark/critic are always welcome. I will update this according to my progress:

- [x] Basic Structure
- [x] Add features to avoid include it in crate that doesn't need it `gridfs`
- [x] Require to be able to create index, https://github.com/mongodb/mongo-rust-driver/pull/188
- [ ] Should we implement MD5 ?
- [ ] ?