### PR TITLE
RUST-968 Remove the `bson-u2i` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,6 @@ tokio-runtime = ["tokio/macros", "tokio/net", "tokio/rt", "tokio/time", "serde_b
 async-std-runtime = ["async-std", "async-std/attributes", "async-std-resolver", "tokio-util/compat"]
 sync = ["async-std-runtime"]
 
-# The bson/u2i feature enables automatic conversion from unsigned to signed types during
-# serialization. This feature is intended for use when serializing data types in third-party crates
-# whose implementation cannot be changed; otherwise, it is preferred to use the helper functions
-# provided in the bson::serde_helpers module.
-bson-u2i = ["bson/u2i"]
-
 # Enable support for v0.4 of the chrono crate in the public API of the BSON library.
 bson-chrono-0_4 = ["bson/chrono-0_4"]
 


### PR DESCRIPTION
RUST-968

Now that the `u2i` feature flag is enabled by default in `bson`, the driver's flag that maps to it is now redundant.