### PR TITLE
RUST-679 Simplify error API to ease pattern matching

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -103,7 +103,7 @@ impl Client {
             Err(err) => {
                 self.inner
                     .topology
-                    .handle_post_handshake_error(err.clone(), &conn, server)
+                    .handle_post_handshake_error(&err, &conn, server)
                     .await;
 
                 // Retryable writes are only supported by storage engines with document-level
@@ -162,7 +162,7 @@ impl Client {
             Err(err) => {
                 self.inner
                     .topology
-                    .handle_post_handshake_error(err.clone(), &conn, server)
+                    .handle_post_handshake_error(&err, &conn, server)
                     .await;
 
                 let err = match retryability {

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -108,7 +108,7 @@ impl Client {
 
                 // Retryable writes are only supported by storage engines with document-level
                 // locking, so users need to disable retryable writes if using mmapv1.
-                if let ErrorKind::CommandError(ref err) = err.kind.as_ref() {
+                if let ErrorKind::CommandError(ref err) = err.kind {
                     if err.code == 20 && err.message.starts_with("Transaction numbers") {
                         let mut err = err.clone();
                         err.message = "This MongoDB deployment does not support retryable writes. \

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -317,7 +317,7 @@ async fn run_test(test_file: TestFile) {
             match ClientOptions::parse(&test_case.uri)
                 .await
                 .as_ref()
-                .map_err(|e| e.as_ref())
+                .map_err(|e| &e.kind)
             {
                 Ok(_) => panic!("expected {}", expected_type),
                 Err(ErrorKind::ArgumentError { .. }) => {}
@@ -342,7 +342,7 @@ async fn run_connection_string_spec_tests() {
 async fn parse_uri(option: &str, suggestion: Option<&str>) {
     match ClientOptionsParser::parse(&format!("mongodb://host:27017/?{}=test", option))
         .as_ref()
-        .map_err(|e| e.as_ref())
+        .map_err(|e| &e.kind)
     {
         Ok(_) => panic!("expected error for option {}", option),
         Err(ErrorKind::ArgumentError { message, .. }) => {

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -156,12 +156,11 @@ impl ConnectionPool {
                 });
             }
             Err(ref e) => {
-                let failure_reason =
-                    if let ErrorKind::WaitQueueTimeoutError { .. } = e.kind.as_ref() {
-                        ConnectionCheckoutFailedReason::Timeout
-                    } else {
-                        ConnectionCheckoutFailedReason::ConnectionError
-                    };
+                let failure_reason = if let ErrorKind::WaitQueueTimeoutError { .. } = e.kind {
+                    ConnectionCheckoutFailedReason::Timeout
+                } else {
+                    ConnectionCheckoutFailedReason::ConnectionError
+                };
 
                 self.emit_event(|handler| {
                     handler.handle_connection_checkout_failed_event(ConnectionCheckoutFailedEvent {

--- a/src/cmap/test/file.rs
+++ b/src/cmap/test/file.rs
@@ -97,7 +97,7 @@ pub struct Error {
 
 impl Error {
     pub fn assert_matches(&self, error: &crate::error::Error, description: &str) {
-        match error.kind.as_ref() {
+        match error.kind {
             ErrorKind::WaitQueueTimeoutError { .. } => {
                 assert_eq!(self.type_, "WaitQueueTimeoutError", "{}", description);
             }

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -163,7 +163,7 @@ impl Executor {
         let manager = pool.manager.clone();
         RUNTIME.execute(async move {
             while let Some(update) = update_receiver.recv().await {
-                match update.message() {
+                match update.into_message() {
                     ServerUpdate::Error { .. } => manager.clear(),
                 }
             }

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -562,7 +562,7 @@ async fn establish_connection(
                 };
                 handler.handle_connection_closed_event(event);
             }
-            server_updater.handle_error(e.clone(), generation).await;
+            server_updater.handle_error(&e, generation).await;
             manager.handle_connection_failed();
         }
         Ok(ref mut connection) => {

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -437,7 +437,7 @@ where
                         }
                     }
                 }
-                Err(e) => match e.kind.as_ref() {
+                Err(e) => match e.kind {
                     ErrorKind::BulkWriteError(failure) => {
                         let failure_ref =
                             cumulative_failure.get_or_insert_with(BulkWriteFailure::new);

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -107,10 +107,7 @@ async fn inconsistent_write_concern_rejected() {
         )
         .await
         .expect_err("insert should fail");
-    assert!(matches!(
-        error.kind.as_ref(),
-        ErrorKind::ArgumentError { .. }
-    ));
+    assert!(matches!(error.kind, ErrorKind::ArgumentError { .. }));
 
     let coll = db.collection(function_name!());
     let wc = WriteConcern {
@@ -123,10 +120,7 @@ async fn inconsistent_write_concern_rejected() {
         .insert_one(doc! {}, options)
         .await
         .expect_err("insert should fail");
-    assert!(matches!(
-        error.kind.as_ref(),
-        ErrorKind::ArgumentError { .. }
-    ));
+    assert!(matches!(error.kind, ErrorKind::ArgumentError { .. }));
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -148,8 +142,5 @@ async fn unacknowledged_write_concern_rejected() {
         )
         .await
         .expect_err("insert should fail");
-    assert!(matches!(
-        error.kind.as_ref(),
-        ErrorKind::ArgumentError { .. }
-    ));
+    assert!(matches!(error.kind, ErrorKind::ArgumentError { .. }));
 }

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -137,7 +137,7 @@ pub(super) trait GetMoreProviderResult {
         match self.as_ref() {
             Ok(res) => res.exhausted,
             Err(e) => {
-                matches!(e.kind.as_ref(), ErrorKind::CommandError(e) if e.code == 43 || e.code == 237)
+                matches!(e.kind, ErrorKind::CommandError(ref e) if e.code == 43 || e.code == 237)
             }
         }
     }

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -310,7 +310,7 @@ async fn handle_write_concern_error() {
     let error = aggregate
         .handle_response(response)
         .expect_err("should get wc error");
-    match *error.kind {
+    match error.kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(_)) => {}
         ref e => panic!("should have gotten WriteConcernError, got {:?} instead", e),
     }

--- a/src/operation/count/test.rs
+++ b/src/operation/count/test.rs
@@ -96,7 +96,7 @@ async fn handle_response_no_n() {
     let response = CommandResponse::with_document(doc! { "ok" : 1 });
 
     let result = count_op.handle_response(response);
-    match result.as_ref().map_err(|e| e.as_ref()) {
+    match result.as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::ResponseError { .. }) => {}
         other => panic!("expected response error, but got {:?}", other),
     }

--- a/src/operation/create/test.rs
+++ b/src/operation/create/test.rs
@@ -102,7 +102,7 @@ async fn handle_write_concern_error() {
     let result = op.handle_response(response);
     assert!(result.is_err());
 
-    match *result.unwrap_err().kind {
+    match result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_err)) => {
             assert_eq!(wc_err.code, 100);
             assert_eq!(wc_err.code_name, "hello world");

--- a/src/operation/delete/test.rs
+++ b/src/operation/delete/test.rs
@@ -143,7 +143,7 @@ async fn handle_write_failure() {
     });
     let write_error_result = op.handle_response(write_error_response);
     assert!(write_error_result.is_err());
-    match *write_error_result.unwrap_err().kind {
+    match write_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteError(ref error)) => {
             let expected_err = WriteError {
                 code: 1234,
@@ -181,7 +181,7 @@ async fn handle_write_concern_failure() {
     let wc_error_result = op.handle_response(wc_error_response);
     assert!(wc_error_result.is_err());
 
-    match *wc_error_result.unwrap_err().kind {
+    match wc_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_error)) => {
             let expected_wc_err = WriteConcernError {
                 code: 456,

--- a/src/operation/distinct/test.rs
+++ b/src/operation/distinct/test.rs
@@ -144,7 +144,7 @@ async fn handle_response_no_values() {
     });
 
     let result = distinct_op.handle_response(response);
-    match result.as_ref().map_err(|e| e.as_ref()) {
+    match result.as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::ResponseError { .. }) => {}
         other => panic!("expected response error, but got {:?}", other),
     }

--- a/src/operation/drop_collection/test.rs
+++ b/src/operation/drop_collection/test.rs
@@ -80,7 +80,7 @@ async fn handle_write_concern_error() {
     let result = op.handle_response(response);
     assert!(result.is_err());
 
-    match *result.unwrap_err().kind {
+    match result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_err)) => {
             assert_eq!(wc_err.code, 100);
             assert_eq!(wc_err.code_name, "hello world");

--- a/src/operation/drop_database/test.rs
+++ b/src/operation/drop_database/test.rs
@@ -78,7 +78,7 @@ async fn handle_write_concern_error() {
     let result = op.handle_response(response);
     assert!(result.is_err());
 
-    match *result.unwrap_err().kind {
+    match result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_err)) => {
             assert_eq!(wc_err.code, 100);
             assert_eq!(wc_err.code_name, "hello world");

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -193,7 +193,7 @@ async fn handle_write_failure() {
     let write_error_result = fixtures.op.handle_response(write_error_response);
     assert!(write_error_result.is_err());
 
-    match *write_error_result.unwrap_err().kind {
+    match write_error_result.unwrap_err().kind {
         ErrorKind::BulkWriteError(ref error) => {
             let write_errors = error.write_errors.clone().unwrap();
             assert_eq!(write_errors.len(), 1);

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -140,7 +140,7 @@ async fn handle_response_no_databases() {
     });
 
     let result = list_databases_op.handle_response(response);
-    match result.as_ref().map_err(|e| e.as_ref()) {
+    match result.as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::ResponseError { .. }) => {}
         other => panic!("expected response error, but got {:?}", other),
     }

--- a/src/operation/update/test.rs
+++ b/src/operation/update/test.rs
@@ -227,7 +227,7 @@ async fn handle_write_failure() {
     });
     let write_error_result = op.handle_response(write_error_response);
     assert!(write_error_result.is_err());
-    match *write_error_result.unwrap_err().kind {
+    match write_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteError(ref error)) => {
             let expected_err = WriteError {
                 code: 1234,
@@ -266,7 +266,7 @@ async fn handle_write_concern_failure() {
     let wc_error_result = op.handle_response(wc_error_response);
     assert!(wc_error_result.is_err());
 
-    match *wc_error_result.unwrap_err().kind {
+    match wc_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_error)) => {
             let expected_wc_err = WriteConcernError {
                 code: 456,

--- a/src/runtime/acknowledged_message.rs
+++ b/src/runtime/acknowledged_message.rs
@@ -21,8 +21,8 @@ impl<M, R> AcknowledgedMessage<M, R> {
     }
 
     /// Get the message.
-    pub(crate) fn message(&self) -> &M {
-        &self.message
+    pub(crate) fn into_message(self) -> M {
+        self.message
     }
 
     /// Send acknowledgement to the receiver.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,10 +18,7 @@ pub(crate) use self::{
     resolver::AsyncResolver,
     stream::AsyncStream,
 };
-use crate::{
-    error::{ErrorKind, Result},
-    options::StreamAddress,
-};
+use crate::{error::Result, options::StreamAddress};
 pub(crate) use http::HttpClient;
 #[cfg(feature = "async-std-runtime")]
 use interval::Interval;
@@ -138,14 +135,14 @@ impl AsyncRuntime {
         {
             tokio::time::timeout(timeout, future)
                 .await
-                .map_err(|e| ErrorKind::Io(e.into()).into())
+                .map_err(|_| std::io::ErrorKind::TimedOut.into())
         }
 
         #[cfg(feature = "async-std-runtime")]
         {
             async_std::future::timeout(timeout, future)
                 .await
-                .map_err(|_| ErrorKind::Io(std::io::ErrorKind::TimedOut.into()).into())
+                .map_err(|_| std::io::ErrorKind::TimedOut.into())
         }
     }
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -64,14 +64,14 @@ impl From<async_std::net::TcpStream> for AsyncTcpStream {
 impl AsyncTcpStream {
     #[cfg(feature = "tokio-runtime")]
     async fn try_connect(address: &SocketAddr, connect_timeout: Duration) -> Result<Self> {
-        use tokio::{net::TcpStream, time::timeout};
+        use tokio::net::TcpStream;
 
         let stream_future = TcpStream::connect(address);
 
         let stream = if connect_timeout == Duration::from_secs(0) {
             stream_future.await?
         } else {
-            timeout(connect_timeout, stream_future).await??
+            RUNTIME.timeout(connect_timeout, stream_future).await??
         };
 
         stream.set_nodelay(true)?;

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -6,7 +6,6 @@ use tokio::sync::RwLockReadGuard;
 use crate::{
     bson::{doc, oid::ObjectId},
     client::Client,
-    error::ErrorKind,
     is_master::{IsMasterCommandResponse, IsMasterReply},
     options::{ClientOptions, ReadPreference, SelectionCriteria, StreamAddress},
     sdam::description::{
@@ -82,10 +81,7 @@ async fn run_test(test_file: TestFile) {
     for (i, phase) in test_file.phases.into_iter().enumerate() {
         for Response(address, command_response) in phase.responses {
             let is_master_reply = if command_response == Default::default() {
-                Err(ErrorKind::OperationError {
-                    message: "dummy error".to_string(),
-                }
-                .into())
+                Err("dummy error".to_string())
             } else {
                 Ok(IsMasterReply {
                     command_response,

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -218,7 +218,7 @@ impl HeartbeatMonitor {
     }
 
     async fn handle_error(&mut self, error: Error, topology: &Topology, server: &Server) -> bool {
-        topology.handle_pre_handshake_error(error, server).await
+        topology.handle_pre_handshake_error(&error, server).await
     }
 }
 
@@ -250,9 +250,7 @@ impl UpdateMonitor {
                     error_generation,
                 } => {
                     if *error_generation == self.generation_subscriber.generation() {
-                        topology
-                            .handle_pre_handshake_error(error.clone(), &server)
-                            .await;
+                        topology.handle_pre_handshake_error(&error, &server).await;
                     }
                 }
             }

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -3,11 +3,7 @@ use std::collections::HashSet;
 use pretty_assertions::assert_eq;
 
 use super::{LookupHosts, SrvPollingMonitor};
-use crate::{
-    error::{ErrorKind, Result},
-    options::StreamAddress,
-    sdam::Topology,
-};
+use crate::{error::Result, options::StreamAddress, sdam::Topology};
 
 fn localhost_test_build_10gen(port: u16) -> StreamAddress {
     StreamAddress {
@@ -88,7 +84,7 @@ async fn replace_all_dns_records() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn timeout_error() {
     run_test(
-        Err(ErrorKind::Io(std::io::ErrorKind::TimedOut.into()).into()),
+        Err(std::io::ErrorKind::TimedOut.into()),
         DEFAULT_HOSTS.iter().cloned().collect(),
     )
     .await;

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -283,7 +283,8 @@ impl Topology {
         server: &Server,
         state_lock: RwLockWriteGuard<'_, TopologyState>,
     ) -> bool {
-        let description = ServerDescription::new(server.address.clone(), Some(Err(error)));
+        let description =
+            ServerDescription::new(server.address.clone(), Some(Err(error.to_string())));
         self.update_and_notify(server, description, state_lock)
             .await
     }
@@ -470,7 +471,7 @@ impl TopologyState {
         server: ServerDescription,
         options: &ClientOptions,
         topology: WeakTopology,
-    ) -> Result<Option<TopologyDescriptionDiff>> {
+    ) -> std::result::Result<Option<TopologyDescriptionDiff>, String> {
         let old_description = self.description.clone();
         self.description.update(server)?;
 

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -227,10 +227,10 @@ impl Topology {
 
     /// Updates the topology based on an error that occurs before the handshake has completed during
     /// an operation.
-    pub(crate) async fn handle_pre_handshake_error(&self, error: Error, server: &Server) -> bool {
+    pub(crate) async fn handle_pre_handshake_error(&self, error: &Error, server: &Server) -> bool {
         let state_lock = self.state.write().await;
         let changed = self
-            .mark_server_as_unknown(error, &server, state_lock)
+            .mark_server_as_unknown(&error, &server, state_lock)
             .await;
         if changed {
             server.pool.clear();
@@ -241,7 +241,7 @@ impl Topology {
     /// Handles an error that occurs after the handshake has completed during an operation.
     pub(crate) async fn handle_post_handshake_error(
         &self,
-        error: Error,
+        error: &Error,
         conn: &Connection,
         server: SelectedServer,
     ) {
@@ -255,7 +255,7 @@ impl Topology {
         } else if error.is_recovering() || error.is_not_master() {
             let state_lock = self.state.write().await;
 
-            self.mark_server_as_unknown(error.clone(), &server, state_lock)
+            self.mark_server_as_unknown(error, &server, state_lock)
                 .await;
 
             let wire_version = conn
@@ -279,7 +279,7 @@ impl Topology {
     /// Returns whether the topology changed as a result of the update.
     async fn mark_server_as_unknown(
         &self,
-        error: Error,
+        error: &Error,
         server: &Server,
         state_lock: RwLockWriteGuard<'_, TopologyState>,
     ) -> bool {

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -74,7 +74,10 @@ impl Server {
 /// TODO: add success cases from application handshakes.
 #[derive(Debug)]
 pub(crate) enum ServerUpdate {
-    Error { error: Error, error_generation: u32 },
+    Error {
+        error: String,
+        error_generation: u32,
+    },
 }
 
 #[derive(Debug)]
@@ -106,9 +109,9 @@ impl ServerUpdateSender {
 
     /// Update the server based on the given error.
     /// This will block until the topology has processed the error.
-    pub(crate) async fn handle_error(&mut self, error: Error, error_generation: u32) {
+    pub(crate) async fn handle_error(&mut self, error: &Error, error_generation: u32) {
         let reason = ServerUpdate::Error {
-            error,
+            error: error.to_string(),
             error_generation,
         };
 

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -212,12 +212,9 @@ async fn sdam_min_pool_size_error() {
         .await
         .expect_err("ping should fail");
     assert!(
-        matches!(
-            ping_err.kind.as_ref(),
-            ErrorKind::ServerSelectionError { .. }
-        ),
+        matches!(ping_err.kind, ErrorKind::ServerSelectionError { .. }),
         "Expected to fail due to server selection timing out, instead got: {:?}",
-        ping_err.kind.as_ref()
+        ping_err.kind
     );
 
     // disable the fail point, then the pool should become ready again

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -193,8 +193,13 @@ impl SrvResolver {
 }
 
 fn ignore_no_records(error: Error) -> Result<()> {
-    match error.kind.as_ref() {
-        ErrorKind::DnsResolve(resolve_error) if matches!(resolve_error.kind(), ResolveErrorKind::NoRecordsFound { .. }) => {
+    match error.kind {
+        ErrorKind::DnsResolve(resolve_error)
+            if matches!(
+                resolve_error.kind(),
+                ResolveErrorKind::NoRecordsFound { .. }
+            ) =>
+        {
             Ok(())
         }
         _ => Err(error),

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -41,7 +41,7 @@ pub fn drop_collection<T>(coll: &Collection<T>)
 where
     T: Serialize + DeserializeOwned + Unpin + Debug + Send + Sync,
 {
-    match coll.drop(None).as_ref().map_err(|e| e.as_ref()) {
+    match coll.drop(None).as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::CommandError(CommandError { code: 26, .. })) | Ok(_) => {}
         e @ Err(_) => {
             e.unwrap();

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -288,7 +288,7 @@ async fn list_authorized_databases() {
 }
 
 fn is_auth_error(error: Error) -> bool {
-    matches!(error.kind.as_ref(), ErrorKind::AuthenticationError { .. })
+    matches!(error.kind, ErrorKind::AuthenticationError { .. })
 }
 
 /// Performs an operation that requires authentication and verifies that it either succeeded or
@@ -576,7 +576,7 @@ async fn x509_auth() {
         .run_command(doc! { "dropUser": &username }, None)
         .await;
 
-    match drop_user_result.as_ref().map_err(|e| e.as_ref()) {
+    match drop_user_result.as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::CommandError(CommandError { code: 11, .. })) | Ok(_) => {}
         e @ Err(_) => {
             e.unwrap();

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -74,7 +74,7 @@ async fn insert_err_details() {
         .unwrap();
 
     let wc_error_result = coll.insert_one(doc! { "test": 1 }, None).await;
-    match *wc_error_result.unwrap_err().kind {
+    match wc_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_error)) => {
             match &wc_error.details {
                 Some(doc) => {
@@ -468,7 +468,6 @@ async fn large_insert_unordered_with_errors() {
         .await
         .expect_err("should get error")
         .kind
-        .as_ref()
     {
         ErrorKind::BulkWriteError(ref failure) => {
             let mut write_errors = failure
@@ -509,7 +508,6 @@ async fn large_insert_ordered_with_errors() {
         .await
         .expect_err("should get error")
         .kind
-        .as_ref()
     {
         ErrorKind::BulkWriteError(ref failure) => {
             let write_errors = failure
@@ -544,7 +542,6 @@ async fn empty_insert() {
         .await
         .expect_err("should get error")
         .kind
-        .as_ref()
     {
         ErrorKind::ArgumentError { .. } => {}
         e => panic!("expected argument error, got {:?}", e),
@@ -712,16 +709,10 @@ async fn find_one_and_delete_hint_server_version() {
     let req2 = VersionReq::parse("4.2.*").unwrap();
     if req1.matches(&client.server_version.as_ref().unwrap()) {
         let error = res.expect_err("find one and delete should fail");
-        assert!(matches!(
-            error.kind.as_ref(),
-            ErrorKind::OperationError { .. }
-        ));
+        assert!(matches!(error.kind, ErrorKind::OperationError { .. }));
     } else if req2.matches(&client.server_version.as_ref().unwrap()) {
         let error = res.expect_err("find one and delete should fail");
-        assert!(matches!(
-            error.kind.as_ref(),
-            ErrorKind::CommandError { .. }
-        ));
+        assert!(matches!(error.kind, ErrorKind::CommandError { .. }));
     } else {
         assert!(res.is_ok());
     }

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -140,7 +140,7 @@ async fn not_master_keep_pool() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| e.as_ref()),
+                result.as_ref().map_err(|e| &e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 10107, .. }))
             ),
             "insert should have failed"
@@ -186,7 +186,7 @@ async fn not_master_reset_pool() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| e.as_ref()),
+                result.as_ref().map_err(|e| &e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 10107, .. }))
             ),
             "insert should have failed"
@@ -231,7 +231,7 @@ async fn shutdown_in_progress() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| e.as_ref()),
+                result.as_ref().map_err(|e| &e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 91, .. }))
             ),
             "insert should have failed"
@@ -276,7 +276,7 @@ async fn interrupted_at_shutdown() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| e.as_ref()),
+                result.as_ref().map_err(|e| &e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 11600, .. }))
             ),
             "insert should have failed"

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -320,7 +320,7 @@ async fn mmapv1_error_raised() {
     }
 
     let err = coll.insert_one(doc! { "x": 1 }, None).await.unwrap_err();
-    match err.kind.as_ref() {
+    match &err.kind {
         ErrorKind::CommandError(err) => {
             assert_eq!(
                 err.message,

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -31,12 +31,14 @@ pub type EventQueue<T> = Arc<RwLock<VecDeque<T>>>;
 pub type CmapEvent = crate::cmap::test::event::Event;
 
 #[derive(Clone, Debug, From)]
+#[allow(clippy::large_enum_variant)]
 pub enum Event {
     CmapEvent(CmapEvent),
     CommandEvent(CommandEvent),
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum CommandEvent {
     CommandStartedEvent(CommandStartedEvent),
     CommandSucceededEvent(CommandSucceededEvent),

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -181,7 +181,7 @@ impl TestClient {
             .run_command(doc! { "dropUser": user }, None)
             .await;
 
-        match drop_user_result.as_ref().map_err(|e| e.as_ref()) {
+        match drop_user_result.as_ref().map_err(|e| &e.kind) {
             Err(ErrorKind::CommandError(CommandError { code: 11, .. })) | Ok(_) => {}
             e @ Err(_) => {
                 e.unwrap();
@@ -345,7 +345,7 @@ pub async fn drop_collection<T>(coll: &Collection<T>)
 where
     T: Serialize + DeserializeOwned + Unpin + Debug,
 {
-    match coll.drop(None).await.as_ref().map_err(|e| e.as_ref()) {
+    match coll.drop(None).await.as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::CommandError(CommandError { code: 26, .. })) | Ok(_) => {}
         e @ Err(_) => {
             e.unwrap();


### PR DESCRIPTION
There were several different places in the driver that we assumed we could clone errors, so I handled each of those places (along with cascading changes due to other places related to that code) in a separate commit to make it easier to follow along with each one. The final commit removes the Arc and the Clone derive from the Error type. Because of this, I think the easier way to review this PR is to review each commit separately so that all of the different unrelated changes don't make things confusing. I'll push a separate commit for each change that's suggested during review, and then once everything looks okay, I'll rebase to move each change into the commit associated with the part that changed and request one final review to make sure that all of the changes look okay after that rebase.