### PR TITLE
minor: fix rustdoc lint invocation

### DIFF
--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -3,4 +3,6 @@
 set -o errexit
 
 . ~/.cargo/env
-cargo +nightly rustdoc -p bson --all-features -- --cfg docsrs -D warnings
+cargo +nightly rustdoc --features aws-auth -- -D warnings
+cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings
+cargo +nightly rustdoc --no-default-features --features sync -- -D warnings

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -3,6 +3,6 @@
 set -o errexit
 
 . ~/.cargo/env
-cargo +nightly rustdoc --features aws-auth -- -D warnings
-cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings
-cargo +nightly rustdoc --no-default-features --features sync -- -D warnings
+cargo rustdoc -- -D warnings
+cargo rustdoc --no-default-features --features async-std-runtime -- -D warnings
+cargo rustdoc --no-default-features --features sync -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,3 +126,4 @@ semver = "1.0.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
+features = ["aws-auth"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,4 +126,3 @@ semver = "1.0.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
-features = ["aws-auth"]

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -82,7 +82,7 @@ pub enum AuthMechanism {
     ///
     /// Note: Only server versions 4.4+ support AWS authentication. Additionally, the driver only
     /// supports AWS authentication with the tokio runtime.
-    #[cfg(feature = "aws-auth")]
+    #[cfg(any(feature = "aws-auth", docsrs))]
     #[cfg_attr(docsrs, doc(cfg(feature = "aws-auth")))]
     MongoDbAws,
 }

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -83,6 +83,7 @@ pub enum AuthMechanism {
     /// Note: Only server versions 4.4+ support AWS authentication. Additionally, the driver only
     /// supports AWS authentication with the tokio runtime.
     #[cfg(feature = "aws-auth")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "aws-auth")))]
     MongoDbAws,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! # Ok(()) }
 //! ```
 //!
-//! A [`Collection`] can be parameterized with any type that implements the
+//! A [`Collection`](struct.Collection.html) can be parameterized with any type that implements the
 //! `Serialize` and `Deserialize` traits from the [`serde`](https://serde.rs/) crate,
 //! not just `Document`:
 //!
@@ -155,8 +155,8 @@
 //! ```
 //!
 //! ### Finding documents in a collection
-//! Results from queries are generally returned via [`Cursor`], a struct which streams the results
-//! back from the server as requested. The [`Cursor`] type implements the
+//! Results from queries are generally returned via [`Cursor`](struct.Cursor.html), a struct which streams
+//! the results back from the server as requested. The [`Cursor`](struct.Cursor.html) type implements the
 //! [`Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) trait from
 //! the [`futures`](https://crates.io/crates/futures) crate, and in order to access its streaming
 //! functionality you need to import at least one of the
@@ -282,7 +282,7 @@
 //! it will only happen in a minor or major version release.
 
 #![warn(missing_docs)]
-#![warn(missing_crate_level_docs)]
+#![warn(rustdoc::missing_crate_level_docs)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@
 //! it will only happen in a minor or major version release.
 
 #![warn(missing_docs)]
-#![warn(rustdoc::missing_crate_level_docs)]
+#![warn(missing_crate_level_docs)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(


### PR DESCRIPTION
In #437, I updated the `check-rustdoc.sh` script to match the one I used in `bson`, but I forgot to change the `-p` flag to say `mongodb`. After fixing that, I saw that the single `rustdoc` invocation wasn't going to work for this crate due to the assumptions we make about only one of tokio and async-std being enabled. This PR then changes the `check-rustdoc.sh` script back to what it was before, and it also fixes a few docs lint issues that were uncovered by doing so.