### PR TITLE
minor: fix rustdoc

### DIFF
--- a/src/collation.rs
+++ b/src/collation.rs
@@ -148,7 +148,7 @@ impl std::fmt::Display for CollationStrength {
 }
 
 /// Setting that determines sort order of case differences during case tertiary level comparisons.
-/// For more info, see http://userguide.icu-project.org/collation/customization.
+/// For more info, see <http://userguide.icu-project.org/collation/customization>.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
@@ -160,7 +160,7 @@ pub enum CollationCaseFirst {
     Lower,
 
     /// Default value. Similar to `Lower` with slight differences.
-    /// See http://userguide.icu-project.org/collation/customization for details of differences.
+    /// See <http://userguide.icu-project.org/collation/customization> for details of differences.
     Off,
 }
 


### PR DESCRIPTION
Teeny tiny PR!! The new version of `cargo-rustdoc` requires explicit [autolinks](https://spec.commonmark.org/0.27/#autolinks). Just 4 <<angle brackets>> to look at.