### PR TITLE
RUST-892 implement FromStr for ServerAddress

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2004,13 +2004,13 @@ mod tests {
     #[test]
     fn test_parse_address_with_from_str() {
         let x = "localhost:27017".parse::<ServerAddress>().unwrap();
-        let ServerAddress::Tcp{host, port} = x;
+        let ServerAddress::Tcp { host, port } = x;
         assert_eq!(host, "localhost");
         assert_eq!(port, Some(27017));
 
         // Port defaults to 27017 (so this doesn't fail)
         let x = "localhost".parse::<ServerAddress>().unwrap();
-        let ServerAddress::Tcp{host, port} = x;
+        let ServerAddress::Tcp { host, port } = x;
         assert_eq!(host, "localhost");
         assert_eq!(port, None);
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2001,6 +2001,23 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_parse_address_with_from_str() {
+        let x = "localhost:27017".parse::<ServerAddress>().unwrap();
+        let ServerAddress::Tcp{host, port} = x;
+        assert_eq!(host, "localhost");
+        assert_eq!(port, Some(27017));
+
+        // Port defaults to 27017 (so this doesn't fail)
+        let x = "localhost".parse::<ServerAddress>().unwrap();
+        let ServerAddress::Tcp{host, port} = x;
+        assert_eq!(host, "localhost");
+        assert_eq!(port, None);
+
+        let x = "localhost:not a number".parse::<ServerAddress>();
+        assert!(x.is_err());
+    }
+
     #[cfg_attr(feature = "tokio-runtime", tokio::test)]
     #[cfg_attr(feature = "async-std-runtime", async_std::test)]
     async fn fails_without_scheme() {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -168,6 +168,13 @@ impl Hash for ServerAddress {
     }
 }
 
+impl FromStr for ServerAddress {
+    type Err = crate::error::Error;
+    fn from_str(address: &str) -> Result<Self> {
+        ServerAddress::parse(address)
+    }
+}
+
 impl ServerAddress {
     /// Parses an address string into a `StreamAddress`.
     pub fn parse(address: impl AsRef<str>) -> Result<Self> {


### PR DESCRIPTION
Implement `FromStr` for `ServerAddress`.  Allows for calling `"a:1234".parse()` (this requires type annotations or turbofish syntax).