### PR TITLE
RUST-827 Improve stability of load-balancing server selection test

### DIFF
--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -181,14 +181,14 @@ async fn load_balancing_test() {
         assert!(
             share_of_selections <= max_share,
             "expected no more than {}% of selections, instead got {}%",
-            max_share * 100,
-            share_of_selections * 100
+            (max_share * 100.0) as u32,
+            (share_of_selections * 100.0) as u32
         );
         assert!(
             share_of_selections >= min_share,
             "expected at least {}% of selections, instead got {}%",
-            min_share * 100,
-            share_of_selections * 100
+            (min_share * 100.0) as u32,
+            (share_of_selections * 100.0) as u32
         );
     }
 

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -183,8 +183,18 @@ async fn load_balancing_test() {
 
         // verify that the lesser picked server (slower one) was picked less than 25% of the time.
         let share_of_selections = (*counts[0] as f64) / ((*counts[0] + *counts[1]) as f64);
-        assert!(share_of_selections <= max_share);
-        assert!(share_of_selections >= min_share);
+        assert!(
+            share_of_selections <= max_share,
+            "expected no more than {}%, instead got {}%",
+            max_share,
+            share_of_selections
+        );
+        assert!(
+            share_of_selections >= min_share,
+            "expected at least {}%, instead got {}%",
+            min_share,
+            share_of_selections
+        );
     }
 
     do_test(&mut client, 0.05, 0.25).await;

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -114,6 +114,13 @@ async fn load_balancing_test() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
     let mut setup_client_options = CLIENT_OPTIONS.clone();
+
+    // TODO: RUST-1004 unskip on auth variants
+    if setup_client_options.credential.is_some() {
+        println!("skipping load_balancing_test test due to auth being enabled");
+        return;
+    }
+
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
     let setup_client = TestClient::with_options(Some(setup_client_options)).await;

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -194,6 +194,9 @@ async fn load_balancing_test() {
 
     let mut client = EventClient::new().await;
 
+    // saturate pools
+    do_test(&mut client, 0.0, 0.50).await;
+
     // verify that normal conditions generally evenly distributes load
     do_test(&mut client, 0.40, 0.50).await;
 

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -195,7 +195,7 @@ async fn load_balancing_test() {
     let mut client = EventClient::new().await;
 
     // saturate pools
-    do_test(&mut client, 0.40, 0.50, 100).await;
+    do_test(&mut client, 0.0, 0.50, 100).await;
 
     // enable a failpoint on one of the mongoses to slow it down
     let options = FailCommandOptions::builder()


### PR DESCRIPTION
RUST-812

This PR increases the iterations of the `in_window::load_balancing_test` and skips it on auth+TLS variants to reduce the amount of flaky failures. The C# driver observed similar flakiness and also took these steps.

Edit: the patch for this PR came back all green :sunglasses: 