### PR TITLE
RUST-740 Return Deserialize structs from list_databases and list_collections

### DIFF
--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod async_encoding;
 
-use std::time::Duration;
+use std::{convert::TryFrom, time::Duration};
 
 use serde::{de::Error, ser, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -15,7 +15,18 @@ pub(crate) fn get_int(val: &Bson) -> Option<i64> {
     match *val {
         Bson::Int32(i) => Some(i64::from(i)),
         Bson::Int64(i) => Some(i),
-        Bson::Double(f) if f == f as i64 as f64 => Some(f as i64),
+        Bson::Double(f) if (f - (f as i64 as f64)).abs() <= f64::EPSILON => Some(f as i64),
+        _ => None,
+    }
+}
+
+/// Coerce numeric types into an `u64` if it would be lossless to do so. If this Bson is not numeric
+/// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
+pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
+    match *val {
+        Bson::Int32(i) => u64::try_from(i).ok(),
+        Bson::Int64(i) => u64::try_from(i).ok(),
+        Bson::Double(f) if (f - (f as u64 as f64)).abs() <= f64::EPSILON => Some(f as u64),
         _ => None,
     }
 }
@@ -125,16 +136,16 @@ pub(crate) fn serialize_batch_size<S: Serializer>(
     }
 }
 
-/// Deserialize an i64 from any BSON number type if it could be done losslessly.
-pub(crate) fn deserialize_i64_from_bson_number<'de, D>(
+/// Deserialize an u64 from any BSON number type if it could be done losslessly.
+pub(crate) fn deserialize_u64_from_bson_number<'de, D>(
     deserializer: D,
-) -> std::result::Result<i64, D::Error>
+) -> std::result::Result<u64, D::Error>
 where
     D: Deserializer<'de>,
 {
     let bson = Bson::deserialize(deserializer)?;
-    get_int(&bson)
-        .ok_or_else(|| D::Error::custom(format!("could not deserialize i64 from {:?}", bson)))
+    get_u64(&bson)
+        .ok_or_else(|| D::Error::custom(format!("could not deserialize u64 from {:?}", bson)))
 }
 
 pub fn doc_size_bytes(doc: &Document) -> usize {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         DropDatabaseOptions,
         ListCollectionsOptions,
     },
+    results::CollectionSpecification,
     selection_criteria::SelectionCriteria,
     Client,
     ClientSession,
@@ -194,7 +195,7 @@ impl Database {
         &self,
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<ListCollectionsOptions>>,
-    ) -> Result<Cursor<Document>> {
+    ) -> Result<Cursor<CollectionSpecification>> {
         let list_collections = ListCollections::new(
             self.name().to_string(),
             filter.into(),
@@ -215,7 +216,7 @@ impl Database {
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<ListCollectionsOptions>>,
         session: &mut ClientSession,
-    ) -> Result<SessionCursor<Document>> {
+    ) -> Result<SessionCursor<CollectionSpecification>> {
         let list_collections = ListCollections::new(
             self.name().to_string(),
             filter.into(),

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -85,7 +85,7 @@ pub struct CreateCollectionOptions {
 
 /// Specifies how strictly the database should apply validation rules to existing documents during
 /// an update.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum ValidationLevel {
@@ -100,7 +100,7 @@ pub enum ValidationLevel {
 
 /// Specifies whether the database should return an error or simply raise a warning if inserted
 /// documents do not pass the validation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum ValidationAction {
@@ -111,7 +111,7 @@ pub enum ValidationAction {
 }
 
 /// Specifies default configuration for indexes created on a collection, including the _id index.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, TypedBuilder, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct IndexOptionDefaults {

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -29,7 +29,7 @@ pub struct DatabaseOptions {
 /// These are the valid options for creating a collection with
 /// [`Database::create_collection`](../struct.Database.html#method.create_collection).
 #[skip_serializing_none]
-#[derive(Debug, Default, TypedBuilder, Serialize)]
+#[derive(Clone, Debug, Default, TypedBuilder, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(strip_option)))]
 #[non_exhaustive]
@@ -55,8 +55,7 @@ pub struct CreateCollectionOptions {
     /// Specifies a validator to restrict the schema of documents which can exist in the
     /// collection. Expressions can be specified using any query operators except `$near`,
     /// `$nearSphere`, `$text`, and `$where`.
-    #[serde(rename = "validator")]
-    pub validation: Option<Document>,
+    pub validator: Option<Document>,
 
     /// Specifies how strictly the database should apply the validation rules to existing documents
     /// during an update.
@@ -86,7 +85,7 @@ pub struct CreateCollectionOptions {
 
 /// Specifies how strictly the database should apply validation rules to existing documents during
 /// an update.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum ValidationLevel {
@@ -101,7 +100,7 @@ pub enum ValidationLevel {
 
 /// Specifies whether the database should return an error or simply raise a warning if inserted
 /// documents do not pass the validation.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum ValidationAction {
@@ -112,8 +111,9 @@ pub enum ValidationAction {
 }
 
 /// Specifies default configuration for indexes created on a collection, including the _id index.
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct IndexOptionDefaults {
     /// The `storageEngine` document should be in the following form:
     ///

--- a/src/operation/create/test.rs
+++ b/src/operation/create/test.rs
@@ -53,7 +53,7 @@ async fn build_validator() {
             coll: "test_coll".to_string(),
         },
         Some(CreateCollectionOptions {
-            validation: Some(query.clone()),
+            validator: Some(query.clone()),
             ..Default::default()
         }),
     );

--- a/src/operation/list_databases/mod.rs
+++ b/src/operation/list_databases/mod.rs
@@ -85,5 +85,4 @@ impl Operation for ListDatabases {
 #[derive(Debug, Deserialize)]
 struct ResponseBody {
     databases: Vec<Document>,
-    total_size: Option<i64>,
 }

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -1,7 +1,5 @@
-use bson::Document;
-
 use crate::{
-    bson::{doc, Bson},
+    bson::{doc, Bson, Document},
     bson_util,
     cmap::{CommandResponse, StreamDescription},
     error::ErrorKind,
@@ -113,6 +111,8 @@ async fn handle_success() {
         },
     ];
 
+    let expected_values: Vec<Document> = databases.clone();
+
     let response = CommandResponse::with_document(doc! {
        "databases" : bson_util::to_bson_array(&databases),
        "totalSize" : total_size,
@@ -123,7 +123,7 @@ async fn handle_success() {
         .handle_response(response, &Default::default())
         .expect("supposed to succeed");
 
-    assert_eq!(actual_values, databases);
+    assert_eq!(actual_values, expected_values);
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -1,5 +1,7 @@
+use bson::Document;
+
 use crate::{
-    bson::{doc, Bson, Document},
+    bson::{doc, Bson},
     bson_util,
     cmap::{CommandResponse, StreamDescription},
     error::ErrorKind,
@@ -111,8 +113,6 @@ async fn handle_success() {
         },
     ];
 
-    let expected_values: Vec<Document> = databases.clone();
-
     let response = CommandResponse::with_document(doc! {
        "databases" : bson_util::to_bson_array(&databases),
        "totalSize" : total_size,
@@ -123,7 +123,7 @@ async fn handle_success() {
         .handle_response(response, &Default::default())
         .expect("supposed to succeed");
 
-    assert_eq!(actual_values, expected_values);
+    assert_eq!(actual_values, databases);
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]

--- a/src/results.rs
+++ b/src/results.rs
@@ -136,8 +136,8 @@ pub struct DatabaseSpecification {
     pub name: String,
 
     /// The amount of disk space in bytes that is consumed by the database.
-    #[serde(deserialize_with = "crate::bson_util::deserialize_i64_from_bson_number")]
-    pub size_on_disk: i64,
+    #[serde(deserialize_with = "crate::bson_util::deserialize_u64_from_bson_number")]
+    pub size_on_disk: u64,
 
     /// Whether the database has any data.
     pub empty: bool,

--- a/src/results.rs
+++ b/src/results.rs
@@ -73,11 +73,11 @@ pub(crate) struct GetMoreResult {
     pub(crate) exhausted: bool,
 }
 
+/// Describes the type of data store returned when executing
+/// [`Database::list_collections`](../struct.Database.html#method.list_collections).
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase", untagged)]
 #[non_exhaustive]
-/// Describes the type of data store returned when executing
-/// [`Database::list_collections`](../struct.Database.html#method.list_collections).
 pub enum CollectionType {
     /// Indicates that the data store is a view.
     View,
@@ -120,10 +120,10 @@ pub struct CollectionSpecificationInfo {
     pub uuid: Option<Binary>,
 }
 
+/// Information about a collection as reported by [`Database::list_collections`](../struct.Database.html#method.list_collections).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// Information about a collection as reported by [`Database::list_collections`](../struct.Database.html#method.list_collections).
 pub struct CollectionSpecification {
     /// The name of the collection.
     pub name: String,
@@ -143,11 +143,11 @@ pub struct CollectionSpecification {
     pub id_index: Option<Document>,
 }
 
+/// A struct modeling the information about an individual database returned from
+/// [`Client::list_databases`](../struct.Client.html#method.list_databases).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// A struct modeling the information about an individual database returned from
-/// [`Client::list_databases`](../struct.Client.html#method.list_databases).
 pub struct DatabaseSpecification {
     /// The name of the database.
     pub name: String,

--- a/src/results.rs
+++ b/src/results.rs
@@ -141,3 +141,23 @@ pub struct CollectionSpecification {
     /// Provides information on the _id index for the collection
     pub id_index: Document,
 }
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+/// A struct modeling the information about an individual database returned from [`crate::Client::list_databases`].
+pub struct DatabaseSpecification {
+    /// The name of the database.
+    pub name: String,
+
+    /// The amount of disk space in bytes that is consumed by the database.
+    #[serde(deserialize_with = "crate::bson_util::deserialize_i64_from_bson_number")]
+    pub size_on_disk: i64,
+
+    /// Whether the database has any data.
+    pub empty: bool,
+
+    /// For sharded clusters, this field includes a document which maps each shard to the size in bytes of the database
+    /// on disk on that shard. For non sharded environments, this field is `None`.
+    pub shards: Option<Document>,
+}

--- a/src/results.rs
+++ b/src/results.rs
@@ -77,7 +77,8 @@ pub(crate) struct GetMoreResult {
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase", untagged)]
 #[non_exhaustive]
-/// Describes the type of data store returned when executing [`crate::Database::list_collections`].
+/// Describes the type of data store returned when executing
+/// [`Database::list_collections`](../struct.Database.html#method.list_collections).
 pub enum CollectionType {
     /// Indicates that the data store is a view.
     View,
@@ -104,7 +105,7 @@ impl<'de> Deserialize<'de> for CollectionType {
 }
 
 /// Info about the collection that is contained in the `CollectionSpecification::info` field of a specification returned from
-/// [`crate::Database::list_collections`].
+/// [`Database::list_collections`](../struct.Database.html#method.list_collections).
 ///
 /// See the MongoDB [manual](https://docs.mongodb.com/manual/reference/command/listCollections/#listCollections.cursor)
 /// for more information.
@@ -123,7 +124,7 @@ pub struct CollectionSpecificationInfo {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// Information about a collection as reported by [`crate::Database::list_collections`].
+/// Information about a collection as reported by [`Database::list_collections`](../struct.Database.html#method.list_collections).
 pub struct CollectionSpecification {
     /// The name of the collection.
     pub name: String,
@@ -145,7 +146,8 @@ pub struct CollectionSpecification {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// A struct modeling the information about an individual database returned from [`crate::Client::list_databases`].
+/// A struct modeling the information about an individual database returned from
+/// [`Client::list_databases`](../struct.Client.html#method.list_databases).
 pub struct DatabaseSpecification {
     /// The name of the database.
     pub name: String,

--- a/src/results.rs
+++ b/src/results.rs
@@ -5,8 +5,7 @@ use std::collections::{HashMap, VecDeque};
 use crate::{bson::{Bson, Document}, db::options::CreateCollectionOptions};
 
 use bson::Binary;
-use serde::Serialize;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// The result of a [`Collection::insert_one`](../struct.Collection.html#method.insert_one)
 /// operation.
@@ -140,7 +139,8 @@ pub struct CollectionSpecification {
     pub info: CollectionSpecificationInfo,
 
     /// Provides information on the _id index for the collection
-    pub id_index: Document,
+    /// For views, this is `None`.
+    pub id_index: Option<Document>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/src/results.rs
+++ b/src/results.rs
@@ -75,8 +75,8 @@ pub(crate) struct GetMoreResult {
 
 /// Describes the type of data store returned when executing
 /// [`Database::list_collections`](../struct.Database.html#method.list_collections).
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(rename_all = "lowercase", untagged)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum CollectionType {
     /// Indicates that the data store is a view.
@@ -84,23 +84,6 @@ pub enum CollectionType {
 
     /// Indicates that the data store is a collection.
     Collection,
-
-    /// An unknown collection type. This is included for forwards compatibility.
-    Other(String),
-}
-
-impl<'de> Deserialize<'de> for CollectionType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de> {
-        let s = String::deserialize(deserializer)?;
-        let out = match s.as_str() {
-            "collection" => CollectionType::Collection,
-            "view" => CollectionType::View,
-            _ => CollectionType::Other(s)
-        };
-        Ok(out)
-    }
 }
 
 /// Info about the collection that is contained in the `CollectionSpecification::info` field of a specification returned from

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -10,6 +10,7 @@ use crate::{
         SelectionCriteria,
         SessionOptions,
     },
+    results::DatabaseSpecification,
     Client as AsyncClient,
     ClientSession,
     RUNTIME,
@@ -116,7 +117,7 @@ impl Client {
         &self,
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<ListDatabasesOptions>>,
-    ) -> Result<Vec<Document>> {
+    ) -> Result<Vec<DatabaseSpecification>> {
         RUNTIME.block_on(
             self.async_client
                 .list_databases(filter.into(), options.into()),

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -20,6 +20,7 @@ use crate::{
         SelectionCriteria,
         WriteConcern,
     },
+    results::CollectionSpecification,
     Database as AsyncDatabase,
     RUNTIME,
 };
@@ -140,7 +141,7 @@ impl Database {
         &self,
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<ListCollectionsOptions>>,
-    ) -> Result<Cursor<Document>> {
+    ) -> Result<Cursor<CollectionSpecification>> {
         RUNTIME
             .block_on(
                 self.async_database
@@ -157,7 +158,7 @@ impl Database {
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<ListCollectionsOptions>>,
         session: &mut ClientSession,
-    ) -> Result<SessionCursor<Document>> {
+    ) -> Result<SessionCursor<CollectionSpecification>> {
         RUNTIME
             .block_on(self.async_database.list_collections_with_session(
                 filter.into(),

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -175,31 +175,6 @@ async fn list_collection_names() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[function_name::named]
-async fn collection_type() {
-    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
-
-    let view = Bson::String("view".to_string());
-    assert_eq!(
-        bson::from_bson::<CollectionType>(view).expect("deserialization should succeed"),
-        CollectionType::View
-    );
-
-    let collection = Bson::String("collection".to_string());
-    assert_eq!(
-        bson::from_bson::<CollectionType>(collection).expect("deserialization should succeed"),
-        CollectionType::Collection
-    );
-
-    let other = Bson::String("blah".to_string());
-    assert_eq!(
-        bson::from_bson::<CollectionType>(other).expect("deserialization should succeed"),
-        CollectionType::Other("blah".to_string())
-    );
-}
-
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-#[function_name::named]
 async fn collection_management() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -635,8 +635,8 @@ impl TestOperation for ListCollections {
         let cursor = db
             .list_collections(self.filter.clone(), self.options.clone())
             .await?;
-        let result = cursor.try_collect::<Vec<Document>>().await?;
-        Ok(Some(Bson::from(result).into()))
+        let result = cursor.try_collect::<Vec<_>>().await?;
+        Ok(Some(bson::to_bson(&result)?.into()))
     }
 
     fn returns_root_documents(&self) -> bool {

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -579,8 +579,7 @@ impl TestOperation for ListDatabases {
         let result = client
             .list_databases(self.filter.clone(), self.options.clone())
             .await?;
-        let result: Vec<Bson> = result.iter().map(Bson::from).collect();
-        Ok(Some(Bson::Array(result).into()))
+        Ok(Some(bson::to_bson(&result)?.into()))
     }
 
     async fn execute_test_runner_operation(&self, _test_runner: &mut TestRunner) {

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -875,19 +875,16 @@ impl TestOperation for ListCollections {
                         session,
                     )
                     .await?;
-                cursor
-                    .with_session(session)
-                    .try_collect::<Vec<Document>>()
-                    .await?
+                cursor.with_session(session).try_collect::<Vec<_>>().await?
             }
             None => {
                 let cursor = database
                     .list_collections(self.filter.clone(), self.options.clone())
                     .await?;
-                cursor.try_collect::<Vec<Document>>().await?
+                cursor.try_collect::<Vec<_>>().await?
             }
         };
-        Ok(Some(Bson::from(result)))
+        Ok(Some(bson::to_bson(&result)?))
     }
 
     async fn execute_on_client(&self, _client: &EventClient) -> Result<Option<Bson>> {

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1188,8 +1188,7 @@ impl TestOperation for ListDatabases {
         let result = client
             .list_databases(self.filter.clone(), self.options.clone())
             .await?;
-        let result: Vec<Bson> = result.iter().map(Bson::from).collect();
-        Ok(Some(Bson::Array(result)))
+        Ok(Some(bson::to_bson(&result)?))
     }
 
     async fn execute_on_session(&self, _session: &ClientSession) {


### PR DESCRIPTION
RUST-740

This PR updates `Client::list_databases` and `Database::list_collections` to return structs that implement `Deserialize` rather than just `Document`.