### PR TITLE
RUST-754 Accept impl Borrow<T> in insert and replace methods

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -1,7 +1,7 @@
 mod batch;
 pub mod options;
 
-use std::{fmt, fmt::Debug, sync::Arc};
+use std::{borrow::Borrow, fmt, fmt::Debug, sync::Arc};
 
 use futures::StreamExt;
 use serde::{
@@ -539,11 +539,11 @@ where
     async fn find_one_and_replace_common(
         &self,
         filter: Document,
-        replacement: T,
+        replacement: impl Borrow<T>,
         options: impl Into<Option<FindOneAndReplaceOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<Option<T>> {
-        let replacement = to_document(&replacement)?;
+        let replacement = to_document(replacement.borrow())?;
 
         let mut options = options.into();
         resolve_options!(self, options, [write_concern]);
@@ -562,7 +562,7 @@ where
     pub async fn find_one_and_replace(
         &self,
         filter: Document,
-        replacement: T,
+        replacement: impl Borrow<T>,
         options: impl Into<Option<FindOneAndReplaceOptions>>,
     ) -> Result<Option<T>> {
         self.find_one_and_replace_common(filter, replacement, options, None)
@@ -579,7 +579,7 @@ where
     pub async fn find_one_and_replace_with_session(
         &self,
         filter: Document,
-        replacement: T,
+        replacement: impl Borrow<T>,
         options: impl Into<Option<FindOneAndReplaceOptions>>,
         session: &mut ClientSession,
     ) -> Result<Option<T>> {
@@ -643,13 +643,13 @@ where
 
     async fn insert_many_common(
         &self,
-        docs: impl IntoIterator<Item = T>,
+        docs: impl IntoIterator<Item = impl Borrow<T>>,
         options: impl Into<Option<InsertManyOptions>>,
         mut session: Option<&mut ClientSession>,
     ) -> Result<InsertManyResult> {
         let docs: ser::Result<Vec<Document>> = docs
             .into_iter()
-            .map(|doc| bson::to_document(&doc))
+            .map(|doc| bson::to_document(doc.borrow()))
             .collect();
         let mut docs: Vec<Document> = docs?;
 
@@ -739,7 +739,7 @@ where
     /// retryable writes.
     pub async fn insert_many(
         &self,
-        docs: impl IntoIterator<Item = T>,
+        docs: impl IntoIterator<Item = impl Borrow<T>>,
         options: impl Into<Option<InsertManyOptions>>,
     ) -> Result<InsertManyResult> {
         self.insert_many_common(docs, options, None).await
@@ -753,7 +753,7 @@ where
     /// retryable writes.
     pub async fn insert_many_with_session(
         &self,
-        docs: impl IntoIterator<Item = T>,
+        docs: impl IntoIterator<Item = impl Borrow<T>>,
         options: impl Into<Option<InsertManyOptions>>,
         session: &mut ClientSession,
     ) -> Result<InsertManyResult> {
@@ -762,11 +762,11 @@ where
 
     async fn insert_one_common(
         &self,
-        doc: T,
+        doc: impl Borrow<T>,
         options: impl Into<Option<InsertOneOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<InsertOneResult> {
-        let doc = to_document(&doc)?;
+        let doc = to_document(doc.borrow())?;
 
         let mut options = options.into();
         resolve_options!(self, options, [write_concern]);
@@ -791,7 +791,7 @@ where
     /// retryable writes.
     pub async fn insert_one(
         &self,
-        doc: T,
+        doc: impl Borrow<T>,
         options: impl Into<Option<InsertOneOptions>>,
     ) -> Result<InsertOneResult> {
         self.insert_one_common(doc, options, None).await
@@ -805,7 +805,7 @@ where
     /// retryable writes.
     pub async fn insert_one_with_session(
         &self,
-        doc: T,
+        doc: impl Borrow<T>,
         options: impl Into<Option<InsertOneOptions>>,
         session: &mut ClientSession,
     ) -> Result<InsertOneResult> {
@@ -815,11 +815,11 @@ where
     async fn replace_one_common(
         &self,
         query: Document,
-        replacement: T,
+        replacement: impl Borrow<T>,
         options: impl Into<Option<ReplaceOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<UpdateResult> {
-        let replacement = to_document(&replacement)?;
+        let replacement = to_document(replacement.borrow())?;
 
         bson_util::replacement_document_check(&replacement)?;
 
@@ -845,7 +845,7 @@ where
     pub async fn replace_one(
         &self,
         query: Document,
-        replacement: T,
+        replacement: impl Borrow<T>,
         options: impl Into<Option<ReplaceOptions>>,
     ) -> Result<UpdateResult> {
         self.replace_one_common(query, replacement, options, None)
@@ -862,7 +862,7 @@ where
     pub async fn replace_one_with_session(
         &self,
         query: Document,
-        replacement: T,
+        replacement: impl Borrow<T>,
         options: impl Into<Option<ReplaceOptions>>,
         session: &mut ClientSession,
     ) -> Result<UpdateResult> {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -80,8 +80,7 @@ impl AsyncRuntime {
     #[cfg(any(feature = "sync", test))]
     pub(crate) fn block_on<F, T>(self, fut: F) -> T
     where
-        F: Future<Output = T> + Send,
-        T: Send,
+        F: Future<Output = T>,
     {
         #[cfg(all(feature = "tokio-runtime", not(feature = "async-std-runtime")))]
         {

--- a/src/sync/cursor.rs
+++ b/src/sync/cursor.rs
@@ -71,14 +71,14 @@ use crate::{
 #[derive(Debug)]
 pub struct Cursor<T>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     async_cursor: AsyncCursor<T>,
 }
 
 impl<T> Cursor<T>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     pub(crate) fn new(async_cursor: AsyncCursor<T>) -> Self {
         Self { async_cursor }
@@ -87,7 +87,7 @@ where
 
 impl<T> Iterator for Cursor<T>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     type Item = Result<T>;
 
@@ -118,14 +118,14 @@ where
 #[derive(Debug)]
 pub struct SessionCursor<T>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     async_cursor: AsyncSessionCursor<T>,
 }
 
 impl<T> SessionCursor<T>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     pub(crate) fn new(async_cursor: AsyncSessionCursor<T>) -> Self {
         Self { async_cursor }
@@ -149,14 +149,14 @@ where
 /// This updates the buffer of the parent `SessionCursor` when dropped.
 pub struct SessionCursorHandle<'cursor, 'session, T = Document>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     async_handle: AsyncSessionCursorHandle<'cursor, 'session, T>,
 }
 
 impl<T> Iterator for SessionCursorHandle<'_, '_, T>
 where
-    T: DeserializeOwned + Unpin + Send,
+    T: DeserializeOwned + Unpin,
 {
     type Item = Result<T>;
 

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Debug,
-    marker::{Send, Sync},
-};
+use std::fmt::Debug;
 
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -95,7 +92,7 @@ impl Database {
     /// used repeatedly without incurring any costs from I/O.
     pub fn collection<T>(&self, name: &str) -> Collection<T>
     where
-        T: Serialize + DeserializeOwned + Unpin + Debug + Send + Sync,
+        T: Serialize + DeserializeOwned + Unpin + Debug,
     {
         Collection::new(self.async_database.collection(name))
     }
@@ -112,7 +109,7 @@ impl Database {
         options: CollectionOptions,
     ) -> Collection<T>
     where
-        T: Serialize + DeserializeOwned + Unpin + Debug + Send + Sync,
+        T: Serialize + DeserializeOwned + Unpin + Debug,
     {
         Collection::new(self.async_database.collection_with_options(name, options))
     }

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Debug,
-    marker::{Send, Sync},
-};
+use std::fmt::Debug;
 
 use pretty_assertions::assert_eq;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -30,7 +27,7 @@ fn init_db_and_coll(client: &Client, db_name: &str, coll_name: &str) -> Collecti
 
 fn init_db_and_typed_coll<T>(client: &Client, db_name: &str, coll_name: &str) -> Collection<T>
 where
-    T: Serialize + DeserializeOwned + Unpin + Debug + Send + Sync,
+    T: Serialize + DeserializeOwned + Unpin + Debug,
 {
     let coll = client.database(db_name).collection(coll_name);
     drop_collection(&coll);
@@ -39,7 +36,7 @@ where
 
 pub fn drop_collection<T>(coll: &Collection<T>)
 where
-    T: Serialize + DeserializeOwned + Unpin + Debug + Send + Sync,
+    T: Serialize + DeserializeOwned + Unpin + Debug,
 {
     match coll.drop(None).as_ref().map_err(|e| &e.kind) {
         Err(ErrorKind::CommandError(CommandError { code: 26, .. })) | Ok(_) => {}

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -541,7 +541,7 @@ async fn empty_insert() {
         .database(function_name!())
         .collection::<Document>(function_name!());
     match coll
-        .insert_many(Vec::new(), None)
+        .insert_many(Vec::<Document>::new(), None)
         .await
         .expect_err("should get error")
         .kind


### PR DESCRIPTION
RUST-754

This PR updates the various insert and replace methods to accept `impl Borrow<T>`, which means that both owned values and values that can be converted into references can be accepted in these methods. 

In a related change, the trait requirements on `T` in the sync driver were relaxed now that tokio and async-std's blocking functions no longer require it.