### PR TITLE
Bump security-related dependencies (1.2.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ derivative = "2.1.1"
 err-derive = "0.2.3"
 futures = "0.3.5"
 hex = "0.4.0"
-hmac = "0.10.1"
+hmac = "0.11"
 lazy_static = "1.4.0"
 md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
@@ -66,7 +66,7 @@ version = "1.6.2"
 optional = true
 
 [dependencies.pbkdf2]
-version = "0.6.0"
+version = "0.8"
 default-features = false
 
 [dependencies.reqwest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,15 +40,15 @@ derivative = "2.1.1"
 err-derive = "0.2.3"
 futures = "0.3.5"
 hex = "0.4.0"
-hmac = "~0.7.1"
+hmac = "0.10.1"
 lazy_static = "1.4.0"
-md-5 = "0.8.0"
+md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
 serde_with = "1.3.1"
-sha-1 = "0.8.1"
-sha2 = "0.8.0"
+sha-1 = "0.9.4"
+sha2 = "0.9.3"
 socket2 = "0.3.12"
 stringprep = "0.1.2"
 strsim = "0.10.0"
@@ -59,14 +59,14 @@ trust-dns-resolver = "0.19.5"
 typed-builder = "0.4.0"
 version_check = "0.9.1"
 webpki = "0.21.0"
-webpki-roots = "0.18.0"
+webpki-roots = "0.21.0"
 
 [dependencies.async-std]
 version = "1.6.2"
 optional = true
 
 [dependencies.pbkdf2]
-version = "0.3.0"
+version = "0.6.0"
 default-features = false
 
 [dependencies.reqwest]

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -454,7 +454,7 @@ pub(crate) enum ClientFirst {
 impl ClientFirst {
     pub(crate) fn to_document(&self) -> Document {
         match self {
-            Self::Scram(version, client_first) => client_first.to_command(&version).body,
+            Self::Scram(version, client_first) => client_first.to_command(version).body,
             Self::X509(command) => command.body.clone(),
         }
     }

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -496,7 +496,7 @@ fn mac<M: Mac + NewMac>(
     auth_mechanism: &str,
 ) -> Result<impl AsRef<[u8]>> {
     let mut mac =
-        M::new_varkey(key).map_err(|_| Error::unknown_authentication_error(auth_mechanism))?;
+        M::new_from_slice(key).map_err(|_| Error::unknown_authentication_error(auth_mechanism))?;
     mac.update(input);
     Ok(mac.finalize().into_bytes())
 }

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -354,7 +354,8 @@ fn xor(lhs: &[u8], rhs: &[u8]) -> Vec<u8> {
 }
 
 fn mac_verify<M: Mac + NewMac>(key: &[u8], input: &[u8], signature: &[u8]) -> Result<()> {
-    let mut mac = M::new_varkey(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
+    let mut mac =
+        M::new_from_slice(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
     mac.update(input);
     match mac.verify(signature) {
         Ok(_) => Ok(()),

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -7,10 +7,10 @@ use std::{
     sync::RwLock,
 };
 
-use hmac::{Hmac, Mac};
+use hmac::{digest::Digest, Hmac, Mac, NewMac};
 use lazy_static::lazy_static;
 use md5::Md5;
-use sha1::{Digest, Sha1};
+use sha1::Sha1;
 use sha2::Sha256;
 
 use crate::{
@@ -42,7 +42,7 @@ const USERNAME_KEY: char = 'n';
 const NO_CHANNEL_BINDING: char = 'n';
 
 /// The minimum number of iterations of the hash function that we will accept from the server.
-const MIN_ITERATION_COUNT: usize = 4096;
+const MIN_ITERATION_COUNT: u32 = 4096;
 
 lazy_static! {
     /// Cache of pre-computed salted passwords.
@@ -55,7 +55,7 @@ lazy_static! {
 struct CacheEntry {
     password: String,
     salt: Vec<u8>,
-    i: usize,
+    i: u32,
     mechanism: ScramVersion,
 }
 
@@ -298,7 +298,7 @@ impl ScramVersion {
     }
 
     /// The "h_i" function as defined in the SCRAM RFC.
-    fn h_i(&self, str: &str, salt: &[u8], iterations: usize) -> Vec<u8> {
+    fn h_i(&self, str: &str, salt: &[u8], iterations: u32) -> Vec<u8> {
         match self {
             ScramVersion::Sha1 => h_i::<Hmac<Sha1>>(str, salt, iterations, 160 / 8),
             ScramVersion::Sha256 => h_i::<Hmac<Sha256>>(str, salt, iterations, 256 / 8),
@@ -311,14 +311,14 @@ impl ScramVersion {
         &self,
         username: &str,
         password: &str,
-        i: usize,
+        i: u32,
         salt: &[u8],
     ) -> Result<Vec<u8>> {
         let normalized_password = match self {
             ScramVersion::Sha1 => {
                 let mut md5 = Md5::new();
-                md5.input(format!("{}:mongo:{}", username, password));
-                Cow::Owned(hex::encode(md5.result()))
+                md5.update(format!("{}:mongo:{}", username, password));
+                Cow::Owned(hex::encode(md5.finalize()))
             }
             ScramVersion::Sha256 => match stringprep::saslprep(password) {
                 Ok(p) => p,
@@ -353,9 +353,9 @@ fn xor(lhs: &[u8], rhs: &[u8]) -> Vec<u8> {
         .collect()
 }
 
-fn mac_verify<M: Mac>(key: &[u8], input: &[u8], signature: &[u8]) -> Result<()> {
+fn mac_verify<M: Mac + NewMac>(key: &[u8], input: &[u8], signature: &[u8]) -> Result<()> {
     let mut mac = M::new_varkey(key).map_err(|_| Error::unknown_authentication_error("SCRAM"))?;
-    mac.input(input);
+    mac.update(input);
     match mac.verify(signature) {
         Ok(_) => Ok(()),
         Err(_) => Err(Error::authentication_error(
@@ -367,11 +367,16 @@ fn mac_verify<M: Mac>(key: &[u8], input: &[u8], signature: &[u8]) -> Result<()> 
 
 fn hash<D: Digest>(val: &[u8]) -> Vec<u8> {
     let mut hash = D::new();
-    hash.input(val);
-    hash.result().to_vec()
+    hash.update(val);
+    hash.finalize().to_vec()
 }
 
-fn h_i<M: Mac + Sync>(str: &str, salt: &[u8], iterations: usize, output_size: usize) -> Vec<u8> {
+fn h_i<M: Mac + NewMac + Sync>(
+    str: &str,
+    salt: &[u8],
+    iterations: u32,
+    output_size: usize,
+) -> Vec<u8> {
     let mut buf = vec![0u8; output_size];
     pbkdf2::pbkdf2::<M>(str.as_bytes(), salt, iterations, buf.as_mut_slice());
     buf
@@ -469,7 +474,7 @@ struct ServerFirst {
     message: String,
     nonce: String,
     salt: Vec<u8>,
-    i: usize,
+    i: u32,
 }
 
 impl ServerFirst {
@@ -494,7 +499,7 @@ impl ServerFirst {
         let salt = base64::decode(parse_kvp(parts[1], SALT_KEY)?.as_str())
             .map_err(|_| Error::invalid_authentication_response("SCRAM"))?;
 
-        let i: usize = match parse_kvp(parts[2], ITERATION_COUNT_KEY)?.parse() {
+        let i: u32 = match parse_kvp(parts[2], ITERATION_COUNT_KEY)?.parse() {
             Ok(num) => num,
             Err(_) => {
                 return Err(Error::authentication_error(
@@ -530,7 +535,7 @@ impl ServerFirst {
         self.salt.as_slice()
     }
 
-    fn i(&self) -> usize {
+    fn i(&self) -> u32 {
         self.i
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -285,7 +285,7 @@ impl Client {
                     message: self
                         .inner
                         .topology
-                        .server_selection_timeout_error_message(&criteria)
+                        .server_selection_timeout_error_message(criteria)
                         .await,
                 }
                 .into());

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1190,7 +1190,7 @@ impl ClientOptionsParser {
                     credential.mechanism_properties = Some(doc);
                 }
 
-                mechanism.validate_credential(&credential)?;
+                mechanism.validate_credential(credential)?;
                 credential.mechanism = options.auth_mechanism.take();
             }
             None => {

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -113,7 +113,7 @@ impl CommandResponse {
     /// Returns whether this response indicates a success or not (i.e. if "ok: 1")
     pub(crate) fn is_success(&self) -> bool {
         match self.raw_response.get("ok") {
-            Some(ref b) => bson_util::get_int(b) == Some(1),
+            Some(b) => bson_util::get_int(b) == Some(1),
             _ => false,
         }
     }

--- a/src/cmap/test/event.rs
+++ b/src/cmap/test/event.rs
@@ -134,10 +134,15 @@ impl EventSubscriber<'_> {
 #[derive(Clone, Debug, Deserialize, From, PartialEq)]
 #[serde(tag = "type")]
 pub enum Event {
-    #[serde(deserialize_with = "self::deserialize_pool_created")]
-    ConnectionPoolCreated(PoolCreatedEvent),
-    ConnectionPoolClosed(PoolClosedEvent),
-    ConnectionPoolReady(PoolReadyEvent),
+    #[serde(
+        deserialize_with = "self::deserialize_pool_created",
+        rename = "ConnectionPoolCreated"
+    )]
+    PoolCreated(PoolCreatedEvent),
+    #[serde(rename = "ConnectionPoolClosed")]
+    PoolClosed(PoolClosedEvent),
+    #[serde(rename = "ConnectionPoolReady")]
+    PoolReady(PoolReadyEvent),
     ConnectionCreated(ConnectionCreatedEvent),
     ConnectionReady(ConnectionReadyEvent),
     ConnectionClosed(ConnectionClosedEvent),
@@ -145,23 +150,24 @@ pub enum Event {
     #[serde(deserialize_with = "self::deserialize_checkout_failed")]
     ConnectionCheckOutFailed(ConnectionCheckoutFailedEvent),
     ConnectionCheckedOut(ConnectionCheckedOutEvent),
-    ConnectionPoolCleared(PoolClearedEvent),
+    #[serde(rename = "ConnectionPoolCleared")]
+    PoolCleared(PoolClearedEvent),
     ConnectionCheckedIn(ConnectionCheckedInEvent),
 }
 
 impl Event {
     pub fn name(&self) -> &'static str {
         match self {
-            Event::ConnectionPoolCreated(_) => "ConnectionPoolCreated",
-            Event::ConnectionPoolReady(_) => "ConnectionPoolReady",
-            Event::ConnectionPoolClosed(_) => "ConnectionPoolClosed",
+            Event::PoolCreated(_) => "ConnectionPoolCreated",
+            Event::PoolReady(_) => "ConnectionPoolReady",
+            Event::PoolClosed(_) => "ConnectionPoolClosed",
             Event::ConnectionCreated(_) => "ConnectionCreated",
             Event::ConnectionReady(_) => "ConnectionReady",
             Event::ConnectionClosed(_) => "ConnectionClosed",
             Event::ConnectionCheckOutStarted(_) => "ConnectionCheckOutStarted",
             Event::ConnectionCheckOutFailed(_) => "ConnectionCheckOutFailed",
             Event::ConnectionCheckedOut(_) => "ConnectionCheckedOut",
-            Event::ConnectionPoolCleared(_) => "ConnectionPoolCleared",
+            Event::PoolCleared(_) => "ConnectionPoolCleared",
             Event::ConnectionCheckedIn(_) => "ConnectionCheckedIn",
         }
     }

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -82,7 +82,7 @@ async fn concurrent_connections() {
     let client = TestClient::with_options(Some(options), true).await;
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
-    if !version.matches(&client.server_version.as_ref().unwrap()) {
+    if !version.matches(client.server_version.as_ref().unwrap()) {
         println!(
             "skipping concurrent_connections test due to server not supporting failpoint option"
         );

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -309,9 +309,7 @@ impl Operation {
 
                 // wait for event to be emitted to ensure drop has completed.
                 subscriber
-                    .wait_for_event(EVENT_TIMEOUT, |e| {
-                        matches!(e, Event::ConnectionPoolClosed(_))
-                    })
+                    .wait_for_event(EVENT_TIMEOUT, |e| matches!(e, Event::PoolClosed(_)))
                     .await
                     .expect("did not receive ConnectionPoolClosed event after closing pool");
             }
@@ -356,7 +354,7 @@ impl Matchable for ConnectionPoolOptions {
 impl Matchable for Event {
     fn content_matches(&self, expected: &Event) -> bool {
         match (self, expected) {
-            (Event::ConnectionPoolCreated(actual), Event::ConnectionPoolCreated(ref expected)) => {
+            (Event::PoolCreated(actual), Event::PoolCreated(ref expected)) => {
                 actual.options.matches(&expected.options)
             }
             (Event::ConnectionCreated(actual), Event::ConnectionCreated(ref expected)) => {
@@ -380,9 +378,9 @@ impl Matchable for Event {
                 Event::ConnectionCheckOutFailed(ref expected),
             ) => actual.reason == expected.reason,
             (Event::ConnectionCheckOutStarted(_), Event::ConnectionCheckOutStarted(_)) => true,
-            (Event::ConnectionPoolCleared(_), Event::ConnectionPoolCleared(_)) => true,
-            (Event::ConnectionPoolReady(_), Event::ConnectionPoolReady(_)) => true,
-            (Event::ConnectionPoolClosed(_), Event::ConnectionPoolClosed(_)) => true,
+            (Event::PoolCleared(_), Event::PoolCleared(_)) => true,
+            (Event::PoolReady(_), Event::PoolReady(_)) => true,
+            (Event::PoolClosed(_), Event::PoolClosed(_)) => true,
             _ => false,
         }
     }
@@ -464,7 +462,7 @@ async fn redact_credential() {
 
     subscriber
         .wait_for_event(EVENT_TIMEOUT, |e| {
-            if let crate::test::Event::CmapEvent(CmapEvent::ConnectionPoolCreated(event)) = e {
+            if let crate::test::Event::CmapEvent(CmapEvent::PoolCreated(event)) = e {
                 let event_debug = format!("{:?}", event);
                 if let Some(ref pass) = credential.password {
                     assert!(!event_debug.contains(pass))

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ impl Error {
         }
         match &self.kind.code_and_message() {
             Some((code, message)) => {
-                if RETRYABLE_READ_CODES.contains(&code) {
+                if RETRYABLE_READ_CODES.contains(code) {
                     return true;
                 }
                 if is_not_master(*code, message) || is_recovering(*code, message) {
@@ -125,7 +125,7 @@ impl Error {
             return true;
         }
         match &self.kind.code_and_message() {
-            Some((code, _)) => RETRYABLE_WRITE_CODES.contains(&code),
+            Some((code, _)) => RETRYABLE_WRITE_CODES.contains(code),
             None => false,
         }
     }

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -73,12 +73,10 @@ async fn build() {
 
     for (original_doc, cmd_doc) in fixtures.documents.iter().zip(cmd_docs.iter_mut()) {
         assert!(cmd_doc.get("_id").is_some());
-        if original_doc.get("_id").is_some() {
-            assert_eq!(original_doc, cmd_doc);
-        } else {
+        if !original_doc.get("_id").is_some() {
             cmd_doc.remove("_id");
-            assert_eq!(original_doc, cmd_doc);
-        };
+        }
+        assert_eq!(original_doc, cmd_doc);
     }
 
     assert_eq!(

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -92,7 +92,7 @@ impl AsyncTcpStream {
         let socket = Socket::new(domain, Type::stream(), Some(Protocol::tcp()))?;
         socket.set_keepalive(Some(KEEPALIVE_TIME))?;
 
-        let address: SockAddr = address.clone().into();
+        let address: SockAddr = (*address).into();
         if connect_timeout == Duration::from_secs(0) {
             socket.connect(&address)?;
         } else {

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -674,7 +674,7 @@ impl TopologyDescription {
         servers: impl Iterator<Item = &'a StreamAddress>,
     ) {
         for server in servers {
-            if !self.servers.contains_key(&server) {
+            if !self.servers.contains_key(server) {
                 self.servers
                     .insert(server.clone(), ServerDescription::new(server.clone(), None));
             }

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -119,7 +119,7 @@ async fn load_balancing_test() {
 
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
-    if !version.matches(&setup_client.server_version.as_ref().unwrap()) {
+    if !version.matches(setup_client.server_version.as_ref().unwrap()) {
         println!(
             "skipping load_balancing_test test due to server not supporting blockConnection option"
         );

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -233,9 +233,7 @@ impl Topology {
     /// an operation.
     pub(crate) async fn handle_pre_handshake_error(&self, error: Error, server: &Server) -> bool {
         let state_lock = self.state.write().await;
-        let changed = self
-            .mark_server_as_unknown(error, &server, state_lock)
-            .await;
+        let changed = self.mark_server_as_unknown(error, server, state_lock).await;
         if changed {
             server.pool.clear();
         }
@@ -495,9 +493,9 @@ impl TopologyState {
         topology: WeakTopology,
     ) -> Option<TopologyDescriptionDiff> {
         let old_description = self.description.clone();
-        self.description.sync_hosts(&hosts);
+        self.description.sync_hosts(hosts);
 
-        self.sync_hosts(&hosts, options, &topology);
+        self.sync_hosts(hosts, options, &topology);
 
         old_description.diff(&self.description)
     }

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -118,7 +118,7 @@ async fn sdam_pool_management() {
 
     subscriber
         .wait_for_event(Duration::from_millis(500), |event| {
-            matches!(event, Event::CmapEvent(CmapEvent::ConnectionPoolReady(_)))
+            matches!(event, Event::CmapEvent(CmapEvent::PoolReady(_)))
         })
         .await
         .expect("should see pool ready event");
@@ -136,14 +136,14 @@ async fn sdam_pool_management() {
 
     subscriber
         .wait_for_event(Duration::from_millis(1000), |event| {
-            matches!(event, Event::CmapEvent(CmapEvent::ConnectionPoolCleared(_)))
+            matches!(event, Event::CmapEvent(CmapEvent::PoolCleared(_)))
         })
         .await
         .expect("should see pool cleared event");
 
     subscriber
         .wait_for_event(Duration::from_millis(1000), |event| {
-            matches!(event, Event::CmapEvent(CmapEvent::ConnectionPoolReady(_)))
+            matches!(event, Event::CmapEvent(CmapEvent::PoolReady(_)))
         })
         .await
         .expect("should see pool ready event");
@@ -196,7 +196,7 @@ async fn sdam_min_pool_size_error() {
 
     subscriber
         .wait_for_event(Duration::from_millis(2000), |event| {
-            matches!(event, Event::CmapEvent(CmapEvent::ConnectionPoolCleared(_)))
+            matches!(event, Event::CmapEvent(CmapEvent::PoolCleared(_)))
         })
         .await
         .expect("should see pool cleared event");
@@ -231,7 +231,7 @@ async fn sdam_min_pool_size_error() {
 
     subscriber
         .wait_for_event(Duration::from_millis(10), |event| {
-            matches!(event, Event::CmapEvent(CmapEvent::ConnectionPoolReady(_)))
+            matches!(event, Event::CmapEvent(CmapEvent::PoolReady(_)))
         })
         .await
         .expect("should see pool ready event");

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -39,7 +39,7 @@ impl SrvResolver {
             replica_set: None,
         };
 
-        self.get_txt_options(&hostname, &mut config).await?;
+        self.get_txt_options(hostname, &mut config).await?;
 
         Ok(config)
     }

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -67,7 +67,7 @@ impl Database {
 
     /// Gets the name of the `Database`.
     pub fn name(&self) -> &str {
-        &self.async_database.name()
+        self.async_database.name()
     }
 
     /// Gets the read preference of the `Database`.

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -83,7 +83,7 @@ async fn insert_err_details() {
                     let result = doc.get_document("writeConcern");
                     match result {
                         Ok(write_concern_doc) => {
-                            assert_eq!(write_concern_doc.contains_key("provenance"), true);
+                            assert!(write_concern_doc.contains_key("provenance"));
                         }
                         Err(e) => panic!("{:?}", e),
                     }
@@ -654,7 +654,7 @@ async fn find_one_and_delete_hint_test(options: Option<FindOneAndDeleteOptions>,
     let client = EventClient::new().await;
 
     let req = VersionReq::parse(">= 4.2").unwrap();
-    if options.is_some() && !req.matches(&client.server_version.as_ref().unwrap()) {
+    if options.is_some() && !req.matches(client.server_version.as_ref().unwrap()) {
         return;
     }
 
@@ -712,13 +712,13 @@ async fn find_one_and_delete_hint_server_version() {
 
     let req1 = VersionReq::parse("< 4.2").unwrap();
     let req2 = VersionReq::parse("4.2.*").unwrap();
-    if req1.matches(&client.server_version.as_ref().unwrap()) {
+    if req1.matches(client.server_version.as_ref().unwrap()) {
         let error = res.expect_err("find one and delete should fail");
         assert!(matches!(
             error.kind.as_ref(),
             ErrorKind::OperationError { .. }
         ));
-    } else if req2.matches(&client.server_version.as_ref().unwrap()) {
+    } else if req2.matches(client.server_version.as_ref().unwrap()) {
         let error = res.expect_err("find one and delete should fail");
         assert!(matches!(
             error.kind.as_ref(),

--- a/src/test/spec/command_monitoring/event.rs
+++ b/src/test/spec/command_monitoring/event.rs
@@ -8,32 +8,31 @@ use crate::{
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TestEvent {
-    CommandStartedEvent {
+    #[serde(rename = "command_started_event")]
+    Started {
         command_name: String,
         database_name: String,
         command: Document,
     },
-
-    CommandSucceededEvent {
+    #[serde(rename = "command_succeeded_event")]
+    Succeeded {
         command_name: String,
         reply: Document,
     },
-
-    CommandFailedEvent {
-        command_name: String,
-    },
+    #[serde(rename = "command_failed_event")]
+    Failed { command_name: String },
 }
 
 impl Matchable for TestEvent {
     fn content_matches(&self, actual: &TestEvent) -> bool {
         match (self, actual) {
             (
-                TestEvent::CommandStartedEvent {
+                TestEvent::Started {
                     command_name: actual_command_name,
                     database_name: actual_database_name,
                     command: actual_command,
                 },
-                TestEvent::CommandStartedEvent {
+                TestEvent::Started {
                     command_name: expected_command_name,
                     database_name: expected_database_name,
                     command: expected_command,
@@ -44,11 +43,11 @@ impl Matchable for TestEvent {
                     && actual_command.matches(expected_command)
             }
             (
-                TestEvent::CommandSucceededEvent {
+                TestEvent::Succeeded {
                     command_name: actual_command_name,
                     reply: actual_reply,
                 },
-                TestEvent::CommandSucceededEvent {
+                TestEvent::Succeeded {
                     command_name: expected_command_name,
                     reply: expected_reply,
                 },
@@ -56,10 +55,10 @@ impl Matchable for TestEvent {
                 actual_command_name == expected_command_name && actual_reply.matches(expected_reply)
             }
             (
-                TestEvent::CommandFailedEvent {
+                TestEvent::Failed {
                     command_name: actual_command_name,
                 },
-                TestEvent::CommandFailedEvent {
+                TestEvent::Failed {
                     command_name: expected_command_name,
                 },
             ) => actual_command_name == expected_command_name,
@@ -71,15 +70,15 @@ impl Matchable for TestEvent {
 impl From<CommandEvent> for TestEvent {
     fn from(event: CommandEvent) -> Self {
         match event {
-            CommandEvent::CommandStartedEvent(event) => TestEvent::CommandStartedEvent {
+            CommandEvent::CommandStartedEvent(event) => TestEvent::Started {
                 command_name: event.command_name,
                 database_name: event.db,
                 command: event.command,
             },
-            CommandEvent::CommandFailedEvent(event) => TestEvent::CommandFailedEvent {
+            CommandEvent::CommandFailedEvent(event) => TestEvent::Failed {
                 command_name: event.command_name,
             },
-            CommandEvent::CommandSucceededEvent(event) => TestEvent::CommandSucceededEvent {
+            CommandEvent::CommandSucceededEvent(event) => TestEvent::Succeeded {
                 command_name: event.command_name,
                 reply: event.reply,
             },

--- a/src/test/spec/command_monitoring/mod.rs
+++ b/src/test/spec/command_monitoring/mod.rs
@@ -58,7 +58,7 @@ async fn run_command_monitoring_test(test_file: TestFile) {
 
         if let Some(ref max_version) = test_case.max_version {
             let req = VersionReq::parse(&format!("<= {}", &max_version)).unwrap();
-            if !req.matches(&client.server_version.as_ref().unwrap()) {
+            if !req.matches(client.server_version.as_ref().unwrap()) {
                 println!("Skipping {}", test_case.description);
                 continue;
             }
@@ -66,7 +66,7 @@ async fn run_command_monitoring_test(test_file: TestFile) {
 
         if let Some(ref min_version) = test_case.min_version {
             let req = VersionReq::parse(&format!(">= {}", &min_version)).unwrap();
-            if !req.matches(&client.server_version.as_ref().unwrap()) {
+            if !req.matches(client.server_version.as_ref().unwrap()) {
                 println!("Skipping {}", test_case.description);
                 continue;
             }

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -56,7 +56,7 @@ async fn run_spec_tests() {
             let db_name = get_db_name(&test_case.description);
             let coll_name = "coll";
 
-            let coll = client.init_db_and_coll(&db_name, &coll_name).await;
+            let coll = client.init_db_and_coll(&db_name, coll_name).await;
 
             if !test_file.data.is_empty() {
                 coll.insert_many(test_file.data.clone(), None)
@@ -73,7 +73,7 @@ async fn run_spec_tests() {
             }
 
             let result = client
-                .run_collection_operation(&test_case.operation, &db_name, &coll_name, None)
+                .run_collection_operation(&test_case.operation, &db_name, coll_name, None)
                 .await;
 
             if let Some(error) = test_case.outcome.error {
@@ -201,7 +201,7 @@ async fn transaction_ids_excluded() {
     assert!(excludes_txn_number("aggregate"));
 
     let req = semver::VersionReq::parse(">=4.2").unwrap();
-    if req.matches(&client.server_version.as_ref().unwrap()) {
+    if req.matches(client.server_version.as_ref().unwrap()) {
         coll.aggregate(
             vec![
                 doc! { "$match": doc! { "x": 1 } },
@@ -285,7 +285,7 @@ async fn mmapv1_error_raised() {
     let client = TestClient::new().await;
 
     let req = semver::VersionReq::parse("<=4.0").unwrap();
-    if !req.matches(&client.server_version.as_ref().unwrap()) || !client.is_replica_set() {
+    if !req.matches(client.server_version.as_ref().unwrap()) || !client.is_replica_set() {
         return;
     }
 
@@ -340,8 +340,8 @@ async fn label_not_added(retry_reads: bool) {
     // Configuring a failpoint is only supported on 4.0+ replica sets and 4.1.5+ sharded clusters.
     let req = VersionReq::parse(">=4.0").unwrap();
     let sharded_req = VersionReq::parse(">=4.1.5").unwrap();
-    if client.is_sharded() && !sharded_req.matches(&client.server_version.as_ref().unwrap())
-        || !req.matches(&client.server_version.as_ref().unwrap())
+    if client.is_sharded() && !sharded_req.matches(client.server_version.as_ref().unwrap())
+        || !req.matches(client.server_version.as_ref().unwrap())
     {
         return;
     }

--- a/src/test/spec/runner/mod.rs
+++ b/src/test/spec/runner/mod.rs
@@ -91,7 +91,7 @@ pub async fn run_v2_test(test_file: TestFile) {
             // does not attach to the server ping. When the driver is updated to send implicit
             // sessions to standalones, this test should be unskipped.
             let req = semver::VersionReq::parse("<= 3.6").unwrap();
-            if req.matches(&client.server_version.as_ref().unwrap()) && client.is_standalone() {
+            if req.matches(client.server_version.as_ref().unwrap()) && client.is_standalone() {
                 continue;
             }
             start_session(&client, &db_name).await;

--- a/src/test/spec/runner/operation.rs
+++ b/src/test/spec/runner/operation.rs
@@ -833,8 +833,8 @@ impl EventClient {
         collection_options: Option<CollectionOptions>,
     ) -> Result<Option<Bson>> {
         let coll = match collection_options {
-            Some(options) => self.get_coll_with_options(&db_name, &coll_name, options),
-            None => self.get_coll(&db_name, &coll_name),
+            Some(options) => self.get_coll_with_options(db_name, coll_name, options),
+            None => self.get_coll(db_name, coll_name),
         };
         operation.execute_on_collection(&coll).await
     }

--- a/src/test/spec/runner/test_file.rs
+++ b/src/test/spec/runner/test_file.rs
@@ -40,13 +40,13 @@ impl RunOn {
     pub fn can_run_on(&self, client: &EventClient) -> bool {
         if let Some(ref min_version) = self.min_server_version {
             let req = VersionReq::parse(&format!(">= {}", &min_version)).unwrap();
-            if !req.matches(&client.server_version.as_ref().unwrap()) {
+            if !req.matches(client.server_version.as_ref().unwrap()) {
                 return false;
             }
         }
         if let Some(ref max_version) = self.max_server_version {
             let req = VersionReq::parse(&format!("<= {}", &max_version)).unwrap();
-            if !req.matches(&client.server_version.as_ref().unwrap()) {
+            if !req.matches(client.server_version.as_ref().unwrap()) {
                 return false;
             }
         }

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -159,7 +159,7 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                             Entity::Bson(ref result) => {
                                 assert!(results_match(
                                     Some(result),
-                                    &expect_result,
+                                    expect_result,
                                     operation.returns_root_documents(),
                                     Some(&test_runner.entities),
                                 ));

--- a/src/test/spec/unified_runner/test_event.rs
+++ b/src/test/spec/unified_runner/test_event.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::enum_variant_names)]
 pub enum TestEvent {
     CommandStartedEvent {
         command_name: Option<String>,

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -77,13 +77,13 @@ impl RunOnRequirement {
     pub async fn can_run_on(&self, client: &TestClient) -> bool {
         if let Some(ref min_version) = self.min_server_version {
             let req = VersionReq::parse(&format!(">= {}", &min_version)).unwrap();
-            if !req.matches(&client.server_version.as_ref().unwrap()) {
+            if !req.matches(client.server_version.as_ref().unwrap()) {
                 return false;
             }
         }
         if let Some(ref max_version) = self.max_server_version {
             let req = VersionReq::parse(&format!("<= {}", &max_version)).unwrap();
-            if !req.matches(&client.server_version.as_ref().unwrap()) {
+            if !req.matches(client.server_version.as_ref().unwrap()) {
                 return false;
             }
         }

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -37,6 +37,7 @@ pub enum Event {
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum CommandEvent {
     CommandStartedEvent(CommandStartedEvent),
     CommandSucceededEvent(CommandSucceededEvent),
@@ -108,16 +109,16 @@ impl EventHandler {
 
 impl CmapEventHandler for EventHandler {
     fn handle_pool_created_event(&self, event: PoolCreatedEvent) {
-        self.handle(CmapEvent::ConnectionPoolCreated(event));
+        self.handle(CmapEvent::PoolCreated(event));
     }
 
     fn handle_pool_cleared_event(&self, event: PoolClearedEvent) {
-        self.handle(CmapEvent::ConnectionPoolCleared(event.clone()));
+        self.handle(CmapEvent::PoolCleared(event.clone()));
         self.pool_cleared_events.write().unwrap().push_back(event);
     }
 
     fn handle_pool_ready_event(&self, event: PoolReadyEvent) {
-        self.handle(CmapEvent::ConnectionPoolReady(event))
+        self.handle(CmapEvent::PoolReady(event))
     }
 }
 

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -252,7 +252,7 @@ impl TestClient {
         } else {
             VersionReq::parse(">= 4.0").unwrap()
         };
-        version.matches(&self.server_version.as_ref().unwrap())
+        version.matches(self.server_version.as_ref().unwrap())
     }
 
     pub async fn enable_failpoint(


### PR DESCRIPTION
This PR backports RUST-682 and RUST-970 to 1.2.x, which is required because `hmac` 0.7 depends on a now yanked version of a different crate (see #433).