### PR TITLE
RUST-882 Stop relying on `From<u64>` for `Bson`

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -281,7 +281,7 @@ impl Client {
         self.inner
             .topology
             .update_command_with_read_pref(connection.address(), &mut cmd, op.selection_criteria())
-            .await;
+            .await?;
 
         match session {
             Some(ref mut session) if op.supports_sessions() && op.is_acknowledged() => {

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -217,7 +217,7 @@ impl Client {
         &self,
         op: &mut T,
         session: &mut Option<&mut ClientSession>,
-        txn_number: Option<u64>,
+        txn_number: Option<i64>,
         first_error: Error,
     ) -> Result<T::O> {
         let server = match self.select_server(op.selection_criteria()).await {
@@ -270,7 +270,7 @@ impl Client {
         op: &mut T,
         connection: &mut Connection,
         session: &mut Option<&mut ClientSession>,
-        txn_number: Option<u64>,
+        txn_number: Option<i64>,
         retryability: &Retryability,
     ) -> Result<T::O> {
         if let Some(wc) = op.write_concern() {

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -230,7 +230,7 @@ impl ClientSession {
     }
 
     /// Gets the current txn_number.
-    pub(crate) fn txn_number(&self) -> u64 {
+    pub(crate) fn txn_number(&self) -> i64 {
         self.server_session.txn_number
     }
 
@@ -240,8 +240,8 @@ impl ClientSession {
     }
 
     /// Increments the txn_number and returns the new value.
-    pub(crate) fn get_and_increment_txn_number(&mut self) -> u64 {
-        self.server_session.txn_number += 1;
+    pub(crate) fn get_and_increment_txn_number(&mut self) -> i64 {
+        self.increment_txn_number();
         self.server_session.txn_number
     }
 
@@ -556,7 +556,7 @@ pub(crate) struct ServerSession {
     dirty: bool,
 
     /// A monotonically increasing transaction number for this session.
-    txn_number: u64,
+    txn_number: i64,
 }
 
 impl ServerSession {

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -58,9 +58,10 @@ impl Command {
         }
     }
 
-    pub(crate) fn set_read_preference(&mut self, read_preference: ReadPreference) {
+    pub(crate) fn set_read_preference(&mut self, read_preference: ReadPreference) -> Result<()> {
         self.body
-            .insert("$readPreference", read_preference.into_document());
+            .insert("$readPreference", read_preference.into_document()?);
+        Ok(())
     }
 
     pub(crate) fn set_start_transaction(&mut self) {

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -41,7 +41,7 @@ impl Command {
         }
     }
 
-    pub(crate) fn set_txn_number(&mut self, txn_number: u64) {
+    pub(crate) fn set_txn_number(&mut self, txn_number: i64) {
         self.body.insert("txnNumber", txn_number);
     }
 

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -63,9 +63,11 @@ async fn speculative_auth_test(
         authorized_db_name.into(),
         doc! { "find": "foo", "limit": 1  },
     );
-    command.set_read_preference(ReadPreference::PrimaryPreferred {
-        options: Default::default(),
-    });
+    command
+        .set_read_preference(ReadPreference::PrimaryPreferred {
+            options: Default::default(),
+        })
+        .unwrap();
 
     let response = conn.send_command(command, None).await.unwrap();
     let doc_response = response.into_document_response().unwrap();

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -49,7 +49,7 @@ async fn acquire_connection_and_send_command() {
         options: Default::default(),
     };
     let mut cmd = Command::new("listDatabases".to_string(), "admin".to_string(), body);
-    cmd.set_read_preference(read_pref);
+    cmd.set_read_preference(read_pref).unwrap();
     if let Some(server_api) = client_options.server_api.as_ref() {
         cmd.set_server_api(server_api);
     }

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -269,7 +269,7 @@ impl<T> Collection<T> {
         resolve_read_concern_with_session!(self, options, session.as_ref())?;
         resolve_selection_criteria_with_session!(self, options, session.as_ref())?;
 
-        let op = CountDocuments::new(self.namespace(), filter.into(), options);
+        let op = CountDocuments::new(self.namespace(), filter.into(), options)?;
         self.client().execute_operation(op, session).await
     }
 

--- a/src/operation/count/test.rs
+++ b/src/operation/count/test.rs
@@ -81,7 +81,7 @@ async fn handle_success() {
     let count_op = Count::empty();
 
     let n = 26;
-    let response = doc! { "ok": 1.0, "n": n };
+    let response = doc! { "ok": 1.0, "n": n as i32 };
 
     let actual_values = handle_response_test(&count_op, response).unwrap();
     assert_eq!(actual_values, n);
@@ -98,7 +98,7 @@ async fn handle_success_agg() {
         "cursor": {
             "id": 0,
             "ns": "a.b",
-            "firstBatch": [ { "n": n } ]
+            "firstBatch": [ { "n": n as i32 } ]
         }
     };
 

--- a/src/operation/count_documents/test.rs
+++ b/src/operation/count_documents/test.rs
@@ -20,7 +20,7 @@ async fn build() {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
     };
-    let mut count_op = CountDocuments::new(ns, Some(doc! { "x": 1 }), None);
+    let mut count_op = CountDocuments::new(ns, Some(doc! { "x": 1 }), None).unwrap();
     let mut count_command = count_op
         .build(&StreamDescription::new_testing())
         .expect("error on build");
@@ -56,7 +56,7 @@ async fn build_with_options() {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
     };
-    let mut count_op = CountDocuments::new(ns, None, Some(options));
+    let mut count_op = CountDocuments::new(ns, None, Some(options)).unwrap();
     let mut count_command = count_op
         .build(&StreamDescription::new_testing())
         .expect("error on build");
@@ -65,8 +65,8 @@ async fn build_with_options() {
         "aggregate": "test_coll",
         "pipeline": [
             { "$match": {} },
-            { "$skip": skip },
-            { "$limit": limit },
+            { "$skip": skip as i64 },
+            { "$limit": limit as i64 },
             { "$group": { "_id": 1, "n": { "$sum": 1 } } },
         ],
         "hint": "_id_1",
@@ -89,7 +89,7 @@ async fn op_selection_criteria() {
             selection_criteria,
             ..Default::default()
         };
-        CountDocuments::new(Namespace::empty(), None, Some(options))
+        CountDocuments::new(Namespace::empty(), None, Some(options)).unwrap()
     });
 }
 
@@ -100,7 +100,7 @@ async fn handle_success() {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
     };
-    let count_op = CountDocuments::new(ns, None, None);
+    let count_op = CountDocuments::new(ns, None, None).unwrap();
 
     let n = 26;
     let response = doc! {
@@ -108,7 +108,7 @@ async fn handle_success() {
         "cursor": {
             "id": 0,
             "ns": "test_db.test_coll",
-            "firstBatch": [ { "_id": 1, "n": n } ],
+            "firstBatch": [ { "_id": 1, "n": n as i32 } ],
         }
     };
 

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -390,11 +390,11 @@ impl Topology {
         server_address: &ServerAddress,
         command: &mut Command,
         criteria: Option<&SelectionCriteria>,
-    ) {
+    ) -> Result<()> {
         self.state
             .read()
             .await
-            .update_command_with_read_pref(server_address, command, criteria);
+            .update_command_with_read_pref(server_address, command, criteria)
     }
 
     /// Gets the latest information on whether sessions are supported or not.
@@ -494,7 +494,7 @@ impl TopologyState {
         server_address: &ServerAddress,
         command: &mut Command,
         criteria: Option<&SelectionCriteria>,
-    ) {
+    ) -> Result<()> {
         let server_type = self
             .description
             .get_server_description(server_address)

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::convert::TryInto;
 
 use derivative::Derivative;
 use serde::{de::Error, Deserialize, Deserializer};
@@ -304,7 +305,7 @@ impl ReadPreference {
         let mut doc = doc! { "mode": mode };
 
         if let Some(max_stale) = max_staleness {
-            doc.insert("maxStalenessSeconds", max_stale.as_secs());
+            doc.insert("maxStalenessSeconds", max_stale.as_secs().try_into().unwrap_or(i64::MAX));
         }
 
         if let Some(tag_sets) = tag_sets {

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, ops::Deref, time::Duration};
+use std::{collections::HashMap, convert::TryInto, fmt::Debug, ops::Deref, time::Duration};
 
 use async_trait::async_trait;
 use futures::stream::TryStreamExt;
@@ -673,7 +673,7 @@ impl TestOperation for CountDocuments {
                     .await?
             }
         };
-        Ok(Some(Bson::from(result).into()))
+        Ok(Some(Bson::Int64(result.try_into().unwrap()).into()))
     }
 
     async fn execute_test_runner_operation(&self, _test_runner: &mut TestRunner) {
@@ -699,7 +699,7 @@ impl TestOperation for EstimatedDocumentCount {
         let result = collection
             .estimated_document_count(self.options.clone())
             .await?;
-        Ok(Some(Bson::from(result).into()))
+        Ok(Some(Bson::Int64(result.try_into().unwrap()).into()))
     }
 
     async fn execute_test_runner_operation(&self, _test_runner: &mut TestRunner) {

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, ops::Deref};
+use std::{collections::HashMap, convert::TryInto, fmt::Debug, ops::Deref};
 
 use async_trait::async_trait;
 use futures::stream::TryStreamExt;
@@ -797,7 +797,7 @@ impl TestOperation for CountDocuments {
                     .await?
             }
         };
-        Ok(Some(Bson::from(result)))
+        Ok(Some(Bson::Int64(result.try_into().unwrap())))
     }
 
     async fn execute_on_database(
@@ -833,7 +833,7 @@ impl TestOperation for EstimatedDocumentCount {
         let result = collection
             .estimated_document_count(self.options.clone())
             .await?;
-        Ok(Some(Bson::from(result)))
+        Ok(Some(Bson::Int64(result.try_into().unwrap())))
     }
 
     async fn execute_on_database(


### PR DESCRIPTION
RUST-882
The `From<u64>` impl for `Bson` was recently removed due to it being lossy for certain values. This functionality was relied upon by the driver in a few areas which needed to be updated.