### PR TITLE
RUST-796 Provide easy way to reborrow session in between cursor iterations

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -488,7 +488,7 @@ where
         let mut cursor = self
             .find_with_session(filter, Some(options), session)
             .await?;
-        let mut cursor = cursor.with_session(session);
+        let mut cursor = cursor.stream(session);
         cursor.next().await.transpose()
     }
 

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -26,7 +26,7 @@ use common::{GenericCursor, GetMoreProvider, GetMoreProviderResult};
 /// as the [`Cursor`] is iterated. When the batch is exhausted and if there are more results, the
 /// [`Cursor`] will fetch the next batch of documents, and so forth until the results are exhausted.
 /// Note that because of this batching, additional network I/O may occur on any given call to
-/// [`Cursor::next`]. Because of this, a [`Cursor`] iterates over `Result<T>` items rather than
+/// `next`. Because of this, a [`Cursor`] iterates over `Result<T>` items rather than
 /// simply `T` items.
 ///
 /// The batch size of the `Cursor` can be configured using the options to the method that returns

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -278,7 +278,7 @@ impl Database {
             .await
             .map(|spec| SessionCursor::new(self.client().clone(), spec))?;
 
-        self.list_collection_names_common(cursor.with_session(session))
+        self.list_collection_names_common(cursor.stream(session))
             .await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ define_if_single_runtime_enabled! {
     pub use crate::{
         client::Client,
         coll::Collection,
-        cursor::{Cursor, session::{SessionCursor, SessionCursorHandle}},
+        cursor::{Cursor, session::{SessionCursor, SessionCursorStream}},
         db::Database,
     };
 
@@ -144,7 +144,7 @@ define_if_single_runtime_enabled! {
     pub(crate) use crate::{
         client::Client,
         coll::Collection,
-        cursor::{Cursor, session::{SessionCursor, SessionCursorHandle}},
+        cursor::{Cursor, session::{SessionCursor, SessionCursorStream}},
         db::Database,
     };
 

--- a/src/sync/cursor.rs
+++ b/src/sync/cursor.rs
@@ -97,7 +97,7 @@ where
 }
 
 /// A `SessionCursor` is a cursor that was created with a `ClientSession` must be iterated using
-/// one. To iterate, retrieve a [`SessionCursorIterator]` using [`SessionCursor::iter`]:
+/// one. To iterate, retrieve a [`SessionCursorIter]` using [`SessionCursor::iter`]:
 ///
 /// ```rust
 /// # use mongodb::{bson::Document, sync::Client, error::Result};
@@ -131,13 +131,13 @@ where
         Self { async_cursor }
     }
 
-    /// Retrieves a [`SessionCursorIterator`] to iterate this cursor. The session provided must be
+    /// Retrieves a [`SessionCursorIter`] to iterate this cursor. The session provided must be
     /// the same session used to create the cursor.
     pub fn iter<'session>(
         &mut self,
         session: &'session mut ClientSession,
-    ) -> SessionCursorIterator<'_, 'session, T> {
-        SessionCursorIterator {
+    ) -> SessionCursorIter<'_, 'session, T> {
+        SessionCursorIter {
             async_stream: self.async_cursor.stream(session),
         }
     }
@@ -172,14 +172,14 @@ where
 /// the current buffer of a `SessionCursor`.
 ///
 /// This updates the buffer of the parent `SessionCursor` when dropped.
-pub struct SessionCursorIterator<'cursor, 'session, T = Document>
+pub struct SessionCursorIter<'cursor, 'session, T = Document>
 where
     T: DeserializeOwned + Unpin,
 {
     async_stream: SessionCursorStream<'cursor, 'session, T>,
 }
 
-impl<T> Iterator for SessionCursorIterator<'_, '_, T>
+impl<T> Iterator for SessionCursorIter<'_, '_, T>
 where
     T: DeserializeOwned + Unpin,
 {

--- a/src/sync/cursor.rs
+++ b/src/sync/cursor.rs
@@ -7,7 +7,7 @@ use crate::{
     ClientSession,
     Cursor as AsyncCursor,
     SessionCursor as AsyncSessionCursor,
-    SessionCursorHandle as AsyncSessionCursorHandle,
+    SessionCursorStream,
     RUNTIME,
 };
 
@@ -97,7 +97,7 @@ where
 }
 
 /// A `SessionCursor` is a cursor that was created with a `ClientSession` must be iterated using
-/// one. To iterate, retrieve a `SessionCursorHandle` using `SessionCursor::with_session`:
+/// one. To iterate, retrieve a [`SessionCursorIterator]` using [`SessionCursor::iter`]:
 ///
 /// ```rust
 /// # use mongodb::{bson::Document, sync::Client, error::Result};
@@ -108,7 +108,7 @@ where
 /// # let coll = client.database("foo").collection::<Document>("bar");
 /// # let mut cursor = coll.find_with_session(None, None, &mut session)?;
 /// #
-/// for doc in cursor.with_session(&mut session) {
+/// for doc in cursor.iter(&mut session) {
 ///   println!("{}", doc?)
 /// }
 /// #
@@ -131,15 +131,40 @@ where
         Self { async_cursor }
     }
 
-    /// Retrieves a `SessionCursorHandle` to iterate this cursor. The session provided must be the
-    /// same session used to create the cursor.
-    pub fn with_session<'session>(
+    /// Retrieves a [`SessionCursorIterator`] to iterate this cursor. The session provided must be
+    /// the same session used to create the cursor.
+    pub fn iter<'session>(
         &mut self,
         session: &'session mut ClientSession,
-    ) -> SessionCursorHandle<'_, 'session, T> {
-        SessionCursorHandle {
-            async_handle: self.async_cursor.with_session(session),
+    ) -> SessionCursorIterator<'_, 'session, T> {
+        SessionCursorIterator {
+            async_stream: self.async_cursor.stream(session),
         }
+    }
+
+    /// Retrieve the next result from the cursor.
+    /// The session provided must be the same session used to create the cursor.
+    ///
+    /// Use this method when the session needs to be used again between iterations or when the added
+    /// functionality of `Iterator` is not needed.
+    ///
+    /// ```
+    /// # use bson::{doc, Document};
+    /// # use mongodb::sync::Client;
+    /// # fn foo() -> mongodb::error::Result<()> {
+    /// # let client = Client::with_uri_str("foo")?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let other_coll = coll.clone();
+    /// # let mut session = client.start_session(None)?;
+    /// let mut cursor = coll.find_with_session(doc! { "x": 1 }, None, &mut session)?;
+    /// while let Some(doc) = cursor.next(&mut session).transpose()? {
+    ///     other_coll.insert_one_with_session(doc, None, &mut session)?;
+    /// }
+    /// # Ok::<(), mongodb::error::Error>(())
+    /// # }
+    /// ```
+    pub fn next(&mut self, session: &mut ClientSession) -> Option<Result<T>> {
+        self.iter(session).next()
     }
 }
 
@@ -147,20 +172,20 @@ where
 /// the current buffer of a `SessionCursor`.
 ///
 /// This updates the buffer of the parent `SessionCursor` when dropped.
-pub struct SessionCursorHandle<'cursor, 'session, T = Document>
+pub struct SessionCursorIterator<'cursor, 'session, T = Document>
 where
     T: DeserializeOwned + Unpin,
 {
-    async_handle: AsyncSessionCursorHandle<'cursor, 'session, T>,
+    async_stream: SessionCursorStream<'cursor, 'session, T>,
 }
 
-impl<T> Iterator for SessionCursorHandle<'_, '_, T>
+impl<T> Iterator for SessionCursorIterator<'_, '_, T>
 where
     T: DeserializeOwned + Unpin,
 {
     type Item = Result<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        RUNTIME.block_on(self.async_handle.next())
+        RUNTIME.block_on(self.async_stream.next())
     }
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -10,5 +10,5 @@ mod test;
 
 pub use client::Client;
 pub use coll::Collection;
-pub use cursor::{Cursor, SessionCursor};
+pub use cursor::{Cursor, SessionCursor, SessionCursorIter};
 pub use db::Database;

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -342,7 +342,7 @@ impl TestOperation for Find {
                     .find_with_session(self.filter.clone(), self.options.clone(), session)
                     .await?;
                 cursor
-                    .with_session(session)
+                    .stream(session)
                     .try_collect::<Vec<Document>>()
                     .await?
             }
@@ -607,7 +607,7 @@ impl TestOperation for Aggregate {
                     .aggregate_with_session(self.pipeline.clone(), self.options.clone(), session)
                     .await?;
                 cursor
-                    .with_session(session)
+                    .stream(session)
                     .try_collect::<Vec<Document>>()
                     .await?
             }
@@ -632,7 +632,7 @@ impl TestOperation for Aggregate {
                     .aggregate_with_session(self.pipeline.clone(), self.options.clone(), session)
                     .await?;
                 cursor
-                    .with_session(session)
+                    .stream(session)
                     .try_collect::<Vec<Document>>()
                     .await?
             }
@@ -875,7 +875,7 @@ impl TestOperation for ListCollections {
                         session,
                     )
                     .await?;
-                cursor.with_session(session).try_collect::<Vec<_>>().await?
+                cursor.stream(session).try_collect::<Vec<_>>().await?
             }
             None => {
                 let cursor = database


### PR DESCRIPTION
RUST-796

This PR adds a `SessionCursor::next(&mut ClientSession)` method to allow for iteration of the cursor that allows for easy reborrowing of the session. As part of this, `SessionCursor::with_session` was renamed to `SessionCursor::stream` to more accurately reflect its intent now that `next` is around. Similar changes were made for the sync driver.

I also went ahead and updated the documentation for cursors in general to be a little more straightforward.