### PR TITLE
RUST-626 Run benchmarks in Evergreen

### DIFF
--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -13,8 +13,10 @@ stepback: true
 command_type: system
 
 # Protect ourself against rogue test case, or curl gone wild, that runs forever
-# 12 minutes is the longest we'll ever run
-exec_timeout_secs: 3600 # 12 minutes is the longest we'll ever run
+# 60 minutes is the longest we'll ever run
+exec_timeout_secs: 3600
+
+pre_error_fails_task: true
 
 # What to do when evergreen hits the timeout (`post:` tasks are run automatically)
 timeout:
@@ -173,7 +175,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          ASYNC_RUNTIME=${ASYNC_RUNTIME} RUST_VERSION=${RUST_VERSION} .evergreen/compile-only.sh
+          ASYNC_RUNTIME=${ASYNC_RUNTIME} .evergreen/run-compile-benchmarks.sh
 
   "upload-mo-artifacts":
     - command: shell.exec
@@ -273,8 +275,6 @@ pre:
 
 post:
   - func: "stop mongo orchestration"
-  - func: "upload-mo-artifacts"
-  - func: "upload benchmark results"
   - func: "cleanup"
 
 tasks:
@@ -286,6 +286,7 @@ tasks:
           MONGODB_VERSION: "4.0"
           TOPOLOGY: "server"
       - func: "run driver benchmarks"
+      - func: "upload benchmark results"
 
   - name: "benchmark-4.0-replica_set"
     tags: ["4.0", "replica_set"]
@@ -295,6 +296,7 @@ tasks:
           MONGODB_VERSION: "4.0"
           TOPOLOGY: "replica_set"
       - func: "run driver benchmarks"
+      - func: "upload benchmark results"
 
   - name: "benchmark-4.0-sharded_cluster"
     tags: ["4.0", "sharded_cluster"]
@@ -304,6 +306,7 @@ tasks:
           MONGODB_VERSION: "4.0"
           TOPOLOGY: "sharded_cluster"
       - func: "run driver benchmarks"
+      - func: "upload benchmark results"
 
   - name: "benchmark-5.0-standalone"
     tags: ["5.0", "standalone"]
@@ -313,6 +316,7 @@ tasks:
           MONGODB_VERSION: "5.0"
           TOPOLOGY: "server"
       - func: "run driver benchmarks"
+      - func: "upload benchmark results"
 
   - name: "benchmark-5.0-replica_set"
     tags: ["5.0", "replica_set"]
@@ -322,6 +326,7 @@ tasks:
           MONGODB_VERSION: "5.0"
           TOPOLOGY: "replica_set"
       - func: "run driver benchmarks"
+      - func: "upload benchmark results"
 
   - name: "benchmark-5.0-sharded_cluster"
     tags: ["5.0", "sharded_cluster"]
@@ -331,28 +336,20 @@ tasks:
           MONGODB_VERSION: "5.0"
           TOPOLOGY: "sharded_cluster"
       - func: "run driver benchmarks"
+      - func: "upload benchmark results"
 
   - name: "benchmark-bson"
     tags: ["bson"]
     commands:
       - func: "run bson benchmarks"
+      - func: "upload benchmark results"
 
-  - name: "compile-only"
+  - name: "benchmark-compile"
     commands:
       - func: "compile only"
+      - func: "upload benchmark results"
 
 axes:
-  - id: "extra-rust-versions"
-    values:
-      - id: "min"
-        display_name: "1.48 (minimum supported version)"
-        variables:
-          RUST_VERSION: "1.48.0"
-      - id: "nightly"
-        display_name: "nightly"
-        variables:
-          RUST_VERSION: "nightly"
-
   - id: "mongodb-version"
     display_name: MongoDB Version
     values:
@@ -457,8 +454,7 @@ buildvariants:
     os:
       - ubuntu-18.04
     async-runtime: "*"
-    extra-rust-versions: "*"
-  display_name: "Compile on Rust ${extra-rust-versions} with ${async-runtime}"
+  display_name: "Compile on ${os} with ${async-runtime}"
   tasks:
-    - "compile-only"
+    - "benchmark-compile"
 

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -195,7 +195,7 @@ functions:
   "upload benchmark results":
     - command: perf.send
       params:
-        file: "benchmark-results.json"
+        file: "src/benchmark-results.json"
 
   "stop mongo orchestration":
     - command: shell.exec

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -279,32 +279,32 @@ post:
   - func: "cleanup"
 
 tasks:
-  - name: "benchmark-4.0-standalone"
-    tags: ["4.0", "standalone"]
+  - name: "benchmark-4.2-standalone"
+    tags: ["4.2", "standalone"]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:
-          MONGODB_VERSION: "4.0"
+          MONGODB_VERSION: "4.2"
           TOPOLOGY: "server"
       - func: "run driver benchmarks"
       - func: "upload benchmark results"
 
-  - name: "benchmark-4.0-replica_set"
-    tags: ["4.0", "replica_set"]
+  - name: "benchmark-4.2-replica_set"
+    tags: ["4.2", "replica_set"]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:
-          MONGODB_VERSION: "4.0"
+          MONGODB_VERSION: "4.2"
           TOPOLOGY: "replica_set"
       - func: "run driver benchmarks"
       - func: "upload benchmark results"
 
-  - name: "benchmark-4.0-sharded_cluster"
-    tags: ["4.0", "sharded_cluster"]
+  - name: "benchmark-4.2-sharded_cluster"
+    tags: ["4.2", "sharded_cluster"]
     commands:
       - func: "bootstrap mongo-orchestration"
         vars:
-          MONGODB_VERSION: "4.0"
+          MONGODB_VERSION: "4.2"
           TOPOLOGY: "sharded_cluster"
       - func: "run driver benchmarks"
       - func: "upload benchmark results"
@@ -358,10 +358,10 @@ axes:
         display_name: "5.0"
         variables:
           MONGODB_VERSION: "5.0"
-      - id: "4.0"
-        display_name: "4.0"
+      - id: "4.2"
+        display_name: "4.2"
         variables:
-          MONGODB_VERSION: "4.0"
+          MONGODB_VERSION: "4.2"
 
   - id: "topology"
     display_name: Topology
@@ -440,7 +440,7 @@ buildvariants:
   display_name: "${os} ${auth-and-tls} with ${async-runtime}"
   tasks:
      - ".5.0"
-     - ".4.0"
+     - ".4.2"
 -
   matrix_name: "bson benchmarks"
   matrix_spec:

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -275,7 +275,7 @@ pre:
 
 post:
   - func: "stop mongo orchestration"
-  - func: "upload mo artifacts"
+  - func: "upload-mo-artifacts"
   - func: "cleanup"
 
 tasks:

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -161,9 +161,6 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          export MONGODB_URI="${MONGODB_URI}"
-          export SSL="${SSL}"
-          . .evergreen/generate-uri.sh
 
           .evergreen/run-bson-benchmarks.sh
 

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -1,0 +1,464 @@
+########################################
+# Evergreen Template for MongoDB Drivers
+########################################
+
+# When a task that used to pass starts to fail
+# Go through all versions that may have been skipped to detect
+# when the task started failing
+stepback: true
+
+# Mark a failure as a system/bootstrap failure (purple box) rather then a task
+# failure by default.
+# Actual testing tasks are marked with `type: test`
+command_type: system
+
+# Protect ourself against rogue test case, or curl gone wild, that runs forever
+# 12 minutes is the longest we'll ever run
+exec_timeout_secs: 3600 # 12 minutes is the longest we'll ever run
+
+# What to do when evergreen hits the timeout (`post:` tasks are run automatically)
+timeout:
+  - command: shell.exec
+    params:
+      script: |
+        ls -la
+
+functions:
+  "fetch source":
+    # Executes git clone and applies the submitted patch, if any
+    - command: git.get_project
+      params:
+        directory: "src"
+    # Applies the subitted patch, if any
+    # Deprecated. Should be removed. But still needed for certain agents (ZAP)
+    - command: git.apply_patch
+    # Make an evergreen exapanstion file with dynamic values
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
+           # Get the current unique version of this checkout
+           if [ "${is_patch}" = "true" ]; then
+              CURRENT_VERSION=$(git describe)-patch-${version_id}
+           else
+              CURRENT_VERSION=latest
+           fi
+
+           export DRIVERS_TOOLS="$(pwd)/../drivers-tools"
+
+           # Python has cygwin path problems on Windows. Detect prospective mongo-orchestration home directory
+           if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
+              export DRIVERS_TOOLS=$(cygpath -m $DRIVERS_TOOLS)
+           fi
+
+           export MONGO_ORCHESTRATION_HOME="$DRIVERS_TOOLS/.evergreen/orchestration"
+           export MONGODB_BINARIES="$DRIVERS_TOOLS/mongodb/bin"
+           export UPLOAD_BUCKET="${project}"
+           export PROJECT_DIRECTORY="$(pwd)"
+
+           cat <<EOT > expansion.yml
+           CURRENT_VERSION: "$CURRENT_VERSION"
+           DRIVERS_TOOLS: "$DRIVERS_TOOLS"
+           MONGO_ORCHESTRATION_HOME: "$MONGO_ORCHESTRATION_HOME"
+           MONGODB_BINARIES: "$MONGODB_BINARIES"
+           UPLOAD_BUCKET: "$UPLOAD_BUCKET"
+           PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
+           PREPARE_SHELL: |
+              set -o errexit
+              set -o xtrace
+              export DRIVERS_TOOLS="$DRIVERS_TOOLS"
+              export MONGO_ORCHESTRATION_HOME="$MONGO_ORCHESTRATION_HOME"
+              export MONGODB_BINARIES="$MONGODB_BINARIES"
+              export UPLOAD_BUCKET="$UPLOAD_BUCKET"
+              export PROJECT_DIRECTORY="$PROJECT_DIRECTORY"
+              export DRIVERS_TOOLS_X509="$DRIVERS_TOOLS/.evergreen/x509gen"
+
+              export TMPDIR="$MONGO_ORCHESTRATION_HOME/db"
+              export PATH="$MONGODB_BINARIES:$PATH"
+              export PROJECT="${project}"
+
+              export AUTH=${AUTH}
+              export SSL=${SSL}
+              export TOPOLOGY=${TOPOLOGY}
+              export MONGODB_VERSION=${MONGODB_VERSION}
+
+              if [ "Windows_NT" != "$OS" ]; then
+                  ulimit -n 64000
+              fi
+           EOT
+           # See what we've done
+           cat expansion.yml
+
+    # Load the expansion file to make an evergreen variable with the current unique version
+    - command: expansions.update
+      params:
+        file: src/expansion.yml
+            
+  "prepare resources":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          rm -rf $DRIVERS_TOOLS
+          git clone git://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+          echo "{ \"releases\": { \"default\": \"$MONGODB_BINARIES\" }}" > $MONGO_ORCHESTRATION_HOME/orchestration.config
+
+  "install dependencies":
+    command: shell.exec
+    params:
+      working_dir: "src"
+      script: |
+        ${PREPARE_SHELL}
+        .evergreen/install-dependencies.sh
+
+  "download benchmark data":
+    command: shell.exec
+    params:
+      working_dir: "src"
+      script: |
+        ${PREPARE_SHELL}
+        cd benchmarks && download-data.sh
+
+  "bootstrap mongo-orchestration":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
+            MONGODB_VERSION=${MONGODB_VERSION} \
+            TOPOLOGY=${TOPOLOGY} \
+            AUTH=${AUTH} \
+            SSL=${SSL} \
+            REQUIRE_API_VERSION=${REQUIRE_API_VERSION} \
+            sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+    # run-orchestration generates expansion file with the MONGODB_URI for the cluster
+    - command: expansions.update
+      params:
+        file: mo-expansion.yml
+
+  "run driver benchmarks":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          export MONGODB_URI="${MONGODB_URI}"
+          export SSL="${SSL}"
+          . .evergreen/generate-uri.sh
+
+          ASYNC_RUNTIME=${ASYNC_RUNTIME} \
+            .evergreen/run-driver-benchmarks.sh
+
+  "run bson benchmarks":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          export MONGODB_URI="${MONGODB_URI}"
+          export SSL="${SSL}"
+          . .evergreen/generate-uri.sh
+
+          .evergreen/run-bson-benchmarks.sh
+
+  "compile only":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          ASYNC_RUNTIME=${ASYNC_RUNTIME} RUST_VERSION=${RUST_VERSION} .evergreen/compile-only.sh
+
+  "upload-mo-artifacts":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: mongodb-logs.tar.gz
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: ${content_type|application/x-gzip}
+        display_name: "mongodb-logs.tar.gz"
+
+  "upload benchmark results":
+    - command: perf.send
+      params:
+        file: "benchmark-results.json"
+
+  "stop mongo orchestration":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          
+          cd "$MONGO_ORCHESTRATION_HOME"
+          # source the mongo-orchestration virtualenv if it exists
+          if [ -f venv/bin/activate ]; then
+            . venv/bin/activate
+          elif [ -f venv/Scripts/activate ]; then
+            . venv/Scripts/activate
+          fi
+          mongo-orchestration stop
+
+
+  "cleanup":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          rm -rf ~/.rustup
+          rm -rf $DRIVERS_TOOLS || true
+
+  "fix absolute paths":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          for filename in $(find ${DRIVERS_TOOLS} -name \*.json); do
+            perl -p -i -e "s|ABSOLUTE_PATH_REPLACEMENT_TOKEN|${DRIVERS_TOOLS}|g" $filename
+          done
+
+  "windows fix":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          for i in $(find ${DRIVERS_TOOLS}/.evergreen ${PROJECT_DIRECTORY}/.evergreen -name \*.sh); do
+            cat $i | tr -d '\r' > $i.new
+            mv $i.new $i
+          done
+
+          # Copy client certificate because symlinks do not work on Windows.
+          if [ "Windows_NT" = "$OS" ]; then # Magic variable in cygwin
+            cp ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem ${MONGO_ORCHESTRATION_HOME}/lib/client.pem
+          fi
+
+  "make files executable":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          for i in $(find ${DRIVERS_TOOLS}/.evergreen ${PROJECT_DIRECTORY}/.evergreen -name \*.sh); do
+            chmod +x $i
+          done
+
+  "init test-results":
+    - command: shell.exec
+      params:
+        script: |
+          ${PREPARE_SHELL}
+          echo '{"results": [{ "status": "FAIL", "test_file": "Build", "log_raw": "No test-results.json found was created"  } ]}' > ${PROJECT_DIRECTORY}/test-results.json
+
+pre:
+  - func: "fetch source"
+  - func: "prepare resources"
+  - func: "windows fix"
+  - func: "fix absolute paths"
+  - func: "init test-results"
+  - func: "make files executable"
+  - func: "install dependencies"
+  - func: "download benchmark data"
+
+post:
+  - func: "stop mongo orchestration"
+  - func: "upload-mo-artifacts"
+  - func: "upload benchmark results"
+  - func: "cleanup"
+
+tasks:
+  - name: "benchmark-4.0-standalone"
+    tags: ["4.0", "standalone"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "4.0"
+          TOPOLOGY: "server"
+      - func: "run driver benchmarks"
+
+  - name: "benchmark-4.0-replica_set"
+    tags: ["4.0", "replica_set"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "4.0"
+          TOPOLOGY: "replica_set"
+      - func: "run driver benchmarks"
+
+  - name: "benchmark-4.0-sharded_cluster"
+    tags: ["4.0", "sharded_cluster"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "4.0"
+          TOPOLOGY: "sharded_cluster"
+      - func: "run driver benchmarks"
+
+  - name: "benchmark-5.0-standalone"
+    tags: ["5.0", "standalone"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "5.0"
+          TOPOLOGY: "server"
+      - func: "run driver benchmarks"
+
+  - name: "benchmark-5.0-replica_set"
+    tags: ["5.0", "replica_set"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "5.0"
+          TOPOLOGY: "replica_set"
+      - func: "run driver benchmarks"
+
+  - name: "benchmark-5.0-sharded_cluster"
+    tags: ["5.0", "sharded_cluster"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "5.0"
+          TOPOLOGY: "sharded_cluster"
+      - func: "run driver benchmarks"
+
+  - name: "benchmark-bson"
+    tags: ["bson"]
+    commands:
+      - func: "run bson benchmarks"
+
+  - name: "compile-only"
+    commands:
+      - func: "compile only"
+
+axes:
+  - id: "extra-rust-versions"
+    values:
+      - id: "min"
+        display_name: "1.48 (minimum supported version)"
+        variables:
+          RUST_VERSION: "1.48.0"
+      - id: "nightly"
+        display_name: "nightly"
+        variables:
+          RUST_VERSION: "nightly"
+
+  - id: "mongodb-version"
+    display_name: MongoDB Version
+    values:
+      - id: "5.0"
+        display_name: "5.0"
+        variables:
+          MONGODB_VERSION: "5.0"
+      - id: "4.0"
+        display_name: "4.0"
+        variables:
+          MONGODB_VERSION: "4.0"
+
+  - id: "topology"
+    display_name: Topology
+    values:
+      - id: "standalone"
+        display_name: Standalone
+        variables:
+           TOPOLOGY: "server"
+      - id: "replica-set"
+        display_name: Replica Set
+        variables:
+           TOPOLOGY: "replica_set"
+      - id: "sharded-cluster"
+        display_name: Sharded
+        variables:
+           TOPOLOGY: "sharded_cluster"
+
+  - id: "async-runtime"
+    display_name: Async Runtime
+    values:
+      - id: "tokio"
+        display_name: "tokio"
+        variables:
+          ASYNC_RUNTIME: "tokio"
+      - id: "async-std"
+        display_name: "async-std"
+        variables:
+          ASYNC_RUNTIME: "async-std"
+
+  # Note that drivers-evergreen-tools expects `SSL` as the environmental
+  # variable, not `TLS`, so we have to use that for the actual value used in the
+  # script; we use `TLS` for the metadata that isn't used by the actual shell
+  # scripts.
+  - id: "auth-and-tls"
+    display_name: Authentication and TLS
+    values:
+      - id: "auth-and-tls"
+        display_name: Auth TLS
+        variables:
+           AUTH: "auth"
+           SSL: "ssl"
+
+  - id: "os"
+    display_name: OS
+    values:
+      - id: ubuntu-18.04
+        display_name: "Ubuntu 18.04"
+        run_on: ubuntu1804-test
+        variables:
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          VENV_BIN_DIR: "bin"
+      - id: macos-10.14
+        display_name: "MacOS 10.14"
+        run_on: macos-1014
+        variables:
+          SINGLE_THREAD: true
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          VENV_BIN_DIR: "bin"
+      - id: windows-64-vs2017
+        display_name: "Windows (VS 2017)"
+        run_on: windows-64-vs2017-test
+        variables:
+          PYTHON: "/cygdrive/c/python/Python36/python"
+          VENV_BIN_DIR: "Scripts"
+
+buildvariants:
+-
+  matrix_name: "driver benchmarks"
+  matrix_spec:
+    os:
+      - ubuntu-18.04
+      - macos-10.14
+      - windows-64-vs2017
+    auth-and-tls: "*"
+    async-runtime: "*"
+  display_name: "${os} ${auth-and-tls} with ${async-runtime}"
+  tasks:
+     - ".5.0"
+     - ".4.0"
+-
+  matrix_name: "bson benchmarks"
+  matrix_spec:
+    os:
+      - ubuntu-18.04
+  display_name: "${os}"
+  tasks:
+     - ".bson"
+
+- matrix_name: "compile-only"
+  matrix_spec:
+    os:
+      - ubuntu-18.04
+    async-runtime: "*"
+    extra-rust-versions: "*"
+  display_name: "Compile on Rust ${extra-rust-versions} with ${async-runtime}"
+  tasks:
+    - "compile-only"
+

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -448,7 +448,7 @@ buildvariants:
   matrix_spec:
     os:
       - ubuntu-18.04
-  display_name: "${os}"
+  display_name: "BSON Benchmarks"
   tasks:
      - ".bson"
 

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -95,7 +95,7 @@ functions:
     - command: expansions.update
       params:
         file: src/expansion.yml
-            
+
   "prepare resources":
     - command: shell.exec
       params:
@@ -201,7 +201,7 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          
+
           cd "$MONGO_ORCHESTRATION_HOME"
           # source the mongo-orchestration virtualenv if it exists
           if [ -f venv/bin/activate ]; then
@@ -272,7 +272,6 @@ pre:
 
 post:
   - func: "stop mongo orchestration"
-  - func: "upload-mo-artifacts"
   - func: "cleanup"
 
 tasks:

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -117,7 +117,7 @@ functions:
       working_dir: "src"
       script: |
         ${PREPARE_SHELL}
-        cd benchmarks && download-data.sh
+        cd benchmarks && ./download-data.sh
 
   "bootstrap mongo-orchestration":
     - command: shell.exec

--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -275,6 +275,7 @@ pre:
 
 post:
   - func: "stop mongo orchestration"
+  - func: "upload mo artifacts"
   - func: "cleanup"
 
 tasks:

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -o errexit
+
+pushd benchmarks
+
+cargo run \
+      --release \
+      -- --output="../benchmark-results.json" --bson
+
+popd

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+. ~/.cargo/env
+
 cd benchmarks
 cargo run \
       --release \

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -8,3 +8,5 @@ cd benchmarks
 cargo run \
       --release \
       -- --output="../benchmark-results.json" --bson
+
+cat ../benchmark-results.json

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -2,10 +2,7 @@
 
 set -o errexit
 
-pushd benchmarks
-
+cd benchmarks
 cargo run \
       --release \
       -- --output="../benchmark-results.json" --bson
-
-popd

--- a/.evergreen/run-compile-benchmarks.sh
+++ b/.evergreen/run-compile-benchmarks.sh
@@ -15,7 +15,8 @@ else
     exit 1
 fi
 
-RUST_VERSION=$(rustc --version)
+rustc --version
+
 SECONDS=0
 cargo build --release
 DURATION_IN_SECONDS="$SECONDS"
@@ -25,13 +26,11 @@ cat > benchmark-results.json <<-EOF
   {
     "info": {
       "test_name": "Compile Time",
-      "args": {
-        "Rust Version": "$RUST_VERSION"
-      }
+      "args": {}
     },
     "metrics": [
       {
-        "name": "Compile Time (s)",
+        "name": "compile_time_seconds",
         "value": $DURATION_IN_SECONDS
       }
     ]

--- a/.evergreen/run-compile-benchmarks.sh
+++ b/.evergreen/run-compile-benchmarks.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o errexit
+
+. ~/.cargo/env
+
+FEATURES=""
+
+if [ "$ASYNC_RUNTIME" = "tokio" ]; then
+    FEATURES="tokio-runtime"
+elif [ "$ASYNC_RUNTIME" = "async-std" ]; then
+    FEATURES="async-std-runtime"
+else
+    echo "invalid async runtime: ${ASYNC_RUNTIME}" >&2
+    exit 1
+fi
+
+RUST_VERSION=$(rustc --version)
+SECONDS=0
+cargo build --release
+DURATION_IN_SECONDS="$SECONDS"
+
+cat > benchmark-results.json <<-EOF
+[
+  {
+    "info": {
+      "test_name": "Compile Time",
+      "args": {
+        "Rust Version": "$RUST_VERSION"
+      }
+    },
+    "metrics": [
+      {
+        "name": "Compile Time (s)",
+        "value": $DURATION_IN_SECONDS
+      }
+    ]
+  }
+]
+EOF
+
+cat benchmark-results.json

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -24,3 +24,5 @@ cargo run \
       --no-default-features \
       --features ${FEATURES} \
       -- --output="../benchmark-results.json" --single --multi --parallel
+
+cat ../benchmark-results.json

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -15,9 +15,6 @@ else
     exit 1
 fi
 
-export MIN_EXECUTION_TIME=1
-export TARGET_ITERATION_COUNT=3
-
 cd benchmarks
 cargo run \
       --release \

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -15,6 +15,9 @@ fi
 
 pushd benchmarks
 
+export MIN_EXECUTION_TIME=1
+export TARGET_ITERATION_COUNT=3
+
 cargo run \
       --release \
       --no-default-features \

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -o errexit
+
+FEATURES=""
+
+if [ "$ASYNC_RUNTIME" = "tokio" ]; then
+    FEATURES="tokio-runtime"
+elif [ "$ASYNC_RUNTIME" = "async-std" ]; then
+    FEATURES="async-std-runtime"
+else
+    echo "invalid async runtime: ${ASYNC_RUNTIME}" >&2
+    exit 1
+fi
+
+pushd benchmarks
+
+cargo run \
+      --release \
+      --no-default-features \
+      --features ${FEATURES} \
+      -- --output="../benchmark-results.json" --single --multi --parallel
+
+popd

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+. ~/.cargo/env
+
 FEATURES=""
 
 if [ "$ASYNC_RUNTIME" = "tokio" ]; then

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -13,15 +13,12 @@ else
     exit 1
 fi
 
-pushd benchmarks
-
 export MIN_EXECUTION_TIME=1
 export TARGET_ITERATION_COUNT=3
 
+cd benchmarks
 cargo run \
       --release \
       --no-default-features \
       --features ${FEATURES} \
       -- --output="../benchmark-results.json" --single --multi --parallel
-
-popd

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -29,3 +29,4 @@ tokio-stream = { version = "0.1.6", features = ["io-util"], optional = true }
 async-std = { version = "1.9.0", optional = true, features = ["attributes", "unstable"] }
 futures = "0.3.8"
 anyhow = "1.0.34"
+serde = "1"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,11 +6,18 @@ edition = "2018"
 
 [features]
 default = ["tokio-runtime"]
-tokio-runtime = ["tokio/fs", "tokio/macros", "tokio/rt", "tokio/rt-multi-thread", "tokio-stream"]
-async-std-runtime = ["async-std"]
+tokio-runtime = [
+  "tokio/fs",
+  "tokio/macros",
+  "tokio/rt",
+  "tokio/rt-multi-thread",
+  "tokio-stream",
+  "mongodb/tokio-runtime"
+]
+async-std-runtime = ["async-std", "mongodb/async-std-runtime"]
 
 [dependencies]
-mongodb = { path = ".." }
+mongodb = { path = "..", default-features = false }
 serde_json = "1.0.59"
 lazy_static = "1.4.0"
 clap = "2.33.3"

--- a/benchmarks/src/bench/find_many.rs
+++ b/benchmarks/src/bench/find_many.rs
@@ -11,13 +11,14 @@ use mongodb::{
 use serde_json::Value;
 
 use crate::{
-    bench::{Benchmark, COLL_NAME, DATABASE_NAME},
+    bench::{drop_database, Benchmark, COLL_NAME, DATABASE_NAME},
     fs::read_to_string,
 };
 
 pub struct FindManyBenchmark {
     db: Database,
     coll: Collection<Document>,
+    uri: String,
 }
 
 // Specifies the options to `FindManyBenchmark::setup` operation.
@@ -34,7 +35,7 @@ impl Benchmark for FindManyBenchmark {
     async fn setup(options: Self::Options) -> Result<Self> {
         let client = Client::with_uri_str(&options.uri).await?;
         let db = client.database(&DATABASE_NAME);
-        db.drop(None).await?;
+        drop_database(options.uri.as_str(), DATABASE_NAME.as_str()).await?;
 
         let num_iter = options.num_iter;
 
@@ -50,7 +51,11 @@ impl Benchmark for FindManyBenchmark {
         let docs = vec![doc.clone(); num_iter];
         coll.insert_many(docs, None).await?;
 
-        Ok(FindManyBenchmark { db, coll })
+        Ok(FindManyBenchmark {
+            db,
+            coll,
+            uri: options.uri,
+        })
     }
 
     async fn do_task(&self) -> Result<()> {
@@ -63,7 +68,7 @@ impl Benchmark for FindManyBenchmark {
     }
 
     async fn teardown(&self) -> Result<()> {
-        self.db.drop(None).await?;
+        drop_database(self.uri.as_str(), self.db.name()).await?;
 
         Ok(())
     }

--- a/benchmarks/src/bench/find_many.rs
+++ b/benchmarks/src/bench/find_many.rs
@@ -2,7 +2,12 @@ use std::{convert::TryInto, path::PathBuf};
 
 use anyhow::{bail, Result};
 use futures::stream::StreamExt;
-use mongodb::{Client, Collection, Database, bson::{Bson, Document}};
+use mongodb::{
+    bson::{Bson, Document},
+    Client,
+    Collection,
+    Database,
+};
 use serde_json::Value;
 
 use crate::{

--- a/benchmarks/src/bench/find_one.rs
+++ b/benchmarks/src/bench/find_one.rs
@@ -1,7 +1,12 @@
 use std::{convert::TryInto, path::PathBuf};
 
 use anyhow::{bail, Result};
-use mongodb::{Client, Collection, Database, bson::{Bson, Document, doc}};
+use mongodb::{
+    bson::{doc, Bson, Document},
+    Client,
+    Collection,
+    Database,
+};
 use serde_json::Value;
 
 use crate::{

--- a/benchmarks/src/bench/insert_many.rs
+++ b/benchmarks/src/bench/insert_many.rs
@@ -62,6 +62,7 @@ impl Benchmark for InsertManyBenchmark {
     }
 
     async fn before_task(&mut self) -> Result<()> {
+        self.coll.drop(None).await?;
         self.db
             .create_collection(COLL_NAME.as_str(), None)
             .await

--- a/benchmarks/src/bench/insert_many.rs
+++ b/benchmarks/src/bench/insert_many.rs
@@ -9,16 +9,17 @@ use mongodb::{
 };
 use serde_json::Value;
 
-use crate::bench::{Benchmark, COLL_NAME, DATABASE_NAME};
+use crate::bench::{drop_database, Benchmark, COLL_NAME, DATABASE_NAME};
 
 pub struct InsertManyBenchmark {
     db: Database,
     num_copies: usize,
     coll: Collection<Document>,
     doc: Document,
+    uri: String,
 }
 
-// Specifies the options to a `InsertManyBenchmark::setup` operation.
+/// Specifies the options to a `InsertManyBenchmark::setup` operation.
 pub struct Options {
     pub num_copies: usize,
     pub path: PathBuf,
@@ -32,9 +33,10 @@ impl Benchmark for InsertManyBenchmark {
     async fn setup(options: Self::Options) -> Result<Self> {
         let client = Client::with_uri_str(&options.uri).await?;
         let db = client.database(&DATABASE_NAME);
-        db.drop(None).await?;
+        drop_database(options.uri.as_str(), DATABASE_NAME.as_str()).await?;
 
         let num_copies = options.num_copies;
+        let uri = options.uri.clone();
 
         // This benchmark uses a file that's quite large, and unfortunately `serde_json` has no
         // async version of `from_reader`, so rather than read the whole file into memory at once,
@@ -55,6 +57,7 @@ impl Benchmark for InsertManyBenchmark {
                 Bson::Document(doc) => doc,
                 _ => bail!("invalid json test file"),
             },
+            uri,
         })
     }
 
@@ -73,7 +76,7 @@ impl Benchmark for InsertManyBenchmark {
     }
 
     async fn teardown(&self) -> Result<()> {
-        self.db.drop(None).await?;
+        drop_database(self.uri.as_str(), self.db.name()).await?;
 
         Ok(())
     }

--- a/benchmarks/src/bench/insert_one.rs
+++ b/benchmarks/src/bench/insert_one.rs
@@ -9,7 +9,7 @@ use mongodb::{
 };
 use serde_json::Value;
 
-use crate::bench::{Benchmark, COLL_NAME, DATABASE_NAME, drop_database};
+use crate::bench::{drop_database, Benchmark, COLL_NAME, DATABASE_NAME};
 
 pub struct InsertOneBenchmark {
     db: Database,
@@ -36,6 +36,7 @@ impl Benchmark for InsertOneBenchmark {
         drop_database(&options.uri, &DATABASE_NAME).await?;
 
         let num_iter = options.num_iter;
+        let uri = options.uri.clone();
 
         // This benchmark uses a file that's quite large, and unfortunately `serde_json` has no
         // async version of `from_reader`, so rather than read the whole file into memory at once,
@@ -56,7 +57,7 @@ impl Benchmark for InsertOneBenchmark {
                 Bson::Document(doc) => doc,
                 _ => bail!("invalid json test file"),
             },
-            uri: options.uri,
+            uri,
         })
     }
 

--- a/benchmarks/src/bench/insert_one.rs
+++ b/benchmarks/src/bench/insert_one.rs
@@ -62,6 +62,7 @@ impl Benchmark for InsertOneBenchmark {
     }
 
     async fn before_task(&mut self) -> Result<()> {
+        self.coll.drop(None).await?;
         self.db
             .create_collection(COLL_NAME.as_str(), None)
             .await

--- a/benchmarks/src/bench/json_multi_export.rs
+++ b/benchmarks/src/bench/json_multi_export.rs
@@ -48,7 +48,7 @@ impl Benchmark for JsonMultiExportBenchmark {
             let path = options.path.clone();
             let coll = coll.clone();
 
-            tasks.push(async move {
+            tasks.push(crate::spawn(async move {
                 let json_file_name = path.join(format!("ldjson{:03}.txt", i));
                 let file = File::open_read(&json_file_name).await?;
 
@@ -61,14 +61,18 @@ impl Benchmark for JsonMultiExportBenchmark {
 
                 let ok: anyhow::Result<()> = Ok(());
                 ok
-            });
+            }));
         }
 
         while let Some(result) = tasks.next().await {
             result?;
         }
 
-        Ok(JsonMultiExportBenchmark { uri: options.uri, db, coll })
+        Ok(JsonMultiExportBenchmark {
+            uri: options.uri,
+            db,
+            coll,
+        })
     }
 
     async fn do_task(&self) -> Result<()> {

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -2,8 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use futures::stream::{FuturesUnordered, StreamExt, TryStreamExt};
-use mongodb::{bson::Document, options::InsertManyOptions, Client, Collection, Database};
-use serde::{Deserialize, Serialize};
+use mongodb::{options::InsertManyOptions, Client, Collection, Database};
 
 use crate::{
     bench::{Benchmark, COLL_NAME, DATABASE_NAME},

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     bench::{Benchmark, COLL_NAME, DATABASE_NAME},
     fs::{BufReader, File},
+    models::json_multi::Tweet,
 };
 
 const TOTAL_FILES: usize = 100;
@@ -87,59 +88,4 @@ impl Benchmark for JsonMultiImportBenchmark {
 
         Ok(())
     }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Tweet {
-    text: String,
-    in_reply_to_status_id: i64,
-    retweet_count: Option<i32>,
-    contributors: Option<i32>,
-    created_at: String,
-    geo: Option<String>,
-    source: String,
-    coordinates: Option<String>,
-    in_reply_to_screen_name: Option<String>,
-    truncated: bool,
-    entities: Entities,
-    retweeted: bool,
-    place: Option<String>,
-    user: User,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Entities {
-    user_mentions: Vec<Mention>,
-    urls: Vec<String>,
-    hashtags: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct Mention {
-    indices: Vec<i32>,
-    screen_name: String,
-    name: String,
-    id: i64,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct User {
-    friends_count: i32,
-    profile_sidebar_fill_color: String,
-    location: String,
-    verified: bool,
-    follow_request_sent: Option<bool>,
-    favourites_count: i32,
-    profile_sidebar_border_color: String,
-    profile_image_url: String,
-    geo_enabled: bool,
-    created_at: String,
-    description: String,
-    time_zone: String,
-    url: String,
-    screen_name: String,
-    notifications: Option<Vec<Document>>,
-    profile_background_color: String,
-    listed_count: i32,
-    lang: String,
 }

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -47,6 +47,7 @@ impl Benchmark for JsonMultiImportBenchmark {
     }
 
     async fn before_task(&mut self) -> Result<()> {
+        self.coll.drop(None).await?;
         self.db.create_collection(COLL_NAME.as_str(), None).await?;
 
         Ok(())

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use futures::stream::{FuturesUnordered, StreamExt, TryStreamExt};
+use futures::stream::TryStreamExt;
 use mongodb::{options::InsertManyOptions, Client, Collection, Database};
 
 use crate::{
@@ -54,7 +54,7 @@ impl Benchmark for JsonMultiImportBenchmark {
     }
 
     async fn do_task(&self) -> Result<()> {
-        let mut tasks = FuturesUnordered::new();
+        let mut tasks = Vec::new();
 
         for i in 0..TOTAL_FILES {
             let coll_ref = self.coll.clone();
@@ -79,8 +79,8 @@ impl Benchmark for JsonMultiImportBenchmark {
             }));
         }
 
-        while !tasks.is_empty() {
-            tasks.next().await;
+        for task in tasks {
+            task.await;
         }
 
         Ok(())

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -47,7 +47,6 @@ impl Benchmark for JsonMultiImportBenchmark {
     }
 
     async fn before_task(&mut self) -> Result<()> {
-        self.coll.drop(None).await?;
         self.db.create_collection(COLL_NAME.as_str(), None).await?;
 
         Ok(())

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -1,19 +1,20 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use futures::stream::{FuturesUnordered, StreamExt};
-use mongodb::{Client, Collection, Database, bson::Document, options::InsertManyOptions};
+use futures::stream::{FuturesUnordered, StreamExt, TryStreamExt};
+use mongodb::{bson::Document, options::InsertManyOptions, Client, Collection, Database};
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    bench::{parse_json_file_to_documents, Benchmark, COLL_NAME, DATABASE_NAME},
-    fs::File,
+    bench::{Benchmark, COLL_NAME, DATABASE_NAME},
+    fs::{BufReader, File},
 };
 
 const TOTAL_FILES: usize = 100;
 
 pub struct JsonMultiImportBenchmark {
     db: Database,
-    coll: Collection<Document>,
+    coll: Collection<Tweet>,
     path: PathBuf,
 }
 
@@ -55,22 +56,23 @@ impl Benchmark for JsonMultiImportBenchmark {
             let coll_ref = self.coll.clone();
             let path = self.path.clone();
 
-            tasks.push(async move {
+            tasks.push(crate::spawn(async move {
                 // Note that errors are unwrapped within threads instead of propagated with `?`.
                 // While we could set up a channel to send errors back to main thread, this is a lot
                 // of work for little gain since we `unwrap()` in main.rs anyway.
-                let mut docs = Vec::new();
+                let mut docs: Vec<Tweet> = Vec::new();
 
                 let json_file_name = path.join(format!("ldjson{:03}.txt", i));
                 let file = File::open_read(&json_file_name).await.unwrap();
 
-                let mut new_docs = parse_json_file_to_documents(file).await.unwrap();
-
-                docs.append(&mut new_docs);
+                let mut lines = BufReader::new(file).lines();
+                while let Some(line) = lines.try_next().await.unwrap() {
+                    docs.push(serde_json::from_str(&line).unwrap());
+                }
 
                 let opts = Some(InsertManyOptions::builder().ordered(false).build());
                 coll_ref.insert_many(docs, opts).await.unwrap();
-            });
+            }));
         }
 
         while !tasks.is_empty() {
@@ -85,4 +87,59 @@ impl Benchmark for JsonMultiImportBenchmark {
 
         Ok(())
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Tweet {
+    text: String,
+    in_reply_to_status_id: i64,
+    retweet_count: Option<i32>,
+    contributors: Option<i32>,
+    created_at: String,
+    geo: Option<String>,
+    source: String,
+    coordinates: Option<String>,
+    in_reply_to_screen_name: Option<String>,
+    truncated: bool,
+    entities: Entities,
+    retweeted: bool,
+    place: Option<String>,
+    user: User,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Entities {
+    user_mentions: Vec<Mention>,
+    urls: Vec<String>,
+    hashtags: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Mention {
+    indices: Vec<i32>,
+    screen_name: String,
+    name: String,
+    id: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct User {
+    friends_count: i32,
+    profile_sidebar_fill_color: String,
+    location: String,
+    verified: bool,
+    follow_request_sent: Option<bool>,
+    favourites_count: i32,
+    profile_sidebar_border_color: String,
+    profile_image_url: String,
+    geo_enabled: bool,
+    created_at: String,
+    description: String,
+    time_zone: String,
+    url: String,
+    screen_name: String,
+    notifications: Option<Vec<Document>>,
+    profile_background_color: String,
+    listed_count: i32,
+    lang: String,
 }

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -10,12 +10,15 @@ use crate::{
     models::json_multi::Tweet,
 };
 
+use super::drop_database;
+
 const TOTAL_FILES: usize = 100;
 
 pub struct JsonMultiImportBenchmark {
     db: Database,
     coll: Collection<Tweet>,
     path: PathBuf,
+    uri: String,
 }
 
 // Specifies the options to a `JsonMultiImportBenchmark::setup` operation.
@@ -31,7 +34,7 @@ impl Benchmark for JsonMultiImportBenchmark {
     async fn setup(options: Self::Options) -> Result<Self> {
         let client = Client::with_uri_str(&options.uri).await?;
         let db = client.database(&DATABASE_NAME);
-        db.drop(None).await?;
+        drop_database(options.uri.as_str(), DATABASE_NAME.as_str()).await?;
 
         let coll = db.collection(&COLL_NAME);
 
@@ -39,6 +42,7 @@ impl Benchmark for JsonMultiImportBenchmark {
             db,
             coll,
             path: options.path,
+            uri: options.uri,
         })
     }
 
@@ -83,7 +87,7 @@ impl Benchmark for JsonMultiImportBenchmark {
     }
 
     async fn teardown(&self) -> Result<()> {
-        self.db.drop(None).await?;
+        drop_database(self.uri.as_str(), self.db.name()).await?;
 
         Ok(())
     }

--- a/benchmarks/src/bench/mod.rs
+++ b/benchmarks/src/bench/mod.rs
@@ -20,7 +20,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
 use mongodb::{
     bson::{doc, Bson, Document},
-    options::{ClientOptions, SelectionCriteria},
+    options::{Acknowledgment, ClientOptions, SelectionCriteria, WriteConcern},
     Client,
 };
 use serde_json::Value;
@@ -132,7 +132,8 @@ pub async fn run_benchmark<B: Benchmark + Send + Sync>(
 }
 
 pub async fn drop_database(uri: &str, database: &str) -> Result<()> {
-    let options = ClientOptions::parse(uri).await?;
+    let mut options = ClientOptions::parse(uri).await?;
+    options.write_concern = Some(WriteConcern::builder().w(Acknowledgment::Majority).build());
     let client = Client::with_options(options.clone())?;
 
     let hello = client

--- a/benchmarks/src/bench/mod.rs
+++ b/benchmarks/src/bench/mod.rs
@@ -8,13 +8,21 @@ pub mod json_multi_export;
 pub mod json_multi_import;
 pub mod run_command;
 
-use std::{convert::TryInto, sync::Arc, time::{Duration, Instant}};
+use std::{
+    convert::TryInto,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use anyhow::{bail, Result};
 use futures::stream::TryStreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
-use mongodb::{Client, bson::{Bson, Document, doc}, options::{ClientOptions, SelectionCriteria}};
+use mongodb::{
+    bson::{doc, Bson, Document},
+    options::{ClientOptions, SelectionCriteria},
+    Client,
+};
 use serde_json::Value;
 
 use crate::fs::{BufReader, File};
@@ -144,9 +152,7 @@ pub async fn drop_database(uri: &str, database: &str) -> Result<()> {
                 .database("admin")
                 .run_command(
                     doc! { "flushRouterConfig": 1 },
-                    SelectionCriteria::Predicate(Arc::new(move |s| {
-                        s.address() == &host
-                    })),
+                    SelectionCriteria::Predicate(Arc::new(move |s| s.address() == &host)),
                 )
                 .await?;
         }

--- a/benchmarks/src/bench/mod.rs
+++ b/benchmarks/src/bench/mod.rs
@@ -85,7 +85,8 @@ pub(crate) async fn parse_json_file_to_documents(file: File) -> Result<Vec<Docum
 
 fn finished(duration: Duration, iter: usize) -> bool {
     let elapsed = duration.as_secs();
-    elapsed >= *MAX_EXECUTION_TIME || (iter >= *TARGET_ITERATION_COUNT && elapsed > *MIN_EXECUTION_TIME)
+    elapsed >= *MAX_EXECUTION_TIME
+        || (iter >= *TARGET_ITERATION_COUNT && elapsed > *MIN_EXECUTION_TIME)
 }
 
 pub async fn run_benchmark<B: Benchmark + Send + Sync>(

--- a/benchmarks/src/bench/mod.rs
+++ b/benchmarks/src/bench/mod.rs
@@ -45,22 +45,22 @@ lazy_static! {
 pub trait Benchmark: Sized {
     type Options;
 
-    // execute once before benchmarking
+    /// execute once before benchmarking
     async fn setup(options: Self::Options) -> Result<Self>;
 
-    // execute at the beginning of every iteration
+    /// execute at the beginning of every iteration
     async fn before_task(&mut self) -> Result<()> {
         Ok(())
     }
 
     async fn do_task(&self) -> Result<()>;
 
-    // execute at the end of every iteration
+    /// execute at the end of every iteration
     async fn after_task(&self) -> Result<()> {
         Ok(())
     }
 
-    // execute once after benchmarking
+    /// execute once after benchmarking
     async fn teardown(&self) -> Result<()> {
         Ok(())
     }

--- a/benchmarks/src/bench/mod.rs
+++ b/benchmarks/src/bench/mod.rs
@@ -144,7 +144,7 @@ pub async fn drop_database(uri: &str, database: &str) -> Result<()> {
 
     // in sharded clusters, take additional steps to ensure database is dropped completely.
     // see: https://docs.mongodb.com/manual/reference/method/db.dropDatabase/#replica-set-and-sharded-clusters
-    let is_sharded = hello.get_str("msg")? == "isbdgrid";
+    let is_sharded = hello.get_str("msg").ok() == Some("isbdgrid");
     if is_sharded {
         client.database(&database).drop(None).await?;
         for host in options.hosts {

--- a/benchmarks/src/bench/mod.rs
+++ b/benchmarks/src/bench/mod.rs
@@ -144,7 +144,7 @@ pub async fn drop_database(uri: &str, database: &str) -> Result<()> {
 
     // in sharded clusters, take additional steps to ensure database is dropped completely.
     // see: https://docs.mongodb.com/manual/reference/method/db.dropDatabase/#replica-set-and-sharded-clusters
-    let is_sharded = hello.get_str("msg").ok() == Some("isbdgrid");
+    let is_sharded = hello.get_str("msg").ok() == Some("isdbgrid");
     if is_sharded {
         client.database(&database).drop(None).await?;
         for host in options.hosts {

--- a/benchmarks/src/bench/run_command.rs
+++ b/benchmarks/src/bench/run_command.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use mongodb::{
     bson::{doc, Document},
     Client,
@@ -25,7 +25,7 @@ impl Benchmark for RunCommandBenchmark {
     async fn setup(options: Self::Options) -> Result<Self> {
         let client = Client::with_uri_str(&options.uri).await?;
         let db = client.database(&DATABASE_NAME);
-        db.drop(None).await?;
+        db.drop(None).await.context("drop database in setup")?;
 
         Ok(RunCommandBenchmark {
             db,
@@ -36,14 +36,14 @@ impl Benchmark for RunCommandBenchmark {
 
     async fn do_task(&self) -> Result<()> {
         for _ in 0..self.num_iter {
-            let _doc = self.db.run_command(self.cmd.clone(), None).await?;
+            let _doc = self.db.run_command(self.cmd.clone(), None).await.context("run command")?;
         }
 
         Ok(())
     }
 
     async fn teardown(&self) -> Result<()> {
-        self.db.drop(None).await?;
+        self.db.drop(None).await.context("drop in teardown")?;
 
         Ok(())
     }

--- a/benchmarks/src/fs.rs
+++ b/benchmarks/src/fs.rs
@@ -45,6 +45,11 @@ impl File {
     pub(crate) async fn write_line(&mut self, s: &str) -> Result<()> {
         Ok(self.inner.write_all(format!("{}\n", s).as_bytes()).await?)
     }
+
+    pub(crate) async fn flush(&mut self) -> Result<()> {
+        self.inner.flush().await?;
+        Ok(())
+    }
 }
 
 pub(crate) struct BufReader {

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -43,6 +43,7 @@ use futures::Future;
 #[cfg(feature = "tokio-runtime")]
 use futures::FutureExt;
 use lazy_static::lazy_static;
+use mongodb::options::ClientOptions;
 
 use crate::{
     bench::{
@@ -141,6 +142,8 @@ const WRITE_BENCHES: &[&'static str] = &[
 ];
 
 async fn run_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<CompositeScore> {
+    let options = ClientOptions::parse(uri).await?;
+
     let mut comp_score = CompositeScore::new("All Benchmarks");
 
     // Run command
@@ -270,7 +273,8 @@ async fn run_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<Comp
     }
 
     // LDJSON multi-file import
-    if ids[7] {
+    // can only run against standalones because otherwise the host machine will run out of memory
+    if ids[7] && options.hosts.len() == 1 {
         let json_multi_import_options = bench::json_multi_import::Options {
             path: DATA_PATH.join("parallel").join("ldjson_multi"),
             uri: uri.to_string(),
@@ -288,7 +292,8 @@ async fn run_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<Comp
     }
 
     // LDJSON multi-file export
-    if ids[8] {
+    // can only run against standalones because otherwise the host machine will run out of memory
+    if ids[8] && options.hosts.len() == 1 {
         let json_multi_export_options = bench::json_multi_export::Options {
             path: DATA_PATH.join("parallel").join("ldjson_multi"),
             uri: uri.to_string(),

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -566,5 +566,6 @@ Run benchmarks by id number (comma-separated):
         file.write_line(serde_json::to_string_pretty(&results).unwrap().as_str())
             .await
             .unwrap();
+        file.flush().await.unwrap();
     }
 }

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -33,6 +33,7 @@ where
 
 mod bench;
 mod fs;
+mod models;
 
 use std::{
     path::{Path, PathBuf},

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -39,7 +39,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use clap::{App, Arg, ArgMatches};
-use futures::{Future, FutureExt};
+use futures::Future;
+#[cfg(feature = "tokio-runtime")]
+use futures::FutureExt;
 use lazy_static::lazy_static;
 
 use crate::{

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 macro_rules! spawn_blocking_and_await {
     ($blocking_call:expr) => {{
         #[cfg(feature = "tokio-runtime")]
@@ -34,88 +33,113 @@ where
 mod bench;
 mod fs;
 mod models;
+mod score;
 
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use clap::{App, Arg, ArgMatches};
 use futures::{Future, FutureExt};
 use lazy_static::lazy_static;
 
-use crate::bench::{
-    bson_decode::BsonDecodeBenchmark, bson_encode::BsonEncodeBenchmark,
-    find_many::FindManyBenchmark, find_one::FindOneBenchmark, insert_many::InsertManyBenchmark,
-    insert_one::InsertOneBenchmark, json_multi_export::JsonMultiExportBenchmark,
-    json_multi_import::JsonMultiImportBenchmark, run_command::RunCommandBenchmark,
+use crate::{
+    bench::{
+        bson_decode::BsonDecodeBenchmark,
+        bson_encode::BsonEncodeBenchmark,
+        find_many::FindManyBenchmark,
+        find_one::FindOneBenchmark,
+        insert_many::InsertManyBenchmark,
+        insert_one::InsertOneBenchmark,
+        json_multi_export::JsonMultiExportBenchmark,
+        json_multi_import::JsonMultiImportBenchmark,
+        run_command::RunCommandBenchmark,
+    },
+    fs::File,
+    score::{score_test, BenchmarkResult, CompositeScore},
 };
 
 lazy_static! {
     static ref DATA_PATH: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("data");
 }
 
-fn get_nth_percentile(durations: &[Duration], n: f64) -> Duration {
-    let index = (durations.len() as f64 * (n / 100.0)) as usize;
-    durations[std::cmp::max(index, 1) - 1]
-}
+// benchmark names
+const FLAT_BSON_ENCODING: &'static str = "Flat BSON Encoding";
+const FLAT_BSON_DECODING: &'static str = "Flat BSON Decoding";
+const DEEP_BSON_ENCODING: &'static str = "Deep BSON Encoding";
+const DEEP_BSON_DECODING: &'static str = "Deep BSON Decoding";
+const FULL_BSON_ENCODING: &'static str = "Full BSON Encoding";
+const FULL_BSON_DECODING: &'static str = "Full BSON Decoding";
+const RUN_COMMAND_BENCH: &'static str = "Run Command";
+const FIND_ONE_BENCH: &'static str = "Find one";
+const FIND_MANY_BENCH: &'static str = "Find many and empty cursor";
+const GRIDFS_DOWNLOAD_BENCH: &'static str = "GridFS download";
+const LDJSON_MULTI_EXPORT_BENCH: &'static str = "LDJSON multi-file export";
+const GRIDFS_MULTI_DOWNLOAD_BENCH: &'static str = "GridFS multi-file download";
+const SMALL_DOC_INSERT_ONE_BENCH: &'static str = "Small doc insertOne";
+const LARGE_DOC_INSERT_ONE_BENCH: &'static str = "Large doc insertOne";
+const SMALL_DOC_BULK_INSERT_BENCH: &'static str = "Small doc bulk insert";
+const LARGE_DOC_BULK_INSERT_BENCH: &'static str = "Large doc bulk insert";
+const GRIDFS_UPLOAD_BENCH: &'static str = "GridFS upload";
+const LDJSON_MULTI_IMPORT_BENCH: &'static str = "LDJSON multi-file import";
+const GRIDFS_MULTI_UPLOAD_BENCH: &'static str = "GridFS multi-file upload";
 
-fn score_test(durations: Vec<Duration>, name: &str, task_size: f64, more_info: bool) -> f64 {
-    let median = get_nth_percentile(&durations, 50.0);
-    let score = task_size / (median.as_millis() as f64 / 1000.0);
-    println!(
-        "TEST: {} -- Score: {}, Median Iteration Time: {:.3}ms\n",
-        name,
-        score,
-        median.as_secs_f64()
-    );
+/// Benchmarks included in the "BSONBench" composite.
+const BSON_BENCHES: &[&'static str] = &[
+    FLAT_BSON_ENCODING,
+    FLAT_BSON_DECODING,
+    DEEP_BSON_ENCODING,
+    DEEP_BSON_DECODING,
+    FULL_BSON_ENCODING,
+    FULL_BSON_DECODING,
+];
 
-    if more_info {
-        println!(
-            "10th percentile: {:#?}",
-            get_nth_percentile(&durations, 10.0),
-        );
-        println!(
-            "25th percentile: {:#?}",
-            get_nth_percentile(&durations, 25.0),
-        );
-        println!(
-            "50th percentile: {:#?}",
-            get_nth_percentile(&durations, 50.0),
-        );
-        println!(
-            "75th percentile: {:#?}",
-            get_nth_percentile(&durations, 75.0),
-        );
-        println!(
-            "90th percentile: {:#?}",
-            get_nth_percentile(&durations, 90.0),
-        );
-        println!(
-            "95th percentile: {:#?}",
-            get_nth_percentile(&durations, 95.0),
-        );
-        println!(
-            "98th percentile: {:#?}",
-            get_nth_percentile(&durations, 98.0),
-        );
-        println!(
-            "99th percentile: {:#?}\n",
-            get_nth_percentile(&durations, 99.0),
-        );
-    }
+/// Benchmarkes included in the "SingleBench" composite.
+/// This consists of all the single-doc benchmarks except Run Command.
+const SINGLE_BENCHES: &[&'static str] = &[
+    FIND_ONE_BENCH,
+    SMALL_DOC_INSERT_ONE_BENCH,
+    LARGE_DOC_INSERT_ONE_BENCH,
+];
 
-    score
-}
+/// Benchmarks included in the "MultiBench" composite.
+const MULTI_BENCHES: &[&'static str] = &[
+    FIND_MANY_BENCH,
+    SMALL_DOC_BULK_INSERT_BENCH,
+    LARGE_DOC_BULK_INSERT_BENCH,
+    GRIDFS_UPLOAD_BENCH,
+    GRIDFS_DOWNLOAD_BENCH,
+];
 
-async fn single_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<f64> {
-    println!("----------------------------");
-    println!("Single-Doc Benchmarks:");
-    println!("----------------------------\n");
+/// Benchmarks included in the "ParallelBench" composite.
+const PARALLEL_BENCHES: &[&'static str] = &[
+    LDJSON_MULTI_IMPORT_BENCH,
+    LDJSON_MULTI_EXPORT_BENCH,
+    GRIDFS_MULTI_UPLOAD_BENCH,
+    GRIDFS_MULTI_DOWNLOAD_BENCH,
+];
 
-    let mut comp_score: f64 = 0.0;
-    let mut benchmark_count = 0_usize;
+/// Benchmarks included in the "ReadBench" composite.
+const READ_BENCHES: &[&'static str] = &[
+    FIND_ONE_BENCH,
+    FIND_MANY_BENCH,
+    GRIDFS_DOWNLOAD_BENCH,
+    LDJSON_MULTI_EXPORT_BENCH,
+    GRIDFS_MULTI_DOWNLOAD_BENCH,
+];
+
+/// Benchmarks included in the "WriteBench" composite.
+const WRITE_BENCHES: &[&'static str] = &[
+    SMALL_DOC_INSERT_ONE_BENCH,
+    LARGE_DOC_INSERT_ONE_BENCH,
+    SMALL_DOC_BULK_INSERT_BENCH,
+    LARGE_DOC_BULK_INSERT_BENCH,
+    GRIDFS_UPLOAD_BENCH,
+    LDJSON_MULTI_IMPORT_BENCH,
+    GRIDFS_MULTI_UPLOAD_BENCH,
+];
+
+async fn run_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<CompositeScore> {
+    let mut comp_score = CompositeScore::new("All Benchmarks");
 
     // Run command
     if ids[0] {
@@ -123,11 +147,10 @@ async fn single_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resu
             num_iter: 10000,
             uri: uri.to_string(),
         };
-        println!("Running Run command...");
+        println!("Running {}...", RUN_COMMAND_BENCH);
         let run_command = bench::run_benchmark::<RunCommandBenchmark>(run_command_options).await?;
 
-        comp_score += score_test(run_command, "Run command", 0.16, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(run_command, RUN_COMMAND_BENCH, 0.16, more_info);
     }
 
     // Find one by ID
@@ -139,11 +162,10 @@ async fn single_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resu
                 .join("tweet.json"),
             uri: uri.to_string(),
         };
-        println!("Running Find one by ID...");
+        println!("Running {}...", FIND_ONE_BENCH);
         let find_one = bench::run_benchmark::<FindOneBenchmark>(find_one_options).await?;
 
-        comp_score += score_test(find_one, "Find one by ID", 16.22, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(find_one, FIND_ONE_BENCH, 16.22, more_info);
     }
 
     // Small doc insertOne
@@ -155,12 +177,16 @@ async fn single_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resu
                 .join("small_doc.json"),
             uri: uri.to_string(),
         };
-        println!("Running Small doc insertOne...");
+        println!("Running {}...", SMALL_DOC_INSERT_ONE_BENCH);
         let small_insert_one =
             bench::run_benchmark::<InsertOneBenchmark>(small_insert_one_options).await?;
 
-        comp_score += score_test(small_insert_one, "Small doc insertOne", 2.75, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(
+            small_insert_one,
+            SMALL_DOC_INSERT_ONE_BENCH,
+            2.75,
+            more_info,
+        );
     }
 
     // Large doc insertOne
@@ -172,28 +198,17 @@ async fn single_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resu
                 .join("large_doc.json"),
             uri: uri.to_string(),
         };
-        println!("Running Large doc insertOne...");
+        println!("Running {}...", LARGE_DOC_INSERT_ONE_BENCH);
         let large_insert_one =
             bench::run_benchmark::<InsertOneBenchmark>(large_insert_one_options).await?;
 
-        comp_score += score_test(large_insert_one, "Large doc insertOne", 27.31, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(
+            large_insert_one,
+            LARGE_DOC_INSERT_ONE_BENCH,
+            27.31,
+            more_info,
+        );
     }
-
-    // Take average of total.
-    comp_score /= benchmark_count as f64;
-
-    println!("\nSingle-doc benchmark composite score: {}\n", comp_score);
-    Ok(comp_score)
-}
-
-async fn multi_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<f64> {
-    println!("----------------------------");
-    println!("Multi-Doc Benchmarks:");
-    println!("----------------------------\n");
-
-    let mut comp_score: f64 = 0.0;
-    let mut benchmark_count = 0_usize;
 
     // Find many and empty the cursor
     if ids[4] {
@@ -204,16 +219,10 @@ async fn multi_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resul
                 .join("tweet.json"),
             uri: uri.to_string(),
         };
-        println!("Running Find many and empty the cursor...");
+        println!("Running {}...", FIND_MANY_BENCH);
         let find_many = bench::run_benchmark::<FindManyBenchmark>(find_many_options).await?;
 
-        comp_score += score_test(
-            find_many,
-            "Find many and empty the cursor",
-            16.22,
-            more_info,
-        );
-        benchmark_count += 1;
+        comp_score += score_test(find_many, FIND_MANY_BENCH, 16.22, more_info);
     }
 
     // Small doc bulk insert
@@ -225,12 +234,16 @@ async fn multi_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resul
                 .join("small_doc.json"),
             uri: uri.to_string(),
         };
-        println!("Running Small doc bulk insert...");
+        println!("Running {}...", SMALL_DOC_BULK_INSERT_BENCH);
         let small_insert_many =
             bench::run_benchmark::<InsertManyBenchmark>(small_insert_many_options).await?;
 
-        comp_score += score_test(small_insert_many, "Small doc bulk insert", 2.75, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(
+            small_insert_many,
+            SMALL_DOC_BULK_INSERT_BENCH,
+            2.75,
+            more_info,
+        );
     }
 
     // Large doc bulk insert
@@ -242,28 +255,17 @@ async fn multi_doc_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Resul
                 .join("large_doc.json"),
             uri: uri.to_string(),
         };
-        println!("Running Large doc bulk insert...");
+        println!("Running {}...", LARGE_DOC_BULK_INSERT_BENCH);
         let large_insert_many =
             bench::run_benchmark::<InsertManyBenchmark>(large_insert_many_options).await?;
 
-        comp_score += score_test(large_insert_many, "Large doc bulk insert", 27.31, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(
+            large_insert_many,
+            LARGE_DOC_BULK_INSERT_BENCH,
+            27.31,
+            more_info,
+        );
     }
-
-    // Take average of total.
-    comp_score /= benchmark_count as f64;
-
-    println!("\nMulti-doc benchmark composite score: {}\n", comp_score);
-    Ok(comp_score)
-}
-
-async fn parallel_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result<f64> {
-    println!("----------------------------");
-    println!("Parallel Benchmarks:");
-    println!("----------------------------\n");
-
-    let mut comp_score: f64 = 0.0;
-    let mut benchmark_count = 0_usize;
 
     // LDJSON multi-file import
     if ids[7] {
@@ -271,17 +273,16 @@ async fn parallel_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result
             path: DATA_PATH.join("parallel").join("ldjson_multi"),
             uri: uri.to_string(),
         };
-        println!("Running LDJSON multi-file import...");
+        println!("Running {}...", LDJSON_MULTI_IMPORT_BENCH);
         let json_multi_import =
             bench::run_benchmark::<JsonMultiImportBenchmark>(json_multi_import_options).await?;
 
         comp_score += score_test(
             json_multi_import,
-            "LDJSON multi-file import",
+            LDJSON_MULTI_IMPORT_BENCH,
             565.0,
             more_info,
         );
-        benchmark_count += 1;
     }
 
     // LDJSON multi-file export
@@ -290,33 +291,17 @@ async fn parallel_benchmarks(uri: &str, more_info: bool, ids: &[bool]) -> Result
             path: DATA_PATH.join("parallel").join("ldjson_multi"),
             uri: uri.to_string(),
         };
-        println!("Running LDJSON multi-file export...");
+        println!("Running {}...", LDJSON_MULTI_EXPORT_BENCH);
         let json_multi_export =
             bench::run_benchmark::<JsonMultiExportBenchmark>(json_multi_export_options).await?;
 
         comp_score += score_test(
             json_multi_export,
-            "LDJSON multi-file export",
+            LDJSON_MULTI_EXPORT_BENCH,
             565.0,
             more_info,
         );
-        benchmark_count += 1;
     }
-
-    // Take average of total.
-    comp_score /= benchmark_count as f64;
-
-    println!("\nParallel benchmark composite score: {}\n", comp_score);
-    Ok(comp_score)
-}
-
-async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
-    println!("----------------------------");
-    println!("BSON Benchmarks:");
-    println!("----------------------------\n");
-
-    let mut comp_score: f64 = 0.0;
-    let mut benchmark_count = 0;
 
     // BSON flat document decode
     if ids[9] {
@@ -324,12 +309,11 @@ async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
             num_iter: 10_000,
             path: DATA_PATH.join("extended_bson").join("flat_bson.json"),
         };
-        println!("Running BSON flat decode...");
+        println!("Running {}...", FLAT_BSON_DECODING);
         let bson_flat_decode =
             bench::run_benchmark::<BsonDecodeBenchmark>(bson_flat_decode_options).await?;
 
-        comp_score += score_test(bson_flat_decode, "BSON flat decode", 75.31, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(bson_flat_decode, FLAT_BSON_DECODING, 75.31, more_info);
     }
 
     // BSON flat document encode
@@ -338,12 +322,11 @@ async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
             num_iter: 10_000,
             path: DATA_PATH.join("extended_bson").join("flat_bson.json"),
         };
-        println!("Running BSON flat encode...");
+        println!("Running {}...", FLAT_BSON_ENCODING);
         let bson_flat_encode =
             bench::run_benchmark::<BsonEncodeBenchmark>(bson_flat_encode_options).await?;
 
-        comp_score += score_test(bson_flat_encode, "BSON flat encode", 75.31, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(bson_flat_encode, FLAT_BSON_ENCODING, 75.31, more_info);
     }
 
     // BSON deep document decode
@@ -352,12 +335,11 @@ async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
             num_iter: 10_000,
             path: DATA_PATH.join("extended_bson").join("deep_bson.json"),
         };
-        println!("Running BSON deep decode...");
+        println!("Running {}...", DEEP_BSON_DECODING);
         let bson_deep_decode =
             bench::run_benchmark::<BsonDecodeBenchmark>(bson_deep_decode_options).await?;
 
-        comp_score += score_test(bson_deep_decode, "BSON deep decode", 19.64, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(bson_deep_decode, DEEP_BSON_DECODING, 19.64, more_info);
     }
 
     // BSON deep document encode
@@ -366,12 +348,11 @@ async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
             num_iter: 10_000,
             path: DATA_PATH.join("extended_bson").join("deep_bson.json"),
         };
-        println!("Running BSON deep encode...");
+        println!("Running {}...", DEEP_BSON_ENCODING);
         let bson_deep_encode =
             bench::run_benchmark::<BsonEncodeBenchmark>(bson_deep_encode_options).await?;
 
-        comp_score += score_test(bson_deep_encode, "BSON deep encode", 19.64, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(bson_deep_encode, DEEP_BSON_ENCODING, 19.64, more_info);
     }
 
     // BSON full document decode
@@ -380,12 +361,11 @@ async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
             num_iter: 10_000,
             path: DATA_PATH.join("extended_bson").join("full_bson.json"),
         };
-        println!("Running BSON full decode...");
+        println!("Running {}...", FULL_BSON_DECODING);
         let bson_full_decode =
             bench::run_benchmark::<BsonDecodeBenchmark>(bson_full_decode_options).await?;
 
-        comp_score += score_test(bson_full_decode, "BSON full decode", 57.34, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(bson_full_decode, FULL_BSON_DECODING, 57.34, more_info);
     }
 
     // BSON full document encode
@@ -394,24 +374,19 @@ async fn bson_benchmarks(more_info: bool, ids: &[bool]) -> Result<f64> {
             num_iter: 10_000,
             path: DATA_PATH.join("extended_bson").join("full_bson.json"),
         };
-        println!("Running BSON full encode...");
+        println!("Running {}...", FULL_BSON_ENCODING);
         let bson_full_encode =
             bench::run_benchmark::<BsonEncodeBenchmark>(bson_full_encode_options).await?;
 
-        comp_score += score_test(bson_full_encode, "BSON full encode", 57.34, more_info);
-        benchmark_count += 1;
+        comp_score += score_test(bson_full_encode, FULL_BSON_ENCODING, 57.34, more_info);
     }
 
-    // Take average of total.
-    comp_score /= benchmark_count as f64;
-
-    println!("\nBSON benchmark composite score: {}\n", comp_score);
     Ok(comp_score)
 }
 
 fn parse_ids(matches: ArgMatches) -> Vec<bool> {
     let id_list: Vec<usize> = match matches.value_of("ids") {
-        Some("all") | None => vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        Some("all") => vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         Some(id_list) => id_list
             .split(',')
             .map(|str| {
@@ -419,6 +394,7 @@ fn parse_ids(matches: ArgMatches) -> Vec<bool> {
                     .expect("invalid test IDs provided, see README")
             })
             .collect(),
+        None => vec![],
     };
 
     let mut ids = vec![false; 15];
@@ -451,7 +427,11 @@ fn parse_ids(matches: ArgMatches) -> Vec<bool> {
         ids[12] = true;
         ids[13] = true;
         ids[14] = true;
-        ids[15] = true;
+    }
+
+    // if none were enabled, that means no arguments were provided and all should be enabled.
+    if !ids.iter().any(|enabled| *enabled) {
+        ids = vec![true; 15];
     }
 
     ids
@@ -527,14 +507,14 @@ Run benchmarks by id number (comma-separated):
                 .short("o")
                 .long("output")
                 .takes_value(true)
-                .help("Produce JSON output for ingestion by Evergreen"),
+                .help("Output file to contain the JSON data to be ingested by Evergreen"),
         )
         .get_matches();
 
     let uri = option_env!("MONGODB_URI").unwrap_or("mongodb://localhost:27017");
 
     let verbose = matches.is_present("verbose");
-    let output_file = matches.value_of("output");
+    let output_file = matches.value_of("output").map(|p| PathBuf::new().join(p));
 
     println!(
         "Running tests{}...\n",
@@ -546,29 +526,45 @@ Run benchmarks by id number (comma-separated):
     );
 
     let ids = parse_ids(matches);
+    let scores = run_benchmarks(uri, verbose, &ids).await.unwrap();
 
-    let mut comp_score: f64 = 0.0;
+    let read_bench = scores.filter("ReadBench", READ_BENCHES);
+    let write_bench = scores.filter("WriteBench", WRITE_BENCHES);
+    let mut driver_bench = CompositeScore::new("DriverBench");
+    driver_bench += read_bench.clone();
+    driver_bench += write_bench.clone();
 
-    // Single
-    if ids[0] || ids[1] || ids[2] || ids[3] {
-        comp_score += single_doc_benchmarks(uri, verbose, &ids).await.unwrap();
-    }
-    // Multi
-    if ids[4] || ids[5] || ids[6] {
-        comp_score += multi_doc_benchmarks(uri, verbose, &ids).await.unwrap();
-    }
-    // Parallel
-    if ids[7] || ids[8] {
-        comp_score += parallel_benchmarks(uri, verbose, &ids).await.unwrap();
+    let composite_scores: Vec<CompositeScore> = vec![
+        scores.filter("BSONBench", BSON_BENCHES),
+        scores.filter("SingleBench", SINGLE_BENCHES),
+        scores.filter("MultiBench", MULTI_BENCHES),
+        scores.filter("ParallelBench", PARALLEL_BENCHES),
+        read_bench,
+        write_bench,
+        driver_bench,
+    ]
+    .into_iter()
+    .filter(|s| s.count() > 0)
+    .collect();
+
+    for score in composite_scores.iter() {
+        println!("{}", score);
     }
 
-    // Bson
-    if ids[9] || ids[10] || ids[11] || ids[12] || ids[13] || ids[14] {
-        // BSON benchmarks are not computed as part of the composite score for the driver since
-        // encoding/decoding is already part of all the other tasks.
-        bson_benchmarks(verbose, &ids).await.unwrap();
-    }
+    if let Some(output_file) = output_file {
+        // attach the individual benchmark results
+        let mut results: Vec<BenchmarkResult> = scores.to_invidivdual_results();
 
-    println!("----------------------------");
-    println!("Driver benchmark composite score = {}", comp_score);
+        // then the composite ones
+        results.extend(
+            composite_scores
+                .into_iter()
+                .map(CompositeScore::into_single_result),
+        );
+
+        let mut file = File::open_write(&output_file).await.unwrap();
+        file.write_line(serde_json::to_string_pretty(&results).unwrap().as_str())
+            .await
+            .unwrap();
+    }
 }

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -1,0 +1,59 @@
+pub(crate) mod json_multi {
+    use mongodb::bson::Document;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct Tweet {
+        text: String,
+        in_reply_to_status_id: i64,
+        retweet_count: Option<i32>,
+        contributors: Option<i32>,
+        created_at: String,
+        geo: Option<String>,
+        source: String,
+        coordinates: Option<String>,
+        in_reply_to_screen_name: Option<String>,
+        truncated: bool,
+        entities: Entities,
+        retweeted: bool,
+        place: Option<String>,
+        user: User,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct Entities {
+        user_mentions: Vec<Mention>,
+        urls: Vec<String>,
+        hashtags: Vec<String>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct Mention {
+        indices: Vec<i32>,
+        screen_name: String,
+        name: String,
+        id: i64,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct User {
+        friends_count: i32,
+        profile_sidebar_fill_color: String,
+        location: String,
+        verified: bool,
+        follow_request_sent: Option<bool>,
+        favourites_count: i32,
+        profile_sidebar_border_color: String,
+        profile_image_url: String,
+        geo_enabled: bool,
+        created_at: String,
+        description: String,
+        time_zone: String,
+        url: String,
+        screen_name: String,
+        notifications: Option<Vec<Document>>,
+        profile_background_color: String,
+        listed_count: i32,
+        lang: String,
+    }
+}

--- a/benchmarks/src/score.rs
+++ b/benchmarks/src/score.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use mongodb::bson::Document;
 use serde::Serialize;
 
 #[derive(Debug, Clone)]
@@ -19,6 +20,7 @@ impl From<BenchmarkScore> for BenchmarkResult {
         BenchmarkResult {
             info: BenchmarkInfo {
                 test_name: score.name,
+                args: Document::new(),
             },
             metrics: vec![
                 BenchmarkMetric {
@@ -101,6 +103,7 @@ impl CompositeScore {
         BenchmarkResult {
             info: BenchmarkInfo {
                 test_name: self.name,
+                args: Document::new(),
             },
             metrics: vec![BenchmarkMetric {
                 name: "score",
@@ -191,6 +194,7 @@ pub(crate) struct BenchmarkResult {
 #[derive(Debug, Serialize)]
 pub(crate) struct BenchmarkInfo {
     test_name: &'static str,
+    args: Document,
 }
 
 #[derive(Debug, Serialize)]

--- a/benchmarks/src/score.rs
+++ b/benchmarks/src/score.rs
@@ -1,0 +1,200 @@
+use std::time::Duration;
+
+use serde::Serialize;
+
+#[derive(Debug, Clone)]
+pub(crate) struct BenchmarkScore {
+    /// The name of the benchmark (e.g. "Large doc bulk insert")
+    name: &'static str,
+
+    /// The median of all the sampled timings for this benchmark.
+    median_iteration_time: Duration,
+
+    /// MB/s throughput achieved during the median of sampled timings.
+    score: f64,
+}
+
+impl From<BenchmarkScore> for BenchmarkResult {
+    fn from(score: BenchmarkScore) -> BenchmarkResult {
+        BenchmarkResult {
+            info: BenchmarkInfo {
+                test_name: score.name,
+            },
+            metrics: vec![
+                BenchmarkMetric {
+                    name: "median_iteration_time",
+                    value: score.median_iteration_time.as_secs_f64(),
+                },
+                BenchmarkMetric {
+                    name: "score",
+                    value: score.score,
+                },
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CompositeScore {
+    /// The name of the suite of benchmarks (e.g. "Single doc")
+    name: &'static str,
+
+    /// List of all the benchmark scores that comprise this suite.
+    benchmarks: Vec<BenchmarkScore>,
+}
+
+impl std::fmt::Display for CompositeScore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} Score = {:.3} MB/s", self.name, self.avg())
+    }
+}
+
+impl std::ops::AddAssign<CompositeScore> for CompositeScore {
+    fn add_assign(&mut self, mut rhs: CompositeScore) {
+        self.benchmarks.append(&mut rhs.benchmarks);
+    }
+}
+
+impl std::ops::AddAssign<BenchmarkScore> for CompositeScore {
+    fn add_assign(&mut self, rhs: BenchmarkScore) {
+        self.benchmarks.push(rhs);
+    }
+}
+
+impl CompositeScore {
+    pub(crate) fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            benchmarks: Vec::new(),
+        }
+    }
+
+    pub(crate) fn count(&self) -> usize {
+        self.benchmarks.len()
+    }
+
+    pub(crate) fn avg(&self) -> f64 {
+        self.benchmarks.iter().map(|b| b.score).sum::<f64>() / self.benchmarks.len() as f64
+    }
+
+    /// Return a new `CompositeScore` that contains results only from benchmarks included in the
+    /// provided array of benchmark names.
+    pub(crate) fn filter(
+        &self,
+        score_name: &'static str,
+        names_to_include: &[&'static str],
+    ) -> CompositeScore {
+        CompositeScore {
+            name: score_name,
+            benchmarks: self
+                .benchmarks
+                .iter()
+                .filter(|b| names_to_include.contains(&b.name))
+                .cloned()
+                .collect(),
+        }
+    }
+
+    /// Convert this composite result into a single result (e.g. for reporting a composite score).
+    pub(crate) fn into_single_result(self) -> BenchmarkResult {
+        let score = self.avg();
+        BenchmarkResult {
+            info: BenchmarkInfo {
+                test_name: self.name,
+            },
+            metrics: vec![BenchmarkMetric {
+                name: "score",
+                value: score,
+            }],
+        }
+    }
+
+    /// Get a vec of the individual benchmark results.
+    pub(crate) fn to_invidivdual_results(&self) -> Vec<BenchmarkResult> {
+        self.benchmarks
+            .clone()
+            .into_iter()
+            .map(BenchmarkResult::from)
+            .collect()
+    }
+}
+
+fn get_nth_percentile(durations: &[Duration], n: f64) -> Duration {
+    let index = (durations.len() as f64 * (n / 100.0)) as usize;
+    durations[std::cmp::max(index, 1) - 1]
+}
+
+pub(crate) fn score_test(
+    durations: Vec<Duration>,
+    name: &'static str,
+    task_size: f64,
+    more_info: bool,
+) -> BenchmarkScore {
+    let median = get_nth_percentile(&durations, 50.0);
+    let score = task_size / median.as_secs_f64();
+    println!(
+        "TEST: {} -- Score: {:.3} MB/s, Median Iteration Time: {:.3}s\n",
+        name,
+        score,
+        median.as_secs_f64()
+    );
+
+    if more_info {
+        println!(
+            "10th percentile: {:#?}",
+            get_nth_percentile(&durations, 10.0),
+        );
+        println!(
+            "25th percentile: {:#?}",
+            get_nth_percentile(&durations, 25.0),
+        );
+        println!(
+            "50th percentile: {:#?}",
+            get_nth_percentile(&durations, 50.0),
+        );
+        println!(
+            "75th percentile: {:#?}",
+            get_nth_percentile(&durations, 75.0),
+        );
+        println!(
+            "90th percentile: {:#?}",
+            get_nth_percentile(&durations, 90.0),
+        );
+        println!(
+            "95th percentile: {:#?}",
+            get_nth_percentile(&durations, 95.0),
+        );
+        println!(
+            "98th percentile: {:#?}",
+            get_nth_percentile(&durations, 98.0),
+        );
+        println!(
+            "99th percentile: {:#?}\n",
+            get_nth_percentile(&durations, 99.0),
+        );
+    }
+
+    BenchmarkScore {
+        name,
+        median_iteration_time: median,
+        score,
+    }
+}
+
+/// Struct modeling the JSON format that Evergreen ingests for performance monitoring.
+#[derive(Debug, Serialize)]
+pub(crate) struct BenchmarkResult {
+    info: BenchmarkInfo,
+    metrics: Vec<BenchmarkMetric>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BenchmarkInfo {
+    test_name: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BenchmarkMetric {
+    name: &'static str,
+    value: f64,
+}

--- a/benchmarks/src/score.rs
+++ b/benchmarks/src/score.rs
@@ -24,11 +24,11 @@ impl From<BenchmarkScore> for BenchmarkResult {
             },
             metrics: vec![
                 BenchmarkMetric {
-                    name: "median_iteration_time",
+                    name: "Median Iteration Time (s)",
                     value: score.median_iteration_time.as_secs_f64(),
                 },
                 BenchmarkMetric {
-                    name: "score",
+                    name: "Score (MB/s)",
                     value: score.score,
                 },
             ],

--- a/benchmarks/src/score.rs
+++ b/benchmarks/src/score.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use mongodb::bson::Document;
 use serde::Serialize;
 
+const SCORE_VALUE_NAME: &'static str = "score";
+
 #[derive(Debug, Clone)]
 pub(crate) struct BenchmarkScore {
     /// The name of the benchmark (e.g. "Large doc bulk insert")
@@ -24,11 +26,11 @@ impl From<BenchmarkScore> for BenchmarkResult {
             },
             metrics: vec![
                 BenchmarkMetric {
-                    name: "Median Iteration Time (s)",
+                    name: "median_iteration_time_seconds",
                     value: score.median_iteration_time.as_secs_f64(),
                 },
                 BenchmarkMetric {
-                    name: "Score (MB/s)",
+                    name: SCORE_VALUE_NAME,
                     value: score.score,
                 },
             ],
@@ -106,7 +108,7 @@ impl CompositeScore {
                 args: Document::new(),
             },
             metrics: vec![BenchmarkMetric {
-                name: "score",
+                name: SCORE_VALUE_NAME,
                 value: score,
             }],
         }


### PR DESCRIPTION
RUST-626

This PR adds an Evergreen config that will be used by the `mongo-rust-driver-benchmarking` project to run benchmarks and record the data using https://github.com/10gen/signal-processing-service. Some updates to the benchmark runner were required to properly calculate the various composite scores.