### PR TITLE
RUST-598 Perform handshake when establishing monitoring connections

### DIFF
--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     cmap::{options::ConnectionPoolOptions, Command, Connection, StreamDescription},
     error::{ErrorKind, Result},
     is_master::{IsMasterCommandResponse, IsMasterReply},
-    options::{AuthMechanism, ClientOptions, Credential, DriverInfo},
+    options::{AuthMechanism, ClientOptions, Credential, DriverInfo, ServerApi},
 };
 
 #[cfg(feature = "tokio-runtime")]
@@ -196,7 +196,7 @@ impl Handshaker {
         );
 
         if let Some(server_api) = server_api {
-            command.set_server_api(server_api)
+            command.set_server_api(&server_api)
         }
 
         Self {
@@ -249,6 +249,7 @@ pub(crate) struct HandshakerOptions {
     app_name: Option<String>,
     credential: Option<Credential>,
     driver_info: Option<DriverInfo>,
+    server_api: Option<ServerApi>,
 }
 
 impl From<ConnectionPoolOptions> for HandshakerOptions {
@@ -257,6 +258,7 @@ impl From<ConnectionPoolOptions> for HandshakerOptions {
             app_name: options.app_name,
             credential: options.credential,
             driver_info: options.driver_info,
+            server_api: options.server_api,
         }
     }
 }
@@ -267,6 +269,7 @@ impl From<ClientOptions> for HandshakerOptions {
             app_name: options.app_name,
             credential: options.credential,
             driver_info: options.driver_info,
+            server_api: options.server_api,
         }
     }
 }

--- a/src/cmap/establish/handshake/test.rs
+++ b/src/cmap/establish/handshake/test.rs
@@ -34,7 +34,7 @@ fn metadata_with_options() {
         )
         .build();
 
-    let handshaker = Handshaker::new(Some(&options));
+    let handshaker = Handshaker::new(Some(options.into()));
 
     let metadata = handshaker.command.body.get_document("client").unwrap();
     assert_eq!(

--- a/src/cmap/establish/mod.rs
+++ b/src/cmap/establish/mod.rs
@@ -1,4 +1,4 @@
-mod handshake;
+pub(super) mod handshake;
 #[cfg(test)]
 mod test;
 
@@ -24,7 +24,7 @@ pub(super) struct ConnectionEstablisher {
 impl ConnectionEstablisher {
     /// Creates a new ConnectionEstablisher from the given options.
     pub(super) fn new(http_client: HttpClient, options: Option<&ConnectionPoolOptions>) -> Self {
-        let handshaker = Handshaker::new(options);
+        let handshaker = Handshaker::new(options.cloned().map(Into::into));
 
         Self {
             handshaker,
@@ -43,8 +43,9 @@ impl ConnectionEstablisher {
 
         let first_round = self
             .handshaker
-            .handshake(&mut connection, self.credential.as_ref())
-            .await?;
+            .handshake(&mut connection)
+            .await?
+            .first_round;
 
         if let Some(ref credential) = self.credential {
             credential

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -39,16 +39,13 @@ async fn speculative_auth_test(
         .tls_options(CLIENT_OPTIONS.tls_options())
         .build();
 
-    let handshaker = Handshaker::new(Some(&pool_options));
+    let handshaker = Handshaker::new(Some(pool_options.clone().into()));
 
     let mut conn = Connection::new_testing(1, Default::default(), 1, Some(pool_options.into()))
         .await
         .unwrap();
 
-    let first_round = handshaker
-        .handshake(&mut conn, Some(&credential))
-        .await
-        .unwrap();
+    let first_round = handshaker.handshake(&mut conn).await.unwrap().first_round;
 
     // We expect that the server will return a response with the `speculativeAuthenticate` field if
     // and only if it's new enough to support it.

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -13,8 +13,11 @@ use std::{sync::Arc, time::Duration};
 use derivative::Derivative;
 
 pub use self::conn::ConnectionInfo;
-pub(crate) use self::conn::{Command, CommandResponse, Connection, StreamDescription};
 use self::options::ConnectionPoolOptions;
+pub(crate) use self::{
+    conn::{Command, CommandResponse, Connection, StreamDescription},
+    establish::handshake::{is_master, Handshaker},
+};
 use crate::{
     error::{ErrorKind, Result},
     event::cmap::{

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -6,7 +6,6 @@ use super::{
 };
 use crate::{
     bson::doc,
-    client::options::ServerApi,
     cmap::{is_master, Command, Connection, Handshaker},
     error::Result,
     is_master::IsMasterReply,


### PR DESCRIPTION
RUST-598

This fixes a bug where monitoring connections didn't perform the MongoDB handshake as part of establishing their connections. I decided to break this off from the other connection storms work since it seemed to be ready and the other stuff is still waiting on spec changes.