### PR TITLE
RUST-738 Remove Arc wrapper around BSON errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bson-u2i = ["bson/u2i"]
 async-trait = "0.1.42"
 base64 = "0.13.0"
 bitflags = "1.1.0"
-bson = "1.2.0"
+bson = { git = "https://github.com/mongodb/bson-rust" }
 chrono = "0.4.7"
 derivative = "2.1.1"
 futures = "0.3.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -205,13 +205,13 @@ where
 
 impl From<bson::de::Error> for ErrorKind {
     fn from(err: bson::de::Error) -> Self {
-        Self::BsonDecode(Arc::new(err))
+        Self::BsonDecode(err)
     }
 }
 
 impl From<bson::ser::Error> for ErrorKind {
     fn from(err: bson::ser::Error) -> Self {
-        Self::BsonEncode(Arc::new(err))
+        Self::BsonEncode(err)
     }
 }
 
@@ -257,11 +257,11 @@ pub enum ErrorKind {
 
     /// Wrapper around `bson::de::Error`.
     #[error("{0}")]
-    BsonDecode(Arc<crate::bson::de::Error>),
+    BsonDecode(crate::bson::de::Error),
 
     /// Wrapper around `bson::ser::Error`.
     #[error("{0}")]
-    BsonEncode(Arc<crate::bson::ser::Error>),
+    BsonEncode(crate::bson::ser::Error),
 
     /// An error occurred when trying to execute a write operation consisting of multiple writes.
     #[error("An error occurred when trying to execute a write operation: {0:?}")]

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -257,7 +257,7 @@ impl ServerDescription {
             .as_ref()
             .map_err(Clone::clone)?
             .as_ref()
-            .and_then(|reply| reply.command_response.election_id.clone());
+            .and_then(|reply| reply.command_response.election_id);
         Ok(me)
     }
 


### PR DESCRIPTION
RUST-738

Now that the BSON errors are `Clone`, we can remove the `Arc` wrapper around them in `ErrorKind`. To bring in these changes, this PR also updates the `Cargo.toml` to track the master branch of `bson-rust`.