### PR TITLE
RUST-1012 remove `Clone` impl from `ClientSession`

### DIFF
--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -99,7 +99,7 @@ lazy_static! {
 ///     }
 /// }
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ClientSession {
     cluster_time: Option<ClusterTime>,
     server_session: ServerSession,

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -14,7 +14,7 @@ use crate::{
     Database,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Entity {
     Client(ClientEntity),
     Database(Database),
@@ -33,7 +33,7 @@ pub struct ClientEntity {
     observe_sensitive_commands: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SessionEntity {
     pub lsid: Document,
     pub client_session: Option<Box<ClientSession>>,

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -12,7 +12,7 @@ use semver::Version;
 use tokio::sync::RwLockWriteGuard;
 
 use crate::{
-    bson::{doc, Document},
+    bson::{doc, Bson, Document},
     options::{CollectionOptions, FindOptions, ReadConcern, ReadPreference, SelectionCriteria},
     test::{run_single_test, run_spec_test, LOCK},
     RUNTIME,
@@ -140,12 +140,27 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                         .execute_entity_operation(id, &mut test_runner)
                         .await;
 
+                    // Precache the BSON result, if any, so that other entities can be saved without cloning.
+                    #[derive(Debug)]
+                    enum ResultEntity {
+                        Bson(Bson),
+                        Other,
+                        None,
+                    }
+
+                    let bson_result = match &result {
+                        Ok(Some(Entity::Bson(bson))) => Ok(ResultEntity::Bson(bson.clone())),
+                        Ok(Some(_)) => Ok(ResultEntity::Other),
+                        Ok(None) => Ok(ResultEntity::None),
+                        Err(e) => Err(e.clone()),
+                    };
+
                     if let Some(ref id) = operation.save_result_as_entity {
-                        match &result {
+                        match result {
                             Ok(Some(entity)) => {
                                 if test_runner
                                     .entities
-                                    .insert(id.clone(), entity.clone())
+                                    .insert(id.clone(), entity)
                                     .is_some()
                                 {
                                     panic!("Entity with id {} already present in entity map", id);
@@ -157,22 +172,19 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                     }
 
                     if let Some(expect_error) = operation.expect_error {
-                        let error = result
+                        let error = bson_result
                             .expect_err(&format!("{} should return an error", operation.name));
                         expect_error.verify_result(error);
                     } else {
-                        let result = result.unwrap_or_else(|e| {
+                        let result = bson_result.unwrap_or_else(|e| {
                             panic!(
                                 "{} should succeed, but the following error: {}",
                                 operation.name, e
                             )
                         });
                         if let Some(ref expect_result) = operation.expect_result {
-                            let result = result.unwrap_or_else(|| {
-                                panic!("{} should return an entity", operation.name)
-                            });
                             match result {
-                                Entity::Bson(ref result) => {
+                                ResultEntity::Bson(ref result) => {
                                     assert!(
                                         results_match(
                                             Some(result),
@@ -185,10 +197,11 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                                         result
                                     );
                                 }
-                                _ => panic!(
+                                ResultEntity::Other => panic!(
                                     "Incorrect entity type returned from {}, expected BSON",
                                     operation.name
                                 ),
+                                ResultEntity::None => panic!("{} should return an entity", operation.name),
                             }
                         }
                     }

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -140,7 +140,8 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                         .execute_entity_operation(id, &mut test_runner)
                         .await;
 
-                    // Precache the BSON result, if any, so that other entities can be saved without cloning.
+                    // Precache the BSON result, if any, so that other entities can be saved without
+                    // cloning.
                     #[derive(Debug)]
                     enum ResultEntity {
                         Bson(Bson),
@@ -158,11 +159,7 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                     if let Some(ref id) = operation.save_result_as_entity {
                         match result {
                             Ok(Some(entity)) => {
-                                if test_runner
-                                    .entities
-                                    .insert(id.clone(), entity)
-                                    .is_some()
-                                {
+                                if test_runner.entities.insert(id.clone(), entity).is_some() {
                                     panic!("Entity with id {} already present in entity map", id);
                                 }
                             }
@@ -201,7 +198,9 @@ pub async fn run_unified_format_test(test_file: TestFile) {
                                     "Incorrect entity type returned from {}, expected BSON",
                                     operation.name
                                 ),
-                                ResultEntity::None => panic!("{} should return an entity", operation.name),
+                                ResultEntity::None => {
+                                    panic!("{} should return an entity", operation.name)
+                                }
                             }
                         }
                     }

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -597,7 +597,9 @@ impl TestOperation for Aggregate {
                             )
                             .await?
                         }
-                        AggregateEntity::Other(debug) => panic!("Cannot execute aggregate on {}", &debug),
+                        AggregateEntity::Other(debug) => {
+                            panic!("Cannot execute aggregate on {}", &debug)
+                        }
                     };
                     cursor
                         .stream(session)


### PR DESCRIPTION
RUST-1012

This was included for testing, i.e. so that `Entity` could continue to impl `Clone`; however, cloning a session is somewhere between meaningless and actively harmful.  Updated the few places where `Entity` was actually cloned to use one-off projections for the actual subtypes needed.