### PR TITLE
RUST-811 Introduce feature flags for `chrono` and `uuid` interop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,16 @@ sync = ["async-std-runtime"]
 # whose implementation cannot be changed; otherwise, it is preferred to use the helper functions
 # provided in the bson::serde_helpers module.
 bson-u2i = ["bson/u2i"]
+# Enable support for v0.4 of the chrono crate in the public API of the BSON library.
+bson-chrono-0_4 = ["bson/chrono-0_4"]
+# Enable support for v0.8 of the uuid crate in the public API of the BSON library.
+bson-uuid-0_8 = ["bson/uuid-0_8"]
 
 [dependencies]
 async-trait = "0.1.42"
 base64 = "0.13.0"
 bitflags = "1.1.0"
-bson = "2.0.0-beta"
+bson = { git = "https://github.com/mongodb/bson-rust" }
 chrono = "0.4.7"
 derivative = "2.1.1"
 futures-core = "0.3.14"

--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -277,11 +277,11 @@ mod test {
         spec::BinarySubtype,
         Binary,
         Bson,
+        DateTime,
         JavaScriptCodeWithScope,
         Regex,
         Timestamp,
     };
-    use chrono::{DateTime, NaiveDateTime, Utc};
 
     use super::doc_size_bytes;
 
@@ -309,10 +309,7 @@ mod test {
             "timestamp": Bson::Timestamp(Timestamp { time: 12233, increment: 34444 }),
             "binary": Bson::Binary(Binary{ subtype: BinarySubtype::Generic, bytes: vec![3, 222, 11] }),
             "objectid": ObjectId::from_bytes([1; 12]),
-            "datetime": DateTime::from_utc(
-                NaiveDateTime::from_timestamp(4444333221, 0),
-                Utc,
-            ),
+            "datetime": DateTime::from_millis(4444333221),
             "symbol": Bson::Symbol("foobar".into()),
         };
 

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
-use crate::bson::{oid::ObjectId, DateTime};
-use chrono::offset::Utc;
-
 use crate::{
+    bson::{oid::ObjectId, DateTime},
     client::ClusterTime,
     is_master::IsMasterReply,
     options::ServerAddress,
@@ -115,7 +113,7 @@ impl ServerDescription {
         // We want to set last_update_time if we got any sort of response from the server.
         match description.reply {
             Ok(None) => {}
-            _ => description.last_update_time = Some(Utc::now().into()),
+            _ => description.last_update_time = Some(DateTime::now()),
         };
 
         if let Ok(Some(ref mut reply)) = description.reply {

--- a/src/sdam/description/topology/server_selection/test/mod.rs
+++ b/src/sdam/description/topology/server_selection/test/mod.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
-use bson::doc;
-use chrono::{TimeZone, Utc};
+use bson::{doc, DateTime};
 use serde::Deserialize;
 
 use crate::{
@@ -90,7 +89,7 @@ impl TestServerDescription {
         let mut command_response = is_master_response_from_server_type(server_type);
         command_response.tags = self.tags;
         command_response.last_write = self.last_write.map(|last_write| LastWrite {
-            last_write_date: Utc.timestamp_millis(last_write.last_write_date).into(),
+            last_write_date: DateTime::from_millis(last_write.last_write_date),
         });
 
         let is_master = IsMasterReply {
@@ -105,7 +104,7 @@ impl TestServerDescription {
         );
         server_desc.last_update_time = self
             .last_update_time
-            .map(|i| Utc.timestamp_millis(i.into()).into());
+            .map(|i| DateTime::from_millis(i.into()));
 
         Some(server_desc)
     }


### PR DESCRIPTION
RUST-811

This update the driver to accommodate the new `"chrono-0_4"` and `"uuid-0_8"` feature flags added to the bson library in https://github.com/mongodb/bson-rust/pull/258.