### PR TITLE
RUST-766 Use `hyper` in place of `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [features]
 default = ["tokio-runtime"]
-tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "hyper", "hyper-rustls", "serde_bytes", "serde_json"]
+tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "hyper", "serde_bytes", "serde_json"]
 async-std-runtime = ["async-std", "async-std/attributes", "async-std-resolver", "tokio-util/compat"]
 sync = ["async-std-runtime"]
 # The bson/u2i feature enables automatic conversion from unsigned to signed types during
@@ -47,8 +47,7 @@ futures-util = { version = "0.3.14", features = ["io"] }
 futures-executor = "0.3.14"
 hex = "0.4.0"
 hmac = "0.10.1"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1", "http2", "runtime"], optional = true }
-hyper-rustls = { version = "0.22", default-features = false, features = ["webpki-tokio"], optional = true }
+hyper = { version = "0.14", default-features = false, features = ["client", "http1", "runtime"], optional = true }
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ futures-util = { version = "0.3.14", features = ["io"] }
 futures-executor = "0.3.14"
 hex = "0.4.0"
 hmac = "0.10.1"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1", "runtime"], optional = true }
+hyper = { version = "0.14", default-features = false, features = ["client", "http1", "tcp"], optional = true }
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [features]
 default = ["tokio-runtime"]
-tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "hyper", "hyper-rustls", "serde_bytes"]
+tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "hyper", "hyper-rustls", "serde_bytes", "serde_json"]
 async-std-runtime = ["async-std", "async-std/attributes", "async-std-resolver", "tokio-util/compat"]
 sync = ["async-std-runtime"]
 # The bson/u2i feature enables automatic conversion from unsigned to signed types during
@@ -54,7 +54,7 @@ md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", optional = true }
 serde_with = "1.3.1"
 sha-1 = "0.9.4"
 sha2 = "0.9.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [features]
 default = ["tokio-runtime"]
-tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "reqwest", "serde_bytes"]
+tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "hyper", "hyper-rustls", "serde_bytes"]
 async-std-runtime = ["async-std", "async-std/attributes", "async-std-resolver", "tokio-util/compat"]
 sync = ["async-std-runtime"]
 # The bson/u2i feature enables automatic conversion from unsigned to signed types during
@@ -47,11 +47,14 @@ futures-util = { version = "0.3.14", features = ["io"] }
 futures-executor = "0.3.14"
 hex = "0.4.0"
 hmac = "0.10.1"
+hyper = { version = "0.14", features = ["client"], optional = true }
+hyper-rustls = { version = "0.22", default-features = false, features = ["webpki-tokio"], optional = true }
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
+serde_json = "1.0"
 serde_with = "1.3.1"
 sha-1 = "0.9.4"
 sha2 = "0.9.3"
@@ -78,12 +81,6 @@ optional = true
 [dependencies.pbkdf2]
 version = "0.7.4"
 default-features = false
-
-[dependencies.reqwest]
-version = "0.11.2"
-optional = true
-default-features = false
-features = ["json", "rustls-tls"]
 
 [dependencies.rustls]
 version = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ futures-util = { version = "0.3.14", features = ["io"] }
 futures-executor = "0.3.14"
 hex = "0.4.0"
 hmac = "0.10.1"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1", "tcp"], optional = true }
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
@@ -75,6 +74,12 @@ optional = true
 
 [dependencies.async-std-resolver]
 version = "0.20.1"
+optional = true
+
+[dependencies.hyper]
+version = "0.14"
+default-features = false
+features = ["client", "http1", "tcp"]
 optional = true
 
 [dependencies.pbkdf2]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ futures-util = { version = "0.3.14", features = ["io"] }
 futures-executor = "0.3.14"
 hex = "0.4.0"
 hmac = "0.10.1"
-hyper = { version = "0.14", features = ["client"], optional = true }
+hyper = { version = "0.14", default-features = false, features = ["client", "http1", "http2", "runtime"], optional = true }
 hyper-rustls = { version = "0.22", default-features = false, features = ["webpki-tokio"], optional = true }
 lazy_static = "1.4.0"
 md-5 = "0.9.1"

--- a/src/client/auth/aws.rs
+++ b/src/client/auth/aws.rs
@@ -182,7 +182,7 @@ impl AwsCredential {
         let uri = format!("http://{}/{}", AWS_ECS_IP, relative_uri);
 
         http_client
-            .get_and_deserialize_json(&uri, None)
+            .get_and_deserialize_json(&uri, &[])
             .await
             .map_err(|_| Error::unknown_authentication_error("MONGODB-AWS"))
     }

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -1,12 +1,34 @@
 #[cfg(feature = "tokio-runtime")]
-use reqwest::{Method, Response};
+use hyper::{
+    body::{self, Buf},
+    client::HttpConnector,
+    Body,
+    Client as HyperClient,
+    Error as HyperError,
+    Method,
+    Request,
+    Response,
+};
+#[cfg(feature = "tokio-runtime")]
+use hyper_rustls::HttpsConnector;
 #[cfg(feature = "tokio-runtime")]
 use serde::Deserialize;
+#[cfg(feature = "tokio-runtime")]
+use serde_json::Error as SerdeError;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct HttpClient {
     #[cfg(feature = "tokio-runtime")]
-    inner: reqwest::Client,
+    inner: HyperClient<HttpsConnector<HttpConnector>>,
+}
+
+#[cfg(feature = "tokio-runtime")]
+#[derive(Debug)]
+pub(crate) enum HttpError {
+    BuildingRequest,
+    Request(HyperError),
+    InvalidUTF8,
+    Parsing(SerdeError),
 }
 
 #[cfg(feature = "tokio-runtime")]
@@ -16,17 +38,18 @@ impl HttpClient {
         &self,
         uri: &str,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
-    ) -> reqwest::Result<T>
+    ) -> Result<T, HttpError>
     where
         T: for<'de> Deserialize<'de>,
     {
-        let value = self
-            .request(Method::GET, uri, headers)
-            .await?
-            .json()
-            .await?;
+        let res = self.request(Method::GET, uri, headers).await?;
 
-        Ok(value)
+        let mut buf = body::aggregate(res.into_body()).await?;
+        let mut bytes = vec![0; buf.remaining()];
+        buf.copy_to_slice(&mut bytes);
+
+        let result = serde_json::from_slice(&bytes)?;
+        Ok(result)
     }
 
     /// Executes an HTTP GET request and returns the response body as a string.
@@ -34,7 +57,7 @@ impl HttpClient {
         &self,
         uri: &str,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
-    ) -> reqwest::Result<String> {
+    ) -> Result<String, HttpError> {
         self.request_and_read_string(Method::GET, uri, headers)
             .await
     }
@@ -44,7 +67,7 @@ impl HttpClient {
         &self,
         uri: &str,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
-    ) -> reqwest::Result<String> {
+    ) -> Result<String, HttpError> {
         self.request_and_read_string(Method::PUT, uri, headers)
             .await
     }
@@ -55,9 +78,14 @@ impl HttpClient {
         method: Method,
         uri: &str,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
-    ) -> reqwest::Result<String> {
-        let text = self.request(method, uri, headers).await?.text().await?;
+    ) -> Result<String, HttpError> {
+        let res = self.request(method, uri, headers).await?;
 
+        let mut buf = body::aggregate(res.into_body()).await?;
+        let mut bytes = vec![0; buf.remaining()];
+        buf.copy_to_slice(&mut bytes);
+
+        let text = String::from_utf8(bytes)?;
         Ok(text)
     }
 
@@ -67,15 +95,57 @@ impl HttpClient {
         method: Method,
         uri: &str,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
-    ) -> reqwest::Result<Response> {
-        let response = headers
-            .into_iter()
-            .fold(self.inner.request(method, uri), |request, (k, v)| {
-                request.header(*k, *v)
-            })
-            .send()
-            .await?;
+    ) -> Result<Response<Body>, HttpError> {
+        let mut request = Request::builder().uri(uri).method(method);
+
+        for header in headers {
+            request = request.header(header.0, header.1);
+        }
+
+        let request = request.body(Body::empty())?;
+        let response = self.inner.request(request).await?;
 
         Ok(response)
+    }
+}
+
+impl Default for HttpClient {
+    fn default() -> Self {
+        #[cfg(feature = "tokio-runtime")]
+        let connector = hyper_rustls::HttpsConnector::with_webpki_roots();
+        #[cfg(feature = "tokio-runtime")]
+        let client = HyperClient::builder().build(connector);
+        Self {
+            #[cfg(feature = "tokio-runtime")]
+            inner: client,
+        }
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl From<hyper::http::Error> for HttpError {
+    fn from(_err: hyper::http::Error) -> Self {
+        Self::BuildingRequest
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl From<HyperError> for HttpError {
+    fn from(err: HyperError) -> Self {
+        Self::Request(err)
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl From<SerdeError> for HttpError {
+    fn from(err: SerdeError) -> Self {
+        Self::Parsing(err)
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl From<std::string::FromUtf8Error> for HttpError {
+    fn from(_err: std::string::FromUtf8Error) -> Self {
+        Self::InvalidUTF8
     }
 }

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -10,16 +10,14 @@ use hyper::{
     Response,
 };
 #[cfg(feature = "tokio-runtime")]
-use hyper_rustls::HttpsConnector;
-#[cfg(feature = "tokio-runtime")]
 use serde::Deserialize;
 #[cfg(feature = "tokio-runtime")]
 use serde_json::Error as SerdeError;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct HttpClient {
     #[cfg(feature = "tokio-runtime")]
-    inner: HyperClient<HttpsConnector<HttpConnector>>,
+    inner: HyperClient<HttpConnector>,
 }
 
 #[cfg(feature = "tokio-runtime")]
@@ -106,19 +104,6 @@ impl HttpClient {
         let response = self.inner.request(request).await?;
 
         Ok(response)
-    }
-}
-
-impl Default for HttpClient {
-    fn default() -> Self {
-        #[cfg(feature = "tokio-runtime")]
-        let connector = hyper_rustls::HttpsConnector::with_webpki_roots();
-        #[cfg(feature = "tokio-runtime")]
-        let client = HyperClient::builder().build(connector);
-        Self {
-            #[cfg(feature = "tokio-runtime")]
-            inner: client,
-        }
     }
 }
 

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -82,7 +82,7 @@ impl HttpClient {
     }
 
     #[allow(clippy::type_complexity)]
-    /// Executes an HTTP equest and returns the response.
+    /// Executes an HTTP request and returns the response.
     pub(crate) fn request<'a>(
         &'a self,
         method: Method,


### PR DESCRIPTION
The PR replaces `reqwest` in favor of `hyper::Client`. This will also allow upstream libraries and end-users to have a choice in whether to use `reqwest` or not.

- Replaces `reqwest::Client` with `hyper::Client`
- Adds `serde_json` as direct dependencies (They were already dependencies of `reqwest`)