### PR TITLE
RUST-952 Emit SDAM events for load balanced topologies

### DIFF
--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -177,20 +177,6 @@ impl ServerDescription {
         description
     }
 
-    pub(crate) fn new_load_balancer(mut address: ServerAddress) -> Self {
-        address = ServerAddress::Tcp {
-            host: address.host().to_lowercase(),
-            port: address.port(),
-        };
-        Self {
-            address,
-            server_type: ServerType::LoadBalancer,
-            last_update_time: None,
-            reply: Ok(None),
-            average_round_trip_time: None,
-        }
-    }
-
     /// Whether this server is "available" as per the definition in the server selection spec.
     pub(crate) fn is_available(&self) -> bool {
         self.server_type.is_available()

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -141,13 +141,7 @@ impl TopologyDescription {
             .hosts
             .into_iter()
             .map(|address| {
-                let description = if topology_type == TopologyType::LoadBalanced {
-                    ServerDescription::new_load_balancer(address.clone())
-                } else {
-                    ServerDescription::new(address.clone(), None)
-                };
-
-                (address, description)
+                (address.clone(), ServerDescription::new(address, None))
             })
             .collect();
 

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -140,9 +140,7 @@ impl TopologyDescription {
         let servers: HashMap<_, _> = options
             .hosts
             .into_iter()
-            .map(|address| {
-                (address.clone(), ServerDescription::new(address, None))
-            })
+            .map(|address| (address.clone(), ServerDescription::new(address, None)))
             .collect();
 
         let session_support_status = if topology_type == TopologyType::LoadBalanced {

--- a/src/sdam/state/mod.rs
+++ b/src/sdam/state/mod.rs
@@ -219,12 +219,15 @@ impl Topology {
                 };
                 handler.handle_server_opening_event(event);
                 if is_load_balanced {
-                    // Load-balanced clients don't have a heartbeat monitor, so we synthesize updating the server to `ServerType::LoadBalancer`.
+                    // Load-balanced clients don't have a heartbeat monitor, so we synthesize
+                    // updating the server to `ServerType::LoadBalancer`.
                     let new_desc = ServerDescription {
                         server_type: ServerType::LoadBalancer,
                         ..ServerDescription::new(server_address.clone(), None)
                     };
-                    topology_state.update(new_desc, &options, topology.downgrade()).map_err(Error::internal)?;
+                    topology_state
+                        .update(new_desc, &options, topology.downgrade())
+                        .map_err(Error::internal)?;
                 }
             }
         }


### PR DESCRIPTION
RUST-952

Some SDAM events are triggered by the heartbeat monitor, which is disabled when connected to a load balancer; this PR synthesizes those events.