### PR TITLE
RUST-881 Run tests with `requireApiVersion: 1`

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1454,6 +1454,7 @@ buildvariants:
   matrix_spec:
     os:
       - ubuntu-18.04
+    async-runtime: "tokio"
     versioned-api: "*"
   display_name: "Versioned API ${versioned-api}"
   tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -337,6 +337,7 @@ functions:
             TOPOLOGY=${TOPOLOGY} \
             AUTH=${AUTH} \
             SSL=${SSL} \
+            REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
             sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
@@ -355,7 +356,10 @@ functions:
           export SSL="${SSL}"
           . .evergreen/generate-uri.sh
 
-          SINGLE_THREAD=${SINGLE_THREAD} ASYNC_RUNTIME=${ASYNC_RUNTIME} .evergreen/run-tests.sh
+          SINGLE_THREAD=${SINGLE_THREAD} \
+            ASYNC_RUNTIME=${ASYNC_RUNTIME} \
+            MONGODB_API_VERSION=${MONGODB_API_VERSION} \
+            .evergreen/run-tests.sh
 
   "run atlas tests":
     - command: shell.exec
@@ -1298,6 +1302,15 @@ axes:
           PYTHON: "/cygdrive/c/python/Python36/python"
           VENV_BIN_DIR: "Scripts"
 
+  - id: "versioned-api"
+    display_name: "Versioned API"
+    values:
+      - id: require-api-v1
+        display_name: "Require API V1"
+        variables:
+          REQUIRE_API_VERSION: "1"
+          MONGODB_API_VERISON: "1"
+
 buildvariants:
 -
   matrix_name: "tests"
@@ -1436,6 +1449,16 @@ buildvariants:
   display_name: "! Compile on Rust ${extra-rust-versions} with ${async-runtime}"
   tasks:
     - "compile-only"
+
+- matrix_name: "versioned-api-tests"
+  matrix_spec:
+    os:
+      - ubuntu-18.04
+    versioned-api: "*"
+  display_name: "Versioned API ${versioned-api}"
+  tasks:
+    - ".latest-standalone"
+    - ".5.0-standalone"
 
 -
   name: "lint"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1457,8 +1457,8 @@ buildvariants:
     versioned-api: "*"
   display_name: "Versioned API ${versioned-api}"
   tasks:
-    - ".latest-standalone"
-    - ".5.0-standalone"
+    - ".latest .standalone"
+    - ".5.0 .standalone"
 
 -
   name: "lint"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1309,7 +1309,7 @@ axes:
         display_name: "Require API V1"
         variables:
           REQUIRE_API_VERSION: "1"
-          MONGODB_API_VERISON: "1"
+          MONGODB_API_VERSION: "1"
 
 buildvariants:
 -

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -179,7 +179,11 @@ async fn connection_error_during_establishment() {
     }
 
     let options = FailCommandOptions::builder().error_code(1234).build();
-    let failpoint = FailPoint::fail_command(&["isMaster"], FailPointMode::Times(10), Some(options));
+    let failpoint = FailPoint::fail_command(
+        &["isMaster", "hello"],
+        FailPointMode::Times(10),
+        Some(options),
+    );
     let _fp_guard = client.enable_failpoint(failpoint, None).await.unwrap();
 
     let handler = Arc::new(EventHandler::new());

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -50,7 +50,8 @@ async fn min_heartbeat_frequency() {
         .app_name("SDAMMinHeartbeatFrequencyTest".to_string())
         .error_code(1234)
         .build();
-    let failpoint = FailPoint::fail_command(&["isMaster"], FailPointMode::Times(5), fp_options);
+    let failpoint =
+        FailPoint::fail_command(&["isMaster", "hello"], FailPointMode::Times(5), fp_options);
 
     let _fp_guard = setup_client
         .enable_failpoint(failpoint, None)
@@ -126,7 +127,8 @@ async fn sdam_pool_management() {
         .app_name("SDAMPoolManagementTest".to_string())
         .error_code(1234)
         .build();
-    let failpoint = FailPoint::fail_command(&["isMaster"], FailPointMode::Times(1), fp_options);
+    let failpoint =
+        FailPoint::fail_command(&["isMaster", "hello"], FailPointMode::Times(1), fp_options);
 
     let _fp_guard = client
         .enable_failpoint(failpoint, None)
@@ -175,7 +177,8 @@ async fn sdam_min_pool_size_error() {
         .app_name("SDAMMinPoolSizeErrorTest".to_string())
         .error_code(1234)
         .build();
-    let failpoint = FailPoint::fail_command(&["isMaster"], FailPointMode::Skip(3), fp_options);
+    let failpoint =
+        FailPoint::fail_command(&["isMaster", "hello"], FailPointMode::Skip(3), fp_options);
 
     let _fp_guard = setup_client
         .enable_failpoint(failpoint, None)

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -52,7 +52,7 @@ lazy_static! {
         std::env::var("MONGODB_URI").unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
     pub(crate) static ref SERVER_API: Option<ServerApi> = match std::env::var("MONGODB_API_VERSION")
     {
-        Ok(server_api_version) => Some(ServerApi {
+        Ok(server_api_version) if !server_api_version.is_empty() => Some(ServerApi {
             version: ServerApiVersion::from_str(server_api_version.as_str()).unwrap(),
             deprecation_errors: None,
             strict: None,

--- a/src/test/spec/json/connection-monitoring-and-pooling/README.rst
+++ b/src/test/spec/json/connection-monitoring-and-pooling/README.rst
@@ -226,4 +226,3 @@ The following tests have not yet been automated, but MUST still be tested
 #. A user MUST be able to subscribe to Connection Monitoring Events in a manner idiomatic to their language and driver
 #. When a check out attempt fails because connection set up throws an error,
    assert that a ConnectionCheckOutFailedEvent with reason="connectionError" is emitted.
-   

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "closeConnection": false,
       "blockConnection": true,

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-is-enforced.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "closeConnection": false,
       "blockConnection": true,

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-maxConnecting-timeout.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "closeConnection": false,
       "blockConnection": true,

--- a/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/pool-checkout-returned-connection-maxConnecting.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750


### PR DESCRIPTION
RUST-881

This adds an evergreen test configuration to run tests against a server that requires the API version be set in every call.  A few tests needed to be updated because setting the API version on the client switches from `isMaster` to `hello`.