### PR TITLE
RUST-162 / RUST-814 Update evergreen test variants

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1330,9 +1330,9 @@ buildvariants:
 - matrix_name: "aws-auth"
   matrix_spec:
     os:
-      - ubuntu-18.04
+      - ubuntu-20.04
     async-runtime: "tokio"
-  display_name: "AWS Auth ${os} with ${async-runtime}"
+  display_name: "${os} AWS Auth with ${async-runtime}"
   tasks:
     - ".aws-auth"
 # TODO: RUST-361 enable these tests once OCSP support is implemented

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1229,6 +1229,12 @@ axes:
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
+      - id: ubuntu-18.04-arm64
+        display_name: "ARM64 Ubuntu 18.04"
+        run_on: ubuntu-1804-arm64-small
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          VENV_BIN_DIR: "bin"
       - id: macos-10.14
         display_name: "MacOS 10.14"
         run_on: macos-1014
@@ -1249,6 +1255,7 @@ buildvariants:
   matrix_spec:
     os:
       - ubuntu-16.04
+      - ubuntu-18.04-arm64
       - macos-10.14
       - windows-64-vs2017-small
     auth-and-tls: "*"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1274,11 +1274,14 @@ buildvariants:
     # the SSL tests on them.
     - if:
         os: "ubuntu-20.04"
+        auth-and-tls: "*"
+        async-runtime: "*"
       then:
         remove_tasks: [".3.6", ".4.0", ".4.2"]
     - if:
         os: "ubuntu-18.04"
         auth-and-tls: "auth-and-tls"
+        async-runtime: "*"
       then:
         remove_tasks: ".3.6"
 - matrix_name: "x509-auth"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1235,8 +1235,8 @@ axes:
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
-      - id: macos-10.14
-        display_name: "MacOS 10.14"
+      - id: macos-10.15
+        display_name: "MacOS 10.15"
         run_on: macos-1014
         variables:
           SINGLE_THREAD: true
@@ -1257,7 +1257,7 @@ buildvariants:
       - ubuntu-18.04
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.14
+      - macos-10.15
       - windows-64-vs2017-small
     auth-and-tls: "*"
     async-runtime: "*"
@@ -1273,7 +1273,7 @@ buildvariants:
     os:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.14
+      - macos-10.15
       - windows-64-vs2017-small
     auth-and-tls: "auth-and-tls"
     async-runtime: "*"
@@ -1286,7 +1286,7 @@ buildvariants:
     os:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.14
+      - macos-10.15
       - windows-64-vs2017-small
     async-runtime: "*"
   display_name: "${os} PLAIN auth with ${async-runtime}"
@@ -1298,7 +1298,7 @@ buildvariants:
     os:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.14
+      - macos-10.15
       - windows-64-vs2017-small
     async-runtime: "*"
   display_name: "Atlas Connectivity ${os} with ${async-runtime}"
@@ -1328,7 +1328,7 @@ buildvariants:
 # - matrix_name: "ocsp-macos"
 #   matrix_spec:
 #     os:
-#       - macos-10.14
+#       - macos-10.15
 #     async-runtime: "*"
 #     mongodb-version:
 #       - latest

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1223,9 +1223,9 @@ axes:
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
-      - id: ubuntu-16.04
-        display_name: "Ubuntu 16.04"
-        run_on: ubuntu1604-test
+      - id: ubuntu-20.04
+        display_name: "Ubuntu 20.04"
+        run_on: ubuntu2004-test
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
@@ -1254,7 +1254,8 @@ buildvariants:
   matrix_name: "tests"
   matrix_spec:
     os:
-      - ubuntu-16.04
+      - ubuntu-18.04
+      - ubuntu-20.04
       - ubuntu-18.04-arm64
       - macos-10.14
       - windows-64-vs2017-small
@@ -1270,7 +1271,8 @@ buildvariants:
 - matrix_name: "x509-auth"
   matrix_spec:
     os:
-      - ubuntu-16.04
+      - ubuntu-20.04
+      - ubuntu-18.04-arm64
       - macos-10.14
       - windows-64-vs2017-small
     auth-and-tls: "auth-and-tls"
@@ -1282,7 +1284,8 @@ buildvariants:
 - matrix_name: "plain-auth"
   matrix_spec:
     os:
-      - ubuntu-16.04
+      - ubuntu-20.04
+      - ubuntu-18.04-arm64
       - macos-10.14
       - windows-64-vs2017-small
     async-runtime: "*"
@@ -1293,7 +1296,8 @@ buildvariants:
 - matrix_name: "atlas-connect"
   matrix_spec:
     os:
-      - ubuntu-16.04
+      - ubuntu-20.04
+      - ubuntu-18.04-arm64
       - macos-10.14
       - windows-64-vs2017-small
     async-runtime: "*"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1235,9 +1235,9 @@ axes:
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
-      - id: macos-10.15
-        display_name: "MacOS 10.15"
-        run_on: macos-1015
+      - id: macos-10.14
+        display_name: "MacOS 10.14"
+        run_on: macos-1014
         variables:
           SINGLE_THREAD: true
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
@@ -1257,7 +1257,7 @@ buildvariants:
       - ubuntu-18.04
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.15
+      - macos-10.14
       - windows-64-vs2017
     auth-and-tls: "*"
     async-runtime: "*"
@@ -1287,7 +1287,7 @@ buildvariants:
     os:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.15
+      - macos-10.14
       - windows-64-vs2017
     auth-and-tls: "auth-and-tls"
     async-runtime: "*"
@@ -1300,7 +1300,7 @@ buildvariants:
     os:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.15
+      - macos-10.14
       - windows-64-vs2017
     async-runtime: "*"
   display_name: "${os} PLAIN auth with ${async-runtime}"
@@ -1312,7 +1312,7 @@ buildvariants:
     os:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
-      - macos-10.15
+      - macos-10.14
       - windows-64-vs2017
     async-runtime: "*"
   display_name: "Atlas Connectivity ${os} with ${async-runtime}"
@@ -1342,7 +1342,7 @@ buildvariants:
 # - matrix_name: "ocsp-macos"
 #   matrix_spec:
 #     os:
-#       - macos-10.15
+#       - macos-10.14
 #     async-runtime: "*"
 #     mongodb-version:
 #       - latest

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1279,7 +1279,7 @@ buildvariants:
       then:
         remove_tasks: [".3.6", ".4.0", ".4.2"]
     - if:
-        os: "ubuntu-18.04"
+        os: ["ubuntu-18.04", "ubuntu-18.04-arm64"]
         auth-and-tls: "auth-and-tls"
         async-runtime: "*"
       then:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1279,11 +1279,18 @@ buildvariants:
       then:
         remove_tasks: [".3.6", ".4.0", ".4.2"]
     - if:
-        os: ["ubuntu-18.04", "ubuntu-18.04-arm64"]
+        os: "ubuntu-18.04"
         auth-and-tls: "auth-and-tls"
         async-runtime: "*"
       then:
         remove_tasks: ".3.6"
+    # ubuntu 1804 ARM64 only has downloads for 4.2+
+    - if:
+        os: ["ubuntu-18.04-arm64"]
+        auth-and-tls: "*"
+        async-runtime: "*"
+      then:
+        remove_tasks: [".3.6", ".4.0"]
 - matrix_name: "x509-auth"
   matrix_spec:
     os:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1330,7 +1330,7 @@ buildvariants:
 - matrix_name: "aws-auth"
   matrix_spec:
     os:
-      - ubuntu-20.04
+      - ubuntu-18.04
     async-runtime: "tokio"
   display_name: "${os} AWS Auth with ${async-runtime}"
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1231,7 +1231,7 @@ axes:
           VENV_BIN_DIR: "bin"
       - id: ubuntu-18.04-arm64
         display_name: "ARM64 Ubuntu 18.04"
-        run_on: ubuntu-1804-arm64-small
+        run_on: ubuntu-1804-arm64-test
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
@@ -1242,9 +1242,9 @@ axes:
           SINGLE_THREAD: true
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
-      - id: windows-64-vs2017-small
+      - id: windows-64-vs2017
         display_name: "Windows (VS 2017)"
-        run_on: windows-64-vs2017-small
+        run_on: windows-64-vs2017-test
         variables:
           PYTHON: "/cygdrive/c/python/Python36/python"
           VENV_BIN_DIR: "Scripts"
@@ -1258,7 +1258,7 @@ buildvariants:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
       - macos-10.15
-      - windows-64-vs2017-small
+      - windows-64-vs2017
     auth-and-tls: "*"
     async-runtime: "*"
   display_name: "${os} ${auth-and-tls} with ${async-runtime}"
@@ -1274,7 +1274,7 @@ buildvariants:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
       - macos-10.15
-      - windows-64-vs2017-small
+      - windows-64-vs2017
     auth-and-tls: "auth-and-tls"
     async-runtime: "*"
   display_name: "${os} X.509 auth with ${async-runtime}"
@@ -1287,7 +1287,7 @@ buildvariants:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
       - macos-10.15
-      - windows-64-vs2017-small
+      - windows-64-vs2017
     async-runtime: "*"
   display_name: "${os} PLAIN auth with ${async-runtime}"
   tasks:
@@ -1299,7 +1299,7 @@ buildvariants:
       - ubuntu-20.04
       - ubuntu-18.04-arm64
       - macos-10.15
-      - windows-64-vs2017-small
+      - windows-64-vs2017
     async-runtime: "*"
   display_name: "Atlas Connectivity ${os} with ${async-runtime}"
   tasks:
@@ -1341,7 +1341,7 @@ buildvariants:
 # - matrix_name: "ocsp-windows"
 #   matrix_spec:
 #     os:
-#       - windows-64-vs2017-small
+#       - windows-64-vs2017
 #     async-runtime: "*"
 #     mongodb-version:
 #       - latest

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1231,13 +1231,13 @@ axes:
           VENV_BIN_DIR: "bin"
       - id: ubuntu-18.04-arm64
         display_name: "ARM64 Ubuntu 18.04"
-        run_on: ubuntu-1804-arm64-test
+        run_on: ubuntu1804-arm64-test
         variables:
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
           VENV_BIN_DIR: "bin"
       - id: macos-10.15
         display_name: "MacOS 10.15"
-        run_on: macos-1014
+        run_on: macos-1015
         variables:
           SINGLE_THREAD: true
           PYTHON: "/opt/mongodbtoolchain/v3/bin/python"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1274,9 +1274,8 @@ buildvariants:
     # the SSL tests on them.
     - if:
         os: "ubuntu-20.04"
-        auth-and-tls: "auth-and-tls"
       then:
-        remove_tasks: [".3.6", ".4.0"]
+        remove_tasks: [".3.6", ".4.0", ".4.2"]
     - if:
         os: "ubuntu-18.04"
         auth-and-tls: "auth-and-tls"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1268,6 +1268,20 @@ buildvariants:
      - ".4.2"
      - ".4.0"
      - ".3.6"
+  rules:
+    # Some older versions of MongoDB do not have specific Linux builds, so we just use
+    # generic Linux builds on them. These do not link to OpenSSL, so we have to skip
+    # the SSL tests on them.
+    - if:
+        os: "ubuntu-20.04"
+        auth-and-tls: "auth-and-tls"
+      then:
+        remove_tasks: [".3.6", ".4.0"]
+    - if:
+        os: "ubuntu-18.04"
+        auth-and-tls: "auth-and-tls"
+      then:
+        remove_tasks: ".3.6"
 - matrix_name: "x509-auth"
   matrix_spec:
     os:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1261,7 +1261,7 @@ buildvariants:
       - windows-64-vs2017
     auth-and-tls: "*"
     async-runtime: "*"
-  display_name: "${os} ${auth-and-tls} with ${async-runtime}"
+  display_name: "! ${os} ${auth-and-tls} with ${async-runtime}"
   tasks:
      - ".latest"
      - ".4.4"
@@ -1370,13 +1370,13 @@ buildvariants:
       - ubuntu-18.04
     async-runtime: "*"
     extra-rust-versions: "*"
-  display_name: "Compile on Rust ${extra-rust-versions} with ${async-runtime}"
+  display_name: "! Compile on Rust ${extra-rust-versions} with ${async-runtime}"
   tasks:
     - "compile-only"
 
 -
   name: "lint"
-  display_name: "Lint"
+  display_name: "! Lint"
   run_on:
     - ubuntu1804-test
   tasks:


### PR DESCRIPTION
RUST-162 / RUST-814

This PR updates our evergreen configuration to run on Ubuntu 18.04 ARM64, Ubuntu 18.04, and Ubuntu 20.04, and it removes testing on Ubuntu 16.04.

I also introduced the concept of "bang builds" (i.e. required builds) by adding an exclamation point in front of the more important variants. This will automatically sort them to the top of the waterfall / a patch view and can help for easy differentiation from the other, less important tasks. I borrowed this idea from the server's [evergreen config](https://evergreen.mongodb.com/waterfall/mongodb-mongo-master). I propose that we limit the tasks scheduled as part of a PR to just the bang builds and have the waterfall take care of running the other tasks, especially now that we have more variants. This should help cut back on needless evergreen cycles and speed up the PR process. Let me know if you all like this approach.

The bang builds are as follows:
- regular tests
- lint
- compile