### PR TITLE
RUST-742 / RUST-739 Improve Error API and eliminate public dependencies on unstable crates

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -110,7 +110,7 @@ impl Client {
 
                 // Retryable writes are only supported by storage engines with document-level
                 // locking, so users need to disable retryable writes if using mmapv1.
-                if let ErrorKind::CommandError(ref mut command_error) = err.kind {
+                if let ErrorKind::CommandError(ref mut command_error) = *err.kind {
                     if command_error.code == 20
                         && command_error.message.starts_with("Transaction numbers")
                     {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(all(test, not(feature = "sync")))]
 mod test;
 
+mod resolver_config;
+
 use std::{
     collections::HashSet,
     fmt::{self, Display, Formatter},
@@ -28,7 +30,6 @@ use serde::{
     Deserializer,
 };
 use strsim::jaro_winkler;
-pub use trust_dns_resolver::config::ResolverConfig;
 use typed_builder::TypedBuilder;
 use webpki_roots::TLS_SERVER_ROOTS;
 
@@ -43,6 +44,8 @@ use crate::{
     selection_criteria::{ReadPreference, SelectionCriteria, TagSet},
     srv::SrvResolver,
 };
+
+pub use resolver_config::ResolverConfig;
 
 const DEFAULT_PORT: u16 = 27017;
 
@@ -820,7 +823,7 @@ impl ClientOptions {
         options.resolver_config = resolver_config.clone();
 
         if srv {
-            let mut resolver = SrvResolver::new(resolver_config).await?;
+            let mut resolver = SrvResolver::new(resolver_config.map(|config| config.inner)).await?;
             let mut config = resolver
                 .resolve_client_options(&options.hosts[0].hostname)
                 .await?;

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -588,7 +588,7 @@ impl ServerCertVerifier for NoCertVerifier {
 
 impl TlsOptions {
     /// Converts `TlsOptions` into a rustls::ClientConfig.
-    pub fn into_rustls_config(self) -> Result<rustls::ClientConfig> {
+    pub(crate) fn into_rustls_config(self) -> Result<rustls::ClientConfig> {
         let mut config = rustls::ClientConfig::new();
 
         if let Some(true) = self.allow_invalid_certificates {

--- a/src/client/options/resolver_config.rs
+++ b/src/client/options/resolver_config.rs
@@ -1,0 +1,43 @@
+use trust_dns_resolver::config::ResolverConfig as TrustDnsResolverConfig;
+
+/// Configuration for the upstream nameservers to use for resolution.
+///
+/// This is a thin wrapper around a `trust_dns_resolver::config::ResolverConfig` provided to ensure
+/// API stability.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolverConfig {
+    pub(crate) inner: TrustDnsResolverConfig,
+}
+
+impl ResolverConfig {
+    /// Creates a default configuration, using 1.1.1.1, 1.0.0.1 and 2606:4700:4700::1111,
+    /// 2606:4700:4700::1001 (thank you, Cloudflare).
+    ///
+    /// Please see: https://www.cloudflare.com/dns/
+    pub fn cloudflare() -> Self {
+        ResolverConfig {
+            inner: TrustDnsResolverConfig::cloudflare(),
+        }
+    }
+
+    /// Creates a default configuration, using 8.8.8.8, 8.8.4.4 and 2001:4860:4860::8888,
+    /// 2001:4860:4860::8844 (thank you, Google).
+    ///
+    /// Please see Google’s privacy statement for important information about what they track, many
+    /// ISP’s track similar information in DNS.
+    pub fn google() -> Self {
+        ResolverConfig {
+            inner: TrustDnsResolverConfig::google(),
+        }
+    }
+
+    /// Creates a configuration, using 9.9.9.9, 149.112.112.112 and 2620:fe::fe, 2620:fe::fe:9, the
+    /// “secure” variants of the quad9 settings (thank you, Quad9).
+    ///
+    /// Please see: https://www.quad9.net/faq/
+    pub fn quad9() -> Self {
+        ResolverConfig {
+            inner: TrustDnsResolverConfig::quad9(),
+        }
+    }
+}

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -316,8 +316,7 @@ async fn run_test(test_file: TestFile) {
 
             match ClientOptions::parse(&test_case.uri)
                 .await
-                .as_ref()
-                .map_err(|e| &e.kind)
+                .map_err(|e| *e.kind)
             {
                 Ok(_) => panic!("expected {}", expected_type),
                 Err(ErrorKind::ArgumentError { .. }) => {}
@@ -341,8 +340,7 @@ async fn run_connection_string_spec_tests() {
 
 async fn parse_uri(option: &str, suggestion: Option<&str>) {
     match ClientOptionsParser::parse(&format!("mongodb://host:27017/?{}=test", option))
-        .as_ref()
-        .map_err(|e| &e.kind)
+        .map_err(|e| *e.kind)
     {
         Ok(_) => panic!("expected error for option {}", option),
         Err(ErrorKind::ArgumentError { message, .. }) => {

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -256,7 +256,7 @@ impl Connection {
     /// Gets the connection's StreamDescription.
     pub(crate) fn stream_description(&self) -> Result<&StreamDescription> {
         self.stream_description.as_ref().ok_or_else(|| {
-            ErrorKind::OperationError {
+            ErrorKind::InternalError {
                 message: "Stream checked out but not handshaked".to_string(),
             }
             .into()

--- a/src/cmap/conn/wire/header.rs
+++ b/src/cmap/conn/wire/header.rs
@@ -18,7 +18,7 @@ impl OpCode {
             1 => Ok(OpCode::Reply),
             2004 => Ok(OpCode::Query),
             2013 => Ok(OpCode::Message),
-            other => Err(ErrorKind::OperationError {
+            other => Err(ErrorKind::ResponseError {
                 message: format!("Invalid wire protocol opcode: {}", other),
             }
             .into()),

--- a/src/cmap/conn/wire/message.rs
+++ b/src/cmap/conn/wire/message.rs
@@ -90,7 +90,7 @@ impl Message {
         if length_remaining == 4 && flags.contains(MessageFlags::CHECKSUM_PRESENT) {
             checksum = Some(reader.read_u32().await?);
         } else if length_remaining != 0 {
-            return Err(ErrorKind::OperationError {
+            return Err(ErrorKind::ResponseError {
                 message: format!(
                     "The server indicated that the reply would be {} bytes long, but it instead \
                      was {}",
@@ -193,7 +193,7 @@ impl MessageSection {
         }
 
         if length_remaining != count_reader.bytes_read() as i32 {
-            return Err(ErrorKind::OperationError {
+            return Err(ErrorKind::ResponseError {
                 message: format!(
                     "The server indicated that the reply would be {} bytes long, but it instead \
                      was {}",

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -278,7 +278,7 @@ impl From<ClientOptions> for HandshakerOptions {
 /// If the given command is not an isMaster, this function will return an error.
 pub(crate) async fn is_master(command: Command, conn: &mut Connection) -> Result<IsMasterReply> {
     if !command.name.eq_ignore_ascii_case("ismaster") {
-        return Err(ErrorKind::OperationError {
+        return Err(ErrorKind::InternalError {
             message: format!("invalid ismaster command: {}", command.name),
         }
         .into());

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -156,7 +156,7 @@ impl ConnectionPool {
                 });
             }
             Err(ref e) => {
-                let failure_reason = if let ErrorKind::WaitQueueTimeoutError { .. } = e.kind {
+                let failure_reason = if let ErrorKind::WaitQueueTimeoutError { .. } = *e.kind {
                     ConnectionCheckoutFailedReason::Timeout
                 } else {
                     ConnectionCheckoutFailedReason::ConnectionError

--- a/src/cmap/test/file.rs
+++ b/src/cmap/test/file.rs
@@ -97,7 +97,7 @@ pub struct Error {
 
 impl Error {
     pub fn assert_matches(&self, error: &crate::error::Error, description: &str) {
-        match error.kind {
+        match error.kind.as_ref() {
             ErrorKind::WaitQueueTimeoutError { .. } => {
                 assert_eq!(self.type_, "WaitQueueTimeoutError", "{}", description);
             }

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -696,7 +696,7 @@ where
                         }
                     }
                 }
-                Err(e) => match e.kind {
+                Err(e) => match *e.kind {
                     ErrorKind::BulkWriteError(failure) => {
                         let failure_ref =
                             cumulative_failure.get_or_insert_with(BulkWriteFailure::new);

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -107,7 +107,7 @@ async fn inconsistent_write_concern_rejected() {
         )
         .await
         .expect_err("insert should fail");
-    assert!(matches!(error.kind, ErrorKind::ArgumentError { .. }));
+    assert!(matches!(*error.kind, ErrorKind::ArgumentError { .. }));
 
     let coll = db.collection(function_name!());
     let wc = WriteConcern {
@@ -120,7 +120,7 @@ async fn inconsistent_write_concern_rejected() {
         .insert_one(doc! {}, options)
         .await
         .expect_err("insert should fail");
-    assert!(matches!(error.kind, ErrorKind::ArgumentError { .. }));
+    assert!(matches!(*error.kind, ErrorKind::ArgumentError { .. }));
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -142,5 +142,5 @@ async fn unacknowledged_write_concern_rejected() {
         )
         .await
         .expect_err("insert should fail");
-    assert!(matches!(error.kind, ErrorKind::ArgumentError { .. }));
+    assert!(matches!(*error.kind, ErrorKind::ArgumentError { .. }));
 }

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -137,7 +137,7 @@ pub(super) trait GetMoreProviderResult {
         match self.as_ref() {
             Ok(res) => res.exhausted,
             Err(e) => {
-                matches!(e.kind, ErrorKind::CommandError(ref e) if e.code == 43 || e.code == 237)
+                matches!(*e.kind, ErrorKind::CommandError(ref e) if e.code == 43 || e.code == 237)
             }
         }
     }

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -310,7 +310,7 @@ async fn handle_write_concern_error() {
     let error = aggregate
         .handle_response(response, &Default::default())
         .expect_err("should get wc error");
-    match error.kind {
+    match *error.kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(_)) => {}
         ref e => panic!("should have gotten WriteConcernError, got {:?} instead", e),
     }

--- a/src/operation/count/test.rs
+++ b/src/operation/count/test.rs
@@ -94,7 +94,7 @@ async fn handle_response_no_n() {
     let response = CommandResponse::with_document(doc! { "ok" : 1 });
 
     let result = count_op.handle_response(response, &Default::default());
-    match result.as_ref().map_err(|e| &e.kind) {
+    match result.map_err(|e| *e.kind) {
         Err(ErrorKind::ResponseError { .. }) => {}
         other => panic!("expected response error, but got {:?}", other),
     }

--- a/src/operation/create/test.rs
+++ b/src/operation/create/test.rs
@@ -100,7 +100,7 @@ async fn handle_write_concern_error() {
     let result = op.handle_response(response, &Default::default());
     assert!(result.is_err());
 
-    match result.unwrap_err().kind {
+    match *result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_err)) => {
             assert_eq!(wc_err.code, 100);
             assert_eq!(wc_err.code_name, "hello world");

--- a/src/operation/delete/test.rs
+++ b/src/operation/delete/test.rs
@@ -143,7 +143,7 @@ async fn handle_write_failure() {
     });
     let write_error_result = op.handle_response(write_error_response, &Default::default());
     assert!(write_error_result.is_err());
-    match write_error_result.unwrap_err().kind {
+    match *write_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteError(ref error)) => {
             let expected_err = WriteError {
                 code: 1234,
@@ -181,7 +181,7 @@ async fn handle_write_concern_failure() {
     let wc_error_result = op.handle_response(wc_error_response, &Default::default());
     assert!(wc_error_result.is_err());
 
-    match wc_error_result.unwrap_err().kind {
+    match *wc_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_error)) => {
             let expected_wc_err = WriteConcernError {
                 code: 456,

--- a/src/operation/distinct/test.rs
+++ b/src/operation/distinct/test.rs
@@ -141,7 +141,7 @@ async fn handle_response_no_values() {
     });
 
     let result = distinct_op.handle_response(response, &Default::default());
-    match result.as_ref().map_err(|e| &e.kind) {
+    match result.map_err(|e| *e.kind) {
         Err(ErrorKind::ResponseError { .. }) => {}
         other => panic!("expected response error, but got {:?}", other),
     }

--- a/src/operation/drop_collection/test.rs
+++ b/src/operation/drop_collection/test.rs
@@ -78,7 +78,7 @@ async fn handle_write_concern_error() {
     let result = op.handle_response(response, &Default::default());
     assert!(result.is_err());
 
-    match result.unwrap_err().kind {
+    match *result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_err)) => {
             assert_eq!(wc_err.code, 100);
             assert_eq!(wc_err.code_name, "hello world");

--- a/src/operation/drop_database/test.rs
+++ b/src/operation/drop_database/test.rs
@@ -76,7 +76,7 @@ async fn handle_write_concern_error() {
     let result = op.handle_response(response, &Default::default());
     assert!(result.is_err());
 
-    match result.unwrap_err().kind {
+    match *result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_err)) => {
             assert_eq!(wc_err.code, 100);
             assert_eq!(wc_err.code_name, "hello world");

--- a/src/operation/find_and_modify/mod.rs
+++ b/src/operation/find_and_modify/mod.rs
@@ -103,24 +103,13 @@ where
     const NAME: &'static str = "findAndModify";
 
     fn build(&self, description: &StreamDescription) -> Result<Command> {
-        if self.options.hint.is_some() {
-            match description.max_wire_version {
-                Some(version) if version < 8 => {
-                    return Err(ErrorKind::OperationError {
-                        message: "Specifying a hint is not supported on server versions < 4.4"
-                            .to_string(),
-                    }
-                    .into());
-                }
-                None => {
-                    return Err(ErrorKind::OperationError {
-                        message: "Specifying a hint is not supported on server versions < 4.4"
-                            .to_string(),
-                    }
-                    .into());
-                }
-                _ => {}
+        if self.options.hint.is_some() && description.max_wire_version.unwrap_or(0) < 8 {
+            return Err(ErrorKind::ArgumentError {
+                message: "Specifying a hint to find_one_and_x is not supported on server versions \
+                          < 4.4"
+                    .to_string(),
             }
+            .into());
         }
 
         let mut body: Document = doc! {

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -199,7 +199,7 @@ async fn handle_write_failure() {
         .handle_response(write_error_response, &Default::default());
     assert!(write_error_result.is_err());
 
-    match write_error_result.unwrap_err().kind {
+    match *write_error_result.unwrap_err().kind {
         ErrorKind::BulkWriteError(ref error) => {
             let write_errors = error.write_errors.clone().unwrap();
             assert_eq!(write_errors.len(), 1);

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -136,7 +136,7 @@ async fn handle_response_no_databases() {
     });
 
     let result = list_databases_op.handle_response(response, &Default::default());
-    match result.as_ref().map_err(|e| &e.kind) {
+    match result.map_err(|e| *e.kind) {
         Err(ErrorKind::ResponseError { .. }) => {}
         other => panic!("expected response error, but got {:?}", other),
     }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -107,7 +107,10 @@ pub(crate) trait Operation {
 
 /// Appends a serializable struct to the input document.
 /// The serializable struct MUST serialize to a Document, otherwise an error will be thrown.
-pub(crate) fn append_options<T: Serialize>(doc: &mut Document, options: Option<&T>) -> Result<()> {
+pub(crate) fn append_options<T: Serialize + Debug>(
+    doc: &mut Document,
+    options: Option<&T>,
+) -> Result<()> {
     match options {
         Some(options) => {
             let temp_doc = bson::to_bson(options)?;
@@ -116,8 +119,8 @@ pub(crate) fn append_options<T: Serialize>(doc: &mut Document, options: Option<&
                     doc.extend(d);
                     Ok(())
                 }
-                _ => Err(ErrorKind::OperationError {
-                    message: "options did not serialize to a Document".to_string(),
+                _ => Err(ErrorKind::InternalError {
+                    message: format!("options did not serialize to a Document: {:?}", options),
                 }
                 .into()),
             }

--- a/src/operation/update/test.rs
+++ b/src/operation/update/test.rs
@@ -226,7 +226,7 @@ async fn handle_write_failure() {
     });
     let write_error_result = op.handle_response(write_error_response, &Default::default());
     assert!(write_error_result.is_err());
-    match write_error_result.unwrap_err().kind {
+    match *write_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteError(ref error)) => {
             let expected_err = WriteError {
                 code: 1234,
@@ -265,7 +265,7 @@ async fn handle_write_concern_failure() {
     let wc_error_result = op.handle_response(wc_error_response, &Default::default());
     assert!(wc_error_result.is_err());
 
-    match wc_error_result.unwrap_err().kind {
+    match *wc_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_error)) => {
             let expected_wc_err = WriteConcernError {
                 code: 456,

--- a/src/sdam/srv_polling/mod.rs
+++ b/src/sdam/srv_polling/mod.rs
@@ -128,7 +128,8 @@ impl SrvPollingMonitor {
             return Ok(resolver);
         }
 
-        let resolver = SrvResolver::new(self.client_options.resolver_config.clone()).await?;
+        let resolver =
+            SrvResolver::new(self.client_options.resolver_config.clone().map(|c| c.inner)).await?;
 
         // Since the connection was not `Some` above, this will always insert the new connection and
         // return a reference to it.

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -211,7 +211,7 @@ async fn sdam_min_pool_size_error() {
         .await
         .expect_err("ping should fail");
     assert!(
-        matches!(ping_err.kind, ErrorKind::ServerSelectionError { .. }),
+        matches!(*ping_err.kind, ErrorKind::ServerSelectionError { .. }),
         "Expected to fail due to server selection timing out, instead got: {:?}",
         ping_err.kind
     );
@@ -290,7 +290,7 @@ async fn auth_error() {
         .await
         .expect_err("insert should fail");
     assert!(matches!(
-        auth_err.kind,
+        *auth_err.kind,
         ErrorKind::AuthenticationError { .. }
     ));
 

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -1,7 +1,7 @@
-use trust_dns_resolver::{config::ResolverConfig, error::ResolveErrorKind};
+use trust_dns_resolver::config::ResolverConfig;
 
 use crate::{
-    error::{Error, ErrorKind, Result},
+    error::{ErrorKind, Result},
     options::StreamAddress,
     runtime::AsyncResolver,
 };
@@ -193,7 +193,7 @@ impl SrvResolver {
 }
 
 fn ignore_no_records(error: Error) -> Result<()> {
-    match error.kind {
+    match *error.kind {
         ErrorKind::DnsResolve(resolve_error)
             if matches!(
                 resolve_error.kind(),

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -5,7 +5,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     bson::{doc, Document},
-    error::{CommandError, ErrorKind, Result},
+    error::Result,
     options::{
         Acknowledgment,
         ClientOptions,
@@ -21,7 +21,7 @@ use crate::{
 
 fn init_db_and_coll(client: &Client, db_name: &str, coll_name: &str) -> Collection<Document> {
     let coll = client.database(db_name).collection(coll_name);
-    drop_collection(&coll);
+    coll.drop(None).unwrap();
     coll
 }
 
@@ -30,20 +30,8 @@ where
     T: Serialize + DeserializeOwned + Unpin + Debug,
 {
     let coll = client.database(db_name).collection(coll_name);
-    drop_collection(&coll);
+    coll.drop(None).unwrap();
     coll
-}
-
-pub fn drop_collection<T>(coll: &Collection<T>)
-where
-    T: Serialize + DeserializeOwned + Unpin + Debug,
-{
-    match coll.drop(None).as_ref().map_err(|e| &e.kind) {
-        Err(ErrorKind::CommandError(CommandError { code: 26, .. })) | Ok(_) => {}
-        e @ Err(_) => {
-            e.unwrap();
-        }
-    };
 }
 
 #[test]

--- a/src/test/atlas_connectivity.rs
+++ b/src/test/atlas_connectivity.rs
@@ -1,6 +1,5 @@
-use crate::{bson::doc, options::ClientOptions, Client};
+use crate::{bson::doc, client::options::ResolverConfig, options::ClientOptions, Client};
 use bson::Document;
-use trust_dns_resolver::config::ResolverConfig;
 
 async fn run_test(uri_env_var: &str, resolver_config: Option<ResolverConfig>) {
     if std::env::var_os("MONGO_ATLAS_TESTS").is_none() {

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -284,7 +284,7 @@ async fn list_authorized_databases() {
 }
 
 fn is_auth_error(error: Error) -> bool {
-    matches!(error.kind, ErrorKind::AuthenticationError { .. })
+    matches!(*error.kind, ErrorKind::AuthenticationError { .. })
 }
 
 /// Performs an operation that requires authentication and verifies that it either succeeded or
@@ -572,7 +572,7 @@ async fn x509_auth() {
         .run_command(doc! { "dropUser": &username }, None)
         .await;
 
-    match drop_user_result.as_ref().map_err(|e| &e.kind) {
+    match drop_user_result.map_err(|e| *e.kind) {
         Err(ErrorKind::CommandError(CommandError { code: 11, .. })) | Ok(_) => {}
         e @ Err(_) => {
             e.unwrap();

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -77,7 +77,7 @@ async fn insert_err_details() {
         .unwrap();
 
     let wc_error_result = coll.insert_one(doc! { "test": 1 }, None).await;
-    match wc_error_result.unwrap_err().kind {
+    match *wc_error_result.unwrap_err().kind {
         ErrorKind::WriteError(WriteFailure::WriteConcernError(ref wc_error)) => {
             match &wc_error.details {
                 Some(doc) => {
@@ -466,7 +466,7 @@ async fn large_insert_unordered_with_errors() {
         .await;
     let options = InsertManyOptions::builder().ordered(false).build();
 
-    match coll
+    match *coll
         .insert_many(docs, options)
         .await
         .expect_err("should get error")
@@ -506,7 +506,7 @@ async fn large_insert_ordered_with_errors() {
         .await;
     let options = InsertManyOptions::builder().ordered(true).build();
 
-    match coll
+    match *coll
         .insert_many(docs, options)
         .await
         .expect_err("should get error")
@@ -540,7 +540,7 @@ async fn empty_insert() {
     let coll = client
         .database(function_name!())
         .collection::<Document>(function_name!());
-    match coll
+    match *coll
         .insert_many(Vec::<Document>::new(), None)
         .await
         .expect_err("should get error")
@@ -717,10 +717,10 @@ async fn find_one_and_delete_hint_server_version() {
     let req2 = VersionReq::parse("4.2.*").unwrap();
     if req1.matches(&client.server_version) {
         let error = res.expect_err("find one and delete should fail");
-        assert!(matches!(error.kind, ErrorKind::OperationError { .. }));
+        assert!(matches!(*error.kind, ErrorKind::ArgumentError { .. }));
     } else if req2.matches(&client.server_version) {
         let error = res.expect_err("find one and delete should fail");
-        assert!(matches!(error.kind, ErrorKind::CommandError { .. }));
+        assert!(matches!(*error.kind, ErrorKind::CommandError { .. }));
     } else {
         assert!(res.is_ok());
     }

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -137,7 +137,7 @@ async fn not_master_keep_pool() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| &e.kind),
+                result.map_err(|e| *e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 10107, .. }))
             ),
             "insert should have failed"
@@ -183,7 +183,7 @@ async fn not_master_reset_pool() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| &e.kind),
+                result.map_err(|e| *e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 10107, .. }))
             ),
             "insert should have failed"
@@ -228,7 +228,7 @@ async fn shutdown_in_progress() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| &e.kind),
+                result.map_err(|e| *e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 91, .. }))
             ),
             "insert should have failed"
@@ -273,7 +273,7 @@ async fn interrupted_at_shutdown() {
         let result = coll.insert_one(doc! { "test": 1 }, None).await;
         assert!(
             matches!(
-                result.as_ref().map_err(|e| &e.kind),
+                result.map_err(|e| *e.kind),
                 Err(ErrorKind::CommandError(CommandError { code: 11600, .. }))
             ),
             "insert should have failed"

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -304,7 +304,7 @@ async fn mmapv1_error_raised() {
     }
 
     let err = coll.insert_one(doc! { "x": 1 }, None).await.unwrap_err();
-    match &err.kind {
+    match *err.kind {
         ErrorKind::CommandError(err) => {
             assert_eq!(
                 err.message,

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -168,7 +168,7 @@ impl TestClient {
             .run_command(doc! { "dropUser": user }, None)
             .await;
 
-        match drop_user_result.as_ref().map_err(|e| &e.kind) {
+        match drop_user_result.map_err(|e| *e.kind) {
             Err(ErrorKind::CommandError(CommandError { code: 11, .. })) | Ok(_) => {}
             e @ Err(_) => {
                 e.unwrap();
@@ -336,7 +336,7 @@ pub async fn drop_collection<T>(coll: &Collection<T>)
 where
     T: Serialize + DeserializeOwned + Unpin + Debug,
 {
-    match coll.drop(None).await.as_ref().map_err(|e| &e.kind) {
+    match coll.drop(None).await.map_err(|e| *e.kind) {
         Err(ErrorKind::CommandError(CommandError { code: 26, .. })) | Ok(_) => {}
         e @ Err(_) => {
             e.unwrap();


### PR DESCRIPTION
RUST-742 / RUST-739

This PR makes a number of breaking updates to the `Error` struct and `ErrorKind` enum, as well as some changes to other areas of the API where we re-export types from unstable crates. Each commit has been made separate to include changes specific to each ticket.

Notable changes
- Wrapped `Error::kind` in a `Box` to reduce the size of `Error`
    - This is the change that a user suggested and I did that writeup about, and they're included here with the unstable dependency stuff since they both modified and reduced the size of `ErrorKind`. I know @kmahar hasn't had a chance to read through the writeup on this yet, but I wanted to open this PR to get the reviews going on the later changes (which are the majority of this PR). Since they're separate commits anyways I can always go back and modify the first one as needed, but I didn't really anticipate having to do so.
- Consolidated several redundant error cases
- Rewrote error cases that simply wrapped errors from other crates to instead just use their messages
- Defined a wrapper `ResolverConfig` type within the driver rather than accepting `trust-dns-resolver`'s `ResolverConfig`, which is unstable
- Hid `TlsOptions::into_rustls_config` from the public API