### PR TITLE
RUST-950 Enable connection to a load balancer

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -220,7 +220,6 @@ impl Client {
                         err.clone(),
                         HandshakePhase::after_completion(&conn),
                         &server,
-                        conn.generation.service_id(),
                     )
                     .await;
                 // release the connection to be processed by the connection pool
@@ -278,7 +277,6 @@ impl Client {
                         err.clone(),
                         HandshakePhase::after_completion(&conn),
                         &server,
-                        conn.generation.service_id(),
                     )
                     .await;
                 drop(server);

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -220,6 +220,7 @@ impl Client {
                         err.clone(),
                         HandshakePhase::after_completion(&conn),
                         &server,
+                        conn.service_id,
                     )
                     .await;
                 // release the connection to be processed by the connection pool
@@ -277,6 +278,7 @@ impl Client {
                         err.clone(),
                         HandshakePhase::after_completion(&conn),
                         &server,
+                        conn.service_id,
                     )
                     .await;
                 drop(server);

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -220,7 +220,7 @@ impl Client {
                         err.clone(),
                         HandshakePhase::after_completion(&conn),
                         &server,
-                        conn.service_id,
+                        conn.generation.service_id(),
                     )
                     .await;
                 // release the connection to be processed by the connection pool
@@ -278,7 +278,7 @@ impl Client {
                         err.clone(),
                         HandshakePhase::after_completion(&conn),
                         &server,
-                        conn.service_id,
+                        conn.generation.service_id(),
                     )
                     .await;
                 drop(server);

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -558,6 +558,7 @@ pub struct ClientOptions {
     pub(crate) heartbeat_freq_test: Option<Duration>,
 
     /// Allow use of the `load_balanced` option.
+    // TODO RUST-653 Remove this when load balancer work is ready for release.
     #[builder(default, setter(skip))]
     #[serde(skip)]
     pub(crate) allow_load_balanced: bool,

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1724,7 +1724,7 @@ impl ClientOptionsParser {
                 let mut write_concern = self.write_concern.get_or_insert_with(Default::default);
                 write_concern.journal = Some(get_bool!(value, k));
             }
-            k @ "loadBalanced" => {
+            k @ "loadbalanced" => {
                 self.load_balanced = Some(get_bool!(value, k));
             }
             k @ "localthresholdms" => {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1150,17 +1150,21 @@ impl ClientOptions {
             if self.hosts.len() > 1 {
                 return Err(ErrorKind::InvalidArgument {
                     message: "cannot specify multiple seeds with loadBalanced=true".to_string(),
-                }.into());
+                }
+                .into());
             }
             if self.repl_set_name.is_some() {
                 return Err(ErrorKind::InvalidArgument {
                     message: "cannot specify replicaSet with loadBalanced=true".to_string(),
-                }.into());
+                }
+                .into());
             }
             if self.direct_connection == Some(true) {
                 return Err(ErrorKind::InvalidArgument {
-                    message: "cannot specify directConnection=true with loadBalanced=true".to_string(),
-                }.into());
+                    message: "cannot specify directConnection=true with loadBalanced=true"
+                        .to_string(),
+                }
+                .into());
             }
         }
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -556,6 +556,11 @@ pub struct ClientOptions {
     #[builder(default)]
     #[cfg(test)]
     pub(crate) heartbeat_freq_test: Option<Duration>,
+
+    /// Allow connecting to a load balancer.
+    #[builder(default)]
+    #[serde(skip)]
+    pub(crate) allow_load_balancer: Option<bool>,
 }
 
 fn default_hosts() -> Vec<ServerAddress> {
@@ -921,6 +926,7 @@ impl From<ClientOptionsParser> for ClientOptions {
             server_api: None,
             #[cfg(test)]
             heartbeat_freq_test: None,
+            allow_load_balancer: None,
         }
     }
 }

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1098,6 +1098,10 @@ impl ClientOptions {
                     options.repl_set_name = Some(replica_set);
                 }
             }
+
+            if options.load_balanced.is_none() {
+                options.load_balanced = config.load_balanced;
+            }
         }
 
         options.validate()?;
@@ -1120,7 +1124,7 @@ impl ClientOptions {
         }
     }
 
-    /// Ensure the options set are valid, returning an error descirbing the problem if they are not.
+    /// Ensure the options set are valid, returning an error describing the problem if they are not.
     pub(crate) fn validate(&self) -> Result<()> {
         if let Some(true) = self.direct_connection {
             if self.hosts.len() > 1 {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1146,6 +1146,24 @@ impl ClientOptions {
             .into());
         }
 
+        if self.load_balanced.unwrap_or(false) {
+            if self.hosts.len() > 1 {
+                return Err(ErrorKind::InvalidArgument {
+                    message: "cannot specify multiple seeds with loadBalanced=true".to_string(),
+                }.into());
+            }
+            if self.repl_set_name.is_some() {
+                return Err(ErrorKind::InvalidArgument {
+                    message: "cannot specify replicaSet with loadBalanced=true".to_string(),
+                }.into());
+            }
+            if self.direct_connection == Some(true) {
+                return Err(ErrorKind::InvalidArgument {
+                    message: "cannot specify directConnection=true with loadBalanced=true".to_string(),
+                }.into());
+            }
+        }
+
         Ok(())
     }
 

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -13,7 +13,10 @@ use self::wire::Message;
 use super::manager::PoolManager;
 use crate::{
     bson::oid::ObjectId,
-    cmap::{PoolGeneration, options::{ConnectionOptions, StreamOptions}},
+    cmap::{
+        options::{ConnectionOptions, StreamOptions},
+        PoolGeneration,
+    },
     error::{ErrorKind, Result},
     event::cmap::{
         CmapEventHandler,
@@ -109,7 +112,9 @@ impl Connection {
     pub(super) async fn connect(pending_connection: PendingConnection) -> Result<Self> {
         let generation = match pending_connection.generation {
             PoolGeneration::Normal(gen) => gen,
-            PoolGeneration::LoadBalanced(_) => 0,  // Placeholder; will be overwritten in `ConnectionEstablisher::establish_connection`.
+            PoolGeneration::LoadBalanced(_) => 0, /* Placeholder; will be overwritten in
+                                                   * `ConnectionEstablisher::
+                                                   * establish_connection`. */
         };
         Self::new(
             pending_connection.id,
@@ -341,7 +346,7 @@ pub(crate) enum ConnectionGeneration {
     LoadBalanced {
         generation: u32,
         service_id: ObjectId,
-    }
+    },
 }
 
 impl ConnectionGeneration {
@@ -355,9 +360,14 @@ impl ConnectionGeneration {
     pub(crate) fn is_stale(&self, current_generation: &PoolGeneration) -> bool {
         match (self, current_generation) {
             (ConnectionGeneration::Normal(cgen), PoolGeneration::Normal(pgen)) => cgen != pgen,
-            (ConnectionGeneration::LoadBalanced { generation: cgen, service_id }, PoolGeneration::LoadBalanced(gen_map)) =>
-                cgen != gen_map.get(service_id).unwrap_or(&0),
-            _ => false,  // TODO RUST-230 Log an error for mode mismatch.
+            (
+                ConnectionGeneration::LoadBalanced {
+                    generation: cgen,
+                    service_id,
+                },
+                PoolGeneration::LoadBalanced(gen_map),
+            ) => cgen != gen_map.get(service_id).unwrap_or(&0),
+            _ => false, // TODO RUST-230 Log an error for mode mismatch.
         }
     }
 }

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -367,10 +367,7 @@ impl ConnectionGeneration {
                 },
                 PoolGeneration::LoadBalanced(gen_map),
             ) => cgen != gen_map.get(service_id).unwrap_or(&0),
-            _ => {
-                load_balanced_mode_mismatch!();
-                false
-            }
+            _ => load_balanced_mode_mismatch!(false),
         }
     }
 }

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         options::{ConnectionOptions, StreamOptions},
         PoolGeneration,
     },
-    error::{ErrorKind, Result},
+    error::{load_balanced_mode_mismatch, ErrorKind, Result},
     event::cmap::{
         CmapEventHandler,
         ConnectionCheckedInEvent,

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -367,7 +367,10 @@ impl ConnectionGeneration {
                 },
                 PoolGeneration::LoadBalanced(gen_map),
             ) => cgen != gen_map.get(service_id).unwrap_or(&0),
-            _ => false, // TODO RUST-230 Log an error for mode mismatch.
+            _ => {
+                load_balanced_mode_mismatch!();
+                false
+            }
         }
     }
 }

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -198,10 +198,15 @@ impl Handshaker {
         let client_first = set_speculative_auth_info(&mut command.body, self.credential.as_ref())?;
 
         let mut is_master_reply = run_is_master(command, conn).await?;
-        if self.command.body.contains_key("loadBalanced") && is_master_reply.command_response.service_id.is_none() {
+        if self.command.body.contains_key("loadBalanced")
+            && is_master_reply.command_response.service_id.is_none()
+        {
             return Err(ErrorKind::IncompatibleServer {
-                message: "Driver attempted to initialize in load balancing mode, but the server does not support this mode.".to_string(),
-            }.into())
+                message: "Driver attempted to initialize in load balancing mode, but the server \
+                          does not support this mode."
+                    .to_string(),
+            }
+            .into());
         }
         conn.stream_description = Some(StreamDescription::from_is_master(is_master_reply.clone()));
 

--- a/src/cmap/establish/mod.rs
+++ b/src/cmap/establish/mod.rs
@@ -16,8 +16,6 @@ use crate::{
     sdam::HandshakePhase,
 };
 
-use thiserror::Error;
-
 /// Contains the logic to establish a connection, including handshaking, authenticating, and
 /// potentially more.
 #[derive(Clone, Debug)]
@@ -96,8 +94,7 @@ impl ConnectionEstablisher {
     }
 }
 
-#[derive(Debug, Clone, Error)]
-#[error("{cause}")]
+#[derive(Debug, Clone)]
 pub(crate) struct EstablishError {
     pub(crate) cause: MongoError,
     pub(crate) handshake_phase: HandshakePhase,

--- a/src/cmap/establish/mod.rs
+++ b/src/cmap/establish/mod.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     client::{auth::Credential, options::ServerApi},
-    error::{ErrorKind, Error as MongoError},
+    error::{Error as MongoError, ErrorKind},
     runtime::HttpClient,
     sdam::HandshakePhase,
 };
@@ -48,17 +48,20 @@ impl ConnectionEstablisher {
         pending_connection: PendingConnection,
     ) -> std::result::Result<Connection, EstablishError> {
         let pool_gen = pending_connection.generation.clone();
-        let mut connection = Connection::connect(pending_connection).await.map_err(|e| EstablishError::pre_hello(e, pool_gen.clone()))?;
+        let mut connection = Connection::connect(pending_connection)
+            .await
+            .map_err(|e| EstablishError::pre_hello(e, pool_gen.clone()))?;
 
-        let handshake = self.handshaker.handshake(&mut connection).await.map_err(|e| EstablishError::pre_hello(e, pool_gen.clone()))?;
+        let handshake = self
+            .handshaker
+            .handshake(&mut connection)
+            .await
+            .map_err(|e| EstablishError::pre_hello(e, pool_gen.clone()))?;
         let service_id = handshake.is_master_reply.command_response.service_id;
 
         // If the handshake response had a `serviceId` field, this is a connection to a load
         // balancer and must derive its generation from the service_generations map.
-        match (
-            pool_gen,
-            service_id,
-        ) {
+        match (pool_gen, service_id) {
             (PoolGeneration::Normal(_), _) => {}
             (PoolGeneration::LoadBalanced(gen_map), Some(service_id)) => {
                 connection.generation = ConnectionGeneration::LoadBalanced {
@@ -70,7 +73,8 @@ impl ConnectionEstablisher {
                 return Err(EstablishError::post_hello(
                     ErrorKind::Internal {
                         message: "load-balanced mode mismatch".to_string(),
-                    }.into(),
+                    }
+                    .into(),
                     connection.generation.clone(),
                 ));
             }

--- a/src/cmap/establish/mod.rs
+++ b/src/cmap/establish/mod.rs
@@ -41,11 +41,8 @@ impl ConnectionEstablisher {
     ) -> Result<Connection> {
         let service_generations = pending_connection.service_generations.clone();
         let mut connection = Connection::connect(pending_connection).await?;
-        
-        let handshake = self
-            .handshaker
-            .handshake(&mut connection)
-            .await?;
+
+        let handshake = self.handshaker.handshake(&mut connection).await?;
 
         // If the handshake response had a `serviceId` field, this is a connection to a load
         // balancer and must derive its generation from the service_generations map.

--- a/src/cmap/establish/mod.rs
+++ b/src/cmap/establish/mod.rs
@@ -11,9 +11,12 @@ use super::{
 };
 use crate::{
     client::{auth::Credential, options::ServerApi},
-    error::{ErrorKind, Result},
+    error::{ErrorKind, Error as MongoError},
     runtime::HttpClient,
+    sdam::HandshakePhase,
 };
+
+use thiserror::Error;
 
 /// Contains the logic to establish a connection, including handshaking, authenticating, and
 /// potentially more.
@@ -43,19 +46,20 @@ impl ConnectionEstablisher {
     pub(super) async fn establish_connection(
         &self,
         pending_connection: PendingConnection,
-    ) -> Result<Connection> {
+    ) -> std::result::Result<Connection, EstablishError> {
         let pool_gen = pending_connection.generation.clone();
-        let mut connection = Connection::connect(pending_connection).await?;
+        let mut connection = Connection::connect(pending_connection).await.map_err(|e| EstablishError::pre_hello(e, pool_gen.clone()))?;
 
-        let handshake = self.handshaker.handshake(&mut connection).await?;
+        let handshake = self.handshaker.handshake(&mut connection).await.map_err(|e| EstablishError::pre_hello(e, pool_gen.clone()))?;
+        let service_id = handshake.is_master_reply.command_response.service_id;
 
         // If the handshake response had a `serviceId` field, this is a connection to a load
         // balancer and must derive its generation from the service_generations map.
         match (
             pool_gen,
-            handshake.is_master_reply.command_response.service_id,
+            service_id,
         ) {
-            (PoolGeneration::Normal(_), None) => {}
+            (PoolGeneration::Normal(_), _) => {}
             (PoolGeneration::LoadBalanced(gen_map), Some(service_id)) => {
                 connection.generation = ConnectionGeneration::LoadBalanced {
                     generation: *gen_map.get(&service_id).unwrap_or(&0),
@@ -63,10 +67,12 @@ impl ConnectionEstablisher {
                 };
             }
             _ => {
-                return Err(ErrorKind::Internal {
-                    message: "load-balanced mode mismatch".to_string(),
-                }
-                .into())
+                return Err(EstablishError::post_hello(
+                    ErrorKind::Internal {
+                        message: "load-balanced mode mismatch".to_string(),
+                    }.into(),
+                    connection.generation.clone(),
+                ));
             }
         }
 
@@ -78,9 +84,32 @@ impl ConnectionEstablisher {
                     self.server_api.as_ref(),
                     handshake.first_round,
                 )
-                .await?;
+                .await
+                .map_err(|e| EstablishError::post_hello(e, connection.generation.clone()))?
         }
 
         Ok(connection)
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+#[error("{cause}")]
+pub(crate) struct EstablishError {
+    pub(crate) cause: MongoError,
+    pub(crate) handshake_phase: HandshakePhase,
+}
+
+impl EstablishError {
+    fn pre_hello(cause: MongoError, generation: PoolGeneration) -> Self {
+        Self {
+            cause,
+            handshake_phase: HandshakePhase::PreHello { generation },
+        }
+    }
+    fn post_hello(cause: MongoError, generation: ConnectionGeneration) -> Self {
+        Self {
+            cause,
+            handshake_phase: HandshakePhase::PostHello { generation },
+        }
     }
 }

--- a/src/cmap/manager.rs
+++ b/src/cmap/manager.rs
@@ -122,9 +122,7 @@ impl PoolManagementRequest {
 #[derive(Debug)]
 pub(super) enum ConnectionSucceeded {
     ForPool(Connection),
-    Used {
-        service_id: Option<ObjectId>,
-    }
+    Used { service_id: Option<ObjectId> },
 }
 
 impl ConnectionSucceeded {

--- a/src/cmap/manager.rs
+++ b/src/cmap/manager.rs
@@ -128,7 +128,7 @@ pub(super) enum ConnectionSucceeded {
 impl ConnectionSucceeded {
     pub(super) fn service_id(&self) -> Option<ObjectId> {
         match self {
-            ConnectionSucceeded::ForPool(conn) => conn.service_id,
+            ConnectionSucceeded::ForPool(conn) => conn.generation.service_id(),
             ConnectionSucceeded::Used { service_id, .. } => *service_id,
         }
     }

--- a/src/cmap/manager.rs
+++ b/src/cmap/manager.rs
@@ -27,7 +27,7 @@ impl PoolManager {
             .send(PoolManagementRequest::Clear {
                 completion_handler: message,
                 cause,
-                service_id: service_id,
+                service_id,
             })
             .is_ok()
         {

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -16,7 +16,7 @@ use derivative::Derivative;
 pub use self::conn::ConnectionInfo;
 pub(crate) use self::{
     conn::{Command, Connection, RawCommand, RawCommandResponse, StreamDescription},
-    establish::{EstablishError, handshake::Handshaker},
+    establish::{handshake::Handshaker, EstablishError},
     status::PoolGenerationSubscriber,
     worker::PoolGeneration,
 };

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -16,7 +16,7 @@ use derivative::Derivative;
 pub use self::conn::ConnectionInfo;
 pub(crate) use self::{
     conn::{Command, Connection, RawCommand, RawCommandResponse, StreamDescription},
-    establish::handshake::Handshaker,
+    establish::{EstablishError, handshake::Handshaker},
     status::PoolGenerationSubscriber,
     worker::PoolGeneration,
 };

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use self::{
     conn::{Command, Connection, RawCommand, RawCommandResponse, StreamDescription},
     establish::handshake::Handshaker,
     status::PoolGenerationSubscriber,
+    worker::PoolGeneration,
 };
 use self::{connection_requester::ConnectionRequestResult, options::ConnectionPoolOptions};
 use crate::{
@@ -166,7 +167,7 @@ impl ConnectionPool {
         self.manager.mark_as_ready().await;
     }
 
-    pub(crate) fn generation(&self) -> u32 {
+    pub(crate) fn generation(&self) -> PoolGeneration {
         self.generation_subscriber.generation()
     }
 }

--- a/src/cmap/mod.rs
+++ b/src/cmap/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use self::{
 };
 use self::{connection_requester::ConnectionRequestResult, options::ConnectionPoolOptions};
 use crate::{
+    bson::oid::ObjectId,
     error::{Error, Result},
     event::cmap::{
         CmapEventHandler,
@@ -156,8 +157,8 @@ impl ConnectionPool {
 
     /// Increments the generation of the pool. Rather than eagerly removing stale connections from
     /// the pool, they are left for the background thread to clean up.
-    pub(crate) async fn clear(&self, cause: Error) {
-        self.manager.clear(cause).await
+    pub(crate) async fn clear(&self, cause: Error, service_id: Option<ObjectId>) {
+        self.manager.clear(cause, service_id).await
     }
 
     /// Mark the pool as "ready", allowing connections to be created and checked out.

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -86,6 +86,9 @@ pub(crate) struct ConnectionPoolOptions {
     /// The default is not to use TLS for connections.
     #[serde(skip)]
     pub(crate) tls_options: Option<TlsOptions>,
+
+    /// Whether or not the client is connecting to a MongoDB cluster through a load balancer.
+    pub(crate) load_balanced: Option<bool>,
 }
 
 impl ConnectionPoolOptions {
@@ -105,6 +108,7 @@ impl ConnectionPoolOptions {
             background_thread_interval: None,
             #[cfg(test)]
             ready: None,
+            load_balanced: options.load_balanced.clone(),
         }
     }
 

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -108,7 +108,7 @@ impl ConnectionPoolOptions {
             background_thread_interval: None,
             #[cfg(test)]
             ready: None,
-            load_balanced: options.load_balanced.clone(),
+            load_balanced: options.load_balanced,
         }
     }
 

--- a/src/cmap/status.rs
+++ b/src/cmap/status.rs
@@ -1,13 +1,15 @@
+use crate::cmap::PoolGeneration;
+
 /// Struct used to track the latest status of the pool.
 #[derive(Clone, Debug)]
 struct PoolStatus {
     /// The current generation of the pool.
-    generation: u32,
+    generation: PoolGeneration,
 }
 
 impl Default for PoolStatus {
     fn default() -> Self {
-        PoolStatus { generation: 0 }
+        PoolStatus { generation: PoolGeneration::normal() }
     }
 }
 
@@ -28,7 +30,7 @@ pub(super) struct PoolGenerationPublisher {
 
 impl PoolGenerationPublisher {
     /// Publish a new generation.
-    pub(super) fn publish(&self, new_generation: u32) {
+    pub(super) fn publish(&self, new_generation: PoolGeneration) {
         let new_status = PoolStatus {
             generation: new_generation,
         };
@@ -46,7 +48,7 @@ pub(crate) struct PoolGenerationSubscriber {
 
 impl PoolGenerationSubscriber {
     /// Get a copy of the latest generation.
-    pub(crate) fn generation(&self) -> u32 {
-        self.receiver.borrow().generation
+    pub(crate) fn generation(&self) -> PoolGeneration {
+        self.receiver.borrow().generation.clone()
     }
 }

--- a/src/cmap/status.rs
+++ b/src/cmap/status.rs
@@ -9,7 +9,9 @@ struct PoolStatus {
 
 impl Default for PoolStatus {
     fn default() -> Self {
-        PoolStatus { generation: PoolGeneration::normal() }
+        PoolStatus {
+            generation: PoolGeneration::normal(),
+        }
     }
 }
 

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -164,7 +164,7 @@ impl Executor {
         RUNTIME.execute(async move {
             while let Some(update) = update_receiver.recv().await {
                 match update.into_message() {
-                    ServerUpdate::Error { error, .. } => manager.clear(error, None).await,
+                    ServerUpdate::Error { error, .. } => manager.clear(error.cause, None).await,
                 }
             }
         });

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -164,7 +164,7 @@ impl Executor {
         RUNTIME.execute(async move {
             while let Some(update) = update_receiver.recv().await {
                 match update.into_message() {
-                    ServerUpdate::Error { error, .. } => manager.clear(error).await,
+                    ServerUpdate::Error { error, .. } => manager.clear(error, None).await,
                 }
             }
         });
@@ -286,6 +286,7 @@ impl Operation {
                             message: "test error".to_string(),
                         }
                         .into(),
+                        None,
                     )
                     .await;
                 }

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -556,12 +556,11 @@ impl ConnectionPoolWorker {
     ) -> Result<()> {
         match (&mut self.generation, connection.generation.service_id()) {
             (PoolGeneration::LoadBalanced(gen_map), Some(sid)) => {
-                let count = self
-                    .service_connection_count
-                    .get_mut(&sid)
-                    .ok_or(Error::from(ErrorKind::Internal {
+                let count = self.service_connection_count.get_mut(&sid).ok_or_else(|| {
+                    Error::from(ErrorKind::Internal {
                         message: "no connection count for load-balanced service".to_string(),
-                    }))?;
+                    })
+                })?;
                 *count -= 1;
                 if *count == 0 {
                     gen_map.remove(&sid);

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -537,11 +537,8 @@ impl ConnectionPoolWorker {
 
     /// Close a connection, emit the event for it being closed, and decrement the
     /// total connection count.
-    fn close_connection(
-        &mut self,
-        connection: Connection,
-        reason: ConnectionClosedReason,
-    ) {
+    #[allow(clippy::single_match)]
+    fn close_connection(&mut self, connection: Connection, reason: ConnectionClosedReason) {
         match (&mut self.generation, connection.generation.service_id()) {
             (PoolGeneration::LoadBalanced(gen_map), Some(sid)) => {
                 match self.service_connection_count.get_mut(&sid) {

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -209,11 +209,7 @@ impl ConnectionPoolWorker {
         #[cfg(not(test))]
         let (mut state, maintenance_frequency) = (PoolState::New, MAINTENACE_FREQUENCY);
 
-        if options
-            .as_ref()
-            .and_then(|opts| opts.load_balanced)
-            .unwrap_or(false)
-        {
+        if is_load_balanced {
             // Because load balancer servers don't have a monitoring connection, the associated
             // connection pool needs start in the ready state.
             state = PoolState::Ready;

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -37,7 +37,11 @@ use crate::{
     RUNTIME,
 };
 
-use std::{collections::{HashMap, VecDeque}, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
 use tokio::sync::mpsc;
 
 const MAX_CONNECTING: u32 = 2;
@@ -372,7 +376,9 @@ impl ConnectionPoolWorker {
 
                 if let Ok(ref mut c) = establish_result {
                     c.mark_as_in_use(manager.clone());
-                    manager.handle_connection_succeeded(ConnectionSucceeded::Used { service_id: c.service_id });
+                    manager.handle_connection_succeeded(ConnectionSucceeded::Used {
+                        service_id: c.service_id,
+                    });
                 }
 
                 establish_result
@@ -407,7 +413,8 @@ impl ConnectionPoolWorker {
             id: self.next_connection_id,
             address: self.address.clone(),
             generation: self.generation,
-            service_generations: self.service_generations
+            service_generations: self
+                .service_generations
                 .iter()
                 .map(|(id, (generation, _))| (*id, *generation))
                 .collect::<HashMap<ObjectId, u32>>(),
@@ -578,7 +585,8 @@ impl ConnectionPoolWorker {
                     .await;
 
                     if let Ok(connection) = connection {
-                        manager.handle_connection_succeeded(ConnectionSucceeded::ForPool(connection))
+                        manager
+                            .handle_connection_succeeded(ConnectionSucceeded::ForPool(connection))
                     }
                 });
             }
@@ -587,7 +595,9 @@ impl ConnectionPoolWorker {
 
     fn is_stale(&self, conn: &Connection) -> bool {
         if let Some(service_id) = conn.service_id {
-            let service_gen = self.service_generations.get(&service_id)
+            let service_gen = self
+                .service_generations
+                .get(&service_id)
                 .map(|(g, _)| g)
                 .unwrap_or(&0);
             conn.generation != *service_gen

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -650,7 +650,6 @@ async fn establish_connection(
     event_handler: Option<&Arc<dyn CmapEventHandler>>,
 ) -> Result<Connection> {
     let connection_id = pending_connection.id;
-    let generation = pending_connection.generation.clone();
     let address = pending_connection.address.clone();
 
     let mut establish_result = establisher.establish_connection(pending_connection).await;
@@ -665,7 +664,7 @@ async fn establish_connection(
                 };
                 handler.handle_connection_closed_event(event);
             }
-            server_updater.handle_error(e.clone(), generation).await;
+            server_updater.handle_error(e.clone()).await;
             manager.handle_connection_failed();
         }
         Ok(ref mut connection) => {
@@ -675,7 +674,7 @@ async fn establish_connection(
         }
     }
 
-    establish_result
+    establish_result.map_err(|e| e.cause)
 }
 
 /// Enum modeling the possible pool states as described in the CMAP spec.

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -487,10 +487,7 @@ impl ConnectionPoolWorker {
                 *gen += 1;
                 true
             }
-            (..) => {
-                load_balanced_mode_mismatch!();
-                false
-            }
+            (..) => load_balanced_mode_mismatch!(false),
         };
         self.generation_publisher.publish(self.generation.clone());
 
@@ -555,7 +552,7 @@ impl ConnectionPoolWorker {
                             self.service_connection_count.remove(&sid);
                         }
                     }
-                    None => load_balanced_mode_mismatch!("no connection count for load-balanced service"),
+                    None => load_balanced_mode_mismatch!(),
                 }
             }
             (PoolGeneration::Normal(_), None) => {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -585,7 +585,7 @@ pub(crate) fn convert_bulk_errors(error: Error) -> Error {
     }
 }
 
-/// Flag a load balanced mode mismatch.  In tests, it will panic; outside of tests, it will
+/// Flag a load-balanced mode mismatch.  In tests, it will panic; outside of tests, it will
 /// evaluate to the argument, or `()` if none is given.
 // TODO RUST-230 Log an error in the non-panic branch for mode mismatch.
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -584,3 +584,26 @@ pub(crate) fn convert_bulk_errors(error: Error) -> Error {
         _ => error,
     }
 }
+
+/// Flag a load balanced mode mismatch; in tests, it will panic, optionally including an argument
+/// in the panic message.  Outside of tests, it will evaluate to `()`.
+// TODO RUST-230 Log an error in the non-panic branch for mode mismatch.
+#[cfg(test)]
+macro_rules! load_balanced_mode_mismatch {
+    () => {
+        panic!("load-balanced mode mismatch")
+    };
+    ($e:expr) => {
+        panic!("load-balanced mode mismatch: {}", $e)
+    };
+}
+#[cfg(not(test))]
+macro_rules! load_balanced_mode_mismatch {
+    () => {
+        ()
+    };
+    ($e:expr) => {{
+        let _ = $e;  // Suppress unused warnings.
+        ()
+    }};
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -585,25 +585,25 @@ pub(crate) fn convert_bulk_errors(error: Error) -> Error {
     }
 }
 
-/// Flag a load balanced mode mismatch; in tests, it will panic, optionally including an argument
-/// in the panic message.  Outside of tests, it will evaluate to `()`.
+/// Flag a load balanced mode mismatch.  In tests, it will panic; outside of tests, it will
+/// evaluate to the argument, or `()` if none is given.
 // TODO RUST-230 Log an error in the non-panic branch for mode mismatch.
 #[cfg(test)]
 macro_rules! load_balanced_mode_mismatch {
-    () => {
+    ($e:expr) => {{
+        let _ = $e;
         panic!("load-balanced mode mismatch")
-    };
-    ($e:expr) => {
-        panic!("load-balanced mode mismatch: {}", $e)
+    }};
+    () => {
+        load_balanced_mode_mismatch!(())
     };
 }
 #[cfg(not(test))]
 macro_rules! load_balanced_mode_mismatch {
-    () => {
-        ()
+    ($e:expr) => {
+        $e
     };
-    ($e:expr) => {{
-        let _ = $e;  // Suppress unused warnings.
-        ()
-    }};
+    () => {
+        load_balanced_mode_mismatch!(())
+    };
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -585,25 +585,19 @@ pub(crate) fn convert_bulk_errors(error: Error) -> Error {
     }
 }
 
-/// Flag a load-balanced mode mismatch.  In tests, it will panic; outside of tests, it will
-/// evaluate to the argument, or `()` if none is given.
+/// Flag a load-balanced mode mismatch.  With debug assertions enabled, it will panic; otherwise,
+/// it will return the argument, or `()` if none is given.
 // TODO RUST-230 Log an error in the non-panic branch for mode mismatch.
-#[cfg(test)]
 macro_rules! load_balanced_mode_mismatch {
     ($e:expr) => {{
-        let _ = $e;
-        panic!("load-balanced mode mismatch")
+        if cfg!(debug_assertions) {
+            panic!("load-balanced mode mismatch")
+        }
+        return $e;
     }};
     () => {
         load_balanced_mode_mismatch!(())
     };
 }
-#[cfg(not(test))]
-macro_rules! load_balanced_mode_mismatch {
-    ($e:expr) => {
-        $e
-    };
-    () => {
-        load_balanced_mode_mismatch!(())
-    };
-}
+
+pub(crate) use load_balanced_mode_mismatch;

--- a/src/is_master.rs
+++ b/src/is_master.rs
@@ -97,6 +97,7 @@ pub(crate) struct IsMasterCommandResponse {
     pub speculative_authenticate: Option<Document>,
     pub max_bson_object_size: i64,
     pub max_write_batch_size: i64,
+    pub service_id: Option<ObjectId>,
 }
 
 impl PartialEq for IsMasterCommandResponse {
@@ -116,6 +117,7 @@ impl PartialEq for IsMasterCommandResponse {
             && self.logical_session_timeout_minutes == other.logical_session_timeout_minutes
             && self.max_bson_object_size == other.max_bson_object_size
             && self.max_write_batch_size == other.max_write_batch_size
+            && self.service_id == other.service_id
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,8 @@ macro_rules! define_if_single_runtime_enabled {
 // and warnings other than our custom ones.
 define_if_single_runtime_enabled! {
     #[macro_use]
+    pub mod error;
+    #[macro_use]
     pub mod options;
 
     pub use ::bson;
@@ -112,7 +114,6 @@ define_if_single_runtime_enabled! {
     mod concern;
     mod cursor;
     mod db;
-    pub mod error;
     pub mod event;
     mod is_master;
     mod operation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,8 +100,6 @@ macro_rules! define_if_single_runtime_enabled {
 // and warnings other than our custom ones.
 define_if_single_runtime_enabled! {
     #[macro_use]
-    pub mod error;
-    #[macro_use]
     pub mod options;
 
     pub use ::bson;
@@ -114,6 +112,7 @@ define_if_single_runtime_enabled! {
     mod concern;
     mod cursor;
     mod db;
+    pub mod error;
     pub mod event;
     mod is_master;
     mod operation;

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -168,6 +168,20 @@ impl ServerDescription {
         description
     }
 
+    pub(crate) fn new_load_balancer(mut address: ServerAddress) -> Self {
+        address = ServerAddress::Tcp {
+            host: address.host().to_lowercase(),
+            port: address.port(),
+        };
+        Self {
+            address,
+            server_type: ServerType::LoadBalancer,
+            last_update_time: None,
+            reply: Ok(None),
+            average_round_trip_time: None,
+        }
+    }
+
     /// Whether this server is "available" as per the definition in the server selection spec.
     pub(crate) fn is_available(&self) -> bool {
         !matches!(self.server_type, ServerType::Unknown)

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -22,6 +22,7 @@ pub enum ServerType {
     RsArbiter,
     RsOther,
     RsGhost,
+    LoadBalancer,
     Unknown,
 }
 

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -114,7 +114,11 @@ impl TopologyDescription {
             .hosts
             .into_iter()
             .map(|address| {
-                let description = ServerDescription::new(address.clone(), None);
+                let description = if topology_type == TopologyType::LoadBalanced {
+                    ServerDescription::new_load_balancer(address.clone())
+                } else {
+                    ServerDescription::new(address.clone(), None)
+                };
 
                 (address, description)
             })
@@ -457,7 +461,9 @@ impl TopologyDescription {
                 self.topology_type = TopologyType::ReplicaSetNoPrimary;
                 self.update_rs_without_primary_server(server_description)?;
             }
-            ServerType::LoadBalancer => return Err("cannot transition to a load balancer".to_string()),
+            ServerType::LoadBalancer => {
+                return Err("cannot transition to a load balancer".to_string())
+            }
         }
 
         Ok(())
@@ -490,7 +496,9 @@ impl TopologyDescription {
             ServerType::RsSecondary | ServerType::RsArbiter | ServerType::RsOther => {
                 self.update_rs_without_primary_server(server_description)?;
             }
-            ServerType::LoadBalancer => return Err("cannot transition to a load balancer".to_string()),
+            ServerType::LoadBalancer => {
+                return Err("cannot transition to a load balancer".to_string())
+            }
         }
 
         Ok(())
@@ -513,7 +521,9 @@ impl TopologyDescription {
             ServerType::RsSecondary | ServerType::RsArbiter | ServerType::RsOther => {
                 self.update_rs_with_primary_from_member(server_description)?;
             }
-            ServerType::LoadBalancer => return Err("cannot transition to a load balancer".to_string()),
+            ServerType::LoadBalancer => {
+                return Err("cannot transition to a load balancer".to_string())
+            }
         }
 
         Ok(())

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -138,7 +138,7 @@ impl TopologyDescription {
     ) -> Result<Vec<&'a ServerDescription>> {
         let servers = match self.topology_type {
             TopologyType::Unknown => Vec::new(),
-            TopologyType::Single => self.servers.values().collect(),
+            TopologyType::Single | TopologyType::LoadBalanced => self.servers.values().collect(),
             TopologyType::Sharded => self.servers_with_type(&[ServerType::Mongos]).collect(),
             TopologyType::ReplicaSetWithPrimary | TopologyType::ReplicaSetNoPrimary => {
                 self.suitable_servers_in_replica_set(read_preference)?

--- a/src/sdam/description/topology/server_selection/test/mod.rs
+++ b/src/sdam/description/topology/server_selection/test/mod.rs
@@ -181,7 +181,7 @@ fn is_master_response_from_server_type(server_type: ServerType) -> Option<IsMast
         ServerType::RsGhost => {
             response.is_replica_set = Some(true);
         }
-        ServerType::Standalone => {}
+        ServerType::Standalone | ServerType::LoadBalancer => {}
     };
 
     Some(response)

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -284,11 +284,9 @@ async fn run_test(test_file: TestFile) {
                     .unwrap_or(0);
                 let conn_generation = ConnectionGeneration::Normal(conn_generation);
                 let handshake_phase = match application_error.when {
-                    ErrorHandshakePhase::BeforeHandshakeCompletes => {
-                        HandshakePhase::PreHello {
-                            generation: pool_generation,
-                        }
-                    }
+                    ErrorHandshakePhase::BeforeHandshakeCompletes => HandshakePhase::PreHello {
+                        generation: pool_generation,
+                    },
                     ErrorHandshakePhase::AfterHandshakeCompletes => {
                         HandshakePhase::AfterCompletion {
                             generation: conn_generation,

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -73,6 +73,7 @@ pub(crate) struct TestIsMasterCommandResponse {
     pub speculative_authenticate: Option<Document>,
     pub max_bson_object_size: Option<i64>,
     pub max_write_batch_size: Option<i64>,
+    pub service_id: Option<ObjectId>,
 }
 
 impl From<TestIsMasterCommandResponse> for IsMasterCommandResponse {
@@ -102,6 +103,7 @@ impl From<TestIsMasterCommandResponse> for IsMasterCommandResponse {
             speculative_authenticate: test.speculative_authenticate,
             max_bson_object_size: test.max_bson_object_size.unwrap_or(1234),
             max_write_batch_size: test.max_write_batch_size.unwrap_or(1234),
+            service_id: test.service_id,
         }
     }
 }

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -291,7 +291,7 @@ async fn run_test(test_file: TestFile) {
                 };
 
                 topology
-                    .handle_application_error(error, handshake_phase, &server)
+                    .handle_application_error(error, handshake_phase, &server, None)
                     .await;
             }
         }
@@ -566,7 +566,7 @@ async fn pool_cleared_error_does_not_mark_unknown() {
     };
     assert!(
         !topology
-            .handle_application_error(error, phase, &server)
+            .handle_application_error(error, phase, &server, None)
             .await
     );
     assert_eq!(

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLockReadGuard;
 use crate::{
     bson::{doc, oid::ObjectId},
     client::Client,
-    cmap::{conn::ConnectionGeneration},
+    cmap::{conn::ConnectionGeneration, PoolGeneration},
     error::{BulkWriteFailure, CommandError, Error, ErrorKind},
     is_master::{IsMasterCommandResponse, IsMasterReply, LastWrite},
     options::{ClientOptions, ReadPreference, SelectionCriteria, ServerAddress},
@@ -274,20 +274,24 @@ async fn run_test(test_file: TestFile) {
                 .and_then(|s| s.upgrade())
             {
                 let error = application_error.to_error();
-                let generation = application_error
+                let pool_generation = application_error
+                    .generation
+                    .map(PoolGeneration::Normal)
+                    .unwrap_or_else(|| server.pool.generation());
+                let conn_generation = application_error
                     .generation
                     .or_else(|| server.pool.generation().as_normal())
                     .unwrap_or(0);
-                let generation = ConnectionGeneration::Normal(generation);
+                let conn_generation = ConnectionGeneration::Normal(conn_generation);
                 let handshake_phase = match application_error.when {
                     ErrorHandshakePhase::BeforeHandshakeCompletes => {
-                        HandshakePhase::PostHello {
-                            generation,
+                        HandshakePhase::PreHello {
+                            generation: pool_generation,
                         }
                     }
                     ErrorHandshakePhase::AfterHandshakeCompletes => {
                         HandshakePhase::AfterCompletion {
-                            generation,
+                            generation: conn_generation,
                             max_wire_version: application_error.max_wire_version,
                         }
                     }

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -6,8 +6,8 @@ use tokio::sync::RwLockReadGuard;
 
 use crate::{
     bson::{doc, oid::ObjectId},
-    cmap::{conn::ConnectionGeneration, PoolGeneration},
     client::Client,
+    cmap::{conn::ConnectionGeneration, PoolGeneration},
     error::{BulkWriteFailure, CommandError, Error, ErrorKind},
     is_master::{IsMasterCommandResponse, IsMasterReply, LastWrite},
     options::{ClientOptions, ReadPreference, SelectionCriteria, ServerAddress},

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -249,6 +249,7 @@ impl UpdateMonitor {
                                 generation: error_generation,
                             },
                             &server,
+                            None,
                         )
                         .await;
                 }

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::{
     description::server::ServerDescription,
-    state::{server::Server, HandshakePhase, Topology, WeakTopology},
+    state::{server::Server, Topology, WeakTopology},
     ServerUpdate,
     ServerUpdateReceiver,
 };
@@ -51,16 +51,19 @@ impl Monitor {
     /// Start the monitor tasks.
     /// A weak reference is used to ensure that the monitor doesn't keep the topology alive after
     /// it's been removed from the topology or the client has been dropped.
-    pub(super) fn start(self) {
-        let mut heartbeat_monitor = HeartbeatMonitor::new(
-            self.address,
-            Arc::downgrade(&self.server),
-            self.topology.clone(),
-            self.client_options,
-        );
-        RUNTIME.execute(async move {
-            heartbeat_monitor.execute().await;
-        });
+    pub(super) fn start(self, is_load_balanced: bool) {
+        // Load balancer servers can't have a monitoring connection.
+        if !is_load_balanced {
+            let mut heartbeat_monitor = HeartbeatMonitor::new(
+                self.address,
+                Arc::downgrade(&self.server),
+                self.topology.clone(),
+                self.client_options,
+            );
+            RUNTIME.execute(async move {
+                heartbeat_monitor.execute().await;
+            });
+        }
 
         let update_monitor = UpdateMonitor {
             server: Arc::downgrade(&self.server),
@@ -240,16 +243,12 @@ impl UpdateMonitor {
             match update.into_message() {
                 ServerUpdate::Error {
                     error,
-                    error_generation,
                 } => {
                     topology
                         .handle_application_error(
-                            error,
-                            HandshakePhase::BeforeCompletion {
-                                generation: error_generation,
-                            },
+                            error.cause,
+                            error.handshake_phase,
                             &server,
-                            None,
                         )
                         .await;
                 }

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -241,15 +241,9 @@ impl UpdateMonitor {
             };
 
             match update.into_message() {
-                ServerUpdate::Error {
-                    error,
-                } => {
+                ServerUpdate::Error { error } => {
                     topology
-                        .handle_application_error(
-                            error.cause,
-                            error.handshake_phase,
-                            &server,
-                        )
+                        .handle_application_error(error.cause, error.handshake_phase, &server)
                         .await;
                 }
             }

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -51,7 +51,8 @@ impl Monitor {
     /// Start the monitor tasks.
     /// A weak reference is used to ensure that the monitor doesn't keep the topology alive after
     /// it's been removed from the topology or the client has been dropped.
-    pub(super) fn start(self, is_load_balanced: bool) {
+    pub(super) fn start(self) {
+        let is_load_balanced = matches!(self.client_options.load_balanced, Some(true));
         // Load balancer servers can't have a monitoring connection.
         if !is_load_balanced {
             let mut heartbeat_monitor = HeartbeatMonitor::new(

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -486,7 +486,9 @@ impl TopologyState {
             // Because load balancer servers don't have a monitoring connection, the associated
             // connection pool needs to be directly marked as ready.
             let server = Arc::clone(&server);
-            RUNTIME.execute(async move { server.pool.mark_as_ready().await; })
+            RUNTIME.execute(async move {
+                server.pool.mark_as_ready().await;
+            })
         }
         self.servers.insert(address, server);
 

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -637,7 +637,7 @@ impl HandshakePhase {
 
     /// Whether this phase is before the handshake completed or not.
     fn is_before_completion(&self) -> bool {
-        matches!(self, HandshakePhase::PreHello { .. })
+        !matches!(self, HandshakePhase::AfterCompletion { .. })
     }
 
     /// The wire version of the server as reported by the handshake. If the handshake did not
@@ -647,7 +647,7 @@ impl HandshakePhase {
             HandshakePhase::AfterCompletion {
                 max_wire_version, ..
             } => Some(*max_wire_version),
-            HandshakePhase::PreHello { .. } | HandshakePhase::PostHello { .. } => None,
+            _ => None,
         }
     }
 }

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -264,7 +264,7 @@ impl Topology {
                     (PoolGeneration::LoadBalanced(_), PoolGeneration::LoadBalanced(_)) => {
                         return false
                     }
-                    _ => {} // TODO RUST-230 Log an error for mode mismatch.
+                    _ => load_balanced_mode_mismatch!(),
                 }
             }
             HandshakePhase::PostHello { generation }

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -259,13 +259,10 @@ impl Topology {
 
         let is_load_balanced = state_lock.description.topology_type() == TopologyType::LoadBalanced;
         if error.is_state_change_error() {
-            let updated = if is_load_balanced {
-                true
-            } else {
-                self
+            let updated = is_load_balanced
+                || self
                     .mark_server_as_unknown(error.to_string(), server, state_lock)
-                    .await
-            };
+                    .await;
 
             if updated && (error.is_shutting_down() || handshake.wire_version().unwrap_or(0) < 8) {
                 server.pool.clear(error, service_id).await;
@@ -279,13 +276,10 @@ impl Topology {
                     || error.is_network_timeout()
                     || error.is_command_error()))
         {
-            let updated = if is_load_balanced {
-                true
-            } else {
-                self
+            let updated = is_load_balanced
+                || self
                     .mark_server_as_unknown(error.to_string(), server, state_lock)
-                    .await
-            };
+                    .await;
             if updated {
                 server.pool.clear(error, service_id).await;
             }

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::{
     bson::oid::ObjectId,
     client::ClusterTime,
-    cmap::{Command, Connection, conn::ConnectionGeneration, PoolGeneration},
+    cmap::{conn::ConnectionGeneration, Command, Connection, PoolGeneration},
     error::{Error, Result},
     options::{ClientOptions, SelectionCriteria, ServerAddress},
     runtime::HttpClient,
@@ -256,9 +256,13 @@ impl Topology {
         match &handshake {
             HandshakePhase::BeforeCompletion { generation } => {
                 match (generation, server.pool.generation()) {
-                    (PoolGeneration::Normal(hgen), PoolGeneration::Normal(sgen)) => if *hgen < sgen { return false },
-                    (PoolGeneration::LoadBalanced(_), PoolGeneration::LoadBalanced(_)) => {},
-                    _ => {},  // TODO RUST-230 Log an error for mode mismatch.
+                    (PoolGeneration::Normal(hgen), PoolGeneration::Normal(sgen)) => {
+                        if *hgen < sgen {
+                            return false;
+                        }
+                    }
+                    (PoolGeneration::LoadBalanced(_), PoolGeneration::LoadBalanced(_)) => {}
+                    _ => {} // TODO RUST-230 Log an error for mode mismatch.
                 }
             }
             HandshakePhase::AfterCompletion { generation, .. } => {

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -261,12 +261,14 @@ impl Topology {
                         }
                     }
                     // Pre-hello handshake errors are ignored in load-balanced mode.
-                    (PoolGeneration::LoadBalanced(_), PoolGeneration::LoadBalanced(_)) => return false,
+                    (PoolGeneration::LoadBalanced(_), PoolGeneration::LoadBalanced(_)) => {
+                        return false
+                    }
                     _ => {} // TODO RUST-230 Log an error for mode mismatch.
                 }
             }
-            HandshakePhase::PostHello { generation } |
-            HandshakePhase::AfterCompletion { generation, .. } => {
+            HandshakePhase::PostHello { generation }
+            | HandshakePhase::AfterCompletion { generation, .. } => {
                 if generation.is_stale(&server.pool.generation()) {
                     return false;
                 }

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -5,11 +5,10 @@ use std::sync::{
 
 use super::WeakTopology;
 use crate::{
-    cmap::{options::ConnectionPoolOptions, ConnectionPool, PoolGeneration},
-    error::Error,
+    cmap::{options::ConnectionPoolOptions, ConnectionPool, EstablishError},
     options::{ClientOptions, ServerAddress},
     runtime::{AcknowledgedMessage, HttpClient},
-    sdam::monitor::Monitor,
+    sdam::{monitor::Monitor},
 };
 
 /// Contains the state for a given server in the topology.
@@ -75,8 +74,7 @@ impl Server {
 #[derive(Debug)]
 pub(crate) enum ServerUpdate {
     Error {
-        error: Error,
-        error_generation: PoolGeneration,
+        error: EstablishError,
     },
 }
 
@@ -109,10 +107,9 @@ impl ServerUpdateSender {
 
     /// Update the server based on the given error.
     /// This will block until the topology has processed the error.
-    pub(crate) async fn handle_error(&mut self, error: Error, error_generation: PoolGeneration) {
+    pub(crate) async fn handle_error(&mut self, error: EstablishError) {
         let reason = ServerUpdate::Error {
             error,
-            error_generation,
         };
 
         let (message, callback) = AcknowledgedMessage::package(reason);

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -5,7 +5,7 @@ use std::sync::{
 
 use super::WeakTopology;
 use crate::{
-    cmap::{options::ConnectionPoolOptions, ConnectionPool},
+    cmap::{options::ConnectionPoolOptions, ConnectionPool, PoolGeneration},
     error::Error,
     options::{ClientOptions, ServerAddress},
     runtime::{AcknowledgedMessage, HttpClient},
@@ -74,7 +74,7 @@ impl Server {
 /// TODO: add success cases from application handshakes.
 #[derive(Debug)]
 pub(crate) enum ServerUpdate {
-    Error { error: Error, error_generation: u32 },
+    Error { error: Error, error_generation: PoolGeneration },
 }
 
 #[derive(Debug)]
@@ -106,7 +106,7 @@ impl ServerUpdateSender {
 
     /// Update the server based on the given error.
     /// This will block until the topology has processed the error.
-    pub(crate) async fn handle_error(&mut self, error: Error, error_generation: u32) {
+    pub(crate) async fn handle_error(&mut self, error: Error, error_generation: PoolGeneration) {
         let reason = ServerUpdate::Error {
             error,
             error_generation,

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -8,7 +8,7 @@ use crate::{
     cmap::{options::ConnectionPoolOptions, ConnectionPool, EstablishError},
     options::{ClientOptions, ServerAddress},
     runtime::{AcknowledgedMessage, HttpClient},
-    sdam::{monitor::Monitor},
+    sdam::monitor::Monitor,
 };
 
 /// Contains the state for a given server in the topology.
@@ -73,9 +73,7 @@ impl Server {
 /// TODO: add success cases from application handshakes.
 #[derive(Debug)]
 pub(crate) enum ServerUpdate {
-    Error {
-        error: EstablishError,
-    },
+    Error { error: EstablishError },
 }
 
 #[derive(Debug)]
@@ -108,9 +106,7 @@ impl ServerUpdateSender {
     /// Update the server based on the given error.
     /// This will block until the topology has processed the error.
     pub(crate) async fn handle_error(&mut self, error: EstablishError) {
-        let reason = ServerUpdate::Error {
-            error,
-        };
+        let reason = ServerUpdate::Error { error };
 
         let (message, callback) = AcknowledgedMessage::package(reason);
         // These only fails if the other ends hang up, which means the monitor is

--- a/src/sdam/state/server.rs
+++ b/src/sdam/state/server.rs
@@ -74,7 +74,10 @@ impl Server {
 /// TODO: add success cases from application handshakes.
 #[derive(Debug)]
 pub(crate) enum ServerUpdate {
-    Error { error: Error, error_generation: PoolGeneration },
+    Error {
+        error: Error,
+        error_generation: PoolGeneration,
+    },
 }
 
 #[derive(Debug)]

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -191,14 +191,14 @@ impl SrvResolver {
                 "replicaset" => {
                     config.replica_set = Some(parts[1].into());
                 }
-                "loadBalanced" => {
+                "loadbalanced" => {
                     let val = match parts[1] {
                         "true" => true,
                         "false" => false,
                         _ => {
                             return Err(ErrorKind::DnsResolve {
                                 message: format!(
-                                    "TXT record option 'loadBalanced={}' was returned, only \
+                                    "TXT record option 'loadbalanced={}' was returned, only \
                                      'true' and 'false' are allowed values.",
                                     parts[1]
                                 ),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -45,6 +45,7 @@ lazy_static! {
         let mut options = ClientOptions::parse_without_srv_resolution(&uri).unwrap();
         options.max_pool_size = Some(MAX_POOL_SIZE);
         options.server_api = SERVER_API.clone();
+        options.allow_load_balancer = Some(true);
 
         options
     };

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -45,7 +45,7 @@ lazy_static! {
         let mut options = ClientOptions::parse_without_srv_resolution(&uri).unwrap();
         options.max_pool_size = Some(MAX_POOL_SIZE);
         options.server_api = SERVER_API.clone();
-        options.allow_load_balancer = Some(true);
+        options.allow_load_balanced = true;
 
         options
     };


### PR DESCRIPTION
RUST-950

This implements the connection establishment portion of load balancer support, i.e.:
- Parsing the `loadBalanced` URI/TXT option
- Modifications to handshake and topology/server type tracking
- Per-`serviceId` connection pool tracking

The work here happened to also encompass RUST-955.