### PR TITLE
RUST-609 Fix flaky maxConnecting test

### DIFF
--- a/src/cmap/test/file.rs
+++ b/src/cmap/test/file.rs
@@ -1,9 +1,13 @@
-use std::collections::VecDeque;
+use std::sync::Arc;
 
 use serde::Deserialize;
 
-use super::event::Event;
-use crate::{cmap::options::ConnectionPoolOptions, error::ErrorKind, test::RunOn};
+use super::{event::Event, State};
+use crate::{
+    cmap::options::ConnectionPoolOptions,
+    error::{ErrorKind, Result},
+    test::RunOn,
+};
 use bson::Document;
 
 #[derive(Debug, Deserialize)]
@@ -13,7 +17,7 @@ pub struct TestFile {
     style: TestStyle,
     pub description: String,
     pub pool_options: Option<ConnectionPoolOptions>,
-    operations: VecDeque<ThreadedOperation>,
+    pub operations: Vec<ThreadedOperation>,
     pub error: Option<Error>,
     pub events: Vec<Event>,
     #[serde(default)]
@@ -30,48 +34,39 @@ enum TestStyle {
 }
 
 #[derive(Debug, Deserialize)]
-struct ThreadedOperation {
+pub struct ThreadedOperation {
     #[serde(flatten)]
     type_: Operation,
 
     thread: Option<String>,
 }
 
+impl ThreadedOperation {
+    pub(super) async fn execute(self, state: Arc<State>) -> Result<()> {
+        match self.thread {
+            Some(thread_name) => {
+                let threads = state.threads.read().await;
+                let thread = threads.get(&thread_name).unwrap();
+                thread.dispatcher.send(self.type_).unwrap();
+                Ok(())
+            }
+            None => self.type_.execute(state).await,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "name")]
 #[serde(rename_all = "camelCase")]
 pub enum Operation {
-    Start {
-        target: String,
-    },
-    Wait {
-        ms: u64,
-    },
-    WaitForThread {
-        target: String,
-    },
-    WaitForEvent {
-        event: String,
-        count: usize,
-    },
-    CheckOut {
-        label: Option<String>,
-    },
-    CheckIn {
-        connection: String,
-    },
+    Start { target: String },
+    Wait { ms: u64 },
+    WaitForThread { target: String },
+    WaitForEvent { event: String, count: usize },
+    CheckOut { label: Option<String> },
+    CheckIn { connection: String },
     Clear,
     Close,
-
-    // In order to execute a `Start` operation, we need to know all of the operations that should
-    // execute in the context of that thread. To achieve this, we preprocess the operations
-    // specified by the test file to replace each instance of `Start` operation with a
-    // `StartHelper` with the corresponding operations. `StartHelper` won't ever actually occur in
-    // the original set of operations specified.
-    StartHelper {
-        target: String,
-        operations: Vec<Operation>,
-    },
 }
 
 #[derive(Debug, Deserialize)]
@@ -93,55 +88,4 @@ impl Error {
             }
         }
     }
-}
-
-impl TestFile {
-    pub fn process_operations(&mut self) -> Vec<Operation> {
-        let mut processed_ops = Vec::new();
-
-        while let Some(operation) = self.operations.pop_front() {
-            match operation.type_ {
-                // When a `Start` operation is encountered, search the rest of the operations for
-                // any that occur in the context of the corresponding thread, remove them from the
-                // original set of operations, and add them to the newly created `StartHelper`
-                // operation.
-                Operation::Start { target } => {
-                    let start_helper = Operation::StartHelper {
-                        operations: remove_by(&mut self.operations, |op| {
-                            op.thread.as_ref() == Some(&target)
-                        })
-                        .into_iter()
-                        .map(|op| op.type_)
-                        .collect(),
-                        target,
-                    };
-
-                    processed_ops.push(start_helper);
-                }
-                other => processed_ops.push(other),
-            }
-        }
-
-        processed_ops
-    }
-}
-
-// Removes all items in the `VecDeque` that fulfill the predicate and return them in order as a new
-// `Vec`.
-fn remove_by<T, F>(vec: &mut VecDeque<T>, pred: F) -> Vec<T>
-where
-    F: Fn(&T) -> bool,
-{
-    let mut i = 0;
-    let mut removed = Vec::new();
-
-    while i < vec.len() {
-        if pred(&vec[i]) {
-            removed.push(vec.remove(i).unwrap());
-        } else {
-            i += 1;
-        }
-    }
-
-    removed
 }

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
@@ -31,30 +31,29 @@
       "target": "thread1"
     },
     {
-      "name": "checkOut",
-      "thread": "thread1"
-    },
-    {
       "name": "start",
       "target": "thread2"
-    },
-    {
-      "name": "wait",
-      "thread": "thread2",
-      "ms": 100
-    },
-    {
-      "name": "checkOut",
-      "thread": "thread2"
     },
     {
       "name": "start",
       "target": "thread3"
     },
     {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 1
+    },
+    {
       "name": "wait",
-      "thread": "thread3",
       "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
     },
     {
       "name": "checkOut",

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
@@ -18,29 +18,30 @@ poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
-  # start creating a Connection. This will take a while
-  # due to the fail point.
+  # start 3 threads
   - name: start
     target: thread1
+  - name: start
+    target: thread2
+  - name: start
+    target: thread3
+  # start creating a Connection. This will take a while
+  # due to the fail point.
   - name: checkOut
     thread: thread1
-  # Start 2 new threads that wait for a little then try
-  # to check out connections. Only one thread should
+  # wait for thread1 to actually start creating a Connection
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 1
+  # wait some more time to ensure thread1 has begun establishing a Connection
+  - name: wait
+    ms: 100
+  # start 2 check out requests. Only one thread should
   # start creating a Connection and the other one should be
   # waiting for pendingConnectionCount to be less than maxConnecting,
   # only starting once thread1 finishes creating its Connection.
-  - name: start
-    target: thread2
-  - name: wait
-    thread: thread2
-    ms: 100
   - name: checkOut
     thread: thread2
-  - name: start
-    target: thread3
-  - name: wait
-    thread: thread3
-    ms: 100
   - name: checkOut
     thread: thread3
   # wait until all Connections have been created.


### PR DESCRIPTION
RUST-609

This PR pulls in the latest version of the "maxConnecting is enforced" spec test, hopefully fixing some intermittent failures we were seeing with it. In order to run the new version of the test, I had to update our CMAP test operations to be dispatched in order that they are listed in the file (see the first commit). This latter change fixes RUST-608.

This PR is part of the "Avoiding Connection Storms" work (DRIVERS-781).