### PR TITLE
RUST-549 Increase ulimit in evergreen tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -81,6 +81,10 @@ functions:
               export SSL=${SSL}
               export TOPOLOGY=${TOPOLOGY}
               export MONGODB_VERSION=${MONGODB_VERSION}
+
+              if [ "Windows_NT" != "$OS" ]; then
+                  ulimit -n 64000
+              fi
            EOT
            # See what we've done
            cat expansion.yml


### PR DESCRIPTION
RUST-549

This PR increases the ulimit to 64000 before starting orchestration or any tests to prevent the "too many open files" test failures we see on async-std with macOS. They seem to be caused by EVG-13244, so this change will not be necessary at some point in the future. Until then, I think it's worth manually setting the ulimit to avoid test failures.