### PR TITLE
RUST-807 Disallow maxPoolSize=0

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -449,8 +449,7 @@ pub struct ClientOptions {
     /// The maximum amount of connections that the Client should allow to be created in a
     /// connection pool for a given server. If an operation is attempted on a server while
     /// `max_pool_size` connections are checked out, the operation will block until an in-progress
-    /// operation finishes and its connection is checked back into the pool.  A value of 0 means no
-    /// limit.
+    /// operation finishes and its connection is checked back into the pool.
     ///
     /// The default value is 100.
     #[builder(default)]
@@ -1177,6 +1176,12 @@ impl ClientOptions {
             for compressor in compressors {
                 compressor.validate()?;
             }
+        }
+
+        if let Some(0) = self.max_pool_size {
+            return Err(crate::error::Error::invalid_argument(
+                "cannot specify maxPoolSize=0",
+            ));
         }
 
         Ok(())

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -53,6 +53,8 @@ async fn run_test(test_file: TestFile) {
                         )
                     )
                 )
+            // The Rust driver disallows `maxPoolSize=0`.
+            || test_case.description.contains("maxPoolSize=0 does not error")
         {
             continue;
         }

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -65,7 +65,7 @@ pub(crate) struct ConnectionPoolOptions {
     pub(crate) max_idle_time: Option<Duration>,
 
     /// The maximum number of connections that the pool can have at a given time. This includes
-    /// connections which are currently checked out of the pool.  A value of 0 means no limit.
+    /// connections which are currently checked out of the pool.
     ///
     /// The default is 10.
     pub(crate) max_pool_size: Option<u32>,

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -109,7 +109,7 @@ pub(crate) struct ConnectionPoolWorker {
     /// The maximum number of connections that the pool can manage, including connections checked
     /// out of the pool. If a thread requests a connection and the pool is empty + there are
     /// already max_pool_size connections in use, it will block until one is returned or the
-    /// wait_queue_timeout is exceeded.  A value of 0 means no limit.
+    /// wait_queue_timeout is exceeded.
     max_pool_size: u32,
 
     /// Receiver used to determine if any threads hold references to this pool. If all the
@@ -341,7 +341,7 @@ impl ConnectionPoolWorker {
     }
 
     fn below_max_connections(&self) -> bool {
-        self.max_pool_size == 0 || self.total_connection_count < self.max_pool_size
+        self.total_connection_count < self.max_pool_size
     }
 
     fn can_service_connection_request(&self) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,13 @@ impl Error {
         .into()
     }
 
+    pub(crate) fn invalid_argument(message: impl Into<String>) -> Error {
+        ErrorKind::InvalidArgument {
+            message: message.into(),
+        }
+        .into()
+    }
+
     pub(crate) fn is_state_change_error(&self) -> bool {
         self.is_recovering() || self.is_not_master()
     }

--- a/src/event/cmap.rs
+++ b/src/event/cmap.rs
@@ -48,7 +48,7 @@ pub struct ConnectionPoolOptions {
     pub max_idle_time: Option<Duration>,
 
     /// The maximum number of connections that the pool can have at a given time. This includes
-    /// connections which are currently checked out of the pool.  A value of 0 means no limit.
+    /// connections which are currently checked out of the pool.
     ///
     /// The default is 100.
     pub max_pool_size: Option<u32>,


### PR DESCRIPTION
RUST-807

This disallows `maxPoolSize=0` and merges the relevant updated spec tests for `minPoolSize`/`maxPoolSize`, skipping the one for `maxPoolSize=0`.