### PR TITLE
RUST-310 Use serde for `ClientOptions` tests

### DIFF
--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -87,6 +87,17 @@ pub(crate) fn serialize_duration_as_int_millis<S: Serializer>(
     }
 }
 
+pub(crate) fn serialize_duration_as_secs<S: Serializer>(
+    val: &Option<Duration>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    match val {
+        Some(duration) if duration.as_secs() > i32::MAX as u64 => serializer.serialize_i64(duration.as_secs() as i64),
+        Some(duration) => serializer.serialize_i32(duration.as_secs() as i32),
+        None => serializer.serialize_none(),
+    }
+}
+
 pub(crate) fn deserialize_duration_from_u64_millis<'de, D>(
     deserializer: D,
 ) -> std::result::Result<Option<Duration>, D::Error>

--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -87,7 +87,8 @@ pub(crate) fn serialize_duration_as_int_millis<S: Serializer>(
     }
 }
 
-pub(crate) fn serialize_duration_as_secs<S: Serializer>(
+#[cfg(test)]
+pub(crate) fn serialize_duration_option_as_int_secs<S: Serializer>(
     val: &Option<Duration>,
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {

--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -92,7 +92,9 @@ pub(crate) fn serialize_duration_as_secs<S: Serializer>(
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {
     match val {
-        Some(duration) if duration.as_secs() > i32::MAX as u64 => serializer.serialize_i64(duration.as_secs() as i64),
+        Some(duration) if duration.as_secs() > i32::MAX as u64 => {
+            serializer.serialize_i64(duration.as_secs() as i64)
+        }
         Some(duration) => serializer.serialize_i32(duration.as_secs() as i32),
         None => serializer.serialize_none(),
     }

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -14,7 +14,7 @@ use std::{borrow::Cow, fmt::Debug, str::FromStr};
 
 use hmac::{Mac, NewMac};
 use rand::Rng;
-use serde::{Deserialize, Serializer, ser::SerializeStruct};
+use serde::{ser::SerializeStruct, Deserialize, Serializer};
 use typed_builder::TypedBuilder;
 
 use self::scram::ScramVersion;
@@ -432,16 +432,22 @@ impl Credential {
             .await
     }
 
-    pub(crate) fn serialize_for_client_options<S>(cred: &Option<Credential>, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    pub(crate) fn serialize_for_client_options<S>(
+        cred: &Option<Credential>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         match cred {
             None => serializer.serialize_none(),
             Some(c) => {
                 let mut state = serializer.serialize_struct("Credential", 3)?;
                 state.serialize_field("authsource", &c.source)?;
-                state.serialize_field("authmechanism", &c.mechanism.as_ref().map(|s| s.as_str().to_string()))?;
+                state.serialize_field(
+                    "authmechanism",
+                    &c.mechanism.as_ref().map(|s| s.as_str().to_string()),
+                )?;
                 state.serialize_field("authmechanismproperties", &c.mechanism_properties)?;
                 state.end()
             }

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -440,6 +440,8 @@ impl Credential {
     where
         S: serde::Serializer,
     {
+        use serde::ser::Serialize;
+
         #[derive(serde::Serialize)]
         struct CredentialHelper<'a> {
             authsource: Option<&'a String>,
@@ -452,7 +454,7 @@ impl Credential {
             authmechanism: c.mechanism.as_ref().map(|s| s.as_str()),
             authmechanismproperties: c.mechanism_properties.as_ref(),
         });
-        serde::Serialize::serialize(&state, serializer)
+        state.serialize(serializer)
     }
 }
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -26,7 +26,14 @@ use rustls::{
     ServerCertVerifier,
     TLSError,
 };
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::{Error, Unexpected}, ser::SerializeStruct};
+use serde::{
+    de::{Error, Unexpected},
+    ser::SerializeStruct,
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
+};
 use serde_with::skip_serializing_none;
 use strsim::jaro_winkler;
 use typed_builder::TypedBuilder;
@@ -554,7 +561,7 @@ impl Default for ClientOptions {
 impl Serialize for ClientOptions {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         #[derive(Serialize)]
         struct ClientOptionsHelper<'a> {
@@ -591,7 +598,10 @@ impl Serialize for ClientOptions {
 
             retrywrites: &'a Option<bool>,
 
-            #[serde(flatten, serialize_with = "SelectionCriteria::serialize_for_client_options")]
+            #[serde(
+                flatten,
+                serialize_with = "SelectionCriteria::serialize_for_client_options"
+            )]
             selectioncriteria: &'a Option<SelectionCriteria>,
 
             #[serde(serialize_with = "serialize_duration_as_int_millis")]
@@ -695,12 +705,17 @@ impl From<TlsOptions> for Option<Tls> {
 }
 
 impl Tls {
-    pub(crate) fn serialize_for_client_options<S>(tls: &Option<Tls>, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    pub(crate) fn serialize_for_client_options<S>(
+        tls: &Option<Tls>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         match tls {
-            Some(Tls::Enabled(tls_options)) => TlsOptions::serialize_for_client_options(tls_options, serializer),
+            Some(Tls::Enabled(tls_options)) => {
+                TlsOptions::serialize_for_client_options(tls_options, serializer)
+            }
             _ => serializer.serialize_none(),
         }
     }
@@ -811,9 +826,12 @@ impl TlsOptions {
         Ok(config)
     }
 
-    pub(crate) fn serialize_for_client_options<S>(tls_options: &TlsOptions, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    pub(crate) fn serialize_for_client_options<S>(
+        tls_options: &TlsOptions,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         let mut state = serializer.serialize_struct("tlsoptions", 4)?;
         if let Some(s) = &tls_options.ca_file_path {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -836,14 +836,14 @@ impl TlsOptions {
     {
         #[derive(Serialize)]
         struct TlsOptionsHelper<'a> {
-            tls: Option<bool>,
+            tls: bool,
             tlscafile: Option<&'a str>,
             tlscertificatekeyfile: Option<&'a str>,
             tlsallowinvalidcertificates: Option<bool>,
         }
 
         let state = TlsOptionsHelper {
-            tls: tls_options.ca_file_path.as_ref().map(|_| true),
+            tls: true,
             tlscafile: tls_options
                 .ca_file_path
                 .as_ref()

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -74,7 +74,12 @@ async fn run_test(test_file: TestFile) {
                 let options = ClientOptions::parse(&test_case.uri)
                     .await
                     .expect(&test_case.description);
-                let mut options_doc = bson::to_document(&options).expect(&test_case.description);
+                let mut options_doc = bson::to_document(&options).unwrap_or_else(|_| {
+                    panic!(
+                        "{}: Failed to serialize ClientOptions",
+                        &test_case.description
+                    )
+                });
                 if let Some(json_options) = test_case.options {
                     let mut json_options: Document = json_options
                         .into_iter()

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -5,7 +5,7 @@ mod test;
 
 use std::time::Duration;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, ser::SerializeStruct};
+use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
 
@@ -65,9 +65,12 @@ impl ReadConcern {
         ReadConcernLevel::from_str(level.as_str()).into()
     }
 
-    pub(crate) fn serialize_for_client_options<S>(read_concern: &Option<ReadConcern>, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    pub(crate) fn serialize_for_client_options<S>(
+        read_concern: &Option<ReadConcern>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         match read_concern {
             None => serializer.serialize_none(),
@@ -249,7 +252,6 @@ impl From<String> for Acknowledgment {
     }
 }
 
-
 impl WriteConcern {
     #[allow(dead_code)]
     pub(crate) fn is_acknowledged(&self) -> bool {
@@ -278,9 +280,12 @@ impl WriteConcern {
         Ok(())
     }
 
-    pub(crate) fn serialize_for_client_options<S>(write_concern: &Option<WriteConcern>, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    pub(crate) fn serialize_for_client_options<S>(
+        write_concern: &Option<WriteConcern>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         match write_concern {
             None => serializer.serialize_none(),

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -2,8 +2,6 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use derivative::Derivative;
 use serde::{de::Error, Deserialize, Deserializer};
-#[cfg(test)]
-use serde::{Serialize, Serializer};
 use typed_builder::TypedBuilder;
 
 use crate::{
@@ -80,7 +78,7 @@ impl SelectionCriteria {
         serializer: S,
     ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         match selection_criteria {
             Some(SelectionCriteria::ReadPreference(pref)) => {
@@ -332,9 +330,11 @@ impl ReadPreference {
         serializer: S,
     ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
-        #[derive(Serialize)]
+        use serde::ser::Serialize;
+
+        #[derive(serde::Serialize)]
         struct ReadPreferenceHelper<'a> {
             readpreference: &'a str,
 

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -1,12 +1,14 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use derivative::Derivative;
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error, Deserialize, Deserializer};
+#[cfg(test)]
+use serde::{Serialize, Serializer};
 use typed_builder::TypedBuilder;
 
 use crate::{
     bson::{doc, Bson, Document},
-    bson_util::{deserialize_duration_from_u64_seconds, serialize_duration_as_secs},
+    bson_util::deserialize_duration_from_u64_seconds,
     error::{ErrorKind, Result},
     options::ServerAddress,
     sdam::public::ServerInfo,
@@ -72,6 +74,7 @@ impl SelectionCriteria {
         SelectionCriteria::Predicate(Arc::new(move |server| server.address() == &address))
     }
 
+    #[cfg(test)]
     pub(crate) fn serialize_for_client_options<S>(
         selection_criteria: &Option<SelectionCriteria>,
         serializer: S,
@@ -323,6 +326,7 @@ impl ReadPreference {
         doc
     }
 
+    #[cfg(test)]
     pub(crate) fn serialize_for_client_options<S>(
         read_preference: &ReadPreference,
         serializer: S,
@@ -336,7 +340,7 @@ impl ReadPreference {
 
             readpreferencetags: Option<&'a Vec<HashMap<String, String>>>,
 
-            #[serde(serialize_with = "serialize_duration_as_secs")]
+            #[serde(serialize_with = "crate::bson_util::serialize_duration_option_as_int_secs")]
             maxstalenessseconds: Option<Duration>,
         }
 

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use derivative::Derivative;
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use typed_builder::TypedBuilder;
 
 use crate::{
@@ -72,12 +72,17 @@ impl SelectionCriteria {
         SelectionCriteria::Predicate(Arc::new(move |server| server.address() == &address))
     }
 
-    pub(crate) fn serialize_for_client_options<S>(selection_criteria: &Option<SelectionCriteria>, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where 
-        S: Serializer
+    pub(crate) fn serialize_for_client_options<S>(
+        selection_criteria: &Option<SelectionCriteria>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
     {
         match selection_criteria {
-            Some(SelectionCriteria::ReadPreference(pref)) => ReadPreference::serialize_for_client_options(pref, serializer),
+            Some(SelectionCriteria::ReadPreference(pref)) => {
+                ReadPreference::serialize_for_client_options(pref, serializer)
+            }
             _ => serializer.serialize_none(),
         }
     }
@@ -318,9 +323,12 @@ impl ReadPreference {
         doc
     }
 
-    pub(crate) fn serialize_for_client_options<S>(read_preference: &ReadPreference, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    pub(crate) fn serialize_for_client_options<S>(
+        read_preference: &ReadPreference,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
     where
-        S: Serializer
+        S: Serializer,
     {
         #[derive(Serialize)]
         struct ReadPreferenceHelper<'a> {
@@ -334,9 +342,9 @@ impl ReadPreference {
 
         let state = match read_preference {
             ReadPreference::Primary => ReadPreferenceHelper {
-               readpreference: "primary",
-               readpreferencetags: None,
-               maxstalenessseconds: None,
+                readpreference: "primary",
+                readpreferencetags: None,
+                maxstalenessseconds: None,
             },
             ReadPreference::PrimaryPreferred { options } => ReadPreferenceHelper {
                 readpreference: "primaryPreferred",


### PR DESCRIPTION
Implemented `Serialize` for `ClientOptions`. It's worth noting that the schema used is specific to the URI Options spec tests, and we currently can't deserialize back into `ClientOptions`.

To make this work, there's a custom implementation of `Serialize` which uses a helper struct to flatten the appropriate nested structs. These nested structs are likewise serialized using the [`serialize_with`](https://serde.rs/field-attrs.html#serialize_with) attribute in order to avoid conflicting serialize implementations.