### PR TITLE
RUST-865 Verify correct cursor behavior with SBE

### DIFF
--- a/src/test/spec/command_monitoring/mod.rs
+++ b/src/test/spec/command_monitoring/mod.rs
@@ -47,7 +47,7 @@ async fn run_command_monitoring_test(test_file: TestFile) {
         "A successful mixed bulk write",
         "A successful unordered bulk write with an unacknowledged write concern",
         // We can't pass this test since it relies on old OP_QUERY behavior (SPEC-1519)
-        "A successful find event with a getmore and the server kills the cursor",
+        "A successful find event with a getmore and the server kills the cursor (<= 4.4)",
     ];
 
     for test_case in test_file.tests {

--- a/src/test/spec/json/command-monitoring/legacy/find.json
+++ b/src/test/spec/json/command-monitoring/legacy/find.json
@@ -413,8 +413,9 @@
       ]
     },
     {
-      "description": "A successful find event with a getmore and the server kills the cursor",
+      "description": "A successful find event with a getmore and the server kills the cursor (<= 4.4)",
       "ignore_if_server_version_less_than": "3.1",
+      "ignore_if_server_version_greater_than": "4.4",
       "ignore_if_topology_type": [
         "sharded"
       ],

--- a/src/test/spec/json/command-monitoring/legacy/find.yml
+++ b/src/test/spec/json/command-monitoring/legacy/find.yml
@@ -43,14 +43,13 @@ tests:
         filter: { _id: { $gt: 1 } }
         sort: { _id: 1 }
         skip: {"$numberLong": "2"}
-        modifiers:
-          $comment: "test"
-          $hint: { _id: 1 }
-          $max: { _id: 6 }
-          $maxTimeMS: 6000
-          $min: { _id: 0 }
-          $returnKey: false
-          $showDiskLoc: false
+        comment: "test"
+        hint: { _id: 1 }
+        max: { _id: 6 }
+        maxTimeMS: 6000
+        min: { _id: 0 }
+        returnKey: false
+        showRecordId: false
     expectations:
       -
         command_started_event:
@@ -195,8 +194,9 @@ tests:
               - { $numberLong: "42" }
           command_name: "killCursors"
   -
-    description: "A successful find event with a getmore and the server kills the cursor"
+    description: "A successful find event with a getmore and the server kills the cursor (<= 4.4)"
     ignore_if_server_version_less_than: "3.1"
+    ignore_if_server_version_greater_than: "4.4"
     ignore_if_topology_type:
       - "sharded"
     operation:

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -11,7 +11,7 @@ use tokio::sync::{
 
 use super::TestClient;
 use crate::{
-    bson::{doc, Document},
+    bson::doc,
     event::{
         cmap::{
             CmapEventHandler,

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -92,14 +92,6 @@ impl CommandEvent {
         }
     }
 
-    pub fn body(&self) -> Option<&Document> {
-        match self {
-            CommandEvent::Started(event) => Some(&event.command),
-            CommandEvent::Failed(_) => None,
-            CommandEvent::Succeeded(event) => Some(&event.reply),
-        }
-    }
-
     fn request_id(&self) -> i32 {
         match self {
             CommandEvent::Started(event) => event.request_id,
@@ -108,14 +100,14 @@ impl CommandEvent {
         }
     }
 
-    fn as_command_started(&self) -> Option<&CommandStartedEvent> {
+    pub fn as_command_started(&self) -> Option<&CommandStartedEvent> {
         match self {
             CommandEvent::Started(e) => Some(e),
             _ => None,
         }
     }
 
-    fn as_command_succeeded(&self) -> Option<&CommandSucceededEvent> {
+    pub fn as_command_succeeded(&self) -> Option<&CommandSucceededEvent> {
         match self {
             CommandEvent::Succeeded(e) => Some(e),
             _ => None,

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -11,7 +11,7 @@ use tokio::sync::{
 
 use super::TestClient;
 use crate::{
-    bson::doc,
+    bson::{doc, Document},
     event::{
         cmap::{
             CmapEventHandler,
@@ -89,6 +89,14 @@ impl CommandEvent {
             CommandEvent::Started(event) => event.command_name.as_str(),
             CommandEvent::Failed(event) => event.command_name.as_str(),
             CommandEvent::Succeeded(event) => event.command_name.as_str(),
+        }
+    }
+
+    pub fn body(&self) -> Option<&Document> {
+        match self {
+            CommandEvent::Started(event) => Some(&event.command),
+            CommandEvent::Failed(_) => None,
+            CommandEvent::Succeeded(event) => Some(&event.reply),
         }
     }
 


### PR DESCRIPTION
RUST-865

Switching find to use SBE (originally scheduled for 5.0, but delayed, see SERVER-59178) will cause a change in `getMore` behavior:  if a batch returned lines up precisely with the `limit`, that will currently exhaust the cursor (i.e. return `id: 0`), but with SBE it will not.  This requires drivers to either call `getMore` an additional time, which will return an empty batch and exhausted cursor, or call `killCursor`.

The Rust driver always loops until cursor exhaustion, so will work correctly post-SBE.  The test added in this PR validates that in this scenario the final `getMore` response is always exhausted.

Some spec tests will fail under the new behavior and have been updated to only run on <= 4.4; the Rust driver skips those tests because they rely on old behavior that the driver does not implement.  Synced those in case that ever changes and we stop skipping them.