### PR TITLE
RUST-856 Fix race between server selection and server monitoring

### DIFF
--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -122,12 +122,14 @@ impl HeartbeatMonitor {
                 None => break,
             };
 
+            // subscribe to check requests before performing the check in case one comes in
+            // after the check completes
+            let mut topology_check_requests_subscriber =
+                topology.subscribe_to_topology_check_requests();
+
             if self.check_server(&topology, &server).await {
                 topology.notify_topology_changed();
             }
-
-            let mut topology_check_requests_subscriber =
-                topology.subscribe_to_topology_check_requests();
 
             // drop strong reference to topology before going back to sleep in case it drops off
             // in between checks.


### PR DESCRIPTION
RUST-856

This PR fixes a race between server selection requesting an update to the topology and a monitor subscribing to those requests, which occasionally would result in the `min_heartbeat_frequency` test failing.