### PR TITLE
minor: bump minimum supported Rust version to 1.45

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1121,9 +1121,9 @@ axes:
   - id: "extra-rust-versions"
     values:
       - id: "min"
-        display_name: "1.43 (minimum supported version)" 
+        display_name: "1.45 (minimum supported version)"
         variables:
-          RUST_VERSION: "1.43.1"
+          RUST_VERSION: "1.45.2"
       - id: "nightly"
         display_name: "nightly"
         variables:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 ### Requirements
 | Driver Version | Required Rust Version |
 |:--------------:|:---------------------:|
-| master         | 1.43+                 |
+| master         | 1.45+                 |
+| 2.0.0-alpha    | 1.45+                 |
 | 1.1.x          | 1.43+                 |
 | 1.0.x          | 1.43+                 |
 | 0.11.x         | 1.43+                 |


### PR DESCRIPTION
This PR updates the README to indicate that 1.45 is the MSRV for the master branch and the 2.0.0-alpha. This is required since `tokio-util`'s MSRV is 1.45. This PR also updates the evergreen config to test this properly.