### PR TITLE
RUST-575 Consider connection pool health during server selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ lazy_static = "1.4.0"
 md-5 = "0.8.0"
 os_info = { version = "2.0.6", default-features = false }
 percent-encoding = "2.0.0"
-rand = "0.7.2"
+rand = { version = "0.7.2", features = ["small_rng"] }
 serde_with = "1.3.1"
 sha-1 = "0.8.1"
 sha2 = "0.8.0"

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -12,7 +12,7 @@ use crate::{
     event::command::{CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent},
     operation::{Operation, Retryability},
     options::SelectionCriteria,
-    sdam::{Server, SessionSupportStatus},
+    sdam::{SelectedServer, SessionSupportStatus},
 };
 
 lazy_static! {
@@ -356,7 +356,7 @@ impl Client {
                 let criteria = SelectionCriteria::Predicate(Arc::new(move |server_info| {
                     server_info.server_type().is_data_bearing()
                 }));
-                let _: Arc<Server> = self.select_server(Some(&criteria)).await?;
+                let _: SelectedServer = self.select_server(Some(&criteria)).await?;
                 Ok(self.inner.topology.session_support_status().await)
             }
             _ => Ok(initial_status),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         ReadPreference,
         SelectionCriteria,
     },
-    sdam::{Server, SessionSupportStatus, Topology},
+    sdam::{SelectedServer, SessionSupportStatus, Topology},
 };
 pub(crate) use session::{ClientSession, ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 use session::{ServerSession, ServerSessionPool};
@@ -246,7 +246,7 @@ impl Client {
 
     /// Select a server using the provided criteria. If none is provided, a primary read preference
     /// will be used instead.
-    async fn select_server(&self, criteria: Option<&SelectionCriteria>) -> Result<Arc<Server>> {
+    async fn select_server(&self, criteria: Option<&SelectionCriteria>) -> Result<SelectedServer> {
         let criteria =
             criteria.unwrap_or(&SelectionCriteria::ReadPreference(ReadPreference::Primary));
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -22,7 +22,7 @@ use rustls::{
     ServerCertVerifier,
     TLSError,
 };
-use serde::Deserialize;
+use serde::{de::Error, Deserialize, Deserializer};
 use strsim::jaro_winkler;
 pub use trust_dns_resolver::config::ResolverConfig;
 use typed_builder::TypedBuilder;
@@ -91,7 +91,7 @@ lazy_static! {
 }
 
 /// A hostname:port address pair.
-#[derive(Clone, Debug, Deserialize, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct StreamAddress {
     /// The hostname of the address.
     pub hostname: String,
@@ -100,6 +100,16 @@ pub struct StreamAddress {
     ///
     /// The default is 27017.
     pub port: Option<u16>,
+}
+
+impl<'de> Deserialize<'de> for StreamAddress {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        Self::parse(s.as_str()).map_err(|e| D::Error::custom(format!("{}", e)))
+    }
 }
 
 impl Default for StreamAddress {

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -1,4 +1,4 @@
-mod server_selection;
+pub(crate) mod server_selection;
 #[cfg(test)]
 mod test;
 

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -1,0 +1,194 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use approx::abs_diff_eq;
+use semver::VersionReq;
+use serde::Deserialize;
+use tokio::sync::RwLockWriteGuard;
+
+use crate::{
+    options::StreamAddress,
+    runtime::AsyncJoinHandle,
+    sdam::{description::topology::server_selection, Server},
+    selection_criteria::ReadPreference,
+    test::{
+        run_spec_test,
+        EventClient,
+        FailCommandOptions,
+        FailPoint,
+        FailPointMode,
+        TestClient,
+        CLIENT_OPTIONS,
+        LOCK,
+    },
+    RUNTIME,
+};
+
+use super::TestTopologyDescription;
+
+#[derive(Debug, Deserialize)]
+struct TestFile {
+    description: String,
+    topology_description: TestTopologyDescription,
+    mocked_topology_state: Vec<TestServer>,
+    iterations: u32,
+    outcome: TestOutcome,
+}
+
+#[derive(Debug, Deserialize)]
+struct TestOutcome {
+    tolerance: f64,
+    expected_frequencies: HashMap<StreamAddress, f64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TestServer {
+    address: StreamAddress,
+    operation_count: u32,
+}
+
+async fn run_test(test_file: TestFile) {
+    println!("Running {}", test_file.description);
+
+    let mut tallies: HashMap<StreamAddress, u32> = HashMap::new();
+
+    let servers: HashMap<StreamAddress, Arc<Server>> = test_file
+        .mocked_topology_state
+        .into_iter()
+        .map(|desc| {
+            (
+                desc.address.clone(),
+                Arc::new(Server::new_mocked(desc.address, desc.operation_count)),
+            )
+        })
+        .collect();
+
+    let topology_description = test_file
+        .topology_description
+        .into_topology_description(None)
+        .unwrap();
+
+    let read_pref = ReadPreference::Nearest {
+        options: Default::default(),
+    }
+    .into();
+
+    for _ in 0..test_file.iterations {
+        let selection =
+            server_selection::attempt_to_select_server(&read_pref, &topology_description, &servers)
+                .expect("selection should not fail")
+                .expect("a server should have been selected");
+        *tallies.entry(selection.address.clone()).or_insert(0) += 1;
+    }
+
+    for (address, expected_frequency) in test_file.outcome.expected_frequencies {
+        let actual_frequency =
+            tallies.get(&address).cloned().unwrap_or(0) as f64 / (test_file.iterations as f64);
+
+        let epsilon = if expected_frequency != 1.0 && expected_frequency != 0.0 {
+            test_file.outcome.tolerance
+        } else {
+            f64::EPSILON
+        };
+
+        assert!(
+            abs_diff_eq!(actual_frequency, expected_frequency, epsilon = epsilon),
+            "{}: for server {} expected frequency = {}, actual = {}",
+            test_file.description,
+            address,
+            expected_frequency,
+            actual_frequency
+        );
+    }
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn select_in_window() {
+    run_spec_test(&["server-selection", "in_window"], run_test).await;
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test(threaded_scheduler))]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn load_balancing_test() {
+    let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
+
+    let mut setup_client_options = CLIENT_OPTIONS.clone();
+    setup_client_options.hosts.drain(1..);
+    setup_client_options.direct_connection = Some(true);
+    let setup_client = TestClient::with_options(Some(setup_client_options)).await;
+
+    let version = VersionReq::parse(">= 4.2.9").unwrap();
+    // blockConnection failpoint option only supported in 4.2.9+.
+    if !version.matches(&setup_client.server_version) {
+        println!(
+            "skipping load_balancing_test test due to server not supporting blockConnection option"
+        );
+        return;
+    }
+
+    if !setup_client.is_sharded() {
+        println!("skipping load_balancing_test test due to topology not being sharded");
+        return;
+    }
+
+    if CLIENT_OPTIONS.hosts.len() != 2 {
+        println!("skipping load_balancing_test test due to topology not having 2 mongoses");
+        return;
+    }
+
+    let options = FailCommandOptions::builder()
+        .block_connection(Duration::from_millis(500))
+        .build();
+    let failpoint = FailPoint::fail_command(&["find"], FailPointMode::AlwaysOn, options);
+
+    let fp_guard = setup_client
+        .enable_failpoint(failpoint, None)
+        .await
+        .expect("enabling failpoint should succeed");
+
+    let mut client = EventClient::new().await;
+
+    /// min_share is the lower bound for the % of times the the less selected server
+    /// was selected. max_share is the upper bound.
+    async fn do_test(client: &mut EventClient, min_share: f64, max_share: f64) {
+        client.command_events.write().unwrap().clear();
+
+        let mut handles: Vec<AsyncJoinHandle<()>> = Vec::new();
+        for _ in 0..10 {
+            let collection = client
+                .database("load_balancing_test")
+                .collection("load_balancing_test");
+            handles.push(
+                RUNTIME
+                    .spawn(async move {
+                        for _ in 0..10 {
+                            let _ = collection.find_one(None, None).await;
+                        }
+                    })
+                    .unwrap(),
+            )
+        }
+
+        futures::future::join_all(handles).await;
+
+        let mut tallies: HashMap<StreamAddress, u32> = HashMap::new();
+        for event in client.get_command_started_events("find") {
+            *tallies.entry(event.connection.address.clone()).or_insert(0) += 1;
+        }
+
+        assert_eq!(tallies.len(), 2);
+        let mut counts: Vec<_> = tallies.values().collect();
+        counts.sort();
+
+        // verify that the lesser picked server (slower one) was picked less than 25% of the time.
+        let share_of_selections = (*counts[0] as f64) / ((*counts[0] + *counts[1]) as f64);
+        assert!(share_of_selections <= max_share);
+        assert!(share_of_selections >= min_share);
+    }
+
+    do_test(&mut client, 0.05, 0.25).await;
+
+    // disable failpoint and rerun, should be close to even split
+    drop(fp_guard);
+    do_test(&mut client, 0.40, 0.50).await;
+}

--- a/src/sdam/description/topology/server_selection/test/mod.rs
+++ b/src/sdam/description/topology/server_selection/test/mod.rs
@@ -1,0 +1,199 @@
+use std::time::Duration;
+
+use bson::{doc, DateTime as BsonDateTime};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::Deserialize;
+
+use crate::{
+    is_master::{IsMasterCommandResponse, IsMasterReply, LastWrite},
+    options::StreamAddress,
+    sdam::{
+        description::topology::{test::f64_ms_as_duration, TopologyType},
+        ServerDescription,
+        ServerType,
+        TopologyDescription,
+    },
+    selection_criteria::TagSet,
+};
+
+mod in_window;
+mod logic;
+
+#[derive(Debug, Deserialize)]
+struct TestTopologyDescription {
+    #[serde(rename = "type")]
+    topology_type: TopologyType,
+    servers: Vec<TestServerDescription>,
+}
+
+impl TestTopologyDescription {
+    fn into_topology_description(
+        self,
+        heartbeat_frequency: Option<Duration>,
+    ) -> Option<TopologyDescription> {
+        let servers: Option<Vec<ServerDescription>> = self
+            .servers
+            .into_iter()
+        // The driver doesn't support server versions low enough not to support max staleness, so we
+        // just manually filter them out here.
+            .filter(|server| server.max_wire_version.map(|version| version >= 5).unwrap_or(true))
+            .map(|sd| sd.into_server_description())
+            .collect();
+
+        let servers = match servers {
+            Some(servers) => servers,
+            None => return None,
+        };
+
+        TopologyDescription {
+            single_seed: servers.len() == 1,
+            topology_type: self.topology_type,
+            set_name: None,
+            max_set_version: None,
+            max_election_id: None,
+            compatibility_error: None,
+            session_support_status: Default::default(),
+            cluster_time: None,
+            local_threshold: None,
+            heartbeat_freq: heartbeat_frequency,
+            servers: servers
+                .into_iter()
+                .map(|server| (server.address.clone(), server))
+                .collect(),
+        }
+        .into()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestServerDescription {
+    address: String,
+    #[serde(rename = "avg_rtt_ms")]
+    avg_rtt_ms: Option<f64>,
+    #[serde(rename = "type")]
+    server_type: TestServerType,
+    tags: Option<TagSet>,
+    last_update_time: Option<i32>,
+    last_write: Option<LastWriteDate>,
+    max_wire_version: Option<i32>,
+}
+
+impl TestServerDescription {
+    fn into_server_description(self) -> Option<ServerDescription> {
+        let server_type = match self.server_type.into_server_type() {
+            Some(server_type) => server_type,
+            None => return None,
+        };
+
+        let mut command_response = is_master_response_from_server_type(server_type);
+        command_response.tags = self.tags;
+        command_response.last_write = self.last_write.map(|last_write| LastWrite {
+            last_write_date: utc_datetime_from_millis(last_write.last_write_date),
+        });
+
+        let is_master = IsMasterReply {
+            command_response,
+            round_trip_time: self.avg_rtt_ms.map(f64_ms_as_duration),
+            cluster_time: None,
+        };
+
+        let mut server_desc = ServerDescription::new(
+            StreamAddress::parse(&self.address).unwrap(),
+            Some(Ok(is_master)),
+        );
+        server_desc.last_update_time = self
+            .last_update_time
+            .map(|i| utc_datetime_from_millis(i as i64));
+
+        Some(server_desc)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LastWriteDate {
+    last_write_date: i64,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+enum TestServerType {
+    Standalone,
+    Mongos,
+    RSPrimary,
+    RSSecondary,
+    RSArbiter,
+    RSOther,
+    RSGhost,
+    Unknown,
+    PossiblePrimary,
+}
+
+impl TestServerType {
+    fn into_server_type(self) -> Option<ServerType> {
+        match self {
+            TestServerType::Standalone => Some(ServerType::Standalone),
+            TestServerType::Mongos => Some(ServerType::Mongos),
+            TestServerType::RSPrimary => Some(ServerType::RSPrimary),
+            TestServerType::RSSecondary => Some(ServerType::RSSecondary),
+            TestServerType::RSArbiter => Some(ServerType::RSArbiter),
+            TestServerType::RSOther => Some(ServerType::RSOther),
+            TestServerType::RSGhost => Some(ServerType::RSGhost),
+            TestServerType::Unknown => Some(ServerType::Unknown),
+            TestServerType::PossiblePrimary => None,
+        }
+    }
+}
+
+fn utc_datetime_from_millis(millis: i64) -> BsonDateTime {
+    let seconds_portion = millis / 1000;
+    let nanos_portion = (millis % 1000) * 1_000_000;
+
+    let naive_datetime = NaiveDateTime::from_timestamp(seconds_portion, nanos_portion as u32);
+    let datetime = DateTime::from_utc(naive_datetime, Utc);
+
+    BsonDateTime(datetime)
+}
+
+fn is_master_response_from_server_type(server_type: ServerType) -> IsMasterCommandResponse {
+    let mut response = IsMasterCommandResponse::default();
+
+    match server_type {
+        ServerType::Unknown => {
+            response.ok = Some(0.0);
+        }
+        ServerType::Mongos => {
+            response.ok = Some(1.0);
+            response.msg = Some("isdbgrid".into());
+        }
+        ServerType::RSPrimary => {
+            response.ok = Some(1.0);
+            response.set_name = Some("foo".into());
+            response.is_master = Some(true);
+        }
+        ServerType::RSOther => {
+            response.ok = Some(1.0);
+            response.set_name = Some("foo".into());
+            response.hidden = Some(true);
+        }
+        ServerType::RSSecondary => {
+            response.ok = Some(1.0);
+            response.set_name = Some("foo".into());
+            response.secondary = Some(true);
+        }
+        ServerType::RSArbiter => {
+            response.ok = Some(1.0);
+            response.set_name = Some("foo".into());
+            response.arbiter_only = Some(true);
+        }
+        ServerType::RSGhost => {
+            response.ok = Some(1.0);
+            response.is_replica_set = Some(true);
+        }
+        ServerType::Standalone => {
+            response.ok = Some(1.0);
+        }
+    };
+
+    response
+}

--- a/src/sdam/mod.rs
+++ b/src/sdam/mod.rs
@@ -11,7 +11,11 @@ pub use self::public::{ServerInfo, ServerType};
 #[cfg(test)]
 pub(crate) use self::description::server::ServerDescription;
 pub(crate) use self::{
-    description::topology::{SessionSupportStatus, TopologyDescription},
+    description::topology::{
+        server_selection::SelectedServer,
+        SessionSupportStatus,
+        TopologyDescription,
+    },
     message_manager::TopologyMessageManager,
     monitor::MIN_HEARTBEAT_FREQUENCY,
     state::{server::Server, Topology},

--- a/src/sdam/srv_polling/mod.rs
+++ b/src/sdam/srv_polling/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use super::{
     monitor::DEFAULT_HEARTBEAT_FREQUENCY,
-    state::{Topology, TopologyState, WeakTopology},
+    state::{Topology, WeakTopology},
 };
 use crate::{
     error::{Error, Result},

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -25,7 +25,6 @@ lazy_static::lazy_static! {
 
 async fn run_test(new_hosts: Result<Vec<StreamAddress>>, expected_hosts: HashSet<StreamAddress>) {
     let topology = Topology::new_from_hosts(DEFAULT_HOSTS.iter());
-    let state = topology.clone_state().await;
     let mut monitor = SrvPollingMonitor::new(topology.downgrade()).unwrap();
 
     monitor
@@ -35,7 +34,6 @@ async fn run_test(new_hosts: Result<Vec<StreamAddress>>, expected_hosts: HashSet
                 min_ttl: None,
             }),
             topology.clone(),
-            state,
         )
         .await;
 

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use crate::{
     cmap::{options::ConnectionPoolOptions, Connection, ConnectionPool},
     error::Result,
@@ -12,9 +14,21 @@ pub(crate) struct Server {
 
     /// The connection pool for the server.
     pool: ConnectionPool,
+
+    /// Number of operations currently using this server.
+    operation_count: AtomicU32,
 }
 
 impl Server {
+    #[cfg(test)]
+    pub(crate) fn new_mocked(address: StreamAddress, operation_count: u32) -> Self {
+        Self {
+            address: address.clone(),
+            pool: ConnectionPool::new_mocked(address),
+            operation_count: AtomicU32::new(operation_count),
+        }
+    }
+
     pub(crate) fn new(
         address: StreamAddress,
         options: &ClientOptions,
@@ -27,6 +41,7 @@ impl Server {
                 Some(ConnectionPoolOptions::from_client_options(options)),
             ),
             address,
+            operation_count: AtomicU32::new(0),
         }
     }
 
@@ -39,5 +54,17 @@ impl Server {
     /// Clears the connection pool associated with the server.
     pub(crate) fn clear_connection_pool(&self) {
         self.pool.clear();
+    }
+
+    pub(crate) fn increment_operation_count(&self) {
+        self.operation_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn decrement_operation_count(&self) {
+        self.operation_count.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    pub(crate) fn operation_count(&self) -> u32 {
+        self.operation_count.load(Ordering::SeqCst)
     }
 }

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -59,6 +59,7 @@ impl SelectionCriteria {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn is_read_pref_primary(&self) -> bool {
         matches!(self, Self::ReadPreference(ReadPreference::Primary))
     }

--- a/src/test/spec/json/server-selection/README.rst
+++ b/src/test/spec/json/server-selection/README.rst
@@ -65,3 +65,45 @@ the TopologyDescription. Each YAML file contains a key for these stages of serve
 Drivers implementing server selection MUST test that their implementation
 correctly returns the set of servers in ``in_latency_window``. Drivers SHOULD also test
 against ``suitable_servers`` if possible.
+
+Selection Within Latency Window YAML Tests
+>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+These tests verify that servers select servers from within the latency
+window correctly. These tests MUST only be implemented by
+multi-threaded or async drivers.
+
+Each YAML file for these tests has the following format:
+
+- ``topology_description``: the state of a mocked cluster
+
+- ``mocked_topology_state``: array of objects containing the operationCounts for
+  each server included in ``topology_description``. Each element will have all
+  of the following fields:
+
+  - ``address``: a unique address identifying this server
+
+  - ``operation_count``: the ``operationCount`` for this server
+
+- ``iterations``: the number of selections that should be run as part of this
+   test
+
+- ``outcome``: an object describing the expected outcome of the selections
+
+  - ``tolerance``: the maximum difference between an observed frequency and an
+    expected one
+
+  - ``expected_frequencies``: a document whose keys are the server addresses
+    from the ``in_window`` array and values are numbers in [0, 1] indicating the
+    frequency at which the server should have been selected.
+
+For each file, create a new TopologyDescription object initialized with the
+values from ``topology_description`` and populate the operationCounts based on
+the information provided in ``mocked_topology_state``. Then, repeatedly select a
+server for a read operation using the mocked TopologyDescription and a "nearest"
+ReadPreference ``iterations`` times. Once ``iterations`` selections have been
+made, verify that each server was selected at a frequency within
+``outcome.tolerance`` of the expected frequency contained in
+``outcome.expected_frequencies`` for that server. If the expected frequency for
+a given server is 1 or 0, then the observed frequency MUST be exactly equal to
+the expected one.

--- a/src/test/spec/json/server-selection/in_window/equilibrium.json
+++ b/src/test/spec/json/server-selection/in_window/equilibrium.json
@@ -1,0 +1,46 @@
+{
+  "description": "When in equilibrium selection is evenly distributed",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 5
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.33,
+      "b:27017": 0.33,
+      "c:27017": 0.33
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/equilibrium.yml
+++ b/src/test/spec/json/server-selection/in_window/equilibrium.yml
@@ -1,0 +1,27 @@
+description: When in equilibrium selection is evenly distributed
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 5
+  - address: b:27017
+    operation_count: 5
+  - address: c:27017
+    operation_count: 5
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.33
+    b:27017: 0.33
+    c:27017: 0.33

--- a/src/test/spec/json/server-selection/in_window/many-choices.json
+++ b/src/test/spec/json/server-selection/in_window/many-choices.json
@@ -1,0 +1,106 @@
+{
+  "description": "Selections from many choices occur at correct frequencies",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "d:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "e:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "f:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "g:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "h:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "i:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 0
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 5
+    },
+    {
+      "address": "d:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "e:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "f:27017",
+      "operation_count": 20
+    },
+    {
+      "address": "g:27017",
+      "operation_count": 20
+    },
+    {
+      "address": "h:27017",
+      "operation_count": 50
+    },
+    {
+      "address": "i:27017",
+      "operation_count": 60
+    }
+  ],
+  "iterations": 10000,
+  "outcome": {
+    "tolerance": 0.03,
+    "expected_frequencies": {
+      "a:27017": 0.22,
+      "b:27017": 0.18,
+      "c:27017": 0.18,
+      "d:27017": 0.125,
+      "e:27017": 0.125,
+      "f:27017": 0.074,
+      "g:27017": 0.074,
+      "h:27017": 0.0277,
+      "i:27017": 0
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/many-choices.yml
+++ b/src/test/spec/json/server-selection/in_window/many-choices.yml
@@ -1,0 +1,63 @@
+description: Selections from many choices occur at correct frequencies
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: d:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: e:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: f:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: g:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: h:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: i:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 0
+  - address: b:27017
+    operation_count: 5
+  - address: c:27017
+    operation_count: 5
+  - address: d:27017
+    operation_count: 10
+  - address: e:27017
+    operation_count: 10
+  - address: f:27017
+    operation_count: 20
+  - address: g:27017
+    operation_count: 20
+  - address: h:27017
+    operation_count: 50
+  - address: i:27017
+    operation_count: 60
+iterations: 10000
+outcome:
+  tolerance: 0.03
+  expected_frequencies:
+    a:27017: 0.22
+    b:27017: 0.18
+    c:27017: 0.18
+    d:27017: 0.125
+    e:27017: 0.125
+    f:27017: 0.074
+    g:27017: 0.074
+    h:27017: 0.0277
+    i:27017: 0

--- a/src/test/spec/json/server-selection/in_window/one-least-two-tied.json
+++ b/src/test/spec/json/server-selection/in_window/one-least-two-tied.json
@@ -1,0 +1,46 @@
+{
+  "description": "Least operations gets most selections, two tied share the rest",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 16
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 16
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.165,
+      "b:27017": 0.66,
+      "c:27017": 0.165
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/one-least-two-tied.yml
+++ b/src/test/spec/json/server-selection/in_window/one-least-two-tied.yml
@@ -1,0 +1,27 @@
+description: Least operations gets most selections, two tied share the rest
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 16
+  - address: b:27017
+    operation_count: 10
+  - address: c:27017
+    operation_count: 16
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.165
+    b:27017: 0.66
+    c:27017: 0.165

--- a/src/test/spec/json/server-selection/in_window/rs-equilibrium.json
+++ b/src/test/spec/json/server-selection/in_window/rs-equilibrium.json
@@ -1,0 +1,46 @@
+{
+  "description": "When in equilibrium selection is evenly distributed (replica set)",
+  "topology_description": {
+    "type": "ReplicaSetWithPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSPrimary"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 6
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.33,
+      "b:27017": 0.33,
+      "c:27017": 0.33
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/rs-equilibrium.yml
+++ b/src/test/spec/json/server-selection/in_window/rs-equilibrium.yml
@@ -1,0 +1,27 @@
+description: When in equilibrium selection is evenly distributed (replica set)
+topology_description:
+  type: ReplicaSetWithPrimary
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: RSPrimary
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 6
+  - address: b:27017
+    operation_count: 6
+  - address: c:27017
+    operation_count: 6
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.33
+    b:27017: 0.33
+    c:27017: 0.33

--- a/src/test/spec/json/server-selection/in_window/rs-three-choices.json
+++ b/src/test/spec/json/server-selection/in_window/rs-three-choices.json
@@ -1,0 +1,46 @@
+{
+  "description": "Selections from three servers occur at proper distributions (replica set)",
+  "topology_description": {
+    "type": "ReplicaSetWithPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSPrimary"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "RSSecondary"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 3
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 20
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.66,
+      "b:27017": 0.33,
+      "c:27017": 0
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/rs-three-choices.yml
+++ b/src/test/spec/json/server-selection/in_window/rs-three-choices.yml
@@ -1,0 +1,27 @@
+description: Selections from three servers occur at proper distributions (replica set)
+topology_description:
+  type: ReplicaSetWithPrimary
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: RSPrimary
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: RSSecondary
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 3
+  - address: b:27017
+    operation_count: 6
+  - address: c:27017
+    operation_count: 20
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.66
+    b:27017: 0.33
+    c:27017: 0

--- a/src/test/spec/json/server-selection/in_window/three-choices.json
+++ b/src/test/spec/json/server-selection/in_window/three-choices.json
@@ -1,0 +1,46 @@
+{
+  "description": "Selections from three servers occur at proper distributions",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 3
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 6
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 20
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.66,
+      "b:27017": 0.33,
+      "c:27017": 0
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/three-choices.yml
+++ b/src/test/spec/json/server-selection/in_window/three-choices.yml
@@ -1,0 +1,27 @@
+description: Selections from three servers occur at proper distributions
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 3
+  - address: b:27017
+    operation_count: 6
+  - address: c:27017
+    operation_count: 20
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.66
+    b:27017: 0.33
+    c:27017: 0

--- a/src/test/spec/json/server-selection/in_window/two-choices.json
+++ b/src/test/spec/json/server-selection/in_window/two-choices.json
@@ -1,0 +1,36 @@
+{
+  "description": "Better of two choices always selected",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 0
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 5
+    }
+  ],
+  "iterations": 100,
+  "outcome": {
+    "tolerance": 0,
+    "expected_frequencies": {
+      "a:27017": 1,
+      "b:27017": 0
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/two-choices.yml
+++ b/src/test/spec/json/server-selection/in_window/two-choices.yml
@@ -1,0 +1,21 @@
+description: Better of two choices always selected
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 0
+  - address: b:27017
+    operation_count: 5
+iterations: 100
+outcome:
+  tolerance: 0.0
+  expected_frequencies:
+    a:27017: 1
+    b:27017: 0

--- a/src/test/spec/json/server-selection/in_window/two-least.json
+++ b/src/test/spec/json/server-selection/in_window/two-least.json
@@ -1,0 +1,46 @@
+{
+  "description": "Two tied for least operations share all selections",
+  "topology_description": {
+    "type": "Sharded",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      },
+      {
+        "address": "c:27017",
+        "avg_rtt_ms": 35,
+        "type": "Mongos"
+      }
+    ]
+  },
+  "mocked_topology_state": [
+    {
+      "address": "a:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "b:27017",
+      "operation_count": 10
+    },
+    {
+      "address": "c:27017",
+      "operation_count": 16
+    }
+  ],
+  "iterations": 2000,
+  "outcome": {
+    "tolerance": 0.05,
+    "expected_frequencies": {
+      "a:27017": 0.5,
+      "b:27017": 0.5,
+      "c:27017": 0
+    }
+  }
+}

--- a/src/test/spec/json/server-selection/in_window/two-least.yml
+++ b/src/test/spec/json/server-selection/in_window/two-least.yml
@@ -1,0 +1,27 @@
+description: Two tied for least operations share all selections
+topology_description:
+  type: Sharded
+  servers:
+    - address: a:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: b:27017
+      avg_rtt_ms: 35
+      type: Mongos
+    - address: c:27017
+      avg_rtt_ms: 35
+      type: Mongos
+mocked_topology_state:
+  - address: a:27017
+    operation_count: 10
+  - address: b:27017
+    operation_count: 10
+  - address: c:27017
+    operation_count: 16
+iterations: 2000
+outcome:
+  tolerance: 0.05
+  expected_frequencies:
+    a:27017: 0.5
+    b:27017: 0.5
+    c:27017: 0

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -29,6 +29,7 @@ use crate::{
         UpdateModifications,
         UpdateOptions,
     },
+    selection_criteria::ReadPreference,
     test::FailPoint,
 };
 
@@ -809,7 +810,10 @@ impl TestOperation for FailPointCommand {
     async fn execute_test_runner_operation(&self, test_runner: &mut TestRunner) {
         let client = test_runner.get_client(&self.client);
         let guard = client
-            .enable_failpoint(self.fail_point.clone())
+            .enable_failpoint(
+                self.fail_point.clone(),
+                Some(ReadPreference::Primary.into()),
+            )
             .await
             .unwrap();
         test_runner.fail_point_guards.push(guard);

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -12,7 +12,10 @@ pub use self::{
 
 use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
-use crate::bson::{doc, oid::ObjectId, Bson};
+use crate::{
+    bson::{doc, oid::ObjectId, Bson},
+    selection_criteria::SelectionCriteria,
+};
 use semver::{Version, VersionReq};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -230,8 +233,12 @@ impl TestClient {
         version.matches(&self.server_version)
     }
 
-    pub async fn enable_failpoint(&self, fp: FailPoint) -> Result<FailPointGuard> {
-        fp.enable(self).await
+    pub async fn enable_failpoint(
+        &self,
+        fp: FailPoint,
+        criteria: impl Into<Option<SelectionCriteria>>,
+    ) -> Result<FailPointGuard> {
+        fp.enable(self, criteria).await
     }
 
     pub fn auth_enabled(&self) -> bool {


### PR DESCRIPTION
RUST-575

This PR updates server selection to consider the number of ongoing operations a each server has instead of randomly selecting from among those in the latency window. This done as part of DRIVERS-781 Avoiding Connection Storms. See https://github.com/mongodb/specifications/commit/07790d1978ebe6b8ff7f574c9ac5e1365dd16e26 for the spec changes.

This also fixes RUST-592.