### PR TITLE
RUST-675 eliminate race in server selection

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -259,6 +259,9 @@ impl Client {
         )?;
 
         loop {
+            let mut topology_change_subscriber =
+                self.inner.topology.subscribe_to_topology_changes();
+
             let selected_server = self
                 .inner
                 .topology
@@ -269,8 +272,6 @@ impl Client {
                 return Ok(server);
             }
 
-            let mut topology_change_subscriber =
-                self.inner.topology.subscribe_to_topology_changes();
             self.inner.topology.request_topology_check();
 
             let time_passed = start_time.to(PreciseTime::now());


### PR DESCRIPTION
RUST-675

This PR eliminates a race in server selection between a task subscribing to topology updates and the update actually occurring. Right now, a client only subscribes to server selection updates after it fails to select a server, so if the topology becomes selectable while a server selection attempt is in progress but before it fails, the client will never know about the update since it will only have started listening for it after the update already happened, leading to a server selection timeout. This PR updates the server selection loop to subscribe to topology updates _before_ it attempts to select a server, preventing this error from occurring.