### PR TITLE
minor: fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Certain tests will only be run against certain topologies. To ensure that the en
 ```bash
 export MONGODB_URI="mongodb://my-standalone-host:27017" # mongod running on 27017
 cargo test --verbose
-export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replicaSet=repl" # replicaset running on 27018 with name repl
+export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replicaSet=repl" # replicaset running on ports 27018, 27019, 27020 with name repl
 cargo test --verbose
 export MONGODB_URI="mongodb://localhost:27021" # mongos running on 27021
 cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Certain tests will only be run against certain topologies. To ensure that the en
 ```bash
 export MONGODB_URI="mongodb://my-standalone-host:27017" # mongod running on 27017
 cargo test --verbose
-export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replicaSet=repl" $ replicaset running on 27018 with name repl
+export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replicaSet=repl" # replicaset running on 27018 with name repl
 cargo test --verbose
 export MONGODB_URI="mongodb://localhost:27021" # mongos running on 27021
 cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Certain tests will only be run against certain topologies. To ensure that the en
 ```bash
 export MONGODB_URI="mongodb://my-standalone-host:27017" # mongod running on 27017
 cargo test --verbose
-export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replSet=repl"
+export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replicaSet=repl" $ replicaset running on 27018 with name repl
 cargo test --verbose
 export MONGODB_URI="mongodb://localhost:27021" # mongos running on 27021
 cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ cargo test --verbose # auth tests included
 #### Topology-specific tests
 Certain tests will only be run against certain topologies. To ensure that the entire test suite is run, make sure to run the tests separately against standalone, replicated, and sharded deployments.
 ```bash
-export MONGODB_URI="mongodb://my-standalone-host:20717" # mongod running on 27017
+export MONGODB_URI="mongodb://my-standalone-host:27017" # mongod running on 27017
 cargo test --verbose
 export MONGODB_URI="mongodb://localhost:27018,localhost:27019,localhost:27020/?replSet=repl"
 cargo test --verbose


### PR DESCRIPTION
I noticed a small typo when I was reading the documentation 😞 

I think this is the right thing to fix? Or should it be the other way around 🤔 