### PR TITLE
RUST-760 Refactor the `StreamAddress` type

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,7 @@ use derivative::Derivative;
 use std::time::Instant;
 
 #[cfg(test)]
-use crate::options::StreamAddress;
+use crate::options::ServerAddress;
 use crate::{
     bson::Document,
     concern::{ReadConcern, WriteConcern},
@@ -263,7 +263,7 @@ impl Client {
     pub(crate) async fn test_select_server(
         &self,
         criteria: Option<&SelectionCriteria>,
-    ) -> Result<StreamAddress> {
+    ) -> Result<ServerAddress> {
         let server = self.select_server(criteria).await?;
         Ok(server.address.clone())
     }

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -101,7 +101,7 @@ lazy_static! {
 
 /// A hostname:port address pair.
 #[derive(Clone, Debug, Eq)]
-#[deprecated = "This type has been renamed to `SeverAddress` and will be removed in the 2.0.0 \
+#[deprecated = "This type has been renamed to `ServerAddress` and will be removed in the 2.0.0 \
                 stable release"]
 pub struct StreamAddress {
     /// The hostname of the address.

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 use crate::{
     bson::{Bson, Document},
-    client::options::{ClientOptions, ClientOptionsParser, StreamAddress},
+    client::options::{ClientOptions, ClientOptionsParser, ServerAddress},
     error::ErrorKind,
     selection_criteria::{ReadPreference, SelectionCriteria},
     test::run_spec_test,
@@ -249,7 +249,7 @@ async fn run_test(test_file: TestFile) {
                     let hosts: Vec<_> = options
                         .hosts
                         .into_iter()
-                        .map(StreamAddress::into_document)
+                        .map(ServerAddress::into_document)
                         .collect();
 
                     assert_eq!(hosts, json_hosts);

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -6,7 +6,7 @@ use crate::{
     bson_util,
     client::{options::ServerApi, ClusterTime},
     error::{CommandError, ErrorKind, Result},
-    options::StreamAddress,
+    options::ServerAddress,
     selection_criteria::ReadPreference,
     ClientSession,
 };
@@ -71,14 +71,14 @@ impl Command {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CommandResponse {
-    source: StreamAddress,
+    source: ServerAddress,
     pub(crate) raw_response: Document,
     cluster_time: Option<ClusterTime>,
 }
 
 impl CommandResponse {
     #[cfg(test)]
-    pub(crate) fn with_document_and_address(source: StreamAddress, doc: Document) -> Self {
+    pub(crate) fn with_document_and_address(source: ServerAddress, doc: Document) -> Self {
         Self {
             source,
             raw_response: doc,
@@ -90,15 +90,15 @@ impl CommandResponse {
     #[cfg(test)]
     pub(crate) fn with_document(doc: Document) -> Self {
         Self::with_document_and_address(
-            StreamAddress {
-                hostname: "localhost".to_string(),
+            ServerAddress {
+                host: "localhost".to_string(),
                 port: None,
             },
             doc,
         )
     }
 
-    pub(crate) fn new(source: StreamAddress, message: Message) -> Result<Self> {
+    pub(crate) fn new(source: ServerAddress, message: Message) -> Result<Self> {
         let raw_response = message.single_document_response()?;
         let cluster_time = raw_response
             .get("$clusterTime")
@@ -151,7 +151,7 @@ impl CommandResponse {
     }
 
     /// The address of the server that sent this response.
-    pub(crate) fn source_address(&self) -> &StreamAddress {
+    pub(crate) fn source_address(&self) -> &ServerAddress {
         &self.source
     }
 }

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -90,7 +90,7 @@ impl CommandResponse {
     #[cfg(test)]
     pub(crate) fn with_document(doc: Document) -> Self {
         Self::with_document_and_address(
-            ServerAddress {
+            ServerAddress::Tcp {
                 host: "localhost".to_string(),
                 port: None,
             },

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         ConnectionCreatedEvent,
         ConnectionReadyEvent,
     },
-    options::{StreamAddress, TlsOptions},
+    options::{ServerAddress, TlsOptions},
     runtime::AsyncStream,
 };
 pub(crate) use command::{Command, CommandResponse};
@@ -37,7 +37,7 @@ pub struct ConnectionInfo {
     pub id: u32,
 
     /// The address that the connection is connected to.
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 }
 
 /// A wrapper around Stream that contains all the CMAP information needed to maintain a connection.
@@ -45,7 +45,7 @@ pub struct ConnectionInfo {
 #[derivative(Debug)]
 pub(crate) struct Connection {
     pub(super) id: u32,
-    pub(super) address: StreamAddress,
+    pub(super) address: ServerAddress,
     pub(crate) generation: u32,
 
     /// The cached StreamDescription from the connection's handshake.
@@ -78,7 +78,7 @@ pub(crate) struct Connection {
 impl Connection {
     async fn new(
         id: u32,
-        address: StreamAddress,
+        address: ServerAddress,
         generation: u32,
         options: Option<ConnectionOptions>,
     ) -> Result<Self> {
@@ -117,7 +117,7 @@ impl Connection {
 
     /// Construct and connect a new connection used for monitoring.
     pub(crate) async fn connect_monitoring(
-        address: StreamAddress,
+        address: ServerAddress,
         connect_timeout: Option<Duration>,
         tls_options: Option<TlsOptions>,
     ) -> Result<Self> {
@@ -137,7 +137,7 @@ impl Connection {
     #[cfg(test)]
     pub(crate) async fn new_testing(
         id: u32,
-        address: StreamAddress,
+        address: ServerAddress,
         generation: u32,
         options: Option<ConnectionOptions>,
     ) -> Result<Self> {
@@ -151,7 +151,7 @@ impl Connection {
         }
     }
 
-    pub(crate) fn address(&self) -> &StreamAddress {
+    pub(crate) fn address(&self) -> &ServerAddress {
         &self.address
     }
 
@@ -325,7 +325,7 @@ impl Drop for Connection {
 #[derive(Debug)]
 pub(super) struct PendingConnection {
     pub(super) id: u32,
-    pub(super) address: StreamAddress,
+    pub(super) address: ServerAddress,
     pub(super) generation: u32,
     pub(super) options: Option<ConnectionOptions>,
 }

--- a/src/cmap/connection_requester.rs
+++ b/src/cmap/connection_requester.rs
@@ -1,11 +1,11 @@
 use tokio::sync::{mpsc, oneshot};
 
 use super::{worker::PoolWorkerHandle, Connection};
-use crate::{error::Result, options::StreamAddress, runtime::AsyncJoinHandle};
+use crate::{error::Result, options::ServerAddress, runtime::AsyncJoinHandle};
 
 /// Returns a new requester/receiver pair.
 pub(super) fn channel(
-    address: StreamAddress,
+    address: ServerAddress,
     handle: PoolWorkerHandle,
 ) -> (ConnectionRequester, ConnectionRequestReceiver) {
     let (sender, receiver) = mpsc::unbounded_channel();
@@ -24,7 +24,7 @@ pub(super) fn channel(
 /// the pool will stop servicing requests, drop its available connections, and close.
 #[derive(Clone, Debug)]
 pub(super) struct ConnectionRequester {
-    address: StreamAddress,
+    address: ServerAddress,
     sender: mpsc::UnboundedSender<oneshot::Sender<ConnectionRequestResult>>,
     handle: PoolWorkerHandle,
 }

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -29,7 +29,7 @@ use crate::{
         ConnectionCheckoutStartedEvent,
         PoolCreatedEvent,
     },
-    options::StreamAddress,
+    options::ServerAddress,
     runtime::HttpClient,
     sdam::ServerUpdateSender,
 };
@@ -47,7 +47,7 @@ const DEFAULT_MAX_POOL_SIZE: u32 = 100;
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub(crate) struct ConnectionPool {
-    address: StreamAddress,
+    address: ServerAddress,
     manager: PoolManager,
     connection_requester: ConnectionRequester,
     generation_subscriber: PoolGenerationSubscriber,
@@ -58,7 +58,7 @@ pub(crate) struct ConnectionPool {
 
 impl ConnectionPool {
     pub(crate) fn new(
-        address: StreamAddress,
+        address: ServerAddress,
         http_client: HttpClient,
         server_updater: ServerUpdateSender,
         options: Option<ConnectionPoolOptions>,
@@ -89,7 +89,7 @@ impl ConnectionPool {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_mocked(address: StreamAddress) -> Self {
+    pub(crate) fn new_mocked(address: ServerAddress) -> Self {
         let (manager, _) = manager::channel();
         let handle = PoolWorkerHandle::new_mocked();
         let (connection_requester, _) = connection_requester::channel(Default::default(), handle);

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -8,7 +8,7 @@ use crate::{
     bson_util,
     client::{auth::Credential, options::ServerApi},
     event::cmap::{CmapEventHandler, ConnectionPoolOptions as EventOptions},
-    options::{ClientOptions, DriverInfo, StreamAddress, TlsOptions},
+    options::{ClientOptions, DriverInfo, ServerAddress, TlsOptions},
 };
 
 /// Contains the options for creating a connection pool.
@@ -146,7 +146,7 @@ impl From<ConnectionPoolOptions> for ConnectionOptions {
 
 #[derive(Clone, Debug, TypedBuilder)]
 pub(crate) struct StreamOptions {
-    pub(crate) address: StreamAddress,
+    pub(crate) address: ServerAddress,
 
     #[builder(default, setter(strip_option))]
     pub(crate) connect_timeout: Option<Duration>,

--- a/src/cmap/test/event.rs
+++ b/src/cmap/test/event.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{de::Unexpected, Deserialize, Deserializer};
 
-use crate::{event::cmap::*, options::StreamAddress, RUNTIME};
+use crate::{event::cmap::*, options::ServerAddress, RUNTIME};
 use tokio::sync::broadcast::error::{RecvError, SendError};
 
 #[derive(Clone, Debug)]
@@ -206,8 +206,8 @@ where
     };
 
     Ok(PoolCreatedEvent {
-        address: StreamAddress {
-            hostname: Default::default(),
+        address: ServerAddress {
+            host: Default::default(),
             port: None,
         },
         options,
@@ -248,8 +248,8 @@ where
     };
 
     Ok(ConnectionCheckoutFailedEvent {
-        address: StreamAddress {
-            hostname: Default::default(),
+        address: ServerAddress {
+            host: Default::default(),
             port: None,
         },
         reason,

--- a/src/cmap/test/event.rs
+++ b/src/cmap/test/event.rs
@@ -206,7 +206,7 @@ where
     };
 
     Ok(PoolCreatedEvent {
-        address: ServerAddress {
+        address: ServerAddress::Tcp {
             host: Default::default(),
             port: None,
         },
@@ -248,7 +248,7 @@ where
     };
 
     Ok(ConnectionCheckoutFailedEvent {
-        address: ServerAddress {
+        address: ServerAddress::Tcp {
             host: Default::default(),
             port: None,
         },

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -28,7 +28,7 @@ use crate::{
         PoolClosedEvent,
         PoolReadyEvent,
     },
-    options::StreamAddress,
+    options::ServerAddress,
     runtime::HttpClient,
     sdam::ServerUpdateSender,
     RUNTIME,
@@ -45,7 +45,7 @@ const MAINTENACE_FREQUENCY: Duration = Duration::from_millis(500);
 #[derivative(Debug)]
 pub(crate) struct ConnectionPoolWorker {
     /// The address the pool's connections will connect to.
-    address: StreamAddress,
+    address: ServerAddress,
 
     /// Current state of the pool. Determines if connections may be checked out
     /// and if min_pool_size connection creation should continue.
@@ -132,7 +132,7 @@ impl ConnectionPoolWorker {
     /// Once all connection requesters are dropped, the worker will stop executing
     /// and close the pool.
     pub(super) fn start(
-        address: StreamAddress,
+        address: ServerAddress,
         http_client: HttpClient,
         server_updater: ServerUpdateSender,
         options: Option<ConnectionPoolOptions>,

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -11,7 +11,7 @@ use futures_core::{Future, Stream};
 use crate::{
     bson::Document,
     error::{Error, ErrorKind, Result},
-    options::StreamAddress,
+    options::ServerAddress,
     results::GetMoreResult,
     Client,
     Namespace,
@@ -153,7 +153,7 @@ pub(crate) struct CursorSpecification {
 impl CursorSpecification {
     pub(crate) fn new(
         ns: Namespace,
-        address: StreamAddress,
+        address: ServerAddress,
         id: i64,
         batch_size: impl Into<Option<u32>>,
         max_time: impl Into<Option<Duration>>,
@@ -176,7 +176,7 @@ impl CursorSpecification {
     }
 
     #[cfg(test)]
-    pub(crate) fn address(&self) -> &StreamAddress {
+    pub(crate) fn address(&self) -> &ServerAddress {
         &self.info.address
     }
 
@@ -195,7 +195,7 @@ impl CursorSpecification {
 #[derive(Clone, Debug)]
 pub(crate) struct CursorInformation {
     pub(crate) ns: Namespace,
-    pub(crate) address: StreamAddress,
+    pub(crate) address: ServerAddress,
     pub(crate) id: i64,
     pub(crate) batch_size: Option<u32>,
     pub(crate) max_time: Option<Duration>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::{fmt::{self, Debug}, sync::Arc};
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::{bson::Document, options::StreamAddress};
+use crate::{bson::Document, options::ServerAddress};
 
 const RECOVERING_CODES: [i32; 5] = [11600, 11602, 13436, 189, 91];
 const NOTMASTER_CODES: [i32; 3] = [10107, 13435, 10058];
@@ -32,7 +32,7 @@ pub struct Error {
 }
 
 impl Error {
-    pub(crate) fn pool_cleared_error(address: &StreamAddress) -> Self {
+    pub(crate) fn pool_cleared_error(address: &ServerAddress) -> Self {
         ErrorKind::ConnectionPoolCleared {
             message: format!(
                 "Connection pool for {} cleared during operation execution",

--- a/src/event/cmap.rs
+++ b/src/event/cmap.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::{
     client::options::{DriverInfo, ServerApi, TlsOptions},
-    options::StreamAddress,
+    options::ServerAddress,
 };
 
 /// We implement `Deserialize` for all of the event types so that we can more easily parse the CMAP
@@ -15,9 +15,9 @@ use crate::{
 /// even present). To facilitate populating the address field with an empty value when
 /// deserializing, we define a private `empty_address` function that the events can specify as the
 /// custom deserialization value for each address field.
-fn empty_address() -> StreamAddress {
-    StreamAddress {
-        hostname: Default::default(),
+fn empty_address() -> ServerAddress {
+    ServerAddress {
+        host: Default::default(),
         port: None,
     }
 }
@@ -29,7 +29,7 @@ pub struct PoolCreatedEvent {
     /// The address of the server that the pool's connections will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The options used for the pool.
     pub options: Option<ConnectionPoolOptions>,
@@ -97,7 +97,7 @@ pub struct PoolReadyEvent {
     /// The address of the server that the pool's connections will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 }
 
 /// Event emitted when a connection pool is cleared.
@@ -107,7 +107,7 @@ pub struct PoolClearedEvent {
     /// The address of the server that the pool's connections will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 }
 
 /// Event emitted when a connection pool is cleared.
@@ -117,7 +117,7 @@ pub struct PoolClosedEvent {
     /// The address of the server that the pool's connections will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 }
 
 /// Event emitted when a connection is created.
@@ -128,7 +128,7 @@ pub struct ConnectionCreatedEvent {
     /// The address of the server that the connection will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The unique ID of the connection. This is not used for anything internally, but can be used
     /// to identify other events related to this connection.
@@ -145,7 +145,7 @@ pub struct ConnectionReadyEvent {
     /// The address of the server that the connection is connected to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The unique ID of the connection. This is not used for anything internally, but can be used
     /// to identify other events related to this connection.
@@ -161,7 +161,7 @@ pub struct ConnectionClosedEvent {
     /// The address of the server that the connection was connected to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The unique ID of the connection. This is not used for anything internally, but can be used
     /// to identify other events related to this connection.
@@ -200,7 +200,7 @@ pub struct ConnectionCheckoutStartedEvent {
     /// The address of the server that the connection will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 }
 
 /// Event emitted when a thread is unable to check out a connection.
@@ -210,7 +210,7 @@ pub struct ConnectionCheckoutFailedEvent {
     /// The address of the server that the connection would have connected to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The reason a connection was unable to be checked out.
     pub reason: ConnectionCheckoutFailedReason,
@@ -237,7 +237,7 @@ pub struct ConnectionCheckedOutEvent {
     /// The address of the server that the connection will connect to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The unique ID of the connection. This is not used for anything internally, but can be used
     /// to identify other events related to this connection.
@@ -253,7 +253,7 @@ pub struct ConnectionCheckedInEvent {
     /// The address of the server that the connection was connected to.
     #[serde(default = "self::empty_address")]
     #[serde(skip)]
-    pub address: StreamAddress,
+    pub address: ServerAddress,
 
     /// The unique ID of the connection. This is not used for anything internally, but can be used
     /// to identify other events related to this connection.

--- a/src/event/cmap.rs
+++ b/src/event/cmap.rs
@@ -16,7 +16,7 @@ use crate::{
 /// deserializing, we define a private `empty_address` function that the events can specify as the
 /// custom deserialization value for each address field.
 fn empty_address() -> ServerAddress {
-    ServerAddress {
+    ServerAddress::Tcp {
         host: Default::default(),
         port: None,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! ```rust
 //! # use mongodb::{
 //! #     error::Result,
-//! #     options::{StreamAddress, ClientOptions},
+//! #     options::{ServerAddress, ClientOptions},
 //! # };
 //! # #[cfg(feature = "sync")]
 //! # use mongodb::sync::Client;
@@ -30,8 +30,8 @@
 //! # fn make_client() -> Result<Client> {
 //! let options = ClientOptions::builder()
 //!                   .hosts(vec![
-//!                       StreamAddress {
-//!                           hostname: "localhost".into(),
+//!                       ServerAddress {
+//!                           host: "localhost".into(),
 //!                           port: Some(27017),
 //!                       }
 //!                   ])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! # fn make_client() -> Result<Client> {
 //! let options = ClientOptions::builder()
 //!                   .hosts(vec![
-//!                       ServerAddress {
+//!                       ServerAddress::Tcp {
 //!                           host: "localhost".into(),
 //!                           port: Some(27017),
 //!                       }

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -8,7 +8,7 @@ use crate::{
     concern::{ReadConcern, ReadConcernLevel},
     error::{ErrorKind, WriteFailure},
     operation::{test, Aggregate, Operation},
-    options::{AggregateOptions, Hint, StreamAddress},
+    options::{AggregateOptions, Hint, ServerAddress},
     Namespace,
 };
 
@@ -182,8 +182,8 @@ async fn handle_success() {
         coll: "test_coll".to_string(),
     };
 
-    let address = StreamAddress {
-        hostname: "localhost".to_string(),
+    let address = ServerAddress {
+        host: "localhost".to_string(),
         port: None,
     };
 
@@ -252,7 +252,7 @@ async fn handle_success() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn handle_max_await_time() {
     let response = CommandResponse::with_document_and_address(
-        StreamAddress::default(),
+        ServerAddress::default(),
         doc! {
             "cursor": {
                 "id": 123,

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -182,7 +182,7 @@ async fn handle_success() {
         coll: "test_coll".to_string(),
     };
 
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "localhost".to_string(),
         port: None,
     };

--- a/src/operation/find/test.rs
+++ b/src/operation/find/test.rs
@@ -200,7 +200,7 @@ async fn handle_success() {
         coll: "test_coll".to_string(),
     };
 
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "localhost".to_string(),
         port: None,
     };
@@ -262,7 +262,7 @@ async fn handle_success() {
 
 fn verify_max_await_time(max_await_time: Option<Duration>, cursor_type: Option<CursorType>) {
     let ns = Namespace::empty();
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "localhost".to_string(),
         port: None,
     };

--- a/src/operation/find/test.rs
+++ b/src/operation/find/test.rs
@@ -5,7 +5,7 @@ use crate::{
     bson_util,
     cmap::{CommandResponse, StreamDescription},
     operation::{test, Find, Operation},
-    options::{CursorType, FindOptions, Hint, ReadConcern, ReadConcernLevel, StreamAddress},
+    options::{CursorType, FindOptions, Hint, ReadConcern, ReadConcernLevel, ServerAddress},
     Namespace,
 };
 
@@ -200,8 +200,8 @@ async fn handle_success() {
         coll: "test_coll".to_string(),
     };
 
-    let address = StreamAddress {
-        hostname: "localhost".to_string(),
+    let address = ServerAddress {
+        host: "localhost".to_string(),
         port: None,
     };
 
@@ -262,8 +262,8 @@ async fn handle_success() {
 
 fn verify_max_await_time(max_await_time: Option<Duration>, cursor_type: Option<CursorType>) {
     let ns = Namespace::empty();
-    let address = StreamAddress {
-        hostname: "localhost".to_string(),
+    let address = ServerAddress {
+        host: "localhost".to_string(),
         port: None,
     };
     let find = Find::new(

--- a/src/operation/get_more/test.rs
+++ b/src/operation/get_more/test.rs
@@ -48,7 +48,7 @@ async fn build() {
         coll: "test_coll".to_string(),
     };
     let cursor_id: i64 = 123;
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "localhost".to_string(),
         port: Some(1234),
     };
@@ -80,7 +80,7 @@ async fn build_batch_size() {
         coll: "test_coll".to_string(),
     };
     let cursor_id: i64 = 123;
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "localhost".to_string(),
         port: Some(1234),
     };
@@ -124,7 +124,7 @@ async fn build_batch_size() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn op_selection_criteria() {
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "myhost.com".to_string(),
         port: Some(1234),
     };
@@ -169,7 +169,7 @@ async fn handle_success() {
         coll: "test_coll".to_string(),
     };
     let cursor_id: i64 = 123;
-    let address = ServerAddress {
+    let address = ServerAddress::Tcp {
         host: "localhost".to_string(),
         port: Some(1234),
     };

--- a/src/operation/get_more/test.rs
+++ b/src/operation/get_more/test.rs
@@ -6,7 +6,7 @@ use crate::{
     cmap::{CommandResponse, StreamDescription},
     cursor::CursorInformation,
     operation::{GetMore, Operation},
-    options::StreamAddress,
+    options::ServerAddress,
     sdam::{ServerDescription, ServerInfo, ServerType},
     Namespace,
 };
@@ -14,7 +14,7 @@ use crate::{
 fn build_test(
     ns: Namespace,
     cursor_id: i64,
-    address: StreamAddress,
+    address: ServerAddress,
     batch_size: Option<u32>,
     max_time: Option<Duration>,
     mut expected_body: Document,
@@ -48,8 +48,8 @@ async fn build() {
         coll: "test_coll".to_string(),
     };
     let cursor_id: i64 = 123;
-    let address = StreamAddress {
-        hostname: "localhost".to_string(),
+    let address = ServerAddress {
+        host: "localhost".to_string(),
         port: Some(1234),
     };
     let batch_size: u32 = 123;
@@ -80,8 +80,8 @@ async fn build_batch_size() {
         coll: "test_coll".to_string(),
     };
     let cursor_id: i64 = 123;
-    let address = StreamAddress {
-        hostname: "localhost".to_string(),
+    let address = ServerAddress {
+        host: "localhost".to_string(),
         port: Some(1234),
     };
 
@@ -124,8 +124,8 @@ async fn build_batch_size() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn op_selection_criteria() {
-    let address = StreamAddress {
-        hostname: "myhost.com".to_string(),
+    let address = ServerAddress {
+        host: "myhost.com".to_string(),
         port: Some(1234),
     };
 
@@ -154,7 +154,7 @@ async fn op_selection_criteria() {
     assert!(predicate(&server_info));
 
     let server_description = ServerDescription {
-        address: StreamAddress::default(),
+        address: ServerAddress::default(),
         ..server_description
     };
     let server_info = ServerInfo::new(&server_description);
@@ -169,8 +169,8 @@ async fn handle_success() {
         coll: "test_coll".to_string(),
     };
     let cursor_id: i64 = 123;
-    let address = StreamAddress {
-        hostname: "localhost".to_string(),
+    let address = ServerAddress {
+        host: "localhost".to_string(),
         port: Some(1234),
     };
 

--- a/src/operation/list_collections/test.rs
+++ b/src/operation/list_collections/test.rs
@@ -3,7 +3,7 @@ use crate::{
     bson_util,
     cmap::{CommandResponse, StreamDescription},
     operation::{ListCollections, Operation},
-    options::{ListCollectionsOptions, StreamAddress},
+    options::{ListCollectionsOptions, ServerAddress},
     Namespace,
 };
 
@@ -171,12 +171,12 @@ async fn handle_success() {
 
     let cursor_spec = list_collections
         .handle_response(
-            CommandResponse::with_document_and_address(StreamAddress::default(), response.clone()),
+            CommandResponse::with_document_and_address(ServerAddress::default(), response.clone()),
             &Default::default(),
         )
         .expect("handle should succeed");
 
-    assert_eq!(cursor_spec.address(), &StreamAddress::default());
+    assert_eq!(cursor_spec.address(), &ServerAddress::default());
     assert_eq!(cursor_spec.id(), 123);
     assert_eq!(cursor_spec.batch_size(), None);
     assert_eq!(cursor_spec.max_time(), None);
@@ -196,12 +196,12 @@ async fn handle_success() {
     );
     let cursor_spec = list_collections
         .handle_response(
-            CommandResponse::with_document_and_address(StreamAddress::default(), response),
+            CommandResponse::with_document_and_address(ServerAddress::default(), response),
             &Default::default(),
         )
         .expect("handle should succeed");
 
-    assert_eq!(cursor_spec.address(), &StreamAddress::default());
+    assert_eq!(cursor_spec.address(), &ServerAddress::default());
     assert_eq!(cursor_spec.id(), 123);
     assert_eq!(cursor_spec.batch_size(), Some(123));
     assert_eq!(cursor_spec.max_time(), None);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -170,7 +170,7 @@ impl AsyncRuntime {
 
             #[cfg(feature = "async-std-runtime")]
             Self::AsyncStd => {
-                let host = (address.host.as_str(), address.port.unwrap_or(27017));
+                let host = (address.host(), address.port().unwrap_or(27017));
                 let socket_addrs = async_std::net::ToSocketAddrs::to_socket_addrs(&host).await?;
                 Ok(socket_addrs)
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use self::{
     resolver::AsyncResolver,
     stream::AsyncStream,
 };
-use crate::{error::Result, options::StreamAddress};
+use crate::{error::Result, options::ServerAddress};
 pub(crate) use http::HttpClient;
 #[cfg(feature = "async-std-runtime")]
 use interval::Interval;
@@ -159,7 +159,7 @@ impl AsyncRuntime {
 
     pub(crate) async fn resolve_address(
         self,
-        address: &StreamAddress,
+        address: &ServerAddress,
     ) -> Result<impl Iterator<Item = SocketAddr>> {
         match self {
             #[cfg(feature = "tokio-runtime")]
@@ -170,7 +170,7 @@ impl AsyncRuntime {
 
             #[cfg(feature = "async-std-runtime")]
             Self::AsyncStd => {
-                let host = (address.hostname.as_str(), address.port.unwrap_or(27017));
+                let host = (address.host.as_str(), address.port.unwrap_or(27017));
                 let socket_addrs = async_std::net::ToSocketAddrs::to_socket_addrs(&host).await?;
                 Ok(socket_addrs)
             }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -15,7 +15,7 @@ use webpki::DNSNameRef;
 use crate::{
     cmap::options::StreamOptions,
     error::{ErrorKind, Result},
-    options::StreamAddress,
+    options::ServerAddress,
     RUNTIME,
 };
 
@@ -108,7 +108,7 @@ impl AsyncTcpStream {
         Ok(stream.into())
     }
 
-    async fn connect(address: &StreamAddress, connect_timeout: Option<Duration>) -> Result<Self> {
+    async fn connect(address: &ServerAddress, connect_timeout: Option<Duration>) -> Result<Self> {
         let timeout = connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT);
 
         let mut socket_addrs: Vec<_> = RUNTIME.resolve_address(address).await?.collect();
@@ -150,12 +150,11 @@ impl AsyncStream {
         // If there are TLS options, wrap the inner stream with rustls.
         match options.tls_options {
             Some(cfg) => {
-                let name =
-                    DNSNameRef::try_from_ascii_str(&options.address.hostname).map_err(|e| {
-                        ErrorKind::DnsResolve {
-                            message: e.to_string(),
-                        }
-                    })?;
+                let name = DNSNameRef::try_from_ascii_str(&options.address.host).map_err(|e| {
+                    ErrorKind::DnsResolve {
+                        message: e.to_string(),
+                    }
+                })?;
                 let mut tls_config = cfg.into_rustls_config()?;
                 tls_config.enable_sni = true;
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -150,11 +150,12 @@ impl AsyncStream {
         // If there are TLS options, wrap the inner stream with rustls.
         match options.tls_options {
             Some(cfg) => {
-                let name = DNSNameRef::try_from_ascii_str(&options.address.host).map_err(|e| {
-                    ErrorKind::DnsResolve {
-                        message: e.to_string(),
-                    }
-                })?;
+                let name =
+                    DNSNameRef::try_from_ascii_str(&options.address.host()).map_err(|e| {
+                        ErrorKind::DnsResolve {
+                            message: e.to_string(),
+                        }
+                    })?;
                 let mut tls_config = cfg.into_rustls_config()?;
                 tls_config.enable_sni = true;
 

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -6,7 +6,7 @@ use chrono::offset::Utc;
 use crate::{
     client::ClusterTime,
     is_master::IsMasterReply,
-    options::StreamAddress,
+    options::ServerAddress,
     selection_criteria::TagSet,
 };
 
@@ -57,7 +57,7 @@ impl Default for ServerType {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServerDescription {
-    pub(crate) address: StreamAddress,
+    pub(crate) address: ServerAddress,
     pub(crate) server_type: ServerType,
     pub(crate) last_update_time: Option<DateTime>,
     pub(crate) average_round_trip_time: Option<Duration>,
@@ -96,10 +96,10 @@ impl PartialEq for ServerDescription {
 
 impl ServerDescription {
     pub(crate) fn new(
-        mut address: StreamAddress,
+        mut address: ServerAddress,
         is_master_reply: Option<Result<IsMasterReply, String>>,
     ) -> Self {
-        address.hostname = address.hostname.to_lowercase();
+        address.host = address.host.to_lowercase();
 
         let mut description = Self {
             address,

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -99,7 +99,10 @@ impl ServerDescription {
         mut address: ServerAddress,
         is_master_reply: Option<Result<IsMasterReply, String>>,
     ) -> Self {
-        address.host = address.host.to_lowercase();
+        address = ServerAddress::Tcp {
+            host: address.host().to_lowercase(),
+            port: address.port(),
+        };
 
         let mut description = Self {
             address,

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -8,7 +8,7 @@ use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng};
 use super::TopologyDescription;
 use crate::{
     error::{ErrorKind, Result},
-    options::StreamAddress,
+    options::ServerAddress,
     sdam::{
         description::{
             server::{ServerDescription, ServerType},
@@ -54,7 +54,7 @@ impl Drop for SelectedServer {
 pub(crate) fn attempt_to_select_server<'a>(
     criteria: &'a SelectionCriteria,
     topology_description: &'a TopologyDescription,
-    servers: &'a HashMap<StreamAddress, Arc<Server>>,
+    servers: &'a HashMap<ServerAddress, Arc<Server>>,
 ) -> Result<Option<SelectedServer>> {
     let in_window = topology_description.suitable_servers_in_latency_window(criteria)?;
     let in_window_servers = in_window

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use tokio::sync::RwLockWriteGuard;
 
 use crate::{
-    options::StreamAddress,
+    options::ServerAddress,
     runtime::AsyncJoinHandle,
     sdam::{description::topology::server_selection, Server},
     selection_criteria::ReadPreference,
@@ -38,21 +38,21 @@ struct TestFile {
 #[derive(Debug, Deserialize)]
 struct TestOutcome {
     tolerance: f64,
-    expected_frequencies: HashMap<StreamAddress, f64>,
+    expected_frequencies: HashMap<ServerAddress, f64>,
 }
 
 #[derive(Debug, Deserialize)]
 struct TestServer {
-    address: StreamAddress,
+    address: ServerAddress,
     operation_count: u32,
 }
 
 async fn run_test(test_file: TestFile) {
     println!("Running {}", test_file.description);
 
-    let mut tallies: HashMap<StreamAddress, u32> = HashMap::new();
+    let mut tallies: HashMap<ServerAddress, u32> = HashMap::new();
 
-    let servers: HashMap<StreamAddress, Arc<Server>> = test_file
+    let servers: HashMap<ServerAddress, Arc<Server>> = test_file
         .mocked_topology_state
         .into_iter()
         .map(|desc| {
@@ -172,7 +172,7 @@ async fn load_balancing_test() {
 
         futures::future::join_all(handles).await;
 
-        let mut tallies: HashMap<StreamAddress, u32> = HashMap::new();
+        let mut tallies: HashMap<ServerAddress, u32> = HashMap::new();
         for event in client.get_command_started_events(&["find"]) {
             *tallies.entry(event.connection.address.clone()).or_insert(0) += 1;
         }

--- a/src/sdam/description/topology/server_selection/test/mod.rs
+++ b/src/sdam/description/topology/server_selection/test/mod.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 
 use crate::{
     is_master::{IsMasterCommandResponse, IsMasterReply, LastWrite},
-    options::StreamAddress,
+    options::ServerAddress,
     sdam::{
         description::topology::{test::f64_ms_as_duration, TopologyType},
         ServerDescription,
@@ -99,7 +99,7 @@ impl TestServerDescription {
         };
 
         let mut server_desc = ServerDescription::new(
-            StreamAddress::parse(&self.address).unwrap(),
+            ServerAddress::parse(&self.address).unwrap(),
             Some(Ok(is_master)),
         );
         server_desc.last_update_time = self

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -8,7 +8,7 @@ use crate::{
     client::Client,
     error::{BulkWriteFailure, CommandError, Error, ErrorKind},
     is_master::{IsMasterCommandResponse, IsMasterReply},
-    options::{ClientOptions, ReadPreference, SelectionCriteria, StreamAddress},
+    options::{ClientOptions, ReadPreference, SelectionCriteria, ServerAddress},
     sdam::{
         description::{
             server::{ServerDescription, ServerType},
@@ -44,7 +44,7 @@ pub struct Response(String, IsMasterCommandResponse);
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApplicationError {
-    address: StreamAddress,
+    address: ServerAddress,
     generation: Option<u32>,
     max_wire_version: i32,
     when: ErrorHandshakePhase,
@@ -165,7 +165,7 @@ async fn run_test(test_file: TestFile) {
                 })
             };
 
-            let address = StreamAddress::parse(&address).unwrap_or_else(|_| {
+            let address = ServerAddress::parse(&address).unwrap_or_else(|_| {
                 panic!(
                     "{}: couldn't parse address \"{:?}\"",
                     test_description.as_str(),
@@ -260,7 +260,7 @@ async fn run_test(test_file: TestFile) {
         );
 
         for (address, server) in phase.outcome.servers {
-            let address = StreamAddress::parse(&address).unwrap_or_else(|_| {
+            let address = ServerAddress::parse(&address).unwrap_or_else(|_| {
                 panic!(
                     "{}: couldn't parse address \"{:?}\"",
                     test_description, address
@@ -422,7 +422,7 @@ async fn direct_connection() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn pool_cleared_error_does_not_mark_unknown() {
-    let address = StreamAddress::parse("a:1234").unwrap();
+    let address = ServerAddress::parse("a:1234").unwrap();
     let options = ClientOptions::builder()
         .hosts(vec![address.clone()])
         .build();

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -14,7 +14,7 @@ use crate::{
     cmap::{is_master, Command, Connection, Handshaker},
     error::{Error, Result},
     is_master::IsMasterReply,
-    options::{ClientOptions, StreamAddress},
+    options::{ClientOptions, ServerAddress},
     RUNTIME,
 };
 
@@ -23,7 +23,7 @@ pub(super) const DEFAULT_HEARTBEAT_FREQUENCY: Duration = Duration::from_secs(10)
 pub(crate) const MIN_HEARTBEAT_FREQUENCY: Duration = Duration::from_millis(500);
 
 pub(crate) struct Monitor {
-    address: StreamAddress,
+    address: ServerAddress,
     server: Arc<Server>,
     client_options: ClientOptions,
     update_receiver: ServerUpdateReceiver,
@@ -34,7 +34,7 @@ impl Monitor {
     /// Creates a monitor associated with a given Server.
     /// This method does not start the monitor. Use `Monitor::start` to do so.
     pub(super) fn new(
-        address: StreamAddress,
+        address: ServerAddress,
         server: &Arc<Server>,
         topology: WeakTopology,
         client_options: ClientOptions,
@@ -76,7 +76,7 @@ impl Monitor {
 
 /// Monitor that performs regular heartbeats to determine server status.
 struct HeartbeatMonitor {
-    address: StreamAddress,
+    address: ServerAddress,
     connection: Option<Connection>,
     handshaker: Handshaker,
     server: Weak<Server>,
@@ -86,7 +86,7 @@ struct HeartbeatMonitor {
 
 impl HeartbeatMonitor {
     fn new(
-        address: StreamAddress,
+        address: ServerAddress,
         server: Weak<Server>,
         topology: WeakTopology,
         client_options: ClientOptions,

--- a/src/sdam/public.rs
+++ b/src/sdam/public.rs
@@ -4,7 +4,7 @@ pub use crate::sdam::description::server::ServerType;
 use crate::{
     bson::DateTime,
     is_master::IsMasterCommandResponse,
-    options::StreamAddress,
+    options::ServerAddress,
     sdam::description::server::ServerDescription,
     selection_criteria::TagSet,
 };
@@ -32,7 +32,7 @@ impl<'a> ServerInfo<'a> {
     }
 
     /// Gets the address of the server.
-    pub fn address(&self) -> &StreamAddress {
+    pub fn address(&self) -> &ServerAddress {
         &self.description.address
     }
 

--- a/src/sdam/srv_polling/mod.rs
+++ b/src/sdam/srv_polling/mod.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     error::{Error, Result},
-    options::{ClientOptions, StreamAddress},
+    options::{ClientOptions, ServerAddress},
     srv::SrvResolver,
     RUNTIME,
 };
@@ -25,7 +25,7 @@ pub(crate) struct SrvPollingMonitor {
 }
 
 struct LookupHosts {
-    hosts: Vec<StreamAddress>,
+    hosts: Vec<ServerAddress>,
     min_ttl: Option<Duration>,
 }
 

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -5,25 +5,25 @@ use pretty_assertions::assert_eq;
 use super::{LookupHosts, SrvPollingMonitor};
 use crate::{
     error::Result,
-    options::{ClientOptions, StreamAddress},
+    options::{ClientOptions, ServerAddress},
     sdam::Topology,
 };
 
-fn localhost_test_build_10gen(port: u16) -> StreamAddress {
-    StreamAddress {
-        hostname: "localhost.test.build.10gen.cc".into(),
+fn localhost_test_build_10gen(port: u16) -> ServerAddress {
+    ServerAddress {
+        host: "localhost.test.build.10gen.cc".into(),
         port: Some(port),
     }
 }
 
 lazy_static::lazy_static! {
-    static ref DEFAULT_HOSTS: Vec<StreamAddress> = vec![
+    static ref DEFAULT_HOSTS: Vec<ServerAddress> = vec![
         localhost_test_build_10gen(27017),
         localhost_test_build_10gen(27108),
     ];
 }
 
-async fn run_test(new_hosts: Result<Vec<StreamAddress>>, expected_hosts: HashSet<StreamAddress>) {
+async fn run_test(new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet<ServerAddress>) {
     let mut options = ClientOptions::new_srv();
     options.hosts = DEFAULT_HOSTS.clone();
     let topology = Topology::new_mocked(options);

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 fn localhost_test_build_10gen(port: u16) -> ServerAddress {
-    ServerAddress {
+    ServerAddress::Tcp {
         host: "localhost.test.build.10gen.cc".into(),
         port: Some(port),
     }

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     client::ClusterTime,
     cmap::{Command, Connection},
     error::{Error, Result},
-    options::{ClientOptions, SelectionCriteria, StreamAddress},
+    options::{ClientOptions, SelectionCriteria, ServerAddress},
     runtime::HttpClient,
     sdam::{
         description::{
@@ -66,7 +66,7 @@ struct Common {
 struct TopologyState {
     http_client: HttpClient,
     description: TopologyDescription,
-    servers: HashMap<StreamAddress, Arc<Server>>,
+    servers: HashMap<ServerAddress, Arc<Server>>,
     #[cfg(test)]
     mocked: bool,
 }
@@ -171,7 +171,7 @@ impl Topology {
 
     /// Gets the addresses of the servers in the cluster.
     #[cfg(test)]
-    pub(crate) async fn servers(&self) -> HashSet<StreamAddress> {
+    pub(crate) async fn servers(&self) -> HashSet<ServerAddress> {
         self.state.read().await.servers.keys().cloned().collect()
     }
 
@@ -350,7 +350,7 @@ impl Topology {
     /// Updates the hosts included in this topology, starting and stopping monitors as necessary.
     pub(crate) async fn update_hosts(
         &self,
-        hosts: HashSet<StreamAddress>,
+        hosts: HashSet<ServerAddress>,
         options: &ClientOptions,
     ) -> bool {
         self.state
@@ -384,7 +384,7 @@ impl Topology {
     /// Updates the given `command` as needed based on the `critiera`.
     pub(crate) async fn update_command_with_read_pref(
         &self,
-        server_address: &StreamAddress,
+        server_address: &ServerAddress,
         command: &mut Command,
         criteria: Option<&SelectionCriteria>,
     ) {
@@ -409,7 +409,7 @@ impl Topology {
 
     pub(crate) async fn get_server_description(
         &self,
-        address: &StreamAddress,
+        address: &ServerAddress,
     ) -> Option<ServerDescription> {
         self.state
             .read()
@@ -420,7 +420,7 @@ impl Topology {
     }
 
     #[cfg(test)]
-    pub(crate) async fn get_servers(&self) -> HashMap<StreamAddress, Weak<Server>> {
+    pub(crate) async fn get_servers(&self) -> HashMap<ServerAddress, Weak<Server>> {
         self.state
             .read()
             .await
@@ -455,7 +455,7 @@ impl TopologyState {
     /// A reference to the containing Topology is needed in order to start the monitoring task.
     fn add_new_server(
         &mut self,
-        address: StreamAddress,
+        address: ServerAddress,
         options: ClientOptions,
         topology: &WeakTopology,
     ) {
@@ -483,7 +483,7 @@ impl TopologyState {
     /// Updates the given `command` as needed based on the `criteria`.
     pub(crate) fn update_command_with_read_pref(
         &self,
-        server_address: &StreamAddress,
+        server_address: &ServerAddress,
         command: &mut Command,
         criteria: Option<&SelectionCriteria>,
     ) {
@@ -519,7 +519,7 @@ impl TopologyState {
     /// removed servers in the topology description.
     fn update_hosts(
         &mut self,
-        hosts: &HashSet<StreamAddress>,
+        hosts: &HashSet<ServerAddress>,
         options: &ClientOptions,
         topology: WeakTopology,
     ) -> Option<TopologyDescriptionDiff> {
@@ -533,7 +533,7 @@ impl TopologyState {
 
     fn sync_hosts(
         &mut self,
-        hosts: &HashSet<StreamAddress>,
+        hosts: &HashSet<ServerAddress>,
         options: &ClientOptions,
         topology: &WeakTopology,
     ) {

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -7,7 +7,7 @@ use super::WeakTopology;
 use crate::{
     cmap::{options::ConnectionPoolOptions, ConnectionPool},
     error::Error,
-    options::{ClientOptions, StreamAddress},
+    options::{ClientOptions, ServerAddress},
     runtime::{AcknowledgedMessage, HttpClient},
     sdam::monitor::Monitor,
 };
@@ -15,7 +15,7 @@ use crate::{
 /// Contains the state for a given server in the topology.
 #[derive(Debug)]
 pub(crate) struct Server {
-    pub(crate) address: StreamAddress,
+    pub(crate) address: ServerAddress,
 
     /// The connection pool for the server.
     pub(crate) pool: ConnectionPool,
@@ -26,7 +26,7 @@ pub(crate) struct Server {
 
 impl Server {
     #[cfg(test)]
-    pub(crate) fn new_mocked(address: StreamAddress, operation_count: u32) -> Self {
+    pub(crate) fn new_mocked(address: ServerAddress, operation_count: u32) -> Self {
         Self {
             address: address.clone(),
             pool: ConnectionPool::new_mocked(address),
@@ -37,7 +37,7 @@ impl Server {
     /// Create a new reference counted `Server` instance and a `Monitor` for that server.
     /// The monitor is not started as part of this; call `Monitor::execute` to start it.
     pub(crate) fn create(
-        address: StreamAddress,
+        address: ServerAddress,
         options: &ClientOptions,
         topology: WeakTopology,
         http_client: HttpClient,

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -8,7 +8,7 @@ use crate::{
     bson::{doc, Bson, Document},
     bson_util::deserialize_duration_from_u64_seconds,
     error::{ErrorKind, Result},
-    options::StreamAddress,
+    options::ServerAddress,
     sdam::public::ServerInfo,
 };
 
@@ -68,7 +68,7 @@ impl SelectionCriteria {
         self.as_read_pref().and_then(|pref| pref.max_staleness())
     }
 
-    pub(crate) fn from_address(address: StreamAddress) -> Self {
+    pub(crate) fn from_address(address: ServerAddress) -> Self {
         SelectionCriteria::Predicate(Arc::new(move |server| server.address() == &address))
     }
 }

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -77,7 +77,7 @@ impl SrvResolver {
             .map(|record| {
                 let hostname = record.target().to_utf8();
                 let port = Some(record.port());
-                ServerAddress { host: hostname, port }
+                ServerAddress::Tcp { host: hostname, port }
             })
             .collect();
 
@@ -91,7 +91,7 @@ impl SrvResolver {
         let results = srv_addresses.into_iter().map(move |mut address| {
             let domain_name = &hostname_parts[1..];
 
-            let mut hostname_parts: Vec<_> = address.host.split('.').collect();
+            let mut hostname_parts: Vec<_> = address.host().split('.').collect();
 
             // Remove empty final section, which indicates a trailing dot.
             if hostname_parts.last().map(|s| s.is_empty()).unwrap_or(false) {
@@ -112,7 +112,7 @@ impl SrvResolver {
 
             // The spec tests list the seeds without the trailing '.', so we remove it by
             // joining the parts we split rather than manipulating the string.
-            address.host = hostname_parts.join(".");
+            address = ServerAddress::Tcp { host: hostname_parts.join("."), port: address.port() };
 
             Ok(address)
         });

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -43,7 +43,7 @@ fn client_options() {
     assert_eq!(
         options,
         ClientOptions::builder()
-            .hosts(vec![ServerAddress {
+            .hosts(vec![ServerAddress::Tcp {
                 host: "localhost".into(),
                 port: Some(27017)
             }])

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -12,7 +12,7 @@ use crate::{
         CollectionOptions,
         DatabaseOptions,
         FindOptions,
-        StreamAddress,
+        ServerAddress,
         WriteConcern,
     },
     sync::{Client, Collection},
@@ -43,8 +43,8 @@ fn client_options() {
     assert_eq!(
         options,
         ClientOptions::builder()
-            .hosts(vec![StreamAddress {
-                hostname: "localhost".into(),
+            .hosts(vec![ServerAddress {
+                host: "localhost".into(),
                 port: Some(27017)
             }])
             .build()

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -7,7 +7,7 @@ use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use crate::{
     bson::{doc, Bson},
     error::{CommandError, Error, ErrorKind},
-    options::{AuthMechanism, ClientOptions, Credential, ListDatabasesOptions, StreamAddress},
+    options::{AuthMechanism, ClientOptions, Credential, ListDatabasesOptions, ServerAddress},
     selection_criteria::{ReadPreference, ReadPreferenceOptions, SelectionCriteria},
     test::{util::TestClient, CLIENT_OPTIONS, LOCK},
     Client,
@@ -617,8 +617,8 @@ async fn plain_auth() {
     }
 
     let options = ClientOptions::builder()
-        .hosts(vec![StreamAddress {
-            hostname: "ldaptest.10gen.cc".into(),
+        .hosts(vec![ServerAddress {
+            host: "ldaptest.10gen.cc".into(),
             port: None,
         }])
         .credential(

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -617,7 +617,7 @@ async fn plain_auth() {
     }
 
     let options = ClientOptions::builder()
-        .hosts(vec![ServerAddress {
+        .hosts(vec![ServerAddress::Tcp {
             host: "ldaptest.10gen.cc".into(),
             port: None,
         }])


### PR DESCRIPTION
RUST-760

This PR refactors the `StreamAddress` type to `ServerAddress` to more clearly indicate its purpose. It also refactors the `hostname` field to just `host` to indicate that an IP address can also be specified. It also updates it to be an enum so that different types of addresses can be supported in the future (e.g. Unix Domain Socket paths).

To ease the transition a little bit, the `StreamAdress` type was retained and deprecated, slated to be removed once we do the 2.0.0 stable release.