### PR TITLE
minor: only include master branch's MSRV in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,7 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 
 ## Installation
 ### Requirements
-| Driver Version | Required Rust Version |
-|:--------------:|:---------------------:|
-| master         | 1.47+                 |
-| 2.0.0-alpha    | 1.46+                 |
-| 1.x            | 1.46+                 |
+- Rust 1.47+
 - MongoDB 3.6+
 
 **Note**: A bug affecting Rust 1.46-1.47 may cause out-of-memory errors when compiling an application that uses the 1.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 This repository contains the officially supported MongoDB Rust driver, a client side library that can be used to interact with MongoDB deployments in Rust applications. It uses the [`bson`](https://docs.rs/bson) crate for BSON support. The driver contains a fully async API that supports either [`tokio`](https://crates.io/crates/tokio) (default) or [`async-std`](https://crates.io/crates/async-std), depending on the feature flags set. The driver also has a sync API that may be enabled via feature flag. 
 
 ## Index
-- [Installation](#Installation)
+- [Installation](#installation)
+    - [Requirements](#requirements)
     - [Importing](#importing)
         - [Configuring the async runtime](#configuring-the-async-runtime)
         - [Enabling the sync API](#enabling-the-sync-api)
@@ -29,13 +30,8 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 | Driver Version | Required Rust Version |
 |:--------------:|:---------------------:|
 | master         | 1.47+                 |
-| 2.0.0-alpha    | 1.45+                 |
-| 1.2.x          | 1.43+                 |
-| 1.1.x          | 1.43+                 |
-| 1.0.x          | 1.43+                 |
-| 0.11.x         | 1.43+                 |
-| 0.10.x         | 1.43+                 |
-| 0.9.x          | 1.39+                 |
+| 2.0.0-alpha    | 1.46+                 |
+| 1.x            | 1.46+                 |
 - MongoDB 3.6+
 
 **Note**: A bug affecting Rust 1.46-1.47 may cause out-of-memory errors when compiling an application that uses the 1.1
@@ -46,7 +42,7 @@ issue. For more information, see https://github.com/rust-lang/rust/issues/75992.
 The driver is available on [crates.io](https://crates.io/crates/mongodb). To use the driver in your application, simply add it to your project's `Cargo.toml`.
 ```toml
 [dependencies]
-mongodb = "1.1.1"
+mongodb = "2.0.0-alpha"
 ```
 
 #### Configuring the async runtime
@@ -55,7 +51,7 @@ The driver supports both of the most popular async runtime crates, namely [`toki
 For example, to instruct the driver to work with [`async-std`](https://crates.io/crates/async-std), add the following to your `Cargo.toml`:
 ```toml
 [dependencies.mongodb]
-version = "1.1.1"
+version = "2.0.0-alpha"
 default-features = false
 features = ["async-std-runtime"]
 ```
@@ -64,7 +60,7 @@ features = ["async-std-runtime"]
 The driver also provides a blocking sync API. To enable this, add the `"sync"` feature to your `Cargo.toml`:
 ```toml
 [dependencies.mongodb]
-version = "1.1.1"
+version = "2.0.0-alpha"
 default-features = false
 features = ["sync"]
 ```


### PR DESCRIPTION
This PR removes past version MSRV information from the master branch README. Note that since we tag all our major and minor releases on the master branch, the README used by crates.io for a given release will continue to display the correct MSRV for that version, even if master has moved forwards afterwards.

Including only a single version will help reduce the proliferation of stale MSRV information for different releases (e.g. the [requirements section in the 2.0.0-alpha release](https://crates.io/crates/mongodb/2.0.0-alpha) has outdated MSRV information for the master branch).  Subsequent patch releases on the version branch then only have to update the MSRV in that branch's README, rather than having to update it in master / other release branches as well. 

Note that the MSRV for the given version may still become out of date if it gets bumped retroactively (e.g. like in #320 ), but we can document that possibility in RUST-730.

This is the model used by [tokio](https://github.com/tokio-rs/tokio/tree/v0.2.x#supported-rust-versions).