### PR TITLE
RUST-1002 Allow authentication to all server types except arbiter

### DIFF
--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -36,13 +36,7 @@ pub enum ServerType {
 
 impl ServerType {
     pub(crate) fn can_auth(self) -> bool {
-        matches!(
-            self,
-            ServerType::Standalone
-                | ServerType::RsPrimary
-                | ServerType::RsSecondary
-                | ServerType::Mongos
-        )
+        !matches!(self, ServerType::RsArbiter)
     }
 
     pub(crate) fn is_data_bearing(self) -> bool {


### PR DESCRIPTION
RUST-1002

This change was related to a DRIVERS ticket that we never got a language ticket for. A user [ran into this](https://jira.mongodb.org/browse/RUST-926?focusedCommentId=4011725&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4011725) and since it was a simple change, I figured I'd just go ahead and fix it instead of triaging. 