### PR TITLE
RUST-1020 Track `bson` master branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ aws-auth = ["reqwest"]
 async-trait = "0.1.42"
 base64 = "0.13.0"
 bitflags = "1.1.0"
-bson = "2.0.0"
+bson = { git = "https://github.com/mongodb/bson-rust", branch = "master" }
 chrono = "0.4.7"
 derivative = "2.1.1"
 futures-core = "0.3.14"


### PR DESCRIPTION
RUST-1020

This PR updates the `Cargo.toml` to track the master branch of the `bson` repo. This will allow our tests and benchmarks to pull in the latest changes from `bson` since the last release. 

I think in general we should have a policy of always tracking the master of bson right up until the release to ensure we have full coverage. Once we need to do a release, we can switch to the latest `bson` release, and then immediately afterwards we can go back to tracking master.