### PR TITLE
RUST-954 Pin connections for transactions when connected to a load balancer

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -160,7 +160,8 @@ impl Client {
     {
         let mut details = self.execute_operation_with_details(op, session).await?;
         let pinned = if details.output.connection.is_pinned() {
-            // Cursor operations on load-balanced transactions will be pinned via the transaction pin.
+            // Cursor operations on load-balanced transactions will be pinned via the transaction
+            // pin.
             None
         } else {
             self.pin_connection_for_cursor(&mut details.output)?
@@ -325,17 +326,19 @@ impl Client {
             }
         };
 
-        let session_pinned = session.as_ref().and_then(|s| s.transaction.pinned_connection());
+        let session_pinned = session
+            .as_ref()
+            .and_then(|s| s.transaction.pinned_connection());
         let mut conn = match (session_pinned, op.pinned_connection()) {
             (Some(c), None) | (None, Some(c)) => c.take_connection().await?,
             (Some(c), Some(_)) => {
-                // An operation executing in a transaction should never have a pinned connection, but in case
-                // it does, prefer the transaction's pin.
+                // An operation executing in a transaction should never have a pinned connection,
+                // but in case it does, prefer the transaction's pin.
                 if cfg!(debug_assertions) {
                     panic!("pinned operation executing in pinned transaction");
                 }
                 c.take_connection().await?
-            },
+            }
             (None, None) => match server.pool.check_out().await {
                 Ok(c) => c,
                 Err(_) => return Err(first_error),

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -205,7 +205,7 @@ impl Client {
 
         let selection_criteria = session
             .as_ref()
-            .and_then(|s| s.transaction.pinned_mongos.as_ref())
+            .and_then(|s| s.transaction.pinned_mongos())
             .or_else(|| op.selection_criteria());
 
         let server = match self.select_server(selection_criteria).await {
@@ -816,7 +816,7 @@ impl Error {
             if self.contains_label(TRANSIENT_TRANSACTION_ERROR)
                 || self.contains_label(UNKNOWN_TRANSACTION_COMMIT_RESULT)
             {
-                session.unpin_mongos();
+                session.unpin();
             }
         }
 

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -159,12 +159,21 @@ impl Client {
         T: DeserializeOwned + Unpin + Send + Sync,
     {
         let mut details = self.execute_operation_with_details(op, session).await?;
-        let pinned = self.pin_connection_for_cursor(&mut details.output)?;
+        let pinned = if details.output.connection.is_pinned() {
+            // Cursor operations on load-balanced transactions will be pinned via the transaction pin.
+            None
+        } else {
+            self.pin_connection_for_cursor(&mut details.output)?
+        };
         Ok(SessionCursor::new(
             self.clone(),
             details.output.operation_output,
             pinned,
         ))
+    }
+
+    fn is_load_balanced(&self) -> bool {
+        self.inner.options.load_balanced.unwrap_or(false)
     }
 
     fn pin_connection_for_cursor<Op, T>(
@@ -174,8 +183,7 @@ impl Client {
     where
         Op: Operation<O = CursorSpecification<T>>,
     {
-        let is_load_balanced = self.inner.options.load_balanced.unwrap_or(false);
-        if is_load_balanced && details.operation_output.info.id != 0 {
+        if self.is_load_balanced() && details.operation_output.info.id != 0 {
             Ok(Some(details.connection.pin()?))
         } else {
             Ok(None)
@@ -317,9 +325,18 @@ impl Client {
             }
         };
 
-        let mut conn = match op.pinned_connection() {
-            Some(c) => c.take_connection().await?,
-            None => match server.pool.check_out().await {
+        let session_pinned = session.as_ref().and_then(|s| s.transaction.pinned_connection());
+        let mut conn = match (session_pinned, op.pinned_connection()) {
+            (Some(c), None) | (None, Some(c)) => c.take_connection().await?,
+            (Some(c), Some(_)) => {
+                // An operation executing in a transaction should never have a pinned connection, but in case
+                // it does, prefer the transaction's pin.
+                if cfg!(debug_assertions) {
+                    panic!("pinned operation executing in pinned transaction");
+                }
+                c.take_connection().await?
+            },
+            (None, None) => match server.pool.check_out().await {
                 Ok(c) => c,
                 Err(_) => return Err(first_error),
             },
@@ -411,7 +428,9 @@ impl Client {
                         cmd.set_start_transaction();
                         cmd.set_autocommit();
                         cmd.set_txn_read_concern(*session);
-                        if is_sharded {
+                        if self.is_load_balanced() {
+                            session.pin_connection(connection.pin()?);
+                        } else if is_sharded {
                             session.pin_mongos(connection.address().clone());
                         }
                         session.transaction.state = TransactionState::InProgress;

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -110,7 +110,7 @@ pub struct ClientSession {
     pub(crate) snapshot_time: Option<Timestamp>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct Transaction {
     pub(crate) state: TransactionState,
     pub(crate) options: Option<TransactionOptions>,
@@ -140,6 +140,15 @@ impl Transaction {
         self.options = None;
         self.pinned_mongos = None;
         self.recovery_token = None;
+    }
+
+    fn take(&mut self) -> Self {
+        Transaction {
+            state: self.state.clone(),
+            options: self.options.take(),
+            pinned_mongos: self.pinned_mongos.take(),
+            recovery_token: self.recovery_token.take(),
+        }
     }
 }
 
@@ -549,7 +558,7 @@ impl Drop for ClientSession {
                 client: self.client.clone(),
                 is_implicit: self.is_implicit,
                 options: self.options.clone(),
-                transaction: self.transaction.clone(),
+                transaction: self.transaction.take(),
                 snapshot_time: self.snapshot_time,
             };
             RUNTIME.execute(async move {

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -114,7 +114,7 @@ pub struct ClientSession {
 pub(crate) struct Transaction {
     pub(crate) state: TransactionState,
     pub(crate) options: Option<TransactionOptions>,
-    pub(crate) pinned_mongos: Option<SelectionCriteria>,
+    pub(crate) pinned: Option<TransactionPin>,
     pub(crate) recovery_token: Option<Document>,
 }
 
@@ -132,21 +132,28 @@ impl Transaction {
     pub(crate) fn abort(&mut self) {
         self.state = TransactionState::Aborted;
         self.options = None;
-        self.pinned_mongos = None;
+        self.pinned = None;
     }
 
     pub(crate) fn reset(&mut self) {
         self.state = TransactionState::None;
         self.options = None;
-        self.pinned_mongos = None;
+        self.pinned = None;
         self.recovery_token = None;
+    }
+
+    pub(crate) fn pinned_mongos(&self) -> Option<&SelectionCriteria> {
+        match &self.pinned {
+            Some(TransactionPin::Mongos(s)) => Some(s),
+            _ => None,
+        }
     }
 
     fn take(&mut self) -> Self {
         Transaction {
             state: self.state.clone(),
             options: self.options.take(),
-            pinned_mongos: self.pinned_mongos.take(),
+            pinned: self.pinned.take(),
             recovery_token: self.recovery_token.take(),
         }
     }
@@ -157,7 +164,7 @@ impl Default for Transaction {
         Self {
             state: TransactionState::None,
             options: None,
-            pinned_mongos: None,
+            pinned: None,
             recovery_token: None,
         }
     }
@@ -175,6 +182,11 @@ pub(crate) enum TransactionState {
         data_committed: bool,
     },
     Aborted,
+}
+
+#[derive(Debug)]
+pub(crate) enum TransactionPin {
+    Mongos(SelectionCriteria),
 }
 
 impl ClientSession {
@@ -265,13 +277,13 @@ impl ClientSession {
 
     /// Pin mongos to session.
     pub(crate) fn pin_mongos(&mut self, address: ServerAddress) {
-        self.transaction.pinned_mongos = Some(SelectionCriteria::Predicate(Arc::new(
+        self.transaction.pinned = Some(TransactionPin::Mongos(SelectionCriteria::Predicate(Arc::new(
             move |server_info: &ServerInfo| *server_info.address() == address,
-        )));
+        ))));
     }
 
-    pub(crate) fn unpin_mongos(&mut self) {
-        self.transaction.pinned_mongos = None;
+    pub(crate) fn unpin(&mut self) {
+        self.transaction.pinned = None;
     }
 
     /// Whether this session is dirty.
@@ -328,7 +340,7 @@ impl ClientSession {
                 .into());
             }
             TransactionState::Committed { .. } => {
-                self.unpin_mongos(); // Unpin session if previous transaction is committed.
+                self.unpin(); // Unpin session if previous transaction is committed.
             }
             _ => {}
         }
@@ -504,8 +516,7 @@ impl ClientSession {
                     .as_ref()
                     .and_then(|options| options.write_concern.as_ref())
                     .cloned();
-                let selection_criteria = self.transaction.pinned_mongos.clone();
-                let abort_transaction = AbortTransaction::new(write_concern, selection_criteria);
+                let abort_transaction = AbortTransaction::new(write_concern, self.transaction.pinned.take());
                 self.transaction.abort();
                 // Errors returned from running an abortTransaction command should be ignored.
                 let _result = self

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -286,9 +286,9 @@ impl ClientSession {
 
     /// Pin mongos to session.
     pub(crate) fn pin_mongos(&mut self, address: ServerAddress) {
-        self.transaction.pinned = Some(TransactionPin::Mongos(SelectionCriteria::Predicate(Arc::new(
-            move |server_info: &ServerInfo| *server_info.address() == address,
-        ))));
+        self.transaction.pinned = Some(TransactionPin::Mongos(SelectionCriteria::Predicate(
+            Arc::new(move |server_info: &ServerInfo| *server_info.address() == address),
+        )));
     }
 
     /// Pin the connection to the session.
@@ -530,7 +530,8 @@ impl ClientSession {
                     .as_ref()
                     .and_then(|options| options.write_concern.as_ref())
                     .cloned();
-                let abort_transaction = AbortTransaction::new(write_concern, self.transaction.pinned.take());
+                let abort_transaction =
+                    AbortTransaction::new(write_concern, self.transaction.pinned.take());
                 self.transaction.abort();
                 // Errors returned from running an abortTransaction command should be ignored.
                 let _result = self

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -313,6 +313,11 @@ impl Connection {
         })
     }
 
+    /// Whether this connection has a live `PinnedConnectionHandle`.
+    pub(crate) fn is_pinned(&self) -> bool {
+        self.pinned_sender.is_some()
+    }
+
     /// Close this connection, emitting a `ConnectionClosedEvent` with the supplied reason.
     pub(super) fn close_and_drop(mut self, reason: ConnectionClosedReason) {
         self.close(reason);

--- a/src/operation/abort_transaction/mod.rs
+++ b/src/operation/abort_transaction/mod.rs
@@ -3,7 +3,7 @@ use bson::Document;
 use crate::{
     bson::doc,
     client::session::TransactionPin,
-    cmap::{Command, conn::PinnedConnectionHandle, StreamDescription},
+    cmap::{conn::PinnedConnectionHandle, Command, StreamDescription},
     error::Result,
     operation::{Operation, Retryability},
     options::WriteConcern,
@@ -18,10 +18,7 @@ pub(crate) struct AbortTransaction {
 }
 
 impl AbortTransaction {
-    pub(crate) fn new(
-        write_concern: Option<WriteConcern>,
-        pinned: Option<TransactionPin>,
-    ) -> Self {
+    pub(crate) fn new(write_concern: Option<WriteConcern>, pinned: Option<TransactionPin>) -> Self {
         Self {
             write_concern,
             pinned,

--- a/src/operation/abort_transaction/mod.rs
+++ b/src/operation/abort_transaction/mod.rs
@@ -3,7 +3,7 @@ use bson::Document;
 use crate::{
     bson::doc,
     client::session::TransactionPin,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, conn::PinnedConnectionHandle, StreamDescription},
     error::Result,
     operation::{Operation, Retryability},
     options::WriteConcern,
@@ -62,6 +62,13 @@ impl Operation for AbortTransaction {
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {
         match &self.pinned {
             Some(TransactionPin::Mongos(s)) => Some(s),
+            _ => None,
+        }
+    }
+
+    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
+        match &self.pinned {
+            Some(TransactionPin::Connection(h)) => Some(h),
             _ => None,
         }
     }

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1077,8 +1077,8 @@ impl TestOperation for TargetedFailPoint {
             let session = test_runner.get_session(&self.session);
             let selection_criteria = session
                 .transaction
-                .pinned_mongos
-                .clone()
+                .pinned_mongos()
+                .cloned()
                 .unwrap_or_else(|| panic!("ClientSession not pinned"));
             let fail_point_guard = test_runner
                 .internal_client
@@ -1312,7 +1312,7 @@ impl TestOperation for AssertSessionPinned {
             assert!(test_runner
                 .get_session(&self.session)
                 .transaction
-                .pinned_mongos
+                .pinned_mongos()
                 .is_some());
         }
         .boxed()
@@ -1334,7 +1334,7 @@ impl TestOperation for AssertSessionUnpinned {
             assert!(test_runner
                 .get_session(&self.session)
                 .transaction
-                .pinned_mongos
+                .pinned_mongos()
                 .is_none());
         }
         .boxed()

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -263,8 +263,8 @@ pub async fn run_v2_test(test_file: TestFile) {
                             let selection_criteria = session
                                 .unwrap()
                                 .transaction
-                                .pinned_mongos
-                                .clone()
+                                .pinned_mongos()
+                                .cloned()
                                 .unwrap_or_else(|| panic!("ClientSession is not pinned"));
 
                             fail_point_guards.push(

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1056,7 +1056,7 @@ impl TestOperation for AssertSessionPinned {
         session: &'a mut ClientSession,
     ) -> BoxFuture<'a, Result<Option<Bson>>> {
         async move {
-            assert!(session.transaction.pinned_mongos.is_some());
+            assert!(session.transaction.pinned_mongos().is_some());
             Ok(None)
         }
         .boxed()
@@ -1072,7 +1072,7 @@ impl TestOperation for AssertSessionUnpinned {
         session: &'a mut ClientSession,
     ) -> BoxFuture<'a, Result<Option<Bson>>> {
         async move {
-            assert!(session.transaction.pinned_mongos.is_none());
+            assert!(session.transaction.pinned_mongos().is_none());
             Ok(None)
         }
         .boxed()


### PR DESCRIPTION
RUST-954

Transaction connection pinning [follows the same rules](https://github.com/mongodb/specifications/blob/master/source/load-balancers/load-balancers.rst#behaviour-with-transactions) as mongos pinning for sharded transactions, so this CL augments that machinery to be able to track a `PinnedConnectionHandle`.

The load balancer spec requires the drivers to track whether a connection is checked out for a cursor vs a transaction vs anything else for the purpose of augmenting the `WaitQueueTimeoutError` message; however, the Rust driver does not support wait queue timeouts, so I've omitted that tracking.