### PR TITLE
 RUST-732 Mark the versioned API options public.

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -295,7 +295,8 @@ impl fmt::Display for ServerAddress {
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum ServerApiVersion {
-    V1,
+    /// Use API version 1.
+    V1, 
 }
 
 impl FromStr for ServerApiVersion {
@@ -500,6 +501,9 @@ pub struct ClientOptions {
     /// supported and is considered undefined behaviour. To run any command with a different API
     /// version or without declaring one, create a separate client that declares the
     /// appropriate API version.
+    ///
+    /// For more information, see the [Versioned API](
+    /// https://docs.mongodb.com/v5.0/reference/versioned-api/) manual page.
     #[builder(default)]
     pub server_api: Option<ServerApi>,
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -494,13 +494,12 @@ pub struct ClientOptions {
 
     /// The declared API version for this client.
     /// The declared API version is applied to all commands run through the client, including those
-    /// sent through any [crate::Database] or [crate::Collection] derived from the client.
+    /// sent through any handle derived from the client.
     ///
-    /// Specifying versioned API options in the command document passed to
-    /// [crate::Database::run_command] AND declaring an API version on the client is not
-    /// supported and is considered undefined behaviour. To run any command with a different API
-    /// version or without declaring one, create a separate client that declares the
-    /// appropriate API version.
+    /// Specifying versioned API options in the command document passed to `run_command` AND
+    /// declaring an API version on the client is not supported and is considered undefined
+    /// behaviour. To run any command with a different API version or without declaring one, create
+    /// a separate client that declares the appropriate API version.
     ///
     /// For more information, see the [Versioned API](
     /// https://docs.mongodb.com/v5.0/reference/versioned-api/) manual page.

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -333,7 +333,8 @@ impl<'de> Deserialize<'de> for ServerApiVersion {
     }
 }
 
-/// Options used to declare a versioned server API.
+/// Options used to declare a versioned server API.  For more information, see the [Versioned API](
+/// https://docs.mongodb.com/v5.0/reference/versioned-api/) manual page.
 #[derive(Clone, Debug, Deserialize, PartialEq, TypedBuilder)]
 #[builder(field_defaults(setter(into)))]
 #[serde(rename_all = "camelCase")]

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -294,7 +294,7 @@ impl fmt::Display for ServerAddress {
 /// Specifies the server API version to declare
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
-pub(crate) enum ServerApiVersion {
+pub enum ServerApiVersion {
     V1,
 }
 
@@ -337,7 +337,7 @@ impl<'de> Deserialize<'de> for ServerApiVersion {
 #[builder(field_defaults(setter(into)))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub(crate) struct ServerApi {
+pub struct ServerApi {
     /// The declared API version.
     pub version: ServerApiVersion,
 
@@ -500,8 +500,8 @@ pub struct ClientOptions {
     /// supported and is considered undefined behaviour. To run any command with a different API
     /// version or without declaring one, create a separate client that declares the
     /// appropriate API version.
-    #[builder(default, setter(skip))]
-    pub(crate) server_api: Option<ServerApi>,
+    #[builder(default)]
+    pub server_api: Option<ServerApi>,
 
     /// The amount of time the Client should attempt to select a server for an operation before
     /// timing outs

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -296,7 +296,7 @@ impl fmt::Display for ServerAddress {
 #[non_exhaustive]
 pub enum ServerApiVersion {
     /// Use API version 1.
-    V1, 
+    V1,
 }
 
 impl FromStr for ServerApiVersion {

--- a/src/cmap/establish/handshake/test.rs
+++ b/src/cmap/establish/handshake/test.rs
@@ -1,5 +1,9 @@
 use super::Handshaker;
-use crate::{bson::doc, cmap::options::ConnectionPoolOptions, options::DriverInfo};
+use crate::{
+    bson::doc,
+    cmap::options::ConnectionPoolOptions,
+    options::{ClientOptions, DriverInfo},
+};
 
 #[test]
 fn metadata_no_options() {
@@ -24,15 +28,17 @@ fn metadata_with_options() {
     let name = "even better Rust driver";
     let version = "the best version, of course";
 
-    let options = ConnectionPoolOptions::builder()
-        .app_name(app_name.to_string())
-        .driver_info(
-            DriverInfo::builder()
-                .name(name.to_string())
-                .version(version.to_string())
-                .build(),
-        )
-        .build();
+    let options = ConnectionPoolOptions::from_client_options(
+        &ClientOptions::builder()
+            .app_name(app_name.to_string())
+            .driver_info(
+                DriverInfo::builder()
+                    .name(name.to_string())
+                    .version(version.to_string())
+                    .build(),
+            )
+            .build(),
+    );
 
     let handshaker = Handshaker::new(Some(options.into()));
 

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -3,7 +3,7 @@ use tokio::sync::RwLockWriteGuard;
 use crate::{
     bson::{doc, Bson},
     cmap::{establish::Handshaker, Command, Connection, ConnectionPoolOptions},
-    options::{AuthMechanism, Credential, ReadPreference},
+    options::{AuthMechanism, ClientOptions, Credential, ReadPreference},
     test::{TestClient, CLIENT_OPTIONS, LOCK},
 };
 
@@ -34,9 +34,11 @@ async fn speculative_auth_test(
         .await
         .unwrap();
 
-    let mut pool_options = ConnectionPoolOptions::builder()
-        .credential(credential.clone())
-        .build();
+    let mut pool_options = ConnectionPoolOptions::from_client_options(
+        &ClientOptions::builder()
+            .credential(credential.clone())
+            .build(),
+    );
     pool_options.tls_options = CLIENT_OPTIONS.tls_options();
 
     let handshaker = Handshaker::new(Some(pool_options.clone().into()));

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -16,9 +16,8 @@ use crate::{
 };
 
 /// Contains the options for creating a connection pool.
-#[derive(Clone, Default, Deserialize, TypedBuilder, Derivative)]
+#[derive(Clone, Default, Deserialize, Derivative)]
 #[derivative(Debug, PartialEq)]
-#[builder(field_defaults(default, setter(into)))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConnectionPoolOptions {
     /// The application name specified by the user. This is sent to the server as part of the
@@ -74,13 +73,11 @@ pub(crate) struct ConnectionPoolOptions {
     /// Whether to start the pool as "ready" or not.
     /// For tests only.
     #[cfg(test)]
-    #[builder(setter(skip), default)]
     pub(crate) ready: Option<bool>,
 
     /// The declared API version
     ///
     /// The default value is to have no declared API version
-    #[builder(setter(skip), default)]
     pub(crate) server_api: Option<ServerApi>,
 
     /// The options specifying how a TLS connection should be configured. If `tls_options` is

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -140,7 +140,7 @@ pub struct Client {
     pub observe_events: Option<Vec<String>>,
     pub ignore_command_monitoring_events: Option<Vec<String>>,
     #[serde(default)]
-    pub(crate) server_api: Option<ServerApi>,
+    pub server_api: Option<ServerApi>,
 }
 
 fn default_uri() -> String {


### PR DESCRIPTION
RUST-732

This approximately reverts the [commit](https://github.com/mongodb/mongo-rust-driver/commit/ffae5c31c6ac368fc0c242c3bcf3b5d8811a7f09) hiding the options; it also updates the documentation for those options to link to the manual (RUST-605).