### PR TITLE
minor: use new rustdoc:: warn prefix

### DIFF
--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -3,6 +3,6 @@
 set -o errexit
 
 . ~/.cargo/env
-cargo rustdoc -- -D warnings
-cargo rustdoc --no-default-features --features async-std-runtime -- -D warnings
-cargo rustdoc --no-default-features --features sync -- -D warnings
+cargo +nightly rustdoc -- -D warnings --cfg docsrs
+cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings --cfg docsrs
+cargo +nightly rustdoc --no-default-features --features sync -- -D warnings --cfg docsrs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,6 @@ macro_rules! define_if_single_runtime_enabled {
 // and warnings other than our custom ones.
 #[warn(renamed_and_removed_lints)]
 define_if_single_runtime_enabled! {
-
     #[macro_use]
     pub mod options;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@
 //! it will only happen in a minor or major version release.
 
 #![warn(missing_docs)]
-#![warn(missing_crate_level_docs)]
+#![warn(rustdoc::missing_crate_level_docs)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,9 +284,8 @@
 #![warn(missing_docs)]
 // `missing_crate_level_docs` was renamed with a `rustdoc::` prefix in rustc 1.55, but isn't
 // supported in the MSRV.
-// TODO: remove this if/when the MSRV is 1.55+.
-#![allow(renamed_and_removed_lints)]  
-#![warn(missing_crate_level_docs)]
+// TODO: remove the wrapping cfg_attr if/when the MSRV is 1.55+.
+#![cfg_attr(docsrs, warn(rustdoc::missing_crate_level_docs))]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(
@@ -316,7 +315,6 @@ macro_rules! define_if_single_runtime_enabled {
 
 // In the case that neither tokio nor async-std is enabled, we want to disable all compiler errors
 // and warnings other than our custom ones.
-#[warn(renamed_and_removed_lints)]
 define_if_single_runtime_enabled! {
     #[macro_use]
     pub mod options;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,8 @@
 //! it will only happen in a minor or major version release.
 
 #![warn(missing_docs)]
-#![warn(rustdoc::missing_crate_level_docs)]
+#![allow(renamed_and_removed_lints)]  // `missing_crate_level_docs` was renamed with a `rustdoc::` prefix
+#![warn(missing_crate_level_docs)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(
@@ -312,7 +313,9 @@ macro_rules! define_if_single_runtime_enabled {
 
 // In the case that neither tokio nor async-std is enabled, we want to disable all compiler errors
 // and warnings other than our custom ones.
+#[warn(renamed_and_removed_lints)]
 define_if_single_runtime_enabled! {
+
     #[macro_use]
     pub mod options;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,10 @@
 //! it will only happen in a minor or major version release.
 
 #![warn(missing_docs)]
-#![allow(renamed_and_removed_lints)]  // `missing_crate_level_docs` was renamed with a `rustdoc::` prefix
+// `missing_crate_level_docs` was renamed with a `rustdoc::` prefix in rustc 1.55, but isn't
+// supported in the MSRV.
+// TODO: remove this if/when the MSRV is 1.55+.
+#![allow(renamed_and_removed_lints)]  
 #![warn(missing_crate_level_docs)]
 #![cfg_attr(
     feature = "cargo-clippy",


### PR DESCRIPTION
The `missing_crate_level_docs` lint was renamed to `rustdoc::missing_crate_level_docs` in rustc 1.55; however, our MSRV doesn't recognize the latter.

Unfortunately, `cfg_attr` doesn't have compiler-provided attributes for compiler version, and the `rustversion` crate that provides macros for such can't be used because macro attributes aren't allowed in inner attribute position, so we're left with suppressing the warning.  I re-enabled it for modules in the crate so the potential surface for problems should be small. 