### PR TITLE
RUST-970 Upgrade to hmac 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ futures-io = "0.3.14"
 futures-util = { version = "0.3.14", features = ["io"] }
 futures-executor = "0.3.14"
 hex = "0.4.0"
-hmac = "0.10.1"
+hmac = "0.11"
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
@@ -76,7 +76,7 @@ version = "0.20.1"
 optional = true
 
 [dependencies.pbkdf2]
-version = "0.7.4"
+version = "0.8"
 default-features = false
 
 [dependencies.reqwest]

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -517,7 +517,7 @@ fn mac<M: Mac + NewMac>(
     auth_mechanism: &str,
 ) -> Result<impl AsRef<[u8]>> {
     let mut mac =
-        M::new_varkey(key).map_err(|_| Error::unknown_authentication_error(auth_mechanism))?;
+        M::new_from_slice(key).map_err(|_| Error::unknown_authentication_error(auth_mechanism))?;
     mac.update(input);
     Ok(mac.finalize().into_bytes())
 }

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -353,7 +353,8 @@ fn xor(lhs: &[u8], rhs: &[u8]) -> Vec<u8> {
 }
 
 fn mac_verify<M: Mac + NewMac>(key: &[u8], input: &[u8], signature: &[u8]) -> Result<()> {
-    let mut mac = M::new_from_slice(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
+    let mut mac =
+        M::new_from_slice(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
     mac.update(input);
     match mac.verify(signature) {
         Ok(_) => Ok(()),

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -353,7 +353,7 @@ fn xor(lhs: &[u8], rhs: &[u8]) -> Vec<u8> {
 }
 
 fn mac_verify<M: Mac + NewMac>(key: &[u8], input: &[u8], signature: &[u8]) -> Result<()> {
-    let mut mac = M::new_varkey(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
+    let mut mac = M::new_from_slice(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
     mac.update(input);
     match mac.verify(signature) {
         Ok(_) => Ok(()),


### PR DESCRIPTION
Includes `hmac = "0.11"` and `pbkdf2 = "0.8"`