### PR TITLE
RUST-571 Fix race between SDAM discovery and SRV polling

### DIFF
--- a/src/sdam/srv_polling/mod.rs
+++ b/src/sdam/srv_polling/mod.rs
@@ -4,45 +4,41 @@ mod test;
 use std::time::Duration;
 
 use super::{
+    description::topology::TopologyType,
     monitor::DEFAULT_HEARTBEAT_FREQUENCY,
     state::{Topology, WeakTopology},
 };
 use crate::{
     error::{Error, Result},
-    options::{ClientOptions, ServerAddress},
-    srv::SrvResolver,
+    options::ClientOptions,
+    srv::{LookupHosts, SrvResolver},
     RUNTIME,
 };
 
-const DEFAULT_RESCAN_SRV_INTERVAL: Duration = Duration::from_secs(60);
+const MIN_RESCAN_SRV_INTERVAL: Duration = Duration::from_secs(60);
 
 pub(crate) struct SrvPollingMonitor {
     initial_hostname: String,
     resolver: Option<SrvResolver>,
     topology: WeakTopology,
-    rescan_interval: Option<Duration>,
+    rescan_interval: Duration,
     client_options: ClientOptions,
-}
-
-struct LookupHosts {
-    hosts: Vec<ServerAddress>,
-    min_ttl: Option<Duration>,
 }
 
 impl SrvPollingMonitor {
     pub(crate) fn new(topology: WeakTopology) -> Option<Self> {
-        let client_options = topology.client_options().clone();
+        let mut client_options = topology.client_options().clone();
 
-        let initial_hostname = match client_options.original_srv_hostname() {
-            Some(hostname) => hostname.clone(),
+        let initial_info = match client_options.original_srv_info.take() {
+            Some(info) => info,
             None => return None,
         };
 
         Some(Self {
-            initial_hostname,
+            initial_hostname: initial_info.hostname,
             resolver: None,
             topology,
-            rescan_interval: None,
+            rescan_interval: initial_info.min_ttl,
             client_options,
         })
     }
@@ -58,23 +54,34 @@ impl SrvPollingMonitor {
         });
     }
 
+    fn rescan_interval(&self) -> Duration {
+        std::cmp::max(self.rescan_interval, MIN_RESCAN_SRV_INTERVAL)
+    }
+
     async fn execute(&mut self) {
+        fn should_poll(tt: TopologyType) -> bool {
+            matches!(tt, TopologyType::Sharded | TopologyType::Unknown)
+        }
+
         while self.topology.is_alive() {
+            RUNTIME.delay_for(self.rescan_interval()).await;
+
             let topology = match self.topology.upgrade() {
                 Some(topology) => topology,
                 None => break,
             };
 
-            if topology.is_sharded().await || topology.is_unknown().await {
+            if should_poll(topology.topology_type().await) {
                 let hosts = self.lookup_hosts().await;
-                self.update_hosts(hosts, topology.clone()).await;
+
+                // verify we should still update before updating in case the topology changed
+                // while the srv lookup was happening.
+                if should_poll(topology.topology_type().await) {
+                    self.update_hosts(hosts, topology.clone()).await;
+                }
             }
 
             std::mem::drop(topology);
-
-            RUNTIME
-                .delay_for(self.rescan_interval.unwrap_or(DEFAULT_RESCAN_SRV_INTERVAL))
-                .await;
         }
     }
 
@@ -95,36 +102,23 @@ impl SrvPollingMonitor {
 
         self.rescan_interval = lookup.min_ttl;
 
+        // TODO: RUST-230 Log error with host that was returned.
         topology
-            .update_hosts(lookup.hosts.into_iter().collect(), &self.client_options)
+            .update_hosts(
+                lookup.hosts.into_iter().filter_map(Result::ok).collect(),
+                &self.client_options,
+            )
             .await;
     }
 
     async fn lookup_hosts(&mut self) -> Result<LookupHosts> {
         let initial_hostname = self.initial_hostname.clone();
         let resolver = self.get_or_create_srv_resolver().await?;
-        let mut new_hosts = Vec::new();
-
-        for host in resolver.get_srv_hosts(&initial_hostname).await? {
-            #[allow(clippy::single_match)]
-            match host {
-                Ok(host) => new_hosts.push(host),
-                Err(_) => {
-                    // TODO RUST-230: Log error with host that was returned.
-                }
-            }
-        }
-
-        Ok(LookupHosts {
-            hosts: new_hosts,
-            min_ttl: resolver
-                .min_ttl()
-                .map(|ttl| Duration::from_secs(ttl as u64)),
-        })
+        resolver.get_srv_hosts(initial_hostname.as_str()).await
     }
 
-    async fn get_or_create_srv_resolver(&mut self) -> Result<&mut SrvResolver> {
-        if let Some(ref mut resolver) = self.resolver {
+    async fn get_or_create_srv_resolver(&mut self) -> Result<&SrvResolver> {
+        if let Some(ref resolver) = self.resolver {
             return Ok(resolver);
         }
 
@@ -139,7 +133,7 @@ impl SrvPollingMonitor {
     fn no_valid_hosts(&mut self, _error: Option<Error>) {
         // TODO RUST-230: Log error/lack of valid results.
 
-        self.rescan_interval = Some(self.heartbeat_freq());
+        self.rescan_interval = self.heartbeat_freq();
     }
 
     fn heartbeat_freq(&self) -> Duration {

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Duration};
 
 use pretty_assertions::assert_eq;
 
@@ -32,8 +32,8 @@ async fn run_test(new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet
     monitor
         .update_hosts(
             new_hosts.map(|hosts| LookupHosts {
-                hosts,
-                min_ttl: None,
+                hosts: hosts.into_iter().map(Result::Ok).collect(),
+                min_ttl: Duration::from_secs(60),
             }),
             topology.clone(),
         )

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -408,12 +408,8 @@ impl Topology {
             .transaction_support_status()
     }
 
-    pub(super) async fn is_sharded(&self) -> bool {
-        self.state.read().await.description.topology_type() == TopologyType::Sharded
-    }
-
-    pub(super) async fn is_unknown(&self) -> bool {
-        self.state.read().await.description.topology_type() == TopologyType::Unknown
+    pub(super) async fn topology_type(&self) -> TopologyType {
+        self.state.read().await.description.topology_type()
     }
 
     pub(crate) async fn get_server_description(

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -142,7 +142,7 @@ async fn run() {
 
                 if actual_hosts == test_file.hosts {
                     break;
-                } else if start.elapsed() < Duration::from_secs(5) {
+                } else if start.elapsed() > Duration::from_secs(5) {
                     panic!(
                         "expected to eventually discover {:?}, instead found {:?}",
                         test_file.hosts, actual_hosts

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -6,8 +6,8 @@ use tokio::sync::RwLockReadGuard;
 use crate::{
     bson::doc,
     client::{auth::AuthMechanism, Client},
-    options::{ClientOptions, ResolverConfig, Tls, TlsOptions},
-    test::{run_spec_test, TestClient, LOCK},
+    options::{ClientOptions, ResolverConfig},
+    test::{run_spec_test, TestClient, CLIENT_OPTIONS, LOCK},
     RUNTIME,
 };
 
@@ -117,10 +117,7 @@ async fn run() {
 
             let mut options_with_tls = options.clone();
             if requires_tls {
-                let tls_options = TlsOptions::builder()
-                    .allow_invalid_certificates(true)
-                    .build();
-                options_with_tls.tls = Some(Tls::Enabled(tls_options));
+                options_with_tls.tls = CLIENT_OPTIONS.tls.clone();
             }
 
             let client = Client::with_options(options_with_tls).unwrap();


### PR DESCRIPTION
RUST-571

The initial dns seedlist tests were pretty flaky, and I believe for (at least) these 3 reasons:
- the test lock was not acquired before running it
- we don't have SDAM monitoring yet, so our checking of the discovered hosts was racy
- there was a race between SRV polling and discovery of an Unknown topology
  - We were not waiting before doing the first SRV poll after client creation, so the SRV pol could update the topology before the monitors had a chance to mark it as a replica set, causing the polling and SDAM to get into a loop of updating the topology back and forth

This PR fixes these three issues, though sadly it appears that we [still have failures in this test](https://evergreen.mongodb.com/task/mongo_rust_driver_tests__async_runtime~tokio_auth_and_tls~auth_and_tls_os~macos_10.14_test_4.2_replica_set_patch_3569cc2279c8a357f0bc332df4b8f990acf61939_60a8394dd1fe07741eec0f7e_21_05_21_22_51_00), though much less frequently. As the macOS queue is heavily stalled right now (my patch is 1200th in the queue after over an hour), I'm just going to put this PR up now and monitor the failures going forward.