### PR TITLE
RUST-873 Test redaction of replies to security-sensitive commands

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,6 +10,8 @@ use derivative::Derivative;
 use std::time::Instant;
 
 #[cfg(test)]
+pub(crate) use self::executor::REDACTED_COMMANDS;
+#[cfg(test)]
 use crate::options::ServerAddress;
 use crate::{
     bson::Document,
@@ -30,8 +32,6 @@ use crate::{
     sdam::{SelectedServer, SessionSupportStatus, Topology},
     ClientSession,
 };
-#[cfg(test)]
-pub(crate) use self::executor::REDACTED_COMMANDS;
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 use session::{ServerSession, ServerSessionPool};
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -30,6 +30,8 @@ use crate::{
     sdam::{SelectedServer, SessionSupportStatus, Topology},
     ClientSession,
 };
+#[cfg(test)]
+pub(crate) use self::executor::REDACTED_COMMANDS;
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 use session::{ServerSession, ServerSessionPool};
 

--- a/src/test/spec/json/command-monitoring/unified/redacted-commands.json
+++ b/src/test/spec/json/command-monitoring/unified/redacted-commands.json
@@ -1,9 +1,10 @@
 {
   "description": "redacted-commands",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.5",
   "runOnRequirements": [
     {
-      "minServerVersion": "5.0"
+      "minServerVersion": "5.0",
+      "auth": false
     }
   ],
   "createEntities": [
@@ -11,8 +12,10 @@
       "client": {
         "id": "client",
         "observeEvents": [
-          "commandStartedEvent"
-        ]
+          "commandStartedEvent",
+          "commandSucceededEvent"
+        ],
+        "observeSensitiveCommands": true
       }
     },
     {
@@ -33,7 +36,10 @@
           "arguments": {
             "commandName": "authenticate",
             "command": {
-              "authenticate": "private"
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+              "db": "$external"
             }
           },
           "expectError": {
@@ -50,6 +56,15 @@
                 "commandName": "authenticate",
                 "command": {
                   "authenticate": {
+                    "$$exists": false
+                  },
+                  "mechanism": {
+                    "$$exists": false
+                  },
+                  "user": {
+                    "$$exists": false
+                  },
+                  "db": {
                     "$$exists": false
                   }
                 }
@@ -68,7 +83,9 @@
           "arguments": {
             "commandName": "saslStart",
             "command": {
-              "saslStart": "private"
+              "saslStart": 1,
+              "payload": "definitely-invalid-payload",
+              "db": "admin"
             }
           },
           "expectError": {
@@ -85,6 +102,12 @@
                 "commandName": "saslStart",
                 "command": {
                   "saslStart": {
+                    "$$exists": false
+                  },
+                  "payload": {
+                    "$$exists": false
+                  },
+                  "db": {
                     "$$exists": false
                   }
                 }
@@ -103,7 +126,9 @@
           "arguments": {
             "commandName": "saslContinue",
             "command": {
-              "saslContinue": "private"
+              "saslContinue": 1,
+              "conversationId": 0,
+              "payload": "definitely-invalid-payload"
             }
           },
           "expectError": {
@@ -120,6 +145,12 @@
                 "commandName": "saslContinue",
                 "command": {
                   "saslContinue": {
+                    "$$exists": false
+                  },
+                  "conversationId": {
+                    "$$exists": false
+                  },
+                  "payload": {
                     "$$exists": false
                   }
                 }
@@ -138,7 +169,7 @@
           "arguments": {
             "commandName": "getnonce",
             "command": {
-              "getnonce": "private"
+              "getnonce": 1
             }
           }
         }
@@ -152,6 +183,19 @@
                 "commandName": "getnonce",
                 "command": {
                   "getnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "getnonce",
+                "reply": {
+                  "ok": {
+                    "$$exists": false
+                  },
+                  "nonce": {
                     "$$exists": false
                   }
                 }
@@ -170,7 +214,9 @@
           "arguments": {
             "commandName": "createUser",
             "command": {
-              "createUser": "private"
+              "createUser": "private",
+              "pwd": {},
+              "roles": []
             }
           },
           "expectError": {
@@ -187,6 +233,12 @@
                 "commandName": "createUser",
                 "command": {
                   "createUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
                     "$$exists": false
                   }
                 }
@@ -205,7 +257,9 @@
           "arguments": {
             "commandName": "updateUser",
             "command": {
-              "updateUser": "private"
+              "updateUser": "private",
+              "pwd": {},
+              "roles": []
             }
           },
           "expectError": {
@@ -222,6 +276,12 @@
                 "commandName": "updateUser",
                 "command": {
                   "updateUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
                     "$$exists": false
                   }
                 }
@@ -338,6 +398,11 @@
     },
     {
       "description": "hello with speculative authenticate",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -345,40 +410,11 @@
           "arguments": {
             "commandName": "hello",
             "command": {
-              "hello": "private",
-              "speculativeAuthenticate": "foo"
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
             }
-          },
-          "expectError": {
-            "isError": true
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "ismaster",
-            "command": {
-              "ismaster": "private",
-              "speculativeAuthenticate": "foo"
-            }
-          },
-          "expectError": {
-            "isError": true
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "isMaster",
-            "command": {
-              "isMaster": "private",
-              "speculativeAuthenticate": "foo"
-            }
-          },
-          "expectError": {
-            "isError": true
           }
         }
       ],
@@ -392,15 +428,85 @@
                 "command": {
                   "hello": {
                     "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
                   }
                 }
               }
             },
             {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello with speculative authenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
               "commandStartedEvent": {
                 "commandName": "ismaster",
                 "command": {
                   "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
                     "$$exists": false
                   }
                 }
@@ -412,6 +518,22 @@
                 "command": {
                   "isMaster": {
                     "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
                   }
                 }
               }
@@ -422,6 +544,11 @@
     },
     {
       "description": "hello without speculative authenticate is not redacted",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -429,27 +556,7 @@
           "arguments": {
             "commandName": "hello",
             "command": {
-              "hello": "public"
-            }
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "ismaster",
-            "command": {
-              "ismaster": "public"
-            }
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "isMaster",
-            "command": {
-              "isMaster": "public"
+              "hello": 1
             }
           }
         }
@@ -462,15 +569,67 @@
               "commandStartedEvent": {
                 "commandName": "hello",
                 "command": {
-                  "hello": "public"
+                  "hello": 1
                 }
               }
             },
             {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello without speculative authenticate is not redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
               "commandStartedEvent": {
                 "commandName": "ismaster",
                 "command": {
-                  "ismaster": "public"
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
                 }
               }
             },
@@ -478,7 +637,17 @@
               "commandStartedEvent": {
                 "commandName": "isMaster",
                 "command": {
-                  "isMaster": "public"
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
                 }
               }
             }

--- a/src/test/spec/json/command-monitoring/unified/redacted-commands.yml
+++ b/src/test/spec/json/command-monitoring/unified/redacted-commands.yml
@@ -1,15 +1,18 @@
 description: "redacted-commands"
 
-schemaVersion: "1.0"
+schemaVersion: "1.5"
 
 runOnRequirements:
   - minServerVersion: "5.0"
+    auth: false
 
 createEntities:
   - client:
       id: &client client
       observeEvents:
         - commandStartedEvent
+        - commandSucceededEvent
+      observeSensitiveCommands: true
   - database:
       id: &database database
       client: *client
@@ -23,10 +26,12 @@ tests:
         arguments:
           commandName: authenticate
           command:
-            authenticate: "private"
-        # Malformed authentication commands will fail against the server, but we
-        # just want to assert that security-related commands are redacted
-        # in command monitoring.
+            authenticate: 1
+            mechanism: "MONGODB-X509"
+            user: "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
+            db: "$external"
+        # An authentication error is expected, but we want to check that the
+        # CommandStartedEvent is redacted
         expectError:
           isError: true
     expectEvents:
@@ -34,11 +39,14 @@ tests:
         events:
           - commandStartedEvent:
               commandName: authenticate
-              # This only asserts that the command name has been redacted from the published command;
-              # however, it's unlikely that a driver would redact this but leave other, sensitive fields.
-              # We cannot simply assert that command is an empty document because it's at root-level, so
-              # additional fields in the actual document will be permitted.
-              command: { authenticate: { $$exists: false } }
+              # We cannot simply assert that command is an empty document
+              # because it's at root-level, so we make a best effort to make
+              # sure sensitive fields are redacted.
+              command:
+                authenticate: { $$exists: false }
+                mechanism: { $$exists: false }
+                user: { $$exists: false }
+                db: { $$exists: false }
 
   - description: "saslStart"
     operations:
@@ -47,7 +55,9 @@ tests:
         arguments:
           commandName: saslStart
           command:
-            saslStart: "private"
+            saslStart: 1
+            payload: "definitely-invalid-payload"
+            db: "admin"
         expectError:
           isError: true
     expectEvents:
@@ -55,7 +65,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: saslStart
-              command: { saslStart: { $$exists: false } }
+              command:
+                saslStart: { $$exists: false }
+                payload: { $$exists: false }
+                db: { $$exists: false }
 
   - description: "saslContinue"
     operations:
@@ -64,7 +77,9 @@ tests:
         arguments:
           commandName: saslContinue
           command:
-            saslContinue: "private"
+            saslContinue: 1
+            conversationId: 0
+            payload: "definitely-invalid-payload"
         expectError:
           isError: true
     expectEvents:
@@ -72,7 +87,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: saslContinue
-              command: { saslContinue: { $$exists: false } }
+              command:
+                saslContinue: { $$exists: false }
+                conversationId: { $$exists: false }
+                payload: { $$exists: false }
 
   - description: "getnonce"
     operations:
@@ -81,13 +99,18 @@ tests:
         arguments:
           commandName: getnonce
           command:
-            getnonce: "private"
+            getnonce: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: getnonce
               command: { getnonce: { $$exists: false } }
+          - commandSucceededEvent:
+              commandName: getnonce
+              reply:
+                ok: { $$exists: false }
+                nonce: { $$exists: false }
 
   - description: "createUser"
     operations:
@@ -97,6 +120,10 @@ tests:
           commandName: createUser
           command:
             createUser: "private"
+            # Passing an object is prohibited and we want to trigger a command
+            # failure
+            pwd: {}
+            roles: []
         expectError:
           isError: true
     expectEvents:
@@ -104,7 +131,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: createUser
-              command: { createUser: { $$exists: false } }
+              command:
+                createUser: { $$exists: false }
+                pwd: { $$exists: false }
+                roles: { $$exists: false }
 
   - description: "updateUser"
     operations:
@@ -114,6 +144,8 @@ tests:
           commandName: updateUser
           command:
             updateUser: "private"
+            pwd: {}
+            roles: []
         expectError:
           isError: true
     expectEvents:
@@ -121,7 +153,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: updateUser
-              command: { updateUser: { $$exists: false } }
+              command:
+                updateUser: { $$exists: false }
+                pwd: { $$exists: false }
+                roles: { $$exists: false }
 
   - description: "copydbgetnonce"
     operations:
@@ -175,76 +210,131 @@ tests:
               command: { copydb: { $$exists: false } }
 
   - description: "hello with speculative authenticate"
+    runOnRequirements:
+      - minServerVersion: "4.9"
     operations:
       - name: runCommand
         object: *database
         arguments:
           commandName: hello
           command:
-            hello: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: ismaster
-          command:
-            ismaster: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: isMaster
-          command:
-            isMaster: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
+            hello: 1
+            speculativeAuthenticate:
+              saslStart: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: hello
-              command: { hello: { $$exists: false } }
+              command:
+                hello: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                # Even though authentication above fails and the reply does not
+                # contain sensitive information, we're expecting the reply to be
+                # redacted as well.
+                isWritablePrimary: { $$exists: false }
+                # This assertion will currently always hold true since we're
+                # not expecting successful authentication, in which case this
+                # field is missing anyways.
+                speculativeAuthenticate: { $$exists: false }
+
+  - description: "legacy hello with speculative authenticate"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: 1
+            speculativeAuthenticate:
+              saslStart: 1
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: 1
+            speculativeAuthenticate:
+              saslStart: 1
+    expectEvents:
+      - client: *client
+        events:
           - commandStartedEvent:
               commandName: ismaster
-              command: { ismaster: { $$exists: false } }
+              command:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
           - commandStartedEvent:
               commandName: isMaster
-              command: { isMaster: { $$exists: false } }
+              command:
+                isMaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
 
   - description: "hello without speculative authenticate is not redacted"
+    runOnRequirements:
+      - minServerVersion: "4.9"
     operations:
       - name: runCommand
         object: *database
         arguments:
           commandName: hello
           command:
-            hello: "public"
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: ismaster
-          command:
-            ismaster: "public"
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: isMaster
-          command:
-            isMaster: "public"
+            hello: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: hello
-              command: { hello: "public" }
+              command:
+                hello: 1
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                isWritablePrimary: { $$exists: true }
+
+  - description: "legacy hello without speculative authenticate is not redacted"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: 1
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: 1
+    expectEvents:
+      - client: *client
+        events:
           - commandStartedEvent:
               commandName: ismaster
-              command: { ismaster: "public" }
+              command:
+                ismaster: 1
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                ismaster: { $$exists: true }
           - commandStartedEvent:
               commandName: isMaster
-              command: { isMaster: "public" }
+              command:
+                isMaster: 1
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                ismaster: { $$exists: true }

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -76,7 +76,7 @@ impl ClientEntity {
             if let Some(ignore_command_names) = ignore_command_names {
                 if ignore_command_names
                     .iter()
-                    .any(|name| event.command_name() == name)
+                    .any(|name| event.command_name().eq_ignore_ascii_case(name))
                 {
                     return false;
                 }

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -38,6 +38,7 @@ static SPEC_VERSIONS: &[Version] = &[
     Version::new(1, 0, 0),
     Version::new(1, 1, 0),
     Version::new(1, 4, 0),
+    Version::new(1, 5, 0),
 ];
 
 const SKIPPED_OPERATIONS: &[&str] = &[

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -62,6 +62,7 @@ pub struct RunOnRequirement {
     topologies: Option<Vec<Topology>>,
     server_parameters: Option<Document>,
     serverless: Option<Serverless>,
+    auth: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -112,6 +113,11 @@ impl RunOnRequirement {
                 _ => (),
             }
         }
+        if let Some(ref auth) = self.auth {
+            if *auth != client.auth_enabled() {
+                return false;
+            }
+        }
         true
     }
 }
@@ -139,6 +145,7 @@ pub struct Client {
     pub use_multiple_mongoses: Option<bool>,
     pub observe_events: Option<Vec<String>>,
     pub ignore_command_monitoring_events: Option<Vec<String>>,
+    pub observe_sensitive_commands: Option<bool>,
     #[serde(default)]
     pub server_api: Option<ServerApi>,
 }

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -60,13 +60,10 @@ impl TestRunner {
                     let id = client.id.clone();
                     let observe_events = client.observe_events.clone();
                     let mut ignore_command_names = client.ignore_command_monitoring_events.clone();
-                    match client.observe_sensitive_commands {
-                        Some(true) => {}
-                        _ => {
-                            ignore_command_names
-                                .get_or_insert_with(Vec::new)
-                                .extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
-                        }
+                    if client.observe_sensitive_commands != Some(true) {
+                        ignore_command_names
+                            .get_or_insert_with(Vec::new)
+                            .extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
                     }
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());
                     let observer = Arc::new(EventHandler::new());

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -62,7 +62,7 @@ impl TestRunner {
                     let mut ignore_command_names = client.ignore_command_monitoring_events.clone();
                     if !client.observe_sensitive_commands.unwrap_or(false) {
                         ignore_command_names
-                            .get_or_insert_with(|| vec![])
+                            .get_or_insert_with(Vec::new)
                             .extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
                     }
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     bson::Document,
-    client::{REDACTED_COMMANDS, options::ClientOptions},
+    client::{options::ClientOptions, REDACTED_COMMANDS},
     concern::{Acknowledgment, WriteConcern},
     options::CollectionOptions,
     test::{util::FailPointGuard, EventHandler, TestClient, SERVER_API},
@@ -61,7 +61,9 @@ impl TestRunner {
                     let observe_events = client.observe_events.clone();
                     let mut ignore_command_names = client.ignore_command_monitoring_events.clone();
                     if !client.observe_sensitive_commands.unwrap_or(false) {
-                        ignore_command_names.get_or_insert_with(|| vec![]).extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
+                        ignore_command_names
+                            .get_or_insert_with(|| vec![])
+                            .extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
                     }
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());
                     let observer = Arc::new(EventHandler::new());

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -60,10 +60,13 @@ impl TestRunner {
                     let id = client.id.clone();
                     let observe_events = client.observe_events.clone();
                     let mut ignore_command_names = client.ignore_command_monitoring_events.clone();
-                    if !client.observe_sensitive_commands.unwrap_or(false) {
-                        ignore_command_names
-                            .get_or_insert_with(Vec::new)
-                            .extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
+                    match client.observe_sensitive_commands {
+                        Some(true) => {}
+                        _ => {
+                            ignore_command_names
+                                .get_or_insert_with(Vec::new)
+                                .extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
+                        }
                     }
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());
                     let observer = Arc::new(EventHandler::new());

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     bson::Document,
-    client::options::ClientOptions,
+    client::{REDACTED_COMMANDS, options::ClientOptions},
     concern::{Acknowledgment, WriteConcern},
     options::CollectionOptions,
     test::{util::FailPointGuard, EventHandler, TestClient, SERVER_API},
@@ -59,7 +59,10 @@ impl TestRunner {
                 TestFileEntity::Client(client) => {
                     let id = client.id.clone();
                     let observe_events = client.observe_events.clone();
-                    let ignore_command_names = client.ignore_command_monitoring_events.clone();
+                    let mut ignore_command_names = client.ignore_command_monitoring_events.clone();
+                    if !client.observe_sensitive_commands.unwrap_or(false) {
+                        ignore_command_names.get_or_insert_with(|| vec![]).extend(REDACTED_COMMANDS.iter().map(|s| String::from(*s)));
+                    }
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());
                     let observer = Arc::new(EventHandler::new());
 


### PR DESCRIPTION
RUST-873

This pulls in spec test changes, which required adding 1.5 to allowed spec versions and implementing support for `auth` and `observeSensitiveCommands`.  Said tests turned up a bug in the redaction - command response redaction hadn't picked up the `speculativeAuthenticate` clause - which is now fixed.