### PR TITLE
minor: add snippets for connecting with sync API and x509 authentication

### DIFF
--- a/tests/connection_snippets.rs
+++ b/tests/connection_snippets.rs
@@ -5,16 +5,104 @@
 extern crate mongodb;
 
 #[cfg(feature = "tokio-runtime")]
-// CONNECTION EXAMPLE STARTS HERE
-#[tokio::main]
-async fn main() -> mongodb::error::Result<()> {
+mod async_scram {
+    // ASYNC SCRAM CONNECTION EXAMPLE STARTS HERE
     use mongodb::{options::ClientOptions, Client};
-    let client_options = ClientOptions::parse(
-        "mongodb+srv://<username>:<password>@<cluster-url>/<dbname>?w=majority",
-    )
-    .await?;
-    let client = Client::with_options(client_options)?;
-    let database = client.database("test");
-    Ok(())
+
+    #[tokio::main]
+    async fn main() -> mongodb::error::Result<()> {
+        let client_options = ClientOptions::parse(
+            "mongodb+srv://<username>:<password>@<cluster-url>/<dbname>?w=majority",
+        )
+        .await?;
+        let client = Client::with_options(client_options)?;
+        let database = client.database("test");
+        // do something with database
+
+        Ok(())
+    }
+    // CONNECTION EXAMPLE ENDS HERE
 }
-// CONNECTION EXAMPLE ENDS HERE
+
+#[cfg(feature = "tokio-runtime")]
+mod async_x509 {
+    // ASYNC X509 CONNECTION EXAMPLE STARTS HERE
+    use mongodb::{
+        options::{AuthMechanism, ClientOptions, Credential, Tls, TlsOptions},
+        Client,
+    };
+    use std::path::PathBuf;
+
+    #[tokio::main]
+    async fn main() -> mongodb::error::Result<()> {
+        let mut client_options =
+            ClientOptions::parse("mongodb+srv://<cluster-url>/<dbname>?w=majority").await?;
+        client_options.credential = Some(
+            Credential::builder()
+                .mechanism(AuthMechanism::MongoDbX509)
+                .build(),
+        );
+        let tls_options = TlsOptions::builder()
+            .ca_file_path(PathBuf::from("/path/to/ca-cert"))
+            .cert_key_file_path(PathBuf::from("/path/to/cert"))
+            .build();
+        client_options.tls = Some(Tls::Enabled(tls_options));
+        let client = Client::with_options(client_options)?;
+
+        let database = client.database("test");
+        // do something with database
+
+        Ok(())
+    }
+    // CONNECTION EXAMPLE ENDS HERE
+}
+
+#[cfg(feature = "sync")]
+mod sync_scram {
+    // SYNC SCRAM CONNECTION EXAMPLE STARTS HERE
+    use mongodb::{options::ClientOptions, sync::Client};
+
+    fn main() -> mongodb::error::Result<()> {
+        let client_options = ClientOptions::parse(
+            "mongodb+srv://<username>:<password>@<cluster-url>/<dbname>?w=majority",
+        )?;
+        let client = Client::with_options(client_options)?;
+        let database = client.database("test");
+        // do something with database
+
+        Ok(())
+    }
+    // CONNECTION EXAMPLE ENDS HERE
+}
+
+#[cfg(feature = "sync")]
+mod sync_x509 {
+    // SYNC X509 CONNECTION EXAMPLE STARTS HERE
+    use mongodb::{
+        options::{AuthMechanism, ClientOptions, Credential, Tls, TlsOptions},
+        sync::Client,
+    };
+    use std::path::PathBuf;
+
+    fn main() -> mongodb::error::Result<()> {
+        let mut client_options =
+            ClientOptions::parse("mongodb+srv://<cluster-url>/<dbname>?w=majority")?;
+        client_options.credential = Some(
+            Credential::builder()
+                .mechanism(AuthMechanism::MongoDbX509)
+                .build(),
+        );
+        let tls_options = TlsOptions::builder()
+            .ca_file_path(PathBuf::from("/path/to/ca-cert"))
+            .cert_key_file_path(PathBuf::from("/path/to/cert"))
+            .build();
+        client_options.tls = Some(Tls::Enabled(tls_options));
+        let client = Client::with_options(client_options)?;
+
+        let database = client.database("test");
+        // do something with database
+
+        Ok(())
+    }
+    // CONNECTION EXAMPLE ENDS HERE
+}


### PR DESCRIPTION
This PR adds a few connection examples for connecting with the sync API and also or connecting with x509 authentication. These will be included in the connect modal in the Atlas UI.