### PR TITLE
minor: hide versioned API from public API

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -209,7 +209,7 @@ impl fmt::Display for StreamAddress {
 /// Specifies the server API version to declare
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
-pub enum ServerApiVersion {
+pub(crate) enum ServerApiVersion {
     Version1,
 }
 
@@ -251,7 +251,7 @@ impl<'de> Deserialize<'de> for ServerApiVersion {
 #[derive(Clone, Debug, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct ServerApi {
+pub(crate) struct ServerApi {
     /// The version string of the declared API version
     pub version: ServerApiVersion,
 
@@ -402,8 +402,8 @@ pub struct ClientOptions {
     /// The declared API version
     ///
     /// The default value is to have no declared API version
-    #[builder(default)]
-    pub server_api: Option<ServerApi>,
+    #[builder(default, skip)]
+    pub(crate) server_api: Option<ServerApi>,
 
     /// The amount of time the Client should attempt to select a server for an operation before
     /// timing outs

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -85,8 +85,8 @@ pub struct ConnectionPoolOptions {
     /// The declared API version
     ///
     /// The default value is to have no declared API version
-    #[builder(default)]
-    pub server_api: Option<ServerApi>,
+    #[builder(skip, default)]
+    pub(crate) server_api: Option<ServerApi>,
 
     /// The options specifying how a TLS connection should be configured. If `tls_options` is
     /// `None`, then TLS will not be used for the connections.
@@ -118,7 +118,6 @@ impl ConnectionPoolOptions {
             .max_idle_time(options.max_idle_time)
             .max_pool_size(options.max_pool_size)
             .min_pool_size(options.min_pool_size)
-            .server_api(options.server_api.clone())
             .tls_options(options.tls_options())
             .wait_queue_timeout(options.wait_queue_timeout)
             .build()

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -130,7 +130,7 @@ pub struct Client {
     pub observe_events: Option<Vec<String>>,
     pub ignore_command_monitoring_events: Option<Vec<String>>,
     #[serde(default)]
-    pub server_api: Option<ServerApi>,
+    pub(crate) server_api: Option<ServerApi>,
 }
 
 fn default_uri() -> String {

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -243,7 +243,7 @@ impl EventClient {
         EventClient::with_options_and_handler(options, event_handler, collect_server_info).await
     }
 
-    pub async fn with_uri_and_mongos_options(
+    pub(crate) async fn with_uri_and_mongos_options(
         uri: &str,
         use_multiple_mongoses: Option<bool>,
         server_api: Option<ServerApi>,


### PR DESCRIPTION
In preparation of releasing the alpha, hide the not-yet-complete versioned API implementation from the public API.