### PR TITLE
Remove redundant semicolons

### DIFF
--- a/src/test/spec/command_monitoring/operation.rs
+++ b/src/test/spec/command_monitoring/operation.rs
@@ -34,7 +34,7 @@ impl<'de> Deserialize<'de> for AnyTestOperation {
         struct OperationDefinition {
             name: String,
             arguments: Bson,
-        };
+        }
 
         let definition = OperationDefinition::deserialize(deserializer)?;
         let boxed_op = match definition.name.as_str() {

--- a/src/test/spec/runner/operation.rs
+++ b/src/test/spec/runner/operation.rs
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for AnyTestOperation {
             result: Option<Bson>,
             error: Option<bool>,
             collection_options: Option<CollectionOptions>,
-        };
+        }
 
         let definition = OperationDefinition::deserialize(deserializer)?;
         let boxed_op = match definition.name.as_str() {


### PR DESCRIPTION
This resolves warnings while running tests.