### PR TITLE
RUST-665 Sync spec tests for field names with dots and dollars

### DIFF
--- a/src/test/spec/json/crud/unified/bulkWrite-insertOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/bulkWrite-insertOne-dots_and_dollars.json
@@ -1,0 +1,374 @@
+{
+  "description": "bulkWrite-insertOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "$a": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "$a": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/bulkWrite-insertOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/bulkWrite-insertOne-dots_and_dollars.yml
@@ -1,0 +1,138 @@
+description: "bulkWrite-insertOne-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Inserting document with top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: &dollarPrefixedKey { _id: 1, $a: 1 }
+        expectResult: &bulkWriteResult
+          deletedCount: 0
+          insertedCount: 1
+          insertedIds: { $$unsetOrMatches: { 0: 1 } }
+          matchedCount: 0
+          modifiedCount: 0
+          upsertedCount: 0
+          upsertedIds: { }
+    expectEvents: &expectEventsDollarPrefixedKey
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKey
+
+  - description: "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: *dollarPrefixedKey
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDollarPrefixedKey
+    outcome: *initialData
+
+  - description: "Inserting document with top-level dotted key"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: &dottedKey { _id: 1, a.b: 1 }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKey
+
+  - description: "Inserting document with dollar-prefixed key in embedded doc"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: &dollarPrefixedKeyInEmbedded { _id: 1, a: { $b: 1 } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKeyInEmbedded
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKeyInEmbedded
+
+  - description: "Inserting document with dotted key in embedded doc"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - insertOne:
+                document: &dottedKeyInEmbedded { _id: 1, a: { b.c: 1 } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKeyInEmbedded
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInEmbedded

--- a/src/test/spec/json/crud/unified/bulkWrite-replaceOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/bulkWrite-replaceOne-dots_and_dollars.json
@@ -1,0 +1,532 @@
+{
+  "description": "bulkWrite-replaceOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a.b": 1
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/bulkWrite-replaceOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/bulkWrite-replaceOne-dots_and_dollars.yml
@@ -1,0 +1,165 @@
+description: "bulkWrite-replaceOne-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "Replacing document with top-level dotted key on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: &dottedKey { _id: 1, a.b: 1 }
+        expectResult: &bulkWriteResult
+          deletedCount: 0
+          insertedCount: 0
+          insertedIds: { $$unsetOrMatches: { } }
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+          upsertedIds: { }
+    expectEvents: &expectEventsDottedKey
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKey
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKey
+
+  - description: "Replacing document with top-level dotted key on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: *dottedKey
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKey
+    outcome: *initialData
+
+  - description: "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: &dollarPrefixedKeyInEmbedded { _id: 1, a: { $b: 1 } }
+        expectResult: *bulkWriteResult
+    expectEvents: &expectEventsDollarPrefixedKeyInEmbedded
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKeyInEmbedded
+
+  - description: "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: *dollarPrefixedKeyInEmbedded
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDollarPrefixedKeyInEmbedded
+    outcome: *initialData
+
+  - description: "Replacing document with dotted key in embedded doc on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: &dottedKeyInEmbedded { _id: 1, a: { b.c: 1 } }
+        expectResult: *bulkWriteResult
+    expectEvents: &expectEventsDottedKeyInEmbedded
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInEmbedded
+
+  - description: "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: *dottedKeyInEmbedded
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKeyInEmbedded
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/bulkWrite-update-validation.json
+++ b/src/test/spec/json/crud/unified/bulkWrite-update-validation.json
@@ -1,0 +1,210 @@
+{
+  "description": "bulkWrite-update-validation",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite replaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "replacement": {
+                    "$set": {
+                      "x": 22
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateOne requires atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "x": 22
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateMany requires atomic modifiers",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  },
+                  "update": {
+                    "x": 44
+                  }
+                }
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/bulkWrite-update-validation.yml
+++ b/src/test/spec/json/crud/unified/bulkWrite-update-validation.yml
@@ -1,0 +1,73 @@
+description: "bulkWrite-update-validation"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "BulkWrite replaceOne prohibits atomic modifiers"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - replaceOne:
+                filter: { _id: 1 }
+                replacement: { $set: { x: 22 } }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome: *initialData
+
+  - description: "BulkWrite updateOne requires atomic modifiers"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: 1 }
+                update: { x: 22 }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome: *initialData
+
+  - description: "BulkWrite updateMany requires atomic modifiers"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateMany:
+                filter: { _id: { $gt: 1 } }
+                update: { x: 44 }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/bulkWrite-updateMany-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/bulkWrite-updateMany-dots_and_dollars.json
@@ -1,0 +1,452 @@
+{
+  "description": "bulkWrite-updateMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/bulkWrite-updateMany-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/bulkWrite-updateMany-dots_and_dollars.yml
@@ -1,0 +1,150 @@
+description: "bulkWrite-updateMany-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, foo: {} }
+
+tests:
+  - description: "Updating document to set top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateMany:
+                filter: { _id: 1 }
+                update: &dollarPrefixedKey
+                  - { $replaceWith: { $setField: { field: { $literal: $a }, value: 1, input: $$ROOT } } }
+        expectResult: &bulkWriteResult
+          deletedCount: 0
+          insertedCount: 0
+          insertedIds: { $$unsetOrMatches: { } }
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+          upsertedIds: { }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKey
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, $a: 1 }
+
+  - description: "Updating document to set top-level dotted key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateMany:
+                filter: { _id: 1 }
+                update: &dottedKey
+                  - { $replaceWith: { $setField: { field: { $literal: a.b }, value: 1, input: $$ROOT } } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKey
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, a.b: 1 }
+
+  - description: "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateMany:
+                filter: { _id: 1 }
+                update: &dollarPrefixedKeyInEmbedded
+                  - { $set: { foo: { $setField: { field: { $literal: $a }, value: 1, input: $foo } } } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { $a: 1 } }
+
+  - description: "Updating document to set dotted key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateMany:
+                filter: { _id: 1 }
+                update: &dottedKeyInEmbedded
+                  - { $set: { foo: { $setField: { field: { $literal: a.b }, value: 1, input: $foo } } } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKeyInEmbedded
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { a.b: 1 } }

--- a/src/test/spec/json/crud/unified/bulkWrite-updateOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/bulkWrite-updateOne-dots_and_dollars.json
@@ -1,0 +1,460 @@
+{
+  "description": "bulkWrite-updateOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "deletedCount": 0,
+            "insertedCount": 0,
+            "insertedIds": {
+              "$$unsetOrMatches": {}
+            },
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/bulkWrite-updateOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/bulkWrite-updateOne-dots_and_dollars.yml
@@ -1,0 +1,150 @@
+description: "bulkWrite-updateOne-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, foo: {} }
+
+tests:
+  - description: "Updating document to set top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: 1 }
+                update: &dollarPrefixedKey
+                  - { $replaceWith: { $setField: { field: { $literal: $a }, value: 1, input: $$ROOT } } }
+        expectResult: &bulkWriteResult
+          deletedCount: 0
+          insertedCount: 0
+          insertedIds: { $$unsetOrMatches: { } }
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+          upsertedIds: { }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKey
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, $a: 1 }
+
+  - description: "Updating document to set top-level dotted key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: 1 }
+                update: &dottedKey
+                  - { $replaceWith: { $setField: { field: { $literal: a.b }, value: 1, input: $$ROOT } } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKey
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, a.b: 1 }
+
+  - description: "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: 1 }
+                update: &dollarPrefixedKeyInEmbedded
+                  - { $set: { foo: { $setField: { field: { $literal: $a }, value: 1, input: $foo } } } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { $a: 1 } }
+
+  - description: "Updating document to set dotted key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          requests:
+            - updateOne:
+                filter: { _id: 1 }
+                update: &dottedKeyInEmbedded
+                  - { $set: { foo: { $setField: { field: { $literal: a.b }, value: 1, input: $foo } } } }
+        expectResult: *bulkWriteResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { a.b: 1 } }

--- a/src/test/spec/json/crud/unified/findOneAndReplace-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/findOneAndReplace-dots_and_dollars.json
@@ -1,0 +1,430 @@
+{
+  "description": "findOneAndReplace-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a.b": 1
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a.b": 1
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "$b": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "_id": 1,
+                    "a": {
+                      "b.c": 1
+                    }
+                  },
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/findOneAndReplace-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/findOneAndReplace-dots_and_dollars.yml
@@ -1,0 +1,140 @@
+description: "findOneAndReplace-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - &initialDocument { _id: 1 }
+
+tests:
+  - description: "Replacing document with top-level dotted key on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: &dottedKey { _id: 1, a.b: 1 }
+        expectResult: *initialDocument
+    expectEvents: &expectEventsDottedKey
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dottedKey
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKey
+
+  - description: "Replacing document with top-level dotted key on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dottedKey
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKey
+    outcome: *initialData
+
+  - description: "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: &dollarPrefixedKeyInEmbedded { _id: 1, a: { $b: 1 } }
+        expectResult: *initialDocument
+    expectEvents: &expectEventsDollarPrefixedKeyInEmbedded
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dollarPrefixedKeyInEmbedded
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKeyInEmbedded
+
+  - description: "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dollarPrefixedKeyInEmbedded
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDollarPrefixedKeyInEmbedded
+    outcome: *initialData
+
+  - description: "Replacing document with dotted key in embedded doc on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: &dottedKeyInEmbedded { _id: 1, a: { b.c: 1 } }
+        expectResult: *initialDocument
+    expectEvents: &expectEventsDottedKeyInEmbedded
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dottedKeyInEmbedded
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInEmbedded
+
+  - description: "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dottedKeyInEmbedded
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKeyInEmbedded
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/findOneAndUpdate-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/findOneAndUpdate-dots_and_dollars.json
@@ -1,0 +1,380 @@
+{
+  "description": "findOneAndUpdate-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "$a"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceWith": {
+                        "$setField": {
+                          "field": {
+                            "$literal": "a.b"
+                          },
+                          "value": 1,
+                          "input": "$$ROOT"
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "$a"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "_id": 1,
+            "foo": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$set": {
+                        "foo": {
+                          "$setField": {
+                            "field": {
+                              "$literal": "a.b"
+                            },
+                            "value": 1,
+                            "input": "$foo"
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "new": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/findOneAndUpdate-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/findOneAndUpdate-dots_and_dollars.yml
@@ -1,0 +1,127 @@
+description: "findOneAndUpdate-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - &initialDocument { _id: 1, foo: {} }
+
+tests:
+  - description: "Updating document to set top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dollarPrefixedKey
+            - { $replaceWith: { $setField: { field: { $literal: $a }, value: 1, input: $$ROOT } } }
+        expectResult: *initialDocument
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dollarPrefixedKey
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, $a: 1 }
+
+  - description: "Updating document to set top-level dotted key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dottedKey
+            - { $replaceWith: { $setField: { field: { $literal: a.b }, value: 1, input: $$ROOT } } }
+        expectResult: *initialDocument
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dottedKey
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, a.b: 1 }
+
+  - description: "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dollarPrefixedKeyInEmbedded
+            - { $set: { foo: { $setField: { field: { $literal: $a }, value: 1, input: $foo } } } }
+        expectResult: *initialDocument
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dollarPrefixedKeyInEmbedded
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { $a: 1 } }
+
+  - description: "Updating document to set dotted key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dottedKeyInEmbedded
+            - { $set: { foo: { $setField: { field: { $literal: a.b }, value: 1, input: $foo } } } }
+        expectResult: *initialDocument
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: { _id: 1 }
+                update: *dottedKeyInEmbedded
+                new: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { a.b: 1 } }

--- a/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.json
@@ -53,10 +53,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -162,10 +163,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -221,10 +223,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -284,10 +287,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }

--- a/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.json
@@ -1,0 +1,334 @@
+{
+  "description": "insertMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "$a": 1
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "$a": 1
+              }
+            ]
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a.b": 1
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a": {
+                  "$b": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "a": {
+                  "b.c": 1
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "insertedCount": 1,
+            "insertedIds": {
+              "$$unsetOrMatches": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.yml
@@ -31,8 +31,8 @@ tests:
           documents:
             - &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedCount: 1
-          insertedIds: { $$unsetOrMatches: { 0: 1 } }
+          # InsertManyResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedIds: { $$unsetOrMatches: { 0: 1 } } }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
         events:

--- a/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/insertMany-dots_and_dollars.yml
@@ -1,0 +1,128 @@
+description: "insertMany-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Inserting document with top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - &dollarPrefixedKey { _id: 1, $a: 1 }
+        expectResult: &insertResult
+          insertedCount: 1
+          insertedIds: { $$unsetOrMatches: { 0: 1 } }
+    expectEvents: &expectEventsDollarPrefixedKey
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKey
+
+  - description: "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - *dollarPrefixedKey
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDollarPrefixedKey
+    outcome: *initialData
+
+  - description: "Inserting document with top-level dotted key"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - &dottedKey { _id: 1, a.b: 1 }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKey
+
+  - description: "Inserting document with dollar-prefixed key in embedded doc"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - &dollarPrefixedKeyInEmbedded { _id: 1, a: { $b: 1 } }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKeyInEmbedded
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKeyInEmbedded
+
+  - description: "Inserting document with dotted key in embedded doc"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents:
+            - &dottedKeyInEmbedded { _id: 1, a: { b.c: 1 } }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKeyInEmbedded
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInEmbedded

--- a/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.json
@@ -63,8 +63,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -165,8 +167,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -219,8 +223,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -277,8 +283,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -386,9 +394,11 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": {
-                "a.b": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": {
+                  "a.b": 1
+                }
               }
             }
           }
@@ -496,8 +506,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -558,8 +570,10 @@
             }
           },
           "expectResult": {
-            "acknowledged": {
-              "$$unsetOrMatches": false
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              }
             }
           }
         }

--- a/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.json
@@ -1,0 +1,600 @@
+{
+  "description": "insertOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "$a": 1
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "$a": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "$a": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with top-level dotted key",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a.b": 1
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in embedded doc",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in embedded doc",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "b.c": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dollar-prefixed key in _id yields server-side error",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$a": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$a": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in _id on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": {
+                "a.b": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "a.b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with dotted key in _id on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": {
+                "a.b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": {
+                        "a.b": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    },
+    {
+      "description": "Inserting document with DBRef-like keys",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "$db": "foo"
+              }
+            }
+          },
+          "expectResult": {
+            "insertedId": {
+              "$$unsetOrMatches": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "a": {
+                        "$db": "foo"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$db": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection1",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$a": 1
+              }
+            }
+          },
+          "expectResult": {
+            "acknowledged": {
+              "$$unsetOrMatches": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll1",
+                  "documents": [
+                    {
+                      "_id": {
+                        "$a": 1
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.yml
@@ -36,7 +36,8 @@ tests:
         arguments:
           document: &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedId: { $$unsetOrMatches: 1 }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
         events:
@@ -155,7 +156,8 @@ tests:
         arguments:
           document: &dottedKeyInId { _id: { a.b: 1 } }
         expectResult:
-          insertedId: { $$unsetOrMatches: { a.b: 1 } }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: { a.b: 1 } } }
     expectEvents: &expectEventsDottedKeyInId
       - client: *client0
         events:
@@ -222,7 +224,8 @@ tests:
         arguments:
           document: *dollarPrefixedKeyInId
         expectResult:
-          acknowledged: { $$unsetOrMatches: false }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { acknowledged: { $$unsetOrMatches: false } }
     expectEvents:
       - client: *client0
         events:

--- a/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.yml
@@ -1,0 +1,235 @@
+description: "insertOne-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+  - collection:
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+      collectionOptions:
+        writeConcern: { w: 0 }
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "Inserting document with top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &dollarPrefixedKey { _id: 1, $a: 1 }
+        expectResult: &insertResult
+          insertedId: { $$unsetOrMatches: 1 }
+    expectEvents: &expectEventsDollarPrefixedKey
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKey
+
+  - description: "Inserting document with top-level dollar-prefixed key on pre-5.0 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: *dollarPrefixedKey
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDollarPrefixedKey
+    outcome: *initialData
+
+  - description: "Inserting document with top-level dotted key"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &dottedKey { _id: 1, a.b: 1 }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKey
+
+  - description: "Inserting document with dollar-prefixed key in embedded doc"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &dollarPrefixedKeyInEmbedded { _id: 1, a: { $b: 1 } }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKeyInEmbedded
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKeyInEmbedded
+
+  - description: "Inserting document with dotted key in embedded doc"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &dottedKeyInEmbedded { _id: 1, a: { b.c: 1 } }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKeyInEmbedded
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInEmbedded
+
+  - description: "Inserting document with dollar-prefixed key in _id yields server-side error"
+    # Note: 5.0+ did not remove restrictions on dollar-prefixed keys in _id documents
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &dollarPrefixedKeyInId { _id: { $a: 1 } }
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dollarPrefixedKeyInId
+    outcome: *initialData
+
+  - description: "Inserting document with dotted key in _id on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &dottedKeyInId { _id: { a.b: 1 } }
+        expectResult:
+          insertedId: { $$unsetOrMatches: { a.b: 1 } }
+    expectEvents: &expectEventsDottedKeyInId
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dottedKeyInId
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInId
+
+  - description: "Inserting document with dotted key in _id on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: *dottedKeyInId
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKeyInId
+    outcome: *initialData
+
+  - description: "Inserting document with DBRef-like keys"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          # Note: an incomplete DBRef document may cause issues loading the test
+          # file with an Extended JSON parser, since the presence of one DBRef
+          # key may cause the parser to require others and/or enforce expected
+          # types (e.g. $ref and $db must be strings).
+          #
+          # Using "$db" here works for libmongoc so long as it's a string type;
+          # however, neither $ref nor $id would be accepted on their own.
+          #
+          # See https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#parsers
+          document: &dbrefLikeKey { _id: 1, a: { $db: "foo" } }
+        expectResult: *insertResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - *dbrefLikeKey
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dbrefLikeKey
+
+  - description: "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: insertOne
+        object: *collection1
+        arguments:
+          document: *dollarPrefixedKeyInId
+        expectResult:
+          acknowledged: { $$unsetOrMatches: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection1Name
+                documents:
+                  - *dollarPrefixedKeyInId
+                writeConcern: { w: 0 }
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/replaceOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/replaceOne-dots_and_dollars.json
@@ -1,0 +1,567 @@
+{
+  "description": "replaceOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Replacing document with top-level dotted key on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with top-level dotted key on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a.b": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a.b": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on 3.6+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "b.c": 1
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "b.c": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection1",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "_id": 1,
+              "a": {
+                "$b": 1
+              }
+            }
+          },
+          "expectResult": {
+            "acknowledged": {
+              "$$unsetOrMatches": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll1",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "_id": 1,
+                        "a": {
+                          "$b": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "w": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/replaceOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/replaceOne-dots_and_dollars.yml
@@ -1,0 +1,180 @@
+description: "replaceOne-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+  - collection:
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+      collectionOptions:
+        writeConcern: { w: 0 }
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "Replacing document with top-level dotted key on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: &dottedKey { _id: 1, a.b: 1 }
+        expectResult: &replaceResult
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents: &expectEventsDottedKey
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKey
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKey
+
+  - description: "Replacing document with top-level dotted key on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dottedKey
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKey
+    outcome: *initialData
+
+  - description: "Replacing document with dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: &dollarPrefixedKeyInEmbedded { _id: 1, a: { $b: 1 } }
+        expectResult: *replaceResult
+    expectEvents: &expectEventsDollarPrefixedKeyInEmbedded
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dollarPrefixedKeyInEmbedded
+
+  - description: "Replacing document with dollar-prefixed key in embedded doc on pre-5.0 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dollarPrefixedKeyInEmbedded
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDollarPrefixedKeyInEmbedded
+    outcome: *initialData
+
+  - description: "Replacing document with dotted key in embedded doc on 3.6+ server"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: &dottedKeyInEmbedded { _id: 1, a: { b.c: 1 } }
+        expectResult: *replaceResult
+    expectEvents: &expectEventsDottedKeyInEmbedded
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - *dottedKeyInEmbedded
+
+  - description: "Replacing document with dotted key in embedded doc on pre-3.6 server yields server-side error"
+    runOnRequirements:
+      - maxServerVersion: "3.4.99"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dottedKeyInEmbedded
+        expectError:
+          isClientError: false
+    expectEvents: *expectEventsDottedKeyInEmbedded
+    outcome: *initialData
+
+  - description: "Unacknowledged write using dollar-prefixed or dotted keys may be silently rejected on pre-5.0 server"
+    runOnRequirements:
+      - maxServerVersion: "4.99"
+    operations:
+      - name: replaceOne
+        object: *collection1
+        arguments:
+          filter: { _id: 1 }
+          replacement: *dollarPrefixedKeyInEmbedded
+        expectResult:
+          acknowledged: { $$unsetOrMatches: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection1Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: 0 }
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/replaceOne-validation.json
+++ b/src/test/spec/json/crud/unified/replaceOne-validation.json
@@ -1,0 +1,82 @@
+{
+  "description": "replaceOne-validation",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne prohibits atomic modifiers",
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "$set": {
+                "x": 22
+              }
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/replaceOne-validation.yml
+++ b/src/test/spec/json/crud/unified/replaceOne-validation.yml
@@ -1,0 +1,37 @@
+description: "replaceOne-validation"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "ReplaceOne prohibits atomic modifiers"
+    operations:
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          replacement: { $set: { x: 22 } }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/updateMany-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/updateMany-dots_and_dollars.json
@@ -1,0 +1,404 @@
+{
+  "description": "updateMany-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/updateMany-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/updateMany-dots_and_dollars.yml
@@ -1,0 +1,138 @@
+description: "updateMany-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, foo: {} }
+
+tests:
+  - description: "Updating document to set top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dollarPrefixedKey
+            - { $replaceWith: { $setField: { field: { $literal: $a }, value: 1, input: $$ROOT } } }
+        expectResult: &updateResult
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKey
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, $a: 1 }
+
+  - description: "Updating document to set top-level dotted key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dottedKey
+            - { $replaceWith: { $setField: { field: { $literal: a.b }, value: 1, input: $$ROOT } } }
+        expectResult: *updateResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKey
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, a.b: 1 }
+
+  - description: "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dollarPrefixedKeyInEmbedded
+            - { $set: { foo: { $setField: { field: { $literal: $a }, value: 1, input: $foo } } } }
+        expectResult: *updateResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { $a: 1 } }
+
+  - description: "Updating document to set dotted key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dottedKeyInEmbedded
+            - { $set: { foo: { $setField: { field: { $literal: a.b }, value: 1, input: $foo } } } }
+        expectResult: *updateResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKeyInEmbedded
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { a.b: 1 } }

--- a/src/test/spec/json/crud/unified/updateMany-validation.json
+++ b/src/test/spec/json/crud/unified/updateMany-validation.json
@@ -1,0 +1,98 @@
+{
+  "description": "updateMany-validation",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateMany requires atomic modifiers",
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "update": {
+              "x": 44
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/updateMany-validation.yml
+++ b/src/test/spec/json/crud/unified/updateMany-validation.yml
@@ -1,0 +1,39 @@
+description: "updateMany-validation"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+tests:
+  - description: "UpdateMany requires atomic modifiers"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          update: { x: 44 }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome: *initialData

--- a/src/test/spec/json/crud/unified/updateOne-dots_and_dollars.json
+++ b/src/test/spec/json/crud/unified/updateOne-dots_and_dollars.json
@@ -1,0 +1,412 @@
+{
+  "description": "updateOne-dots_and_dollars",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "foo": {}
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Updating document to set top-level dollar-prefixed key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "$a"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "$a"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "$a": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set top-level dotted key on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$replaceWith": {
+                  "$setField": {
+                    "field": {
+                      "$literal": "a.b"
+                    },
+                    "value": 1,
+                    "input": "$$ROOT"
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$replaceWith": {
+                            "$setField": {
+                              "field": {
+                                "$literal": "a.b"
+                              },
+                              "value": 1,
+                              "input": "$$ROOT"
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {},
+              "a.b": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "$a"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "$a"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "$a": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Updating document to set dotted key in embedded doc on 5.0+ server",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": [
+              {
+                "$set": {
+                  "foo": {
+                    "$setField": {
+                      "field": {
+                        "$literal": "a.b"
+                      },
+                      "value": 1,
+                      "input": "$foo"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": [
+                        {
+                          "$set": {
+                            "foo": {
+                              "$setField": {
+                                "field": {
+                                  "$literal": "a.b"
+                                },
+                                "value": 1,
+                                "input": "$foo"
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "foo": {
+                "a.b": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/updateOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/updateOne-dots_and_dollars.yml
@@ -1,0 +1,138 @@
+description: "updateOne-dots_and_dollars"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, foo: {} }
+
+tests:
+  - description: "Updating document to set top-level dollar-prefixed key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dollarPrefixedKey
+            - { $replaceWith: { $setField: { field: { $literal: $a }, value: 1, input: $$ROOT } } }
+        expectResult: &updateResult
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKey
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, $a: 1 }
+
+  - description: "Updating document to set top-level dotted key on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dottedKey
+            - { $replaceWith: { $setField: { field: { $literal: a.b }, value: 1, input: $$ROOT } } }
+        expectResult: *updateResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKey
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: {}, a.b: 1 }
+
+  - description: "Updating document to set dollar-prefixed key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dollarPrefixedKeyInEmbedded
+            - { $set: { foo: { $setField: { field: { $literal: $a }, value: 1, input: $foo } } } }
+        expectResult: *updateResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dollarPrefixedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { $a: 1 } }
+
+  - description: "Updating document to set dotted key in embedded doc on 5.0+ server"
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: &dottedKeyInEmbedded
+            - { $set: { foo: { $setField: { field: { $literal: a.b }, value: 1, input: $foo } } } }
+        expectResult: *updateResult
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: { _id: 1 }
+                    u: *dottedKeyInEmbedded
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1, foo: { a.b: 1 } }

--- a/src/test/spec/json/crud/unified/updateOne-validation.json
+++ b/src/test/spec/json/crud/unified/updateOne-validation.json
@@ -1,0 +1,80 @@
+{
+  "description": "updateOne-validation",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne requires atomic modifiers",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 22
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll0",
+          "databaseName": "crud-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/updateOne-validation.yml
+++ b/src/test/spec/json/crud/unified/updateOne-validation.yml
@@ -1,0 +1,37 @@
+description: "updateOne-validation"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "UpdateOne requires atomic modifiers"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { x: 22 }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events: []
+    outcome: *initialData

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -116,6 +116,9 @@ fn results_match_inner(
             };
 
             for (key, value) in expected_doc {
+                if key == "upsertedCount" {
+                    continue
+                }
                 if !results_match_inner(actual_doc.get(key), value, false, false, entities) {
                     return false;
                 }

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -117,7 +117,7 @@ fn results_match_inner(
 
             for (key, value) in expected_doc {
                 if key == "upsertedCount" {
-                    continue
+                    continue;
                 }
                 if !results_match_inner(actual_doc.get(key), value, false, false, entities) {
                     return false;

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -183,7 +183,7 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                                     expect_result,
                                     operation.returns_root_documents(),
                                     Some(&test_runner.entities),
-                                ));
+                                ), "result mismatch, expected = {:#?}  actual = {:#?}", expect_result, result);
                             }
                             _ => panic!(
                                 "Incorrect entity type returned from {}, expected BSON",

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -178,12 +178,17 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                             });
                         match result {
                             Entity::Bson(ref result) => {
-                                assert!(results_match(
-                                    Some(result),
+                                assert!(
+                                    results_match(
+                                        Some(result),
+                                        expect_result,
+                                        operation.returns_root_documents(),
+                                        Some(&test_runner.entities),
+                                    ),
+                                    "result mismatch, expected = {:#?}  actual = {:#?}",
                                     expect_result,
-                                    operation.returns_root_documents(),
-                                    Some(&test_runner.entities),
-                                ), "result mismatch, expected = {:#?}  actual = {:#?}", expect_result, result);
+                                    result
+                                );
                             }
                             _ => panic!(
                                 "Incorrect entity type returned from {}, expected BSON",


### PR DESCRIPTION
RUST-665

This updates the spec tests to validate that the Rust driver allows fields with dollar-prefixed or dotted keys; the driver did not special case those characters, so no changes on that front were necessary.

As a lemma, updated the unified runner to be more consistent about not comparing values for expected "upsertedCount" keys (this was previously implemented for some but not all circumstances), and to print expected and actual values for mismatch.