### PR TITLE
RUST-697 / RUST-701 Add sessions and transactions to unified test runner

### DIFF
--- a/src/test/spec/json/unified-runner-examples/poc-sessions.json
+++ b/src/test/spec/json/unified-runner-examples/poc-sessions.json
@@ -1,0 +1,466 @@
+{
+  "description": "poc-sessions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "session-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "session-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server supports explicit sessions",
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server supports implicit sessions",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Dirty explicit session is discarded",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.1.8",
+          "topologies": [
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 3
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 3
+              }
+            }
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "expectResult": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 2
+                },
+                "commandName": "insert",
+                "databaseName": "session-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {
+                    "_id": -1
+                  },
+                  "lsid": {
+                    "$$type": "object"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "session-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "session-tests",
+          "documents": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-runner-examples/poc-sessions.yml
+++ b/src/test/spec/json/unified-runner-examples/poc-sessions.yml
@@ -1,0 +1,214 @@
+description: "poc-sessions"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name session-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "Server supports explicit sessions"
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - &find_with_implicit_session
+        name: find
+        object: *collection0
+        arguments:
+          filter: { _id: -1 }
+        expectResult: []
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 2 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$sessionLsid: *session0 }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Server supports implicit sessions"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - *find_with_implicit_session
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - { _id: 2 }
+                ordered: true
+                # Original test did not include any assertion, but we can use
+                # $$type to expect an arbitrary lsid document
+                lsid: { $$type: object }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Dirty explicit session is discarded"
+    # Original test specified retryWrites=true, but that is now the default.
+    # Retryable writes will require a sharded-replicaset, though.
+    runOnRequirements:
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.1.8"
+        topologies: [ sharded-replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              closeConnection: true
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 3 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 3 } } }
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          # ajv's YAML parser is unable to handle anchors on array elements, so
+          # we define an anchor on the commandStartedEvent object instead
+          - commandStartedEvent: &insert_attempt
+              command:
+                insert: *collection0Name
+                documents: 
+                  - { _id: 2 }
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent: *insert_attempt
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: 
+                  - { _id: 3 }
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 2
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }

--- a/src/test/spec/json/unified-runner-examples/poc-transactions.json
+++ b/src/test/spec/json/unified-runner-examples/poc-transactions.json
@@ -1,0 +1,323 @@
+{
+  "description": "poc-transactions",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Client side error in command starting transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "assertSessionTransactionState",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0",
+            "state": "starting"
+          }
+        }
+      ]
+    },
+    {
+      "description": "explicitly create collection using create command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "create",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create index on a non-existing collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.3.4",
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "name": "x_1",
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "transaction-tests",
+            "collectionName": "test",
+            "indexName": "x_1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "drop",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "test",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "createIndexes",
+                "databaseName": "transaction-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": {
+                    "$$exists": false
+                  },
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-runner-examples/poc-transactions.yml
+++ b/src/test/spec/json/unified-runner-examples/poc-transactions.yml
@@ -1,0 +1,171 @@
+description: "poc-transactions"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [ replicaset ]
+  - minServerVersion: "4.1.8"
+    topologies: [ sharded-replicaset ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name transaction-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Client side error in command starting transaction"
+    operations:
+      - name: startTransaction
+        object: *session0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          update: { x: 1 }
+        # Original test only asserted a generic error
+        expectError: { isClientError: true }
+      - name: assertSessionTransactionState
+        object: testRunner
+        arguments:
+          session: *session0
+          state: starting
+
+  - description: "explicitly create collection using create command"
+    runOnRequirements:
+      - minServerVersion: "4.3.4"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: startTransaction
+        object: *session0
+      - name: createCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *collection0Name
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: commitTransaction
+        object: *session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+                writeConcern: { $$exists: false }
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: create
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+
+  - description: "create index on a non-existing collection"
+    runOnRequirements:
+      - minServerVersion: "4.3.4"
+        topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: startTransaction
+        object: *session0
+      - name: createIndex
+        object: *collection0
+        arguments:
+          session: *session0
+          name: &indexName "x_1"
+          keys: { x: 1 }
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+          indexName: *indexName
+      - name: commitTransaction
+        object: *session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+          indexName: *indexName
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+                writeConcern: { $$exists: false }
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0Name
+                indexes:
+                  - name: *indexName
+                    key: { x: 1 }
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: createIndexes
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session0 }
+                txnNumber: 1
+                startTransaction: { $$exists: false }
+                autocommit: false
+                writeConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -118,7 +118,8 @@ impl Deref for ClientEntity {
 }
 
 impl SessionEntity {
-    pub fn new(client_session: ClientSession, lsid: Document) -> Self {
+    pub fn new(client_session: ClientSession) -> Self {
+        let lsid = client_session.id().clone();
         Self {
             client_session: Some(Box::new(client_session)),
             lsid,

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -2,8 +2,10 @@ use std::{ops::Deref, sync::Arc};
 
 use crate::{
     bson::{Bson, Document},
+    event::command::CommandStartedEvent,
     test::{CommandEvent, EventHandler},
     Client,
+    ClientSession,
     Collection,
     Database,
 };
@@ -13,6 +15,7 @@ pub enum Entity {
     Client(ClientEntity),
     Database(Database),
     Collection(Collection<Document>),
+    Session(ClientSession),
     Bson(Bson),
     None,
 }
@@ -72,6 +75,11 @@ impl ClientEntity {
             true
         })
     }
+
+    /// Gets all events of type commandStartedEvent, excluding configureFailPoint events.
+    pub fn get_all_command_started_events(&self) -> Vec<CommandStartedEvent> {
+        self.observer.get_all_command_started_events()
+    }
 }
 
 impl From<Database> for Entity {
@@ -119,6 +127,13 @@ impl Entity {
         match self {
             Self::Collection(collection) => collection,
             _ => panic!("Expected collection entity, got {:?}", &self),
+        }
+    }
+
+    pub fn as_client_session(&self) -> &ClientSession {
+        match self {
+            Self::Session(client_session) => client_session,
+            _ => panic!("Expected client session entity, got {:?}", &self),
         }
     }
 

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -14,7 +14,11 @@ pub fn results_match(
     results_match_inner(actual, expected, returns_root_documents, true, entities)
 }
 
-pub fn events_match(actual: &TestEvent, expected: &TestEvent, entities: Option<&EntityMap>) -> bool {
+pub fn events_match(
+    actual: &TestEvent,
+    expected: &TestEvent,
+    entities: Option<&EntityMap>,
+) -> bool {
     match (actual, expected) {
         (
             TestEvent::Started {
@@ -195,8 +199,14 @@ fn special_operator_matches(
         "$$sessionLsid" => match entities {
             Some(entity_map) => {
                 let session_id = value.as_str().unwrap();
-                let session = entity_map.get(session_id).unwrap().as_client_session();
-                results_match_inner(actual, &Bson::from(session.id()), false, false, entities)
+                let session = entity_map.get(session_id).unwrap().as_session_entity();
+                results_match_inner(
+                    actual,
+                    &Bson::from(session.lsid.clone()),
+                    false,
+                    false,
+                    entities,
+                )
             }
             None => panic!("Could not find entity: {}", value),
         },

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -14,7 +14,7 @@ pub fn results_match(
     results_match_inner(actual, expected, returns_root_documents, true, entities)
 }
 
-pub fn events_match(actual: &TestEvent, expected: &TestEvent) -> bool {
+pub fn events_match(actual: &TestEvent, expected: &TestEvent, entities: Option<&EntityMap>) -> bool {
     match (actual, expected) {
         (
             TestEvent::Started {
@@ -42,7 +42,7 @@ pub fn events_match(actual: &TestEvent, expected: &TestEvent) -> bool {
                     actual_command.as_ref(),
                     &Bson::Document(expected_command.clone()),
                     false,
-                    None,
+                    entities,
                 )
             } else {
                 true
@@ -181,8 +181,8 @@ fn special_operator_matches(
         "$$exists" => value.as_bool().unwrap() == actual.is_some(),
         "$$type" => type_matches(value, actual.unwrap()),
         "$$unsetOrMatches" => {
-            if let Some(bson) = actual {
-                results_match_inner(Some(value), bson, false, false, entities)
+            if actual.is_some() {
+                results_match_inner(actual, value, false, false, entities)
             } else {
                 true
             }
@@ -192,7 +192,14 @@ fn special_operator_matches(
             entity_matches(id, actual, entities.unwrap())
         }
         "$$matchesHexBytes" => panic!("GridFS not implemented"),
-        "$$sessionLsid" => panic!("Explicit sessions not implemented"),
+        "$$sessionLsid" => match entities {
+            Some(entity_map) => {
+                let session_id = value.as_str().unwrap();
+                let session = entity_map.get(session_id).unwrap().as_client_session();
+                results_match_inner(actual, &Bson::from(session.id()), false, false, entities)
+            }
+            None => panic!("Could not find entity: {}", value),
+        },
         other => panic!("unknown special operator: {}", other),
     }
 }

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub use self::{
-    entity::{ClientEntity, Entity},
+    entity::{ClientEntity, Entity, SessionEntity},
     matcher::{events_match, results_match},
     operation::{Operation, OperationObject},
     test_event::TestEvent,
@@ -34,8 +34,11 @@ pub use self::{
 static SPEC_VERSIONS: &[Version] = &[Version::new(1, 0, 0), Version::new(1, 1, 0)];
 
 const SKIPPED_OPERATIONS: &[&str] = &[
+    "assertIndexExists",
+    "assertIndexNotExists",
     "bulkWrite",
     "count",
+    "createIndex",
     "download",
     "download_by_name",
     "listCollectionObjects",
@@ -43,9 +46,6 @@ const SKIPPED_OPERATIONS: &[&str] = &[
     "listIndexNames",
     "listIndexes",
     "mapReduce",
-    "startTransaction",
-    "abortTransaction",
-    "commitTransaction",
     "watch",
 ];
 

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -73,6 +73,15 @@ pub async fn run_unified_format_test(test_file: TestFile) {
     let mut test_runner = TestRunner::new().await;
 
     if let Some(requirements) = test_file.run_on_requirements {
+        // TODO RUST-122: Unskip this test on sharded clusters
+        if test_runner.internal_client.is_sharded() && test_file.description == "poc-transactions" {
+            println!(
+                "Skipping {}: sharded transactions not supported",
+                &test_file.description
+            );
+            return;
+        }
+
         let mut can_run_on = false;
         for requirement in requirements {
             if requirement.can_run_on(&test_runner.internal_client).await {

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -205,7 +205,7 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                 assert_eq!(actual_events.len(), expected_events.len());
 
                 for (actual, expected) in actual_events.iter().zip(expected_events) {
-                    assert!(events_match(actual, expected));
+                    assert!(events_match(actual, expected, Some(&test_runner.entities)));
                 }
             }
         }

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -7,7 +7,7 @@ use super::{Operation, TestEvent};
 
 use crate::{
     bson::{doc, Bson, Deserializer as BsonDeserializer, Document},
-    client::options::ServerApi,
+    client::options::{ServerApi, SessionOptions},
     concern::{Acknowledgment, ReadConcernLevel},
     error::Error,
     options::{
@@ -205,7 +205,7 @@ pub struct Collection {
 pub struct Session {
     pub id: String,
     pub client: String,
-    pub session_options: Option<Document>,
+    pub session_options: Option<SessionOptions>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -1,9 +1,8 @@
-use bson::from_document;
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     bson::Document,
-    client::options::{ClientOptions, SessionOptions},
+    client::options::ClientOptions,
     concern::{Acknowledgment, WriteConcern},
     options::CollectionOptions,
     test::{util::FailPointGuard, EventHandler, TestClient, SERVER_API},
@@ -119,16 +118,11 @@ impl TestRunner {
                 TestFileEntity::Session(session) => {
                     let id = session.id.clone();
                     let client = self.get_client(&session.client);
-                    let options: Option<SessionOptions> = session
-                        .session_options
-                        .as_ref()
-                        .map(|doc| from_document(doc.clone()).unwrap());
-                    let client_session = client.start_session(options).await.unwrap();
-                    let lsid = client_session.id().clone();
-                    (
-                        id,
-                        Entity::Session(SessionEntity::new(client_session, lsid)),
-                    )
+                    let client_session = client
+                        .start_session(session.session_options.clone())
+                        .await
+                        .unwrap();
+                    (id, Entity::Session(SessionEntity::new(client_session)))
                 }
                 TestFileEntity::Bucket(_) => {
                     panic!("GridFS not implemented");

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -12,7 +12,7 @@ use crate::{
     Database,
 };
 
-use super::{ClientEntity, CollectionData, Entity, TestFileEntity};
+use super::{ClientEntity, CollectionData, Entity, SessionEntity, TestFileEntity};
 
 pub type EntityMap = HashMap<String, Entity>;
 
@@ -123,9 +123,11 @@ impl TestRunner {
                         .session_options
                         .as_ref()
                         .map(|doc| from_document(doc.clone()).unwrap());
+                    let client_session = client.start_session(options).await.unwrap();
+                    let lsid = client_session.id().clone();
                     (
                         id,
-                        Entity::Session(client.start_session(options).await.unwrap()),
+                        Entity::Session(SessionEntity::new(client_session, lsid)),
                     )
                 }
                 TestFileEntity::Bucket(_) => {
@@ -148,5 +150,13 @@ impl TestRunner {
 
     pub fn get_collection(&self, id: &str) -> &Collection<Document> {
         self.entities.get(id).unwrap().as_collection()
+    }
+
+    pub fn get_session(&self, id: &str) -> &SessionEntity {
+        self.entities.get(id).unwrap().as_session_entity()
+    }
+
+    pub fn get_mut_session(&mut self, id: &str) -> &mut SessionEntity {
+        self.entities.get_mut(id).unwrap().as_mut_session_entity()
     }
 }

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -137,6 +137,20 @@ impl EventHandler {
             .collect()
     }
 
+    /// Gets all of the command started events, excluding configureFailPoint events.
+    pub fn get_all_command_started_events(&self) -> Vec<CommandStartedEvent> {
+        let events = self.command_events.read().unwrap();
+        events
+            .iter()
+            .filter_map(|event| match event {
+                CommandEvent::Started(event) if event.command_name != "configureFailPoint" => {
+                    Some(event.clone())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
     pub fn get_filtered_command_events<F>(&self, filter: F) -> Vec<CommandEvent>
     where
         F: Fn(&CommandEvent) -> bool,
@@ -360,16 +374,7 @@ impl EventClient {
 
     /// Gets all command started events, excluding configureFailPoint events.
     pub fn get_all_command_started_events(&self) -> Vec<CommandStartedEvent> {
-        let events = self.handler.command_events.read().unwrap();
-        events
-            .iter()
-            .filter_map(|event| match event {
-                CommandEvent::Started(event) if event.command_name != "configureFailPoint" => {
-                    Some(event.clone())
-                }
-                _ => None,
-            })
-            .collect()
+        self.handler.get_all_command_started_events()
     }
 
     pub fn get_command_events(&self, command_names: &[&str]) -> Vec<CommandEvent> {


### PR DESCRIPTION
As above. Implemented a new unified test runner entity which wraps on a `ClientSession` and on its LSID, so that when the session is dropped, the LSID persists in the entity map to cross-reference with expected events.

Currently skipping one test in `poc-transactions` because it relies on index management, which isn't implemented AFAIK.