### PR TITLE
RUST-555 Implement exhaust cursor support

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -216,11 +216,11 @@ impl Client {
             }) => {
                 let connection = if more_to_come { Some(conn) } else { None };
 
-                return Ok(CursorResponse {
+                Ok(CursorResponse {
                     response,
                     connection,
                     session: None,
-                });
+                })
             }
 
             Err(err) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     },
     sdam::{Server, SessionSupportStatus, Topology},
 };
+pub(crate) use executor::OperationResult;
 pub(crate) use session::{ClientSession, ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 use session::{ServerSession, ServerSessionPool};
 
@@ -161,7 +162,7 @@ impl Client {
         options: impl Into<Option<ListDatabasesOptions>>,
     ) -> Result<Vec<Document>> {
         let op = ListDatabases::new(filter.into(), false, options.into());
-        self.execute_operation(op).await
+        self.execute_operation(op).await.map(|r| r.response)
     }
 
     /// Gets the names of the databases present in the cluster the Client is connected to.
@@ -171,7 +172,7 @@ impl Client {
         options: impl Into<Option<ListDatabasesOptions>>,
     ) -> Result<Vec<String>> {
         let op = ListDatabases::new(filter.into(), true, options.into());
-        match self.execute_operation(op).await {
+        match self.execute_operation(op).await.map(|r| r.response) {
             Ok(databases) => databases
                 .into_iter()
                 .map(|doc| {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     },
     sdam::{Server, SessionSupportStatus, Topology},
 };
-pub(crate) use executor::OperationResult;
+pub(crate) use executor::CursorResponse;
 pub(crate) use session::{ClientSession, ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 use session::{ServerSession, ServerSessionPool};
 
@@ -162,7 +162,7 @@ impl Client {
         options: impl Into<Option<ListDatabasesOptions>>,
     ) -> Result<Vec<Document>> {
         let op = ListDatabases::new(filter.into(), false, options.into());
-        self.execute_operation(op).await.map(|r| r.response)
+        self.execute_operation(op).await
     }
 
     /// Gets the names of the databases present in the cluster the Client is connected to.
@@ -172,7 +172,7 @@ impl Client {
         options: impl Into<Option<ListDatabasesOptions>>,
     ) -> Result<Vec<String>> {
         let op = ListDatabases::new(filter.into(), true, options.into());
-        match self.execute_operation(op).await.map(|r| r.response) {
+        match self.execute_operation(op).await {
             Ok(databases) => databases
                 .into_iter()
                 .map(|doc| {

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -256,7 +256,6 @@ impl Connection {
     /// itself.
     pub(crate) async fn read_response(&mut self) -> Result<CommandResponse> {
         let response_message_result = Message::read_from(&mut self.stream).await;
-        self.command_executing = false;
         self.error = response_message_result.is_err();
 
         let response_message = response_message_result?;

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -183,7 +183,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let drop = DropCollection::new(self.namespace(), options);
-        self.client().execute_operation(drop).await
+        self.client()
+            .execute_operation(drop)
+            .await
+            .map(|r| r.response)
     }
 
     /// Runs an aggregation operation.
@@ -207,7 +210,7 @@ where
         client
             .execute_cursor_operation(aggregate)
             .await
-            .map(|(spec, session)| Cursor::new(client.clone(), spec, session))
+            .map(|(spec, session)| Cursor::new(client.clone(), spec, session, false))
     }
 
     /// Estimates the number of documents in the collection using collection metadata.
@@ -219,7 +222,10 @@ where
         resolve_options!(self, options, [read_concern, selection_criteria]);
 
         let op = Count::new(self.namespace(), options);
-        self.client().execute_operation(op).await
+        self.client()
+            .execute_operation(op)
+            .await
+            .map(|r| r.response)
     }
 
     /// Gets the number of documents matching `filter`.
@@ -308,7 +314,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let delete = Delete::new(self.namespace(), query, None, options);
-        self.client().execute_operation(delete).await
+        self.client()
+            .execute_operation(delete)
+            .await
+            .map(|r| r.response)
     }
 
     /// Deletes up to one document found matching `query`.
@@ -326,7 +335,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let delete = Delete::new(self.namespace(), query, Some(1), options);
-        self.client().execute_operation(delete).await
+        self.client()
+            .execute_operation(delete)
+            .await
+            .map(|r| r.response)
     }
 
     /// Finds the distinct values of the field specified by `field_name` across the collection.
@@ -345,7 +357,10 @@ where
             filter.into(),
             options,
         );
-        self.client().execute_operation(op).await
+        self.client()
+            .execute_operation(op)
+            .await
+            .map(|r| r.response)
     }
 
     /// Finds the documents in the collection matching `filter`.
@@ -360,7 +375,7 @@ where
         client
             .execute_cursor_operation(find)
             .await
-            .map(|(result, session)| Cursor::new(client.clone(), result, session))
+            .map(|(result, session)| Cursor::new(client.clone(), result, session, false))
     }
 
     /// Finds a single document in the collection matching `filter`.
@@ -393,7 +408,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let op = FindAndModify::<T>::with_delete(self.namespace(), filter, options);
-        self.client().execute_operation(op).await
+        self.client()
+            .execute_operation(op)
+            .await
+            .map(|r| r.response)
     }
 
     /// Atomically finds up to one document in the collection matching `filter` and replaces it with
@@ -415,7 +433,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let op = FindAndModify::<T>::with_replace(self.namespace(), filter, replacement, options)?;
-        self.client().execute_operation(op).await
+        self.client()
+            .execute_operation(op)
+            .await
+            .map(|r| r.response)
     }
 
     /// Atomically finds up to one document in the collection matching `filter` and updates it.
@@ -438,7 +459,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let op = FindAndModify::<T>::with_update(self.namespace(), filter, update, options)?;
-        self.client().execute_operation(op).await
+        self.client()
+            .execute_operation(op)
+            .await
+            .map(|r| r.response)
     }
 
     /// Inserts the data in `docs` into the collection.
@@ -485,7 +509,12 @@ where
             n_attempted += current_batch_size;
 
             let insert = Insert::new(self.namespace(), current_batch, options.clone());
-            match self.client().execute_operation(insert).await {
+            match self
+                .client()
+                .execute_operation(insert)
+                .await
+                .map(|r| r.response)
+            {
                 Ok(result) => {
                     if cumulative_failure.is_none() {
                         let cumulative_result =
@@ -556,7 +585,7 @@ where
         self.client()
             .execute_operation(insert)
             .await
-            .map(InsertOneResult::from_insert_many_result)
+            .map(|r| InsertOneResult::from_insert_many_result(r.response))
             .map_err(convert_bulk_errors)
     }
 
@@ -585,7 +614,10 @@ where
             false,
             options.map(UpdateOptions::from_replace_options),
         );
-        self.client().execute_operation(update).await
+        self.client()
+            .execute_operation(update)
+            .await
+            .map(|r| r.response)
     }
 
     /// Updates all documents matching `query` in the collection.
@@ -610,7 +642,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let update = Update::new(self.namespace(), query, update, true, options);
-        self.client().execute_operation(update).await
+        self.client()
+            .execute_operation(update)
+            .await
+            .map(|r| r.response)
     }
 
     /// Updates up to one document matching `query` in the collection.
@@ -634,7 +669,10 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let update = Update::new(self.namespace(), query, update.into(), false, options);
-        self.client().execute_operation(update).await
+        self.client()
+            .execute_operation(update)
+            .await
+            .map(|r| r.response)
     }
 
     /// Kill the server side cursor that id corresponds to.

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -183,10 +183,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let drop = DropCollection::new(self.namespace(), options);
-        self.client()
-            .execute_operation(drop)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(drop).await
     }
 
     /// Runs an aggregation operation.
@@ -210,7 +207,7 @@ where
         client
             .execute_cursor_operation(aggregate)
             .await
-            .map(|(spec, session)| Cursor::new(client.clone(), spec, session, false))
+            .map(|spec| Cursor::new(client.clone(), spec, false))
     }
 
     /// Estimates the number of documents in the collection using collection metadata.
@@ -222,10 +219,7 @@ where
         resolve_options!(self, options, [read_concern, selection_criteria]);
 
         let op = Count::new(self.namespace(), options);
-        self.client()
-            .execute_operation(op)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(op).await
     }
 
     /// Gets the number of documents matching `filter`.
@@ -314,10 +308,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let delete = Delete::new(self.namespace(), query, None, options);
-        self.client()
-            .execute_operation(delete)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(delete).await
     }
 
     /// Deletes up to one document found matching `query`.
@@ -335,10 +326,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let delete = Delete::new(self.namespace(), query, Some(1), options);
-        self.client()
-            .execute_operation(delete)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(delete).await
     }
 
     /// Finds the distinct values of the field specified by `field_name` across the collection.
@@ -357,10 +345,7 @@ where
             filter.into(),
             options,
         );
-        self.client()
-            .execute_operation(op)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(op).await
     }
 
     /// Finds the documents in the collection matching `filter`.
@@ -375,7 +360,7 @@ where
         client
             .execute_cursor_operation(find)
             .await
-            .map(|(result, session)| Cursor::new(client.clone(), result, session, false))
+            .map(|result| Cursor::new(client.clone(), result, false))
     }
 
     /// Finds a single document in the collection matching `filter`.
@@ -408,10 +393,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let op = FindAndModify::<T>::with_delete(self.namespace(), filter, options);
-        self.client()
-            .execute_operation(op)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(op).await
     }
 
     /// Atomically finds up to one document in the collection matching `filter` and replaces it with
@@ -433,10 +415,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let op = FindAndModify::<T>::with_replace(self.namespace(), filter, replacement, options)?;
-        self.client()
-            .execute_operation(op)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(op).await
     }
 
     /// Atomically finds up to one document in the collection matching `filter` and updates it.
@@ -459,10 +438,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let op = FindAndModify::<T>::with_update(self.namespace(), filter, update, options)?;
-        self.client()
-            .execute_operation(op)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(op).await
     }
 
     /// Inserts the data in `docs` into the collection.
@@ -509,12 +485,7 @@ where
             n_attempted += current_batch_size;
 
             let insert = Insert::new(self.namespace(), current_batch, options.clone());
-            match self
-                .client()
-                .execute_operation(insert)
-                .await
-                .map(|r| r.response)
-            {
+            match self.client().execute_operation(insert).await {
                 Ok(result) => {
                     if cumulative_failure.is_none() {
                         let cumulative_result =
@@ -585,7 +556,7 @@ where
         self.client()
             .execute_operation(insert)
             .await
-            .map(|r| InsertOneResult::from_insert_many_result(r.response))
+            .map(InsertOneResult::from_insert_many_result)
             .map_err(convert_bulk_errors)
     }
 
@@ -614,10 +585,7 @@ where
             false,
             options.map(UpdateOptions::from_replace_options),
         );
-        self.client()
-            .execute_operation(update)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(update).await
     }
 
     /// Updates all documents matching `query` in the collection.
@@ -642,10 +610,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let update = Update::new(self.namespace(), query, update, true, options);
-        self.client()
-            .execute_operation(update)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(update).await
     }
 
     /// Updates up to one document matching `query` in the collection.
@@ -669,10 +634,7 @@ where
         resolve_options!(self, options, [write_concern]);
 
         let update = Update::new(self.namespace(), query, update.into(), false, options);
-        self.client()
-            .execute_operation(update)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(update).await
     }
 
     /// Kill the server side cursor that id corresponds to.

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -10,7 +10,7 @@ use futures::{Future, Stream};
 
 use crate::{
     bson::Document,
-    client::OperationResult,
+    client::CursorResponse,
     cmap::Connection,
     error::{ErrorKind, Result},
     operation::GetMore,
@@ -227,7 +227,7 @@ pub(crate) struct CursorInformation {
 /// Reads a `getMore` response form the server without sending a `getMore` command.
 pub(super) async fn read_exhaust_get_more(
     mut conn: Connection,
-) -> Result<OperationResult<GetMoreResult>> {
+) -> Result<CursorResponse<GetMoreResult>> {
     let response = conn.read_response().await?;
 
     let connection = if response.more_to_come {
@@ -238,8 +238,9 @@ pub(super) async fn read_exhaust_get_more(
 
     let get_more_result = GetMore::handle_response(response)?;
 
-    Ok(OperationResult {
+    Ok(CursorResponse {
         response: get_more_result,
         connection,
+        session: None,
     })
 }

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -224,7 +224,7 @@ pub(crate) struct CursorInformation {
     pub(crate) max_time: Option<Duration>,
 }
 
-/// Reads a `getMore` response form the server without sending a `getMore` command.
+/// Reads a `getMore` response from the server without sending a `getMore` command.
 pub(super) async fn read_exhaust_get_more(
     mut conn: Connection,
 ) -> Result<CursorResponse<GetMoreResult>> {

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -15,7 +15,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     bson::{from_document, Document},
-    client::{ClientSession, OperationResult},
+    client::{ClientSession, CursorResponse},
     cmap::Connection,
     error::Result,
     operation::GetMore,
@@ -101,12 +101,11 @@ where
 {
     pub(crate) fn new(
         client: Client,
-        spec: OperationResult<CursorSpecification>,
-        session: Option<ClientSession>,
+        spec: CursorResponse<CursorSpecification>,
         request_exhaust: bool,
     ) -> Self {
         let provider =
-            ImplicitSessionGetMoreProvider::new(&spec.response, session, request_exhaust);
+            ImplicitSessionGetMoreProvider::new(&spec.response, spec.session, request_exhaust);
 
         Self {
             client: client.clone(),
@@ -259,7 +258,7 @@ impl GetMoreProvider for ImplicitSessionGetMoreProvider {
                                 .execute_operation_with_session(get_more, session)
                                 .await
                         }
-                        (None, None) => client.execute_operation(get_more).await,
+                        (None, None) => client.execute_cursor_operation(get_more).await,
                     };
 
                     ImplicitSessionGetMoreResult {

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -11,7 +11,7 @@ use super::common::{
 };
 use crate::{
     bson::Document,
-    client::{ClientSession, OperationResult},
+    client::{ClientSession, CursorResponse},
     cmap::Connection,
     cursor::CursorSpecification,
     error::Result,
@@ -35,7 +35,7 @@ pub(crate) struct SessionCursor {
 impl SessionCursor {
     fn new(
         client: Client,
-        spec: OperationResult<CursorSpecification>,
+        spec: CursorResponse<CursorSpecification>,
         request_exhaust: bool,
     ) -> Self {
         let exhausted = spec.response.id() == 0;

--- a/src/cursor/test.rs
+++ b/src/cursor/test.rs
@@ -19,7 +19,7 @@ fn doc_x(i: i32) -> Document {
 async fn exhaust_test() {
     let client = EventClient::new().await;
 
-    if client.server_version_lt(4, 2) || (client.server_version_gte(4, 4) && client.is_sharded()) {
+    if client.server_version_lt(4, 2) || client.is_sharded() {
         return;
     }
 

--- a/src/cursor/test.rs
+++ b/src/cursor/test.rs
@@ -1,0 +1,91 @@
+use futures::stream::TryStreamExt;
+
+use super::Cursor;
+use crate::{
+    bson::{doc, Document},
+    operation::{Find, GetMoreResponseBody},
+    options::FindOptions,
+    test::EventClient,
+    Namespace,
+};
+
+fn doc_x(i: i32) -> Document {
+    doc! { "x": i }
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn exhaust_test() {
+    let client = EventClient::new().await;
+    let events = client.command_events.clone();
+
+    let coll = client
+        .init_db_and_coll(function_name!(), function_name!())
+        .await;
+
+    let docs = (1i32..=20).map(doc_x);
+    coll.insert_many(docs, None).await.unwrap();
+
+    let op = Find::new(
+        Namespace {
+            db: function_name!().into(),
+            coll: function_name!().into(),
+        },
+        None,
+        Some(
+            FindOptions::builder()
+                .batch_size(5)
+                .sort(doc! { "x": 1 })
+                .build(),
+        ),
+    );
+
+    let operation_result = client.execute_operation(op).await.unwrap();
+
+    let mut cursor: Cursor = Cursor::new(client.client.into_client(), operation_result, None, true);
+
+    for i in 1i32..=20 {
+        let doc = cursor.try_next().await.unwrap().unwrap();
+
+        assert_eq!(doc.get_i32("x"), Ok(i));
+    }
+
+    assert!(cursor.try_next().await.unwrap().is_none());
+
+    let events_guard = events.read().unwrap();
+
+    // Assert that only one getMore was sent.
+    assert_eq!(
+        events_guard
+            .iter()
+            .filter(|event| event.is_command_started() && event.command_name() == "getMore")
+            .count(),
+        1
+    );
+
+    let get_more_replies: Vec<_> = events_guard
+        .iter()
+        .filter_map(|c| {
+            let command_succeeded = c.as_command_succeeded()?;
+
+            if command_succeeded.command_name != "getMore" {
+                return None;
+            }
+
+            Some(&command_succeeded.reply)
+        })
+        .collect();
+
+    // Assert that only one explicit getMore response was sent from the server.
+    assert_eq!(get_more_replies.len(), 1);
+
+    let GetMoreResponseBody { cursor } = bson::from_document(get_more_replies[0].clone()).unwrap();
+
+    // Assert that only five responses were present in the reply to the explicit getMore.
+    assert_eq!(cursor.next_batch.len(), 5);
+
+    // Assert that the last document in the reply to the explicit getMore was the 10th document,
+    // meaning the last ten must have come from exhaust replies.
+    assert_eq!(cursor.next_batch[4].get_i32("x"), Ok(10));
+}

--- a/src/cursor/test.rs
+++ b/src/cursor/test.rs
@@ -19,7 +19,7 @@ fn doc_x(i: i32) -> Document {
 async fn exhaust_test() {
     let client = EventClient::new().await;
 
-    if client.server_version_lt(4, 2) {
+    if client.server_version_lt(4, 2) || (client.server_version_gte(4, 4) && client.is_sharded()) {
         return;
     }
 

--- a/src/cursor/test.rs
+++ b/src/cursor/test.rs
@@ -18,6 +18,11 @@ fn doc_x(i: i32) -> Document {
 #[function_name::named]
 async fn exhaust_test() {
     let client = EventClient::new().await;
+
+    if client.server_version_lt(4, 2) {
+        return;
+    }
+
     let events = client.command_events.clone();
 
     let coll = client

--- a/src/cursor/test.rs
+++ b/src/cursor/test.rs
@@ -41,9 +41,9 @@ async fn exhaust_test() {
         ),
     );
 
-    let operation_result = client.execute_operation(op).await.unwrap();
+    let cursor_response = client.execute_cursor_operation(op).await.unwrap();
 
-    let mut cursor: Cursor = Cursor::new(client.client.into_client(), operation_result, None, true);
+    let mut cursor: Cursor = Cursor::new(client.client.into_client(), cursor_response, true);
 
     for i in 1i32..=20 {
         let doc = cursor.try_next().await.unwrap().unwrap();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -182,10 +182,7 @@ impl Database {
         resolve_options!(self, options, [write_concern]);
 
         let drop_database = DropDatabase::new(self.name().to_string(), options);
-        self.client()
-            .execute_operation(drop_database)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(drop_database).await
     }
 
     /// Gets information about each of the collections in the database. The cursor will yield a
@@ -204,7 +201,7 @@ impl Database {
         self.client()
             .execute_cursor_operation(list_collections)
             .await
-            .map(|(spec, session)| Cursor::new(self.client().clone(), spec, session, false))
+            .map(|spec| Cursor::new(self.client().clone(), spec, false))
     }
 
     /// Gets the names of the collections in the database.
@@ -218,7 +215,7 @@ impl Database {
             .client()
             .execute_cursor_operation(list_collections)
             .await
-            .map(|(spec, session)| Cursor::new(self.client().clone(), spec, session, false))?;
+            .map(|spec| Cursor::new(self.client().clone(), spec, false))?;
 
         cursor
             .and_then(|doc| match doc.get("name").and_then(Bson::as_str) {
@@ -254,10 +251,7 @@ impl Database {
             },
             options,
         );
-        self.client()
-            .execute_operation(create)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(create).await
     }
 
     /// Runs a database-level command.
@@ -271,10 +265,7 @@ impl Database {
         selection_criteria: impl Into<Option<SelectionCriteria>>,
     ) -> Result<Document> {
         let operation = RunCommand::new(self.name().into(), command, selection_criteria.into())?;
-        self.client()
-            .execute_operation(operation)
-            .await
-            .map(|r| r.response)
+        self.client().execute_operation(operation).await
     }
 
     /// Runs an aggregation operation.
@@ -298,6 +289,6 @@ impl Database {
         client
             .execute_cursor_operation(aggregate)
             .await
-            .map(|(spec, session)| Cursor::new(client.clone(), spec, session, false))
+            .map(|spec| Cursor::new(client.clone(), spec, false))
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -182,7 +182,10 @@ impl Database {
         resolve_options!(self, options, [write_concern]);
 
         let drop_database = DropDatabase::new(self.name().to_string(), options);
-        self.client().execute_operation(drop_database).await
+        self.client()
+            .execute_operation(drop_database)
+            .await
+            .map(|r| r.response)
     }
 
     /// Gets information about each of the collections in the database. The cursor will yield a
@@ -201,7 +204,7 @@ impl Database {
         self.client()
             .execute_cursor_operation(list_collections)
             .await
-            .map(|(spec, session)| Cursor::new(self.client().clone(), spec, session))
+            .map(|(spec, session)| Cursor::new(self.client().clone(), spec, session, false))
     }
 
     /// Gets the names of the collections in the database.
@@ -215,7 +218,7 @@ impl Database {
             .client()
             .execute_cursor_operation(list_collections)
             .await
-            .map(|(spec, session)| Cursor::new(self.client().clone(), spec, session))?;
+            .map(|(spec, session)| Cursor::new(self.client().clone(), spec, session, false))?;
 
         cursor
             .and_then(|doc| match doc.get("name").and_then(Bson::as_str) {
@@ -251,7 +254,10 @@ impl Database {
             },
             options,
         );
-        self.client().execute_operation(create).await
+        self.client()
+            .execute_operation(create)
+            .await
+            .map(|r| r.response)
     }
 
     /// Runs a database-level command.
@@ -265,7 +271,10 @@ impl Database {
         selection_criteria: impl Into<Option<SelectionCriteria>>,
     ) -> Result<Document> {
         let operation = RunCommand::new(self.name().into(), command, selection_criteria.into())?;
-        self.client().execute_operation(operation).await
+        self.client()
+            .execute_operation(operation)
+            .await
+            .map(|r| r.response)
     }
 
     /// Runs an aggregation operation.
@@ -289,6 +298,6 @@ impl Database {
         client
             .execute_cursor_operation(aggregate)
             .await
-            .map(|(spec, session)| Cursor::new(client.clone(), spec, session))
+            .map(|(spec, session)| Cursor::new(client.clone(), spec, session, false))
     }
 }

--- a/src/operation/get_more/test.rs
+++ b/src/operation/get_more/test.rs
@@ -26,7 +26,7 @@ fn build_test(
         batch_size,
         max_time,
     };
-    let get_more = GetMore::new(info);
+    let get_more = GetMore::new(info, false);
 
     let build_result = get_more.build(&StreamDescription::new_testing());
     assert!(build_result.is_ok());
@@ -118,7 +118,7 @@ async fn build_batch_size() {
         batch_size: Some((std::i32::MAX as u32) + 1),
         max_time: None,
     };
-    let op = GetMore::new(info);
+    let op = GetMore::new(info, false);
     assert!(op.build(&StreamDescription::new_testing()).is_err())
 }
 
@@ -137,7 +137,7 @@ async fn op_selection_criteria() {
         batch_size: None,
         max_time: None,
     };
-    let get_more = GetMore::new(info);
+    let get_more = GetMore::new(info, false);
     let server_description = ServerDescription {
         address,
         server_type: ServerType::Unknown,
@@ -182,7 +182,7 @@ async fn handle_success() {
         batch_size: None,
         max_time: None,
     };
-    let get_more = GetMore::new(info);
+    let get_more = GetMore::new(info, false);
 
     let batch = vec![doc! { "_id": 1 }, doc! { "_id": 2 }, doc! { "_id": 3 }];
 

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -51,6 +51,9 @@ pub(crate) use list_databases::ListDatabases;
 pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;
 
+#[cfg(test)]
+pub(crate) use get_more::GetMoreResponseBody;
+
 /// A trait modeling the behavior of a server side operation.
 pub(crate) trait Operation {
     /// The output type of this operation.
@@ -96,6 +99,10 @@ pub(crate) trait Operation {
     /// The level of retryability the operation supports.
     fn retryability(&self) -> Retryability {
         Retryability::None
+    }
+
+    fn request_exhaust(&self) -> bool {
+        false
     }
 }
 

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -59,7 +59,7 @@ impl CommandEvent {
         }
     }
 
-    fn as_command_succeeded(&self) -> Option<&CommandSucceededEvent> {
+    pub(crate) fn as_command_succeeded(&self) -> Option<&CommandSucceededEvent> {
         match self {
             CommandEvent::CommandSucceededEvent(e) => Some(e),
             _ => None,
@@ -104,7 +104,7 @@ impl CommandEventHandler for EventHandler {
 
 #[derive(Clone)]
 pub struct EventClient {
-    client: TestClient,
+    pub client: TestClient,
     pub command_events: EventQueue<CommandEvent>,
     pub pool_cleared_events: EventQueue<PoolClearedEvent>,
 }

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -79,7 +79,8 @@ impl TestClient {
             client
                 .execute_operation_with_session(is_master, &mut session)
                 .await
-                .unwrap(),
+                .unwrap()
+                .response,
         ))
         .unwrap();
 
@@ -88,7 +89,8 @@ impl TestClient {
         let response = client
             .execute_operation_with_session(build_info, &mut session)
             .await
-            .unwrap();
+            .unwrap()
+            .response;
 
         let info: BuildInfo = bson::from_bson(Bson::Document(response)).unwrap();
         let server_version = info.version.split('-').next().unwrap();
@@ -117,6 +119,10 @@ impl TestClient {
             options.hosts = options.hosts.iter().cloned().take(1).collect();
         }
         Self::with_options(Some(options)).await
+    }
+
+    pub fn into_client(self) -> Client {
+        self.client
     }
 
     pub async fn create_user(


### PR DESCRIPTION
This pull request augments the driver with two new features: the ability to send the exhaust flag to the server through the internal cursor API, and the ability to read exhaust responses from the server (indicated by the `moreToCome` flag). These are decoupled from a behavioral standpoint; if the driver sends the `exhaust` flag, it can still read non-exhaust responses fine if that's what the server returns, and the driver can properly handle responses with `moreToCome` regardless of whether it sent `exhaust` on the operation corresponding to the response. The changes to the driver fall into three buckets:

* operation execution API changes

The operation execution API (i.e. `src/client/executor.rs`) was updated so that top-level execution methods all return an `Option<Connection>` along with the actual response from the operation. A connection will be present if and only if the server response contained the `moreToCome` flag

* operation layer changes

The operation trait was updated to allow operations to specify whether or not they support sending the exhaust flag to the server. This behavior is only implemented for the `getMore` command, and it is not exposed through any public API to users.

Additionally, the `Command` struct was updated to support setting the `exhaust` flag when it's serialized to the wire protocol.

* cursor implementation changes

The cursor API was updated so that a connection can optionally be passed in when constructing a cursor, with an invariant that a connection being passed in means that the initial operation response contained the `moreToCome` flag. Additionally, `GetMoreProvider` was augmented to support reading an exhaust response, and `GetMoreProviderResult` was augmented to support retrieving the connection in the case that the server response contains the `moreToCome` flag. The corresponding cursor implementations were updated to implement these new features through the new API methods on those traits.