### PR TITLE
RUST-623 Upgrade os_info to 3.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ hex = "0.4.0"
 hmac = "~0.7.1"
 lazy_static = "1.4.0"
 md-5 = "0.8.0"
-os_info = { version = "2.0.6", default-features = false }
+os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
 serde_with = "1.3.1"

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -120,7 +120,7 @@ lazy_static! {
         if info.os_type() != Type::Unknown {
             let version = info.version();
 
-            if *version != Version::unknown() {
+            if *version != Version::Unknown {
                 metadata.os.version = Some(info.version().to_string());
             }
         }


### PR DESCRIPTION
When running this library on alpine I received the error 
```
os_info::imp::lsb_release lsb_release command failed with Os { 
code: 2, kind: NotFound, message: "No such file or directory" 
}
```
I think this has been fixed in a later version of os_info
https://github.com/stanislav-tkach/os_info/commit/602ff91f0904a4673a96f56fe79fb8a46222fa72  

This patch up grades os-info to 3.0.1