### PR TITLE
RUST-682 Update encryption dependencies

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1135,9 +1135,9 @@ axes:
   - id: "extra-rust-versions"
     values:
       - id: "min"
-        display_name: "1.45 (minimum supported version)"
+        display_name: "1.47 (minimum supported version)"
         variables:
-          RUST_VERSION: "1.45.2"
+          RUST_VERSION: "1.47.0"
       - id: "nightly"
         display_name: "nightly"
         variables:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ version = "0.20.0"
 optional = true
 
 [dependencies.pbkdf2]
-version = "0.6.0"
+version = "0.7.4"
 default-features = false
 
 [dependencies.reqwest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,15 @@ chrono = "0.4.7"
 derivative = "2.1.1"
 futures = "0.3.5"
 hex = "0.4.0"
-hmac = "~0.7.1"
+hmac = "0.10.1"
 lazy_static = "1.4.0"
-md-5 = "0.8.0"
+md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
 serde_with = "1.3.1"
-sha-1 = "0.8.1"
-sha2 = "0.8.0"
+sha-1 = "0.9.4"
+sha2 = "0.9.3"
 socket2 = "0.3.12"
 stringprep = "0.1.2"
 strsim = "0.10.0"
@@ -58,7 +58,7 @@ trust-dns-resolver = "0.20.0"
 typed-builder = "0.4.0"
 version_check = "0.9.1"
 webpki = "0.21.0"
-webpki-roots = "0.18.0"
+webpki-roots = "0.21.0"
 thiserror = "1.0.24"
 
 [dependencies.async-std]
@@ -70,7 +70,7 @@ version = "0.20.0"
 optional = true
 
 [dependencies.pbkdf2]
-version = "0.3.0"
+version = "0.6.0"
 default-features = false
 
 [dependencies.reqwest]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 ### Requirements
 | Driver Version | Required Rust Version |
 |:--------------:|:---------------------:|
-| master         | 1.45+                 |
+| master         | 1.47+                 |
 | 2.0.0-alpha    | 1.45+                 |
 | 1.2.x          | 1.43+                 |
 | 1.1.x          | 1.43+                 |

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -12,7 +12,7 @@ mod x509;
 
 use std::{borrow::Cow, str::FromStr};
 
-use hmac::Mac;
+use hmac::{Mac, NewMac};
 use rand::Rng;
 use serde::Deserialize;
 use typed_builder::TypedBuilder;
@@ -482,9 +482,13 @@ pub(crate) fn generate_nonce() -> String {
     base64::encode(&result)
 }
 
-fn mac<M: Mac>(key: &[u8], input: &[u8], auth_mechanism: &str) -> Result<impl AsRef<[u8]>> {
+fn mac<M: Mac + NewMac>(
+    key: &[u8],
+    input: &[u8],
+    auth_mechanism: &str,
+) -> Result<impl AsRef<[u8]>> {
     let mut mac =
         M::new_varkey(key).map_err(|_| Error::unknown_authentication_error(auth_mechanism))?;
-    mac.input(input);
-    Ok(mac.result().code())
+    mac.update(input);
+    Ok(mac.finalize().into_bytes())
 }


### PR DESCRIPTION
This PR leaves PBKDF2 at 0.6 instead of 0.7 to avoid bumping MSRV to 1.47.