### PR TITLE
RUST-656 Allow "serverless" entry in runOnRequirement

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,7 +11,7 @@ mod spec;
 mod util;
 
 pub(crate) use self::{
-    spec::{run_single_test, run_spec_test, RunOn, Topology},
+    spec::{run_single_test, run_spec_test, RunOn, Serverless, Topology},
     util::{
         assert_matches,
         CmapEvent,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -59,5 +59,6 @@ lazy_static! {
         }),
         _ => None,
     };
-    pub(crate) static ref SERVERLESS: Option<String> = std::env::var("SERVERLESS").ok();
+    pub(crate) static ref SERVERLESS: bool =
+        matches!(std::env::var("SERVERLESS"), Ok(s) if s == "serverless");
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -59,4 +59,5 @@ lazy_static! {
         }),
         _ => None,
     };
+    pub(crate) static ref SERVERLESS: Option<String> = std::env::var("SERVERLESS").ok();
 }

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     v2_runner::{operation::Operation, run_v2_test, test_file::RunOn},
 };
 
-use serde::{Deserialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
 
 use crate::bson::Bson;

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
     v2_runner::{operation::Operation, run_v2_test, test_file::RunOn},
 };
 
-use serde::de::DeserializeOwned;
+use serde::{Deserialize, de::DeserializeOwned};
 use serde_json::Value;
 
 use crate::bson::Bson;
@@ -84,4 +84,12 @@ where
         .unwrap_or_else(|e| panic!("{}: {}", path.display().to_string(), e)),
     )
     .await
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
+pub(crate) enum Serverless {
+    Require,
+    Forbid,
+    Allow,
 }

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -20,7 +20,7 @@ use crate::{
         SelectionCriteria,
         WriteConcern,
     },
-    test::{spec::unified_runner::results_match, Serverless, TestClient, DEFAULT_URI},
+    test::{spec::unified_runner::results_match, Serverless, TestClient, DEFAULT_URI, SERVERLESS},
 };
 
 #[derive(Debug, Deserialize)]
@@ -101,6 +101,14 @@ impl RunOnRequirement {
                 None,
             ) {
                 return false;
+            }
+        }
+        if let Some(ref serverless) = self.serverless {
+            let is_serverless = SERVERLESS.as_ref().map_or(false, |s| s == "serverless");
+            match serverless {
+                Serverless::Forbid if is_serverless => return false,
+                Serverless::Require if !is_serverless => return false,
+                _ => (),
             }
         }
         true

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -61,6 +61,7 @@ pub struct RunOnRequirement {
     max_server_version: Option<String>,
     topologies: Option<Vec<Topology>>,
     server_parameters: Option<Document>,
+    serverless: Option<Serverless>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -71,6 +72,14 @@ pub enum Topology {
     Sharded,
     #[serde(rename = "sharded-replicaset")]
     ShardedReplicaSet,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase", deny_unknown_fields)]
+pub enum Serverless {
+    Require,
+    Forbid,
+    Allow,
 }
 
 impl RunOnRequirement {

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -20,7 +20,7 @@ use crate::{
         SelectionCriteria,
         WriteConcern,
     },
-    test::{spec::unified_runner::results_match, TestClient, DEFAULT_URI},
+    test::{spec::unified_runner::results_match, Serverless, TestClient, DEFAULT_URI},
 };
 
 #[derive(Debug, Deserialize)]
@@ -72,14 +72,6 @@ pub enum Topology {
     Sharded,
     #[serde(rename = "sharded-replicaset")]
     ShardedReplicaSet,
-}
-
-#[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase", deny_unknown_fields)]
-pub enum Serverless {
-    Require,
-    Forbid,
-    Allow,
 }
 
 impl RunOnRequirement {

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -104,10 +104,9 @@ impl RunOnRequirement {
             }
         }
         if let Some(ref serverless) = self.serverless {
-            let is_serverless = SERVERLESS.as_ref().map_or(false, |s| s == "serverless");
             match serverless {
-                Serverless::Forbid if is_serverless => return false,
-                Serverless::Require if !is_serverless => return false,
+                Serverless::Forbid if *SERVERLESS => return false,
+                Serverless::Require if !*SERVERLESS => return false,
                 _ => (),
             }
         }

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer};
 use crate::{
     bson::Document,
     options::{FindOptions, ReadPreference, SelectionCriteria, SessionOptions},
-    test::{spec::deserialize_uri_options_to_uri_string, EventClient, FailPoint, TestClient},
+    test::{spec::deserialize_uri_options_to_uri_string, EventClient, FailPoint, Serverless, TestClient},
 };
 
 use super::{operation::Operation, test_event::CommandStartedEvent};
@@ -27,10 +27,12 @@ pub struct TestFile {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct RunOn {
     pub min_server_version: Option<String>,
     pub max_server_version: Option<String>,
     pub topology: Option<Vec<String>>,
+    pub(crate) serverless: Option<Serverless>,
 }
 
 impl RunOn {

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer};
 use crate::{
     bson::Document,
     options::{FindOptions, ReadPreference, SelectionCriteria, SessionOptions},
-    test::{spec::deserialize_uri_options_to_uri_string, EventClient, FailPoint, Serverless, TestClient},
+    test::{spec::deserialize_uri_options_to_uri_string, EventClient, FailPoint, Serverless, TestClient, SERVERLESS},
 };
 
 use super::{operation::Operation, test_event::CommandStartedEvent};
@@ -52,6 +52,14 @@ impl RunOn {
         if let Some(ref topology) = self.topology {
             if !topology.contains(&client.topology_string()) {
                 return false;
+            }
+        }
+        if let Some(ref serverless) = self.serverless {
+            let is_serverless = SERVERLESS.as_ref().map_or(false, |s| s == "serverless");
+            match serverless {
+                Serverless::Forbid if is_serverless => return false,
+                Serverless::Require if !is_serverless => return false,
+                _ => (),
             }
         }
         true

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -33,8 +33,7 @@ pub struct TestFile {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RunOn {
     pub min_server_version: Option<String>,
     pub max_server_version: Option<String>,
@@ -62,10 +61,9 @@ impl RunOn {
             }
         }
         if let Some(ref serverless) = self.serverless {
-            let is_serverless = SERVERLESS.as_ref().map_or(false, |s| s == "serverless");
             match serverless {
-                Serverless::Forbid if is_serverless => return false,
-                Serverless::Require if !is_serverless => return false,
+                Serverless::Forbid if *SERVERLESS => return false,
+                Serverless::Require if !*SERVERLESS => return false,
                 _ => (),
             }
         }

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -8,7 +8,14 @@ use serde::{Deserialize, Deserializer};
 use crate::{
     bson::Document,
     options::{FindOptions, ReadPreference, SelectionCriteria, SessionOptions},
-    test::{spec::deserialize_uri_options_to_uri_string, EventClient, FailPoint, Serverless, TestClient, SERVERLESS},
+    test::{
+        spec::deserialize_uri_options_to_uri_string,
+        EventClient,
+        FailPoint,
+        Serverless,
+        TestClient,
+        SERVERLESS,
+    },
 };
 
 use super::{operation::Operation, test_event::CommandStartedEvent};


### PR DESCRIPTION
RUST-656

This allows the "serverless" entry, but does not set up the evergreen environment for running tests against a serverless deployment; the goal is to unblock other changes that happen to pick up spec test updates with `serverless: forbid`.