### PR TITLE
RUST-847 Redact `Credential` `Debug` output (1.2.x)

### DIFF
--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -10,7 +10,7 @@ mod scram;
 mod test;
 mod x509;
 
-use std::{borrow::Cow, str::FromStr};
+use std::{borrow::Cow, fmt::Debug, str::FromStr};
 
 use hmac::Mac;
 use rand::Rng;
@@ -324,7 +324,7 @@ impl FromStr for AuthMechanism {
 ///
 /// Some fields (mechanism and source) may be omitted and will either be negotiated or assigned a
 /// default value, depending on the values of other fields in the credential.
-#[derive(Clone, Debug, Default, Deserialize, TypedBuilder, PartialEq)]
+#[derive(Clone, Default, Deserialize, TypedBuilder, PartialEq)]
 #[non_exhaustive]
 pub struct Credential {
     /// The username to authenticate with. This applies to all mechanisms but may be omitted when
@@ -434,6 +434,14 @@ impl Credential {
         mechanism
             .authenticate_stream(conn, self, server_api, http_client)
             .await
+    }
+}
+
+impl Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Credential")
+            .field(&"REDACTED".to_string())
+            .finish()
     }
 }
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1080,7 +1080,7 @@ impl ClientOptionsParser {
                     None
                 } else {
                     let port_string_without_colon = &port[1..];
-                    let p = u16::from_str_radix(port_string_without_colon, 10).map_err(|_| {
+                    let p: u16 = port_string_without_colon.parse().map_err(|_| {
                         ErrorKind::ArgumentError {
                             message: format!(
                                 "invalid port specified in connection string: {}",
@@ -1325,7 +1325,7 @@ impl ClientOptionsParser {
 
         macro_rules! get_duration {
             ($value:expr, $option:expr) => {
-                match u64::from_str_radix($value, 10) {
+                match $value.parse::<u64>() {
                     Ok(i) => i,
                     _ => {
                         return Err(ErrorKind::ArgumentError {
@@ -1342,7 +1342,7 @@ impl ClientOptionsParser {
 
         macro_rules! get_u32 {
             ($value:expr, $option:expr) => {
-                match u32::from_str_radix(value, 10) {
+                match value.parse::<u32>() {
                     Ok(u) => u,
                     Err(_) => {
                         return Err(ErrorKind::ArgumentError {
@@ -1359,7 +1359,7 @@ impl ClientOptionsParser {
 
         macro_rules! get_i32 {
             ($value:expr, $option:expr) => {
-                match i32::from_str_radix(value, 10) {
+                match value.parse::<i32>() {
                     Ok(u) => u,
                     Err(_) => {
                         return Err(ErrorKind::ArgumentError {
@@ -1631,7 +1631,7 @@ impl ClientOptionsParser {
             "w" => {
                 let mut write_concern = self.write_concern.get_or_insert_with(Default::default);
 
-                match i32::from_str_radix(value, 10) {
+                match value.parse::<i32>() {
                     Ok(w) => {
                         if w < 0 {
                             return Err(ErrorKind::ArgumentError {

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -224,8 +224,8 @@ impl Handshaker {
         });
 
         Ok(HandshakeResult {
-            first_round,
             is_master_reply,
+            first_round,
         })
     }
 }

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -86,9 +86,9 @@ impl ConnectionPool {
             address,
             manager,
             connection_requester,
+            generation_subscriber,
             wait_queue_timeout,
             event_handler,
-            generation_subscriber,
         }
     }
 

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -20,12 +20,15 @@ use crate::{
     test::{
         assert_matches,
         run_spec_test,
+        CmapEvent,
         EventClient,
         Matchable,
+        TestClient,
         CLIENT_OPTIONS,
         LOCK,
         SERVER_API,
     },
+    Client,
     RUNTIME,
 };
 use bson::doc;
@@ -434,4 +437,45 @@ async fn cmap_spec_tests() {
     }
 
     run_spec_test(&["connection-monitoring-and-pooling"], run_cmap_spec_tests).await;
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn redact_credential() {
+    let _lock = LOCK.run_concurrently().await;
+
+    let client = TestClient::new().await;
+    if !client.auth_enabled() {
+        println!("skipping redact_credential due to auth not being enabled");
+        return;
+    }
+
+    let mut options = CLIENT_OPTIONS.clone();
+    options.direct_connection = Some(true);
+    options.hosts.drain(1..);
+
+    let credential = options.credential.clone().unwrap();
+
+    let handler = Arc::new(crate::test::EventHandler::new());
+    let mut subscriber = handler.subscribe();
+    options.cmap_event_handler = Some(handler.clone());
+
+    let _client = Client::with_options(options).unwrap();
+
+    subscriber
+        .wait_for_event(EVENT_TIMEOUT, |e| {
+            if let crate::test::Event::CmapEvent(CmapEvent::ConnectionPoolCreated(event)) = e {
+                if let Some(ref pass) = credential.password {
+                    assert!(!format!("{:?}", event).contains(pass))
+                }
+                if let Some(ref user) = credential.username {
+                    assert!(!format!("{:?}", event).contains(user))
+                }
+                true
+            } else {
+                false
+            }
+        })
+        .await
+        .expect("expected connection pool created event");
 }

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -465,12 +465,14 @@ async fn redact_credential() {
     subscriber
         .wait_for_event(EVENT_TIMEOUT, |e| {
             if let crate::test::Event::CmapEvent(CmapEvent::ConnectionPoolCreated(event)) = e {
+                let event_debug = format!("{:?}", event);
                 if let Some(ref pass) = credential.password {
-                    assert!(!format!("{:?}", event).contains(pass))
+                    assert!(!event_debug.contains(pass))
                 }
                 if let Some(ref user) = credential.username {
-                    assert!(!format!("{:?}", event).contains(user))
+                    assert!(!event_debug.contains(user))
                 }
+                assert!(event_debug.contains("REDACTED"));
                 true
             } else {
                 false

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -449,8 +449,8 @@ pub struct FindOneAndUpdateOptions {
 /// Specifies the options to a [`Collection::aggregate`](../struct.Collection.html#method.aggregate)
 /// operation.
 #[skip_serializing_none]
-#[serde(rename_all = "camelCase")]
 #[derive(Clone, Debug, Default, Deserialize, TypedBuilder, Serialize)]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct AggregateOptions {
     /// Enables writing to temporary files. When set to true, aggregation stages can write data to

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::RwLockWriteGuard;
 use crate::{
     bson::{doc, Document},
     options::{CollectionOptions, FindOptions, ReadConcern, ReadPreference, SelectionCriteria},
-    test::{run_spec_test, LOCK},
+    test::{run_spec_test, TestClient, LOCK},
 };
 
 pub use self::{
@@ -245,5 +245,10 @@ async fn test_examples() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn test_versioned_api() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
+
+    // TODO RUST-725 Unskip these tests on 5.0
+    if TestClient::new().await.server_version_gte(5, 0) {
+        return;
+    }
     run_spec_test(&["versioned-api"], run_unified_format_test).await;
 }

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -14,7 +14,7 @@ use crate::{
     bson::doc,
     client::options::ServerApi,
     event::{
-        cmap::{CmapEventHandler, PoolClearedEvent, PoolReadyEvent},
+        cmap::{CmapEventHandler, PoolClearedEvent, PoolCreatedEvent, PoolReadyEvent},
         command::{
             CommandEventHandler,
             CommandFailedEvent,
@@ -107,6 +107,10 @@ impl EventHandler {
 }
 
 impl CmapEventHandler for EventHandler {
+    fn handle_pool_created_event(&self, event: PoolCreatedEvent) {
+        self.handle(CmapEvent::ConnectionPoolCreated(event));
+    }
+
     fn handle_pool_cleared_event(&self, event: PoolClearedEvent) {
         self.handle(CmapEvent::ConnectionPoolCleared(event.clone()));
         self.pool_cleared_events.write().unwrap().push_back(event);

--- a/src/test/util/matchable.rs
+++ b/src/test/util/matchable.rs
@@ -17,7 +17,7 @@ pub trait Matchable: Sized + 'static {
         if expected.is_placeholder() {
             return true;
         }
-        if let Some(expected) = Any::downcast_ref::<Self>(expected) {
+        if let Some(expected) = <dyn Any>::downcast_ref::<Self>(expected) {
             self.content_matches(expected)
         } else {
             false


### PR DESCRIPTION
RUST-847

This PR redacts the debug output for `Credential` to just `Credential("REDACTED")` in the 1.2.x driver. I opted to include a redacted implementation rather than omit one so that the `Credential` struct is more easily usable in structs that are `Debug`. This also does allow some amount of debugging of it via print statements in that you can tell one is present in an options struct.

This fixes the security issue reported as part of RUST-591 for the 1.2.x driver. The issue was already resolved in the 2.0.0-beta release of the driver.