### PR TITLE
RUST-823 Reduce default `max_pool_size` to 10

### DIFF
--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -40,7 +40,7 @@ use worker::ConnectionPoolWorker;
 #[cfg(test)]
 use self::worker::PoolWorkerHandle;
 
-const DEFAULT_MAX_POOL_SIZE: u32 = 100;
+const DEFAULT_MAX_POOL_SIZE: u32 = 10;
 
 /// A pool of connections implementing the CMAP spec. All state is kept internally in an `Arc`, and
 /// internal state that is mutable is additionally wrapped by a lock.

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -57,7 +57,7 @@ pub(crate) struct ConnectionPoolOptions {
     /// The maximum number of connections that the pool can have at a given time. This includes
     /// connections which are currently checked out of the pool.
     ///
-    /// The default is 100.
+    /// The default is 10.
     pub(crate) max_pool_size: Option<u32>,
 
     /// The minimum number of connections that the pool can have at a given time. This includes


### PR DESCRIPTION
RUST-823

This PR updates the default `max_pool_size` to 10. For some background on the motivation, see [here](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing) and [here](https://kwahome.medium.com/database-connections-less-is-more-86c406b6fad). Note that this is also in line with the defaults for [`r2d2`](https://docs.rs/r2d2/0.8.9/r2d2/struct.Builder.html#method.max_size) and [`bb8`](https://docs.rs/bb8/0.7.0/bb8/struct.Builder.html#method.max_size).