### PR TITLE
RUST-764 Use unsigned integers for values that should always be non-negative

### DIFF
--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -108,14 +108,13 @@ where
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
-pub(crate) fn serialize_u32_as_i32<S: Serializer>(
+pub(crate) fn serialize_u32_option_as_i32<S: Serializer>(
     val: &Option<u32>,
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {
     match val {
-        Some(val) if { *val <= std::i32::MAX as u32 } => serializer.serialize_i32(*val as i32),
+        Some(ref val) => bson::serde_helpers::serialize_u32_as_i32(val, serializer),
         None => serializer.serialize_none(),
-        _ => Err(ser::Error::custom("u32 specified does not fit into an i32")),
     }
 }
 
@@ -133,6 +132,16 @@ pub(crate) fn serialize_batch_size<S: Serializer>(
         _ => Err(ser::Error::custom(
             "batch size must be able to fit into a signed 32-bit integer",
         )),
+    }
+}
+
+pub(crate) fn serialize_u64_option_as_i64<S: Serializer>(
+    val: &Option<u64>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    match val {
+        Some(ref v) => bson::serde_helpers::serialize_u64_as_i64(v, serializer),
+        None => serializer.serialize_none(),
     }
 }
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -3,6 +3,7 @@ mod test;
 
 use std::{
     collections::HashSet,
+    convert::TryFrom,
     fmt::{self, Display, Formatter},
     fs::File,
     hash::{Hash, Hasher},
@@ -1641,18 +1642,17 @@ impl ClientOptionsParser {
                 let mut write_concern = self.write_concern.get_or_insert_with(Default::default);
 
                 match i32::from_str_radix(value, 10) {
-                    Ok(w) => {
-                        if w < 0 {
+                    Ok(w) => match u32::try_from(w) {
+                        Ok(uw) => write_concern.w = Some(Acknowledgment::from(uw)),
+                        Err(_) => {
                             return Err(ErrorKind::ArgumentError {
                                 message: "connection string `w` option cannot be a negative \
                                           integer"
                                     .to_string(),
                             }
-                            .into());
+                            .into())
                         }
-
-                        write_concern.w = Some(Acknowledgment::from(w));
-                    }
+                    },
                     Err(_) => {
                         write_concern.w = Some(Acknowledgment::from(value.to_string()));
                     }

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -260,7 +260,7 @@ where
     pub async fn estimated_document_count(
         &self,
         options: impl Into<Option<EstimatedDocumentCountOptions>>,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         let mut options = options.into();
         resolve_options!(self, options, [read_concern, selection_criteria]);
 
@@ -274,7 +274,7 @@ where
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<CountOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         let mut options = options.into();
         resolve_options!(self, options, [read_concern, selection_criteria]);
 
@@ -290,7 +290,7 @@ where
         &self,
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<CountOptions>>,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         self.count_documents_common(filter, options, None).await
     }
 
@@ -303,7 +303,7 @@ where
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<CountOptions>>,
         session: &mut ClientSession,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         self.count_documents_common(filter, options, session).await
     }
 

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -10,7 +10,8 @@ use crate::{
         deserialize_duration_from_u64_millis,
         serialize_batch_size,
         serialize_duration_as_int_millis,
-        serialize_u32_as_i32,
+        serialize_u32_option_as_i32,
+        serialize_u64_option_as_i64,
     },
     concern::{ReadConcern, WriteConcern},
     options::Collation,
@@ -498,7 +499,8 @@ pub struct CountOptions {
     pub hint: Option<Hint>,
 
     /// The maximum number of documents to count.
-    pub limit: Option<i64>,
+    #[serde(serialize_with = "serialize_u64_option_as_i64")]
+    pub limit: Option<u64>,
 
     /// The maximum amount of time to allow the query to run.
     ///
@@ -508,7 +510,8 @@ pub struct CountOptions {
     pub max_time: Option<Duration>,
 
     /// The number of documents to skip before counting.
-    pub skip: Option<i64>,
+    #[serde(serialize_with = "serialize_u64_option_as_i64")]
+    pub skip: Option<u64>,
 
     /// The collation to use for the operation.
     ///
@@ -618,7 +621,7 @@ pub struct FindOptions {
     /// only the number of documents kept in memory at a given time (and by extension, the
     /// number of round trips needed to return the entire set of documents returned by the
     /// query.
-    #[serde(serialize_with = "serialize_u32_as_i32")]
+    #[serde(serialize_with = "serialize_u32_option_as_i32")]
     pub batch_size: Option<u32>,
 
     /// Tags the query with an arbitrary string to help trace the operation through the database
@@ -650,7 +653,8 @@ pub struct FindOptions {
     ///
     /// Note: this option is deprecated starting in MongoDB version 4.0 and removed in MongoDB 4.2.
     /// Use the maxTimeMS option instead.
-    pub max_scan: Option<i64>,
+    #[serde(serialize_with = "serialize_u64_option_as_i64")]
+    pub max_scan: Option<u64>,
 
     /// The maximum amount of time to allow the query to run.
     ///
@@ -689,7 +693,8 @@ pub struct FindOptions {
     pub show_record_id: Option<bool>,
 
     /// The number of documents to skip before counting.
-    pub skip: Option<i64>,
+    #[serde(serialize_with = "serialize_u64_option_as_i64")]
+    pub skip: Option<u64>,
 
     /// The order of the documents for the purposes of the operation.
     pub sort: Option<Document>,
@@ -774,7 +779,8 @@ pub struct FindOneOptions {
     ///
     /// Note: this option is deprecated starting in MongoDB version 4.0 and removed in MongoDB 4.2.
     /// Use the maxTimeMS option instead.
-    pub max_scan: Option<i64>,
+    #[serde(serialize_with = "serialize_u64_option_as_i64")]
+    pub max_scan: Option<u64>,
 
     /// The maximum amount of time to allow the query to run.
     ///
@@ -806,7 +812,8 @@ pub struct FindOneOptions {
     pub show_record_id: Option<bool>,
 
     /// The number of documents to skip before counting.
-    pub skip: Option<i64>,
+    #[serde(serialize_with = "crate::bson_util::serialize_u64_option_as_i64")]
+    pub skip: Option<u64>,
 
     /// The order of the documents for the purposes of the operation.
     pub sort: Option<Document>,

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -499,7 +499,6 @@ pub struct CountOptions {
     pub hint: Option<Hint>,
 
     /// The maximum number of documents to count.
-    #[serde(serialize_with = "serialize_u64_option_as_i64")]
     pub limit: Option<u64>,
 
     /// The maximum amount of time to allow the query to run.
@@ -510,7 +509,6 @@ pub struct CountOptions {
     pub max_time: Option<Duration>,
 
     /// The number of documents to skip before counting.
-    #[serde(serialize_with = "serialize_u64_option_as_i64")]
     pub skip: Option<u64>,
 
     /// The collation to use for the operation.
@@ -522,7 +520,6 @@ pub struct CountOptions {
     /// The criteria used to select a server for this operation.
     ///
     /// If none specified, the default set on the collection will be used.
-    #[serde(skip_serializing)]
     pub selection_criteria: Option<SelectionCriteria>,
 
     /// The level of the read concern.

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -809,7 +809,7 @@ pub struct FindOneOptions {
     pub show_record_id: Option<bool>,
 
     /// The number of documents to skip before counting.
-    #[serde(serialize_with = "crate::bson_util::serialize_u64_option_as_i64")]
+    #[serde(serialize_with = "serialize_u64_option_as_i64")]
     pub skip: Option<u64>,
 
     /// The order of the documents for the purposes of the operation.

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -39,12 +39,14 @@ pub struct CreateCollectionOptions {
 
     /// The maximum size (in bytes) for a capped collection. This option is ignored if `capped` is
     /// not set to true.
-    pub size: Option<i64>,
+    #[serde(serialize_with = "bson_util::serialize_u64_option_as_i64")]
+    pub size: Option<u64>,
 
     /// The maximum number of documents in a capped collection. The `size` limit takes precedence
     /// over this option. If a capped collection reaches the size limit before it reaches the
     /// maximum number of documents, MongoDB removes old documents.
-    pub max: Option<i64>,
+    #[serde(serialize_with = "bson_util::serialize_u64_option_as_i64")]
+    pub max: Option<u64>,
 
     /// The storage engine that the collection should use. The value should take the following
     /// form:

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -37,7 +37,7 @@ impl Count {
 }
 
 impl Operation for Count {
-    type O = i64;
+    type O = u64;
     const NAME: &'static str = "count";
 
     fn build(&self, description: &StreamDescription) -> Result<Command> {
@@ -122,5 +122,5 @@ impl Operation for Count {
 
 #[derive(Debug, Deserialize)]
 struct ResponseBody {
-    n: i64,
+    n: u64,
 }

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -64,7 +64,7 @@ impl CountDocuments {
 }
 
 impl Operation for CountDocuments {
-    type O = i64;
+    type O = u64;
     const NAME: &'static str = Aggregate::NAME;
 
     fn build(&self, description: &StreamDescription) -> Result<Command> {
@@ -98,7 +98,7 @@ impl Operation for CountDocuments {
             }
         };
 
-        bson_util::get_int(n).ok_or_else(|| {
+        bson_util::get_u64(n).ok_or_else(|| {
             ErrorKind::ResponseError {
                 message: format!(
                     "server response to count_documents aggregate should have contained integer \

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -152,7 +152,7 @@ struct WriteResponseBody<T = EmptyBody> {
     #[serde(flatten)]
     body: T,
 
-    n: i64,
+    n: u64,
 
     #[serde(rename = "writeErrors")]
     write_errors: Option<Vec<BulkWriteError>>,

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -152,6 +152,6 @@ impl Operation for Update {
 #[derive(Deserialize)]
 struct UpdateBody {
     #[serde(rename = "nModified")]
-    n_modified: i64,
+    n_modified: u64,
     upserted: Option<Vec<Document>>,
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -50,9 +50,13 @@ impl InsertManyResult {
 #[non_exhaustive]
 pub struct UpdateResult {
     /// The number of documents that matched the filter.
-    pub matched_count: i64,
+    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u64_as_i64")]
+    pub matched_count: u64,
+
     /// The number of documents that were modified by the operation.
-    pub modified_count: i64,
+    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u64_as_i64")]
+    pub modified_count: u64,
+
     /// The `_id` field of the upserted document.
     pub upserted_id: Option<Bson>,
 }
@@ -64,7 +68,8 @@ pub struct UpdateResult {
 #[non_exhaustive]
 pub struct DeleteResult {
     /// The number of documents deleted by the operation.
-    pub deleted_count: i64,
+    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u64_as_i64")]
+    pub deleted_count: u64,
 }
 
 #[derive(Debug, Clone)]

--- a/src/sync/coll.rs
+++ b/src/sync/coll.rs
@@ -184,7 +184,7 @@ where
     pub fn estimated_document_count(
         &self,
         options: impl Into<Option<EstimatedDocumentCountOptions>>,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         RUNTIME.block_on(
             self.async_collection
                 .estimated_document_count(options.into()),
@@ -199,7 +199,7 @@ where
         &self,
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<CountOptions>>,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         RUNTIME.block_on(
             self.async_collection
                 .count_documents(filter.into(), options.into()),
@@ -215,7 +215,7 @@ where
         filter: impl Into<Option<Document>>,
         options: impl Into<Option<CountOptions>>,
         session: &mut ClientSession,
-    ) -> Result<i64> {
+    ) -> Result<u64> {
         RUNTIME.block_on(self.async_collection.count_documents_with_session(
             filter.into(),
             options.into(),

--- a/src/test/spec/command_monitoring/operation.rs
+++ b/src/test/spec/command_monitoring/operation.rs
@@ -150,7 +150,7 @@ pub(super) struct Find {
     #[serde(default)]
     sort: Option<Document>,
     #[serde(default)]
-    skip: Option<i64>,
+    skip: Option<u64>,
     #[serde(default, rename = "batchSize")]
     batch_size: Option<i64>,
     #[serde(default)]

--- a/src/test/spec/crud_v1/count.rs
+++ b/src/test/spec/crud_v1/count.rs
@@ -11,8 +11,8 @@ use crate::{
 #[derive(Debug, Deserialize)]
 struct Arguments {
     pub filter: Option<Document>,
-    pub skip: Option<i64>,
-    pub limit: Option<i64>,
+    pub skip: Option<u64>,
+    pub limit: Option<u64>,
     pub collation: Option<Collation>,
 }
 
@@ -45,7 +45,7 @@ async fn run_count_test(test_file: TestFile) {
 
         let arguments: Arguments = bson::from_bson(Bson::Document(test_case.operation.arguments))
             .expect(&test_case.description);
-        let outcome: Outcome<i64> =
+        let outcome: Outcome<u64> =
             bson::from_bson(Bson::Document(test_case.outcome)).expect(&test_case.description);
 
         if let Some(ref c) = outcome.collection {

--- a/src/test/spec/crud_v1/delete_many.rs
+++ b/src/test/spec/crud_v1/delete_many.rs
@@ -18,7 +18,7 @@ struct Arguments {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResultDoc {
-    pub deleted_count: i64,
+    pub deleted_count: u64,
 }
 
 #[function_name::named]

--- a/src/test/spec/crud_v1/delete_one.rs
+++ b/src/test/spec/crud_v1/delete_one.rs
@@ -18,7 +18,7 @@ struct Arguments {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResultDoc {
-    pub deleted_count: i64,
+    pub deleted_count: u64,
 }
 
 #[function_name::named]

--- a/src/test/spec/crud_v1/find.rs
+++ b/src/test/spec/crud_v1/find.rs
@@ -13,7 +13,7 @@ use crate::{
 #[serde(rename_all = "camelCase")]
 struct Arguments {
     pub filter: Document,
-    pub skip: Option<i64>,
+    pub skip: Option<u64>,
     pub limit: Option<i64>,
     pub batch_size: Option<u32>,
     pub collation: Option<Collation>,

--- a/src/test/spec/crud_v1/replace_one.rs
+++ b/src/test/spec/crud_v1/replace_one.rs
@@ -20,9 +20,9 @@ struct Arguments {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResultDoc {
-    pub matched_count: i64,
-    pub modified_count: i64,
-    pub upserted_count: Option<i64>,
+    pub matched_count: u64,
+    pub modified_count: u64,
+    pub upserted_count: Option<u64>,
     pub upserted_id: Option<Bson>,
 }
 

--- a/src/test/spec/crud_v1/update_many.rs
+++ b/src/test/spec/crud_v1/update_many.rs
@@ -21,9 +21,9 @@ struct Arguments {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResultDoc {
-    pub matched_count: i64,
-    pub modified_count: i64,
-    pub upserted_count: Option<i64>,
+    pub matched_count: u64,
+    pub modified_count: u64,
+    pub upserted_count: Option<u64>,
     pub upserted_id: Option<Bson>,
 }
 

--- a/src/test/spec/crud_v1/update_one.rs
+++ b/src/test/spec/crud_v1/update_one.rs
@@ -21,9 +21,9 @@ struct Arguments {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ResultDoc {
-    pub matched_count: i64,
-    pub modified_count: i64,
-    pub upserted_count: Option<i64>,
+    pub matched_count: u64,
+    pub modified_count: u64,
+    pub upserted_count: Option<u64>,
     pub upserted_id: Option<Bson>,
 }
 

--- a/src/test/spec/read_write_concern/document.rs
+++ b/src/test/spec/read_write_concern/document.rs
@@ -32,7 +32,7 @@ fn write_concern_from_document(write_concern_doc: Document) -> Option<WriteConce
     for (key, value) in write_concern_doc {
         match (&key[..], value) {
             ("w", Bson::Int32(i)) => {
-                write_concern.w = Some(Acknowledgment::from(i));
+                write_concern.w = Some(Acknowledgment::from(i as u32));
             }
             ("w", Bson::String(s)) => {
                 write_concern.w = Some(Acknowledgment::from(s));


### PR DESCRIPTION
RUST-764

This updates a number of results and options in the driver that current use signed integers where unsigned integers could be used instead, since the values stored there will always be positive.