### PR TITLE
RUST-759 Skip serializing None for DropCollectionOptions

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -814,6 +814,7 @@ pub struct FindOneOptions {
 
 /// Specifies the options to a [`Collection::drop`](../struct.Collection.html#method.drop)
 /// operation.
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Default, TypedBuilder, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(strip_option)))]

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -14,6 +14,7 @@ use crate::{
         AggregateOptions,
         CollectionOptions,
         DeleteOptions,
+        DropCollectionOptions,
         FindOneAndDeleteOptions,
         FindOneOptions,
         FindOptions,
@@ -1006,4 +1007,16 @@ async fn assert_options_inherited(client: &EventClient, command_name: &str) {
         event.command.contains_key("$readPreference"),
         !client.is_standalone()
     );
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn drop_skip_serializing_none() {
+    let client = TestClient::new().await;
+    let coll: Collection<Document> = client
+        .database(function_name!())
+        .collection(function_name!());
+    let options = DropCollectionOptions::builder().build();
+    assert!(coll.drop(options).await.is_ok());
 }


### PR DESCRIPTION
Most of our options structs include the `serde_with::skip_serializing_none` attribute to avoid sending null values to the server for unspecified options. We don't include this attribute on `DropCollectionOptions`, which means that if a user specifies `None` for `write_concern`, the server will return a TypeMismatch error. It's likely that this hasn't been encountered since `write_concern` is the only field in `DropCollectionOptions`, so users would likely just omit the options completely rather than specifying `None`; however, we should still fix this to avoid unnecessary errors.