### PR TITLE
RUST-610 Test that monitors wait at least minHeartbeatFrequencyMS between failed checks

### DIFF
--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -210,12 +210,7 @@ impl HeartbeatMonitor {
             }
         };
 
-        if result
-            .as_ref()
-            .err()
-            .map(|e| e.kind.is_network_error())
-            .unwrap_or(false)
-        {
+        if result.is_err() {
             self.connection.take();
         }
 

--- a/src/test/auth_aws.rs
+++ b/src/test/auth_aws.rs
@@ -1,8 +1,12 @@
-use super::TestClient;
+use tokio::sync::RwLockReadGuard;
+
+use super::{TestClient, LOCK};
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn auth_aws() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
     let client = TestClient::new().await;
     let coll = client.database("aws").collection("somecoll");
 


### PR DESCRIPTION
RUST-610

This PR implements a new SDAM spec prose test that ensures the monitors wait at least 500ms between failed checks. This is part of the Avoiding Connection Storms project (DRIVERS-781).

relevant spec change: https://github.com/mongodb/specifications/commit/6c5b2acbf5a30b2c79e904532d51ba9ed8783247