### PR TITLE
RUST-774 Allow tests to specify `backgroundThreadIntervalMS` to fix a race condition.

### DIFF
--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -1,11 +1,11 @@
-use std::{sync::Arc, time::Duration};
 #[cfg(test)]
 use std::cmp::Ordering;
+use std::{sync::Arc, time::Duration};
 
 use derivative::Derivative;
-use serde::{Deserialize};
 #[cfg(test)]
 use serde::de::{Deserializer, Error};
+use serde::Deserialize;
 use typed_builder::TypedBuilder;
 
 use crate::{
@@ -46,7 +46,11 @@ pub(crate) struct ConnectionPoolOptions {
 
     /// Interval between background thread maintenance runs (e.g. ensure minPoolSize).
     #[cfg(test)]
-    #[serde(default, rename = "backgroundThreadIntervalMS", deserialize_with = "BackgroundThreadInterval::deserialize_from_i64_millis")]
+    #[serde(
+        default,
+        rename = "backgroundThreadIntervalMS",
+        deserialize_with = "BackgroundThreadInterval::deserialize_from_i64_millis"
+    )]
     pub(crate) background_thread_interval: Option<BackgroundThreadInterval>,
 
     /// Connections that have been ready for usage in the pool for longer than `max_idle_time` will
@@ -136,11 +140,17 @@ impl BackgroundThreadInterval {
         D: Deserializer<'de>,
     {
         let millis = Option::<i64>::deserialize(deserializer)?;
-        let millis = if let Some(m) = millis { m } else { return Ok(None) };
+        let millis = if let Some(m) = millis {
+            m
+        } else {
+            return Ok(None);
+        };
         Ok(Some(match millis.cmp(&0) {
             Ordering::Less => BackgroundThreadInterval::Never,
             Ordering::Equal => return Err(D::Error::custom("zero is not allowed")),
-            Ordering::Greater => BackgroundThreadInterval::Every(Duration::from_millis(millis as u64)),
+            Ordering::Greater => {
+                BackgroundThreadInterval::Every(Duration::from_millis(millis as u64))
+            }
         }))
     }
 }

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -150,17 +150,13 @@ impl Executor {
     async fn execute_test(self) {
         let mut subscriber = self.state.handler.subscribe();
 
-        // CMAP spec requires setting this to 50ms.
-        let mut options = self.pool_options;
-        options.maintenance_frequency = Some(Duration::from_millis(50));
-
         let (update_sender, mut update_receiver) = ServerUpdateSender::channel();
 
         let pool = ConnectionPool::new(
             CLIENT_OPTIONS.hosts[0].clone(),
             Default::default(),
             update_sender,
-            Some(options),
+            Some(self.pool_options),
         );
 
         // Mock a monitoring task responding to errors reported by the pool.

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -18,6 +18,8 @@ use super::{
     Connection,
     DEFAULT_MAX_POOL_SIZE,
 };
+#[cfg(test)]
+use super::options::BackgroundThreadInterval;
 use crate::{
     error::{Error, ErrorKind, Result},
     event::cmap::{
@@ -177,7 +179,11 @@ impl ConnectionPoolWorker {
         #[cfg(test)]
         let maintenance_frequency = options
             .as_ref()
-            .and_then(|opts| opts.maintenance_frequency)
+            .and_then(|opts| opts.background_thread_interval)
+            .map(|i| match i {
+                BackgroundThreadInterval::Never => Duration::MAX,
+                BackgroundThreadInterval::Every(d) => d,
+            })
             .unwrap_or(MAINTENACE_FREQUENCY);
 
         #[cfg(not(test))]

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -181,7 +181,9 @@ impl ConnectionPoolWorker {
             .as_ref()
             .and_then(|opts| opts.background_thread_interval)
             .map(|i| match i {
-                BackgroundThreadInterval::Never => Duration::MAX,
+                // One year is long enough to count as never for tests, but not so long that it
+                // will overflow interval math.
+                BackgroundThreadInterval::Never => Duration::from_secs(31_556_952),
                 BackgroundThreadInterval::Every(d) => d,
             })
             .unwrap_or(MAINTENACE_FREQUENCY);

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -1,5 +1,7 @@
 use derivative::Derivative;
 
+#[cfg(test)]
+use super::options::BackgroundThreadInterval;
 use super::{
     conn::PendingConnection,
     connection_requester,
@@ -18,8 +20,6 @@ use super::{
     Connection,
     DEFAULT_MAX_POOL_SIZE,
 };
-#[cfg(test)]
-use super::options::BackgroundThreadInterval;
 use crate::{
     error::{Error, ErrorKind, Result},
     event::cmap::{

--- a/src/test/spec/json/connection-monitoring-and-pooling/README.rst
+++ b/src/test/spec/json/connection-monitoring-and-pooling/README.rst
@@ -36,7 +36,20 @@ Unit Test Format:
 
 All Unit Tests have some of the following fields:
 
-- ``poolOptions``: if present, connection pool options to use when creating a pool
+- ``poolOptions``: If present, connection pool options to use when creating a pool;
+  both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
+  and the following test-specific options are allowed:
+
+  - ``backgroundThreadIntervalMS``: A time interval between the end of a
+    `Background Thread Run <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__
+    and the beginning of the next Run. If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
+    If the option is not specified, an implementation is free to use any value it finds reasonable.
+
+    Possible values (0 is not allowed):
+
+    - A negative value: never begin a Run.
+    - A positive value: the interval between Runs in milliseconds.
+
 - ``operations``: A list of operations to perform. All operations support the following fields:
 
   - ``name``: A string describing which operation to issue.
@@ -155,8 +168,6 @@ For each YAML file with ``style: unit``:
 
   - If ``poolOptions`` is specified, use those options to initialize both pools
   - The returned pool must have an ``address`` set as a string value.
-  - If the pool uses a background thread to satisfy ``minPoolSize``, ensure it
-    attempts to create a new connection every 50ms.
 
 - Process each ``operation`` in ``operations`` (on the main thread)
 

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-idle.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-idle.json
@@ -3,7 +3,8 @@
   "style": "unit",
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
-    "maxIdleTimeMS": 10
+    "maxIdleTimeMS": 10,
+    "backgroundThreadIntervalMS": -1
   },
   "operations": [
     {
@@ -23,6 +24,11 @@
     },
     {
       "name": "checkOut"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 2
     }
   ],
   "events": [

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-idle.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-idle.yml
@@ -3,6 +3,7 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
+  backgroundThreadIntervalMS: -1
 operations:
   - name: ready
   - name: checkOut
@@ -12,6 +13,9 @@ operations:
   - name: wait
     ms: 50
   - name: checkOut
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
 events:
   - type: ConnectionPoolCreated
     address: 42

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-stale.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-stale.json
@@ -2,6 +2,9 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
+  "poolOptions": {
+    "backgroundThreadIntervalMS": -1
+  },
   "operations": [
     {
       "name": "ready"
@@ -22,6 +25,11 @@
     },
     {
       "name": "checkOut"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 2
     }
   ],
   "events": [

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-stale.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-no-stale.yml
@@ -1,6 +1,8 @@
 version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
+poolOptions:
+  backgroundThreadIntervalMS: -1
 operations:
   - name: ready
   - name: checkOut
@@ -10,6 +12,9 @@ operations:
   - name: clear
   - name: ready
   - name: checkOut
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
 events:
   - type: ConnectionPoolCreated
     address: 42

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-clear-min-size.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-clear-min-size.json
@@ -3,7 +3,8 @@
   "style": "unit",
   "description": "pool clear halts background minPoolSize establishments",
   "poolOptions": {
-    "minPoolSize": 1
+    "minPoolSize": 1,
+    "backgroundThreadIntervalMS": 50
   },
   "operations": [
     {

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-clear-min-size.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-clear-min-size.yml
@@ -3,6 +3,7 @@ style: unit
 description: pool clear halts background minPoolSize establishments
 poolOptions:
   minPoolSize: 1
+  backgroundThreadIntervalMS: 50
 operations:
   - name: ready
   - name: waitForEvent


### PR DESCRIPTION
This also picks up the changes for RUST-775.