### PR TITLE
RUST-48 Causal consistency support

### DIFF
--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -391,7 +391,9 @@ impl Client {
             .update_command_with_read_pref(connection.address(), &mut cmd, op.selection_criteria())
             .await;
 
-        if let ReadConcernSupport::Supported(Some(rc)) = op.read_concern_support() {
+        if let ReadConcernSupport::Supported(Some(rc)) =
+            op.read_concern_support(&stream_description)
+        {
             cmd.set_read_concern(rc.clone());
         }
 
@@ -432,7 +434,7 @@ impl Client {
                         session.transaction.state,
                         TransactionState::None | TransactionState::Starting
                     )
-                    && op.read_concern_support().is_supported()
+                    && op.read_concern_support(&stream_description).is_supported()
                 {
                     cmd.set_after_cluster_time(session);
                 }

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -427,7 +427,7 @@ impl Client {
                         session.transaction.state,
                         TransactionState::None | TransactionState::Starting
                     )
-                    && op.supports_read_concern(&stream_description)
+                    && op.supports_read_concern(stream_description)
                 {
                     cmd.set_after_cluster_time(session);
                 }

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -436,7 +436,12 @@ impl Client {
                     TransactionState::Starting => {
                         cmd.set_start_transaction();
                         cmd.set_autocommit();
-                        cmd.set_txn_read_concern(*session);
+
+                        if let Some(ref options) = session.transaction.options {
+                            if let Some(ref read_concern) = options.read_concern {
+                                cmd.set_read_concern_level(read_concern.level.clone());
+                            }
+                        }
                         if self.is_load_balanced() {
                             session.pin_connection(connection.pin()?);
                         } else if is_sharded {

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -417,17 +417,21 @@ impl Client {
                     }
                     cmd.set_snapshot_read_concern(session);
                 }
-                // If this is a causally consistent session, set `readConcern.afterClusterTime`. Causal consistency
-                // defaults to true, unless snapshot is true.
+                // If this is a causally consistent session, set `readConcern.afterClusterTime`.
+                // Causal consistency defaults to true, unless snapshot is true.
                 else if session
                     .options()
                     .and_then(|opts| opts.causal_consistency)
                     .unwrap_or(true)
-                    && matches!(session.transaction.state, TransactionState::None|TransactionState::Starting)
+                    && matches!(
+                        session.transaction.state,
+                        TransactionState::None | TransactionState::Starting
+                    )
                     && op.supports_read_concern()
                 {
                     cmd.set_after_cluster_time(session);
                 }
+
                 match session.transaction.state {
                     TransactionState::Starting => {
                         cmd.set_start_transaction();

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -30,7 +30,6 @@ use crate::{
         CommandResponse,
         CommitTransaction,
         Operation,
-        ReadConcernSupport,
         Response,
         Retryability,
     },
@@ -391,12 +390,6 @@ impl Client {
             .update_command_with_read_pref(connection.address(), &mut cmd, op.selection_criteria())
             .await;
 
-        if let ReadConcernSupport::Supported(Some(rc)) =
-            op.read_concern_support(&stream_description)
-        {
-            cmd.set_read_concern(rc.clone());
-        }
-
         match session {
             Some(ref mut session) if op.supports_sessions() && op.is_acknowledged() => {
                 cmd.set_session(session);
@@ -434,7 +427,7 @@ impl Client {
                         session.transaction.state,
                         TransactionState::None | TransactionState::Starting
                     )
-                    && op.read_concern_support(&stream_description).is_supported()
+                    && op.supports_read_concern(&stream_description)
                 {
                     cmd.set_after_cluster_time(session);
                 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -242,6 +242,9 @@ impl Client {
 
     /// Starts a new `ClientSession`.
     pub async fn start_session(&self, options: Option<SessionOptions>) -> Result<ClientSession> {
+        if let Some(ref options) = options {
+            options.validate()?;
+        }
         match self.get_session_support_status().await? {
             SessionSupportStatus::Supported {
                 logical_session_timeout,

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1480,7 +1480,7 @@ impl ClientOptionsParser {
                     credential.source = options
                         .auth_source
                         .clone()
-                        .or(db.clone())
+                        .or_else(|| db.clone())
                         .or_else(|| Some("admin".into()));
                 } else if authentication_requested {
                     return Err(ErrorKind::InvalidArgument {
@@ -2410,7 +2410,7 @@ impl SessionOptions {
         {
             if causal_consistency && snapshot {
                 return Err(ErrorKind::InvalidArgument {
-                    message: format!("snapshot and causal consistency are mutually exclusive"),
+                    message: "snapshot and causal consistency are mutually exclusive".to_string(),
                 }
                 .into());
             }

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -466,6 +466,7 @@ pub struct ClientOptions {
     /// Specifies the default read concern for operations performed on the Client. See the
     /// ReadConcern type documentation for more details.
     #[builder(default)]
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 
     /// The name of the replica set that the Client should connect to.

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -466,7 +466,6 @@ pub struct ClientOptions {
     /// Specifies the default read concern for operations performed on the Client. See the
     /// ReadConcern type documentation for more details.
     #[builder(default)]
-    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 
     /// The name of the replica set that the Client should connect to.

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2393,8 +2393,7 @@ pub struct SessionOptions {
 
     /// If true, all operations performed in the context of this session
     /// will be [causally consistent](https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/).
-    /// Note that causally consistent reads will NOT be causally consistent with respect to
-    /// unacknowledged writes.
+    ///
     /// Defaults to true.
     pub causal_consistency: Option<bool>,
 
@@ -2406,7 +2405,8 @@ pub struct SessionOptions {
 
 impl SessionOptions {
     pub(crate) fn validate(&self) -> Result<()> {
-        if let (Some(causal_consistency), Some(snapshot)) = (self.causal_consistency, self.snapshot) {
+        if let (Some(causal_consistency), Some(snapshot)) = (self.causal_consistency, self.snapshot)
+        {
             if causal_consistency && snapshot {
                 return Err(ErrorKind::InvalidArgument {
                     message: format!("snapshot and causal consistency are mutually exclusive"),

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2391,10 +2391,31 @@ pub struct SessionOptions {
     /// associated with the operations within the transaction.
     pub default_transaction_options: Option<TransactionOptions>,
 
+    /// If true, all operations performed in the context of this session
+    /// will be [causally consistent](https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/).
+    /// Note that causally consistent reads will NOT be causally consistent with respect to
+    /// unacknowledged writes.
+    /// Defaults to true.
+    pub causal_consistency: Option<bool>,
+
     /// If true, all read operations performed using this client session will share the same
     /// snapshot.  Defaults to false.
     // TODO RUST-18 enforce snapshot exclusivity with causalConsistency.
     pub snapshot: Option<bool>,
+}
+
+impl SessionOptions {
+    pub(crate) fn validate(&self) -> Result<()> {
+        if let (Some(causal_consistency), Some(snapshot)) = (self.causal_consistency, self.snapshot) {
+            if causal_consistency && snapshot {
+                return Err(ErrorKind::InvalidArgument {
+                    message: format!("snapshot and causal consistency are mutually exclusive"),
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Contains the options that can be used for a transaction.

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2394,12 +2394,11 @@ pub struct SessionOptions {
     /// If true, all operations performed in the context of this session
     /// will be [causally consistent](https://docs.mongodb.com/manual/core/causal-consistency-read-write-concerns/).
     ///
-    /// Defaults to true.
+    /// Defaults to true if [`SessionOptions::snapshot`] is unspecified.
     pub causal_consistency: Option<bool>,
 
     /// If true, all read operations performed using this client session will share the same
     /// snapshot.  Defaults to false.
-    // TODO RUST-18 enforce snapshot exclusivity with causalConsistency.
     pub snapshot: Option<bool>,
 }
 

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -259,6 +259,21 @@ impl ClientSession {
         }
     }
 
+    /// Advance operation time for this session. If the provided timestamp is earlier than this
+    /// session's current operation time, then the operation time is unchanged.
+    pub fn advance_operation_time(&mut self, ts: Timestamp) {
+        self.operation_time = match self.operation_time {
+            Some(current_op_time) if current_op_time < ts => Some(ts),
+            None => Some(ts),
+            _ => self.operation_time,
+        }
+    }
+
+    /// The operation time returned by the last operation executed in this session.
+    pub fn operation_time(&self) -> Option<Timestamp> {
+        self.operation_time
+    }
+
     /// Mark this session (and the underlying server session) as dirty.
     pub(crate) fn mark_dirty(&mut self) {
         self.server_session.dirty = true;
@@ -273,15 +288,6 @@ impl ClientSession {
     /// Gets the current txn_number.
     pub(crate) fn txn_number(&self) -> i64 {
         self.server_session.txn_number
-    }
-
-    /// Advance operation time
-    pub(crate) fn advance_operation_time(&mut self, ts: Timestamp) {
-        self.operation_time = match self.operation_time {
-            Some(current_op_time) if current_op_time < ts => Some(ts),
-            None => Some(ts),
-            _ => self.operation_time,
-        }
     }
 
     /// Increments the txn_number.

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -533,65 +533,118 @@ async fn for_each_op_with_session<F>(
         .database(test_name)
         .collection::<bson::Document>(test_name);
     let initial_operation_time = session.operation_time;
-    coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
     test_func("insert", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session).await.unwrap();
+    coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
+        .await
+        .unwrap();
     test_func("insert", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session).await.unwrap();
+    coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
+        .await
+        .unwrap();
     test_func("update", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session).await.unwrap();
+    coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+        .await
+        .unwrap();
     test_func("update", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session).await.unwrap();
+    coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+        .await
+        .unwrap();
     test_func("update", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
     test_func("delete", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
     test_func("delete", &client, &session, initial_operation_time, false);
 
     let initial_operation_time = session.operation_time;
-    coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
-    test_func("findAndModify", &client, &session, initial_operation_time, false);
+    coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "findAndModify",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
 
     let initial_operation_time = session.operation_time;
-    coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session).await.unwrap();
-    test_func("findAndModify", &client, &session, initial_operation_time, false);
+    coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "findAndModify",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
 
     let initial_operation_time = session.operation_time;
-    coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session).await.unwrap();
-    test_func("findAndModify", &client, &session, initial_operation_time, false);
+    coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "findAndModify",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
 
     let initial_operation_time = session.operation_time;
-    coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session).await.unwrap();
-    test_func("aggregate", &client, &session, initial_operation_time, false);
+    coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "aggregate",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
 
     let initial_operation_time = session.operation_time;
-    coll.find_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    coll.find_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
     test_func("find", &client, &session, initial_operation_time, true);
 
     let initial_operation_time = session.operation_time;
-    coll.find_one_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
     test_func("find", &client, &session, initial_operation_time, true);
 
     let initial_operation_time = session.operation_time;
-    coll.distinct_with_session("x", None, None, &mut session).await.unwrap();
+    coll.distinct_with_session("x", None, None, &mut session)
+        .await
+        .unwrap();
     test_func("distinct", &client, &session, initial_operation_time, true);
 
     let initial_operation_time = session.operation_time;
-    coll.count_documents_with_session(None, None, &mut session).await.unwrap();
+    coll.count_documents_with_session(None, None, &mut session)
+        .await
+        .unwrap();
     test_func("aggregate", &client, &session, initial_operation_time, true);
-
 }
 
 /// Tests 1-4 of the causal consistency specs
@@ -612,15 +665,13 @@ async fn test_causal_consistency() {
         session: &ClientSession,
         initial_operation_time: Option<Timestamp>,
         is_read: bool,
-    )
-    {
+    ) {
         let (command_started, command_ended) =
             client.get_successful_command_execution(command_name);
 
-        println!("{}", command_started.command);
-
-        // Assert that the sent readConcern.afterClusterTime matches the session.operationTime (on a read)
-       if is_read {
+        // Assert that the sent readConcern.afterClusterTime matches the session.operationTime (on a
+        // read)
+        if is_read {
             assert_eq!(
                 command_started
                     .command
@@ -644,8 +695,11 @@ async fn test_causal_consistency() {
     let session = client.start_session(None).await.unwrap();
     assert!(session.operation_time.is_none());
 
-
-
-    for_each_op_with_session(function_name!(), session_operation_time_test, client, session).await;
-
+    for_each_op_with_session(
+        function_name!(),
+        session_operation_time_test,
+        client,
+        session,
+    )
+    .await;
 }

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, time::Duration};
 
-use bson::Document;
+use bson::{Document, Timestamp};
 use futures::stream::StreamExt;
 use tokio::sync::RwLockReadGuard;
 
@@ -10,6 +10,7 @@ use crate::{
     options::{Acknowledgment, FindOptions, InsertOneOptions, ReadPreference, WriteConcern},
     selection_criteria::SelectionCriteria,
     test::{EventClient, TestClient, CLIENT_OPTIONS, LOCK},
+    ClientSession,
     Collection,
     RUNTIME,
 };
@@ -517,4 +518,134 @@ async fn find_and_getmore_share_session() {
     for read_pref in read_preferences {
         run_test(&client, &coll, read_pref).await;
     }
+}
+
+async fn for_each_op_with_session<F>(
+    test_name: &str,
+    test_func: F,
+    client: EventClient,
+    mut session: ClientSession,
+) where
+    F: Fn(&str, &EventClient, &ClientSession, Option<Timestamp>, bool) -> (),
+{
+    // collection operations
+    let coll = client
+        .database(test_name)
+        .collection::<bson::Document>(test_name);
+    let initial_operation_time = session.operation_time;
+    coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    test_func("insert", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session).await.unwrap();
+    test_func("insert", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session).await.unwrap();
+    test_func("update", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session).await.unwrap();
+    test_func("update", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session).await.unwrap();
+    test_func("update", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    test_func("delete", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    test_func("delete", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    test_func("findAndModify", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session).await.unwrap();
+    test_func("findAndModify", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session).await.unwrap();
+    test_func("findAndModify", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session).await.unwrap();
+    test_func("aggregate", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    test_func("find", &client, &session, initial_operation_time, true);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_with_session(doc! { "x": 1 }, None, &mut session).await.unwrap();
+    test_func("find", &client, &session, initial_operation_time, true);
+
+    let initial_operation_time = session.operation_time;
+    coll.distinct_with_session("x", None, None, &mut session).await.unwrap();
+    test_func("distinct", &client, &session, initial_operation_time, true);
+
+    let initial_operation_time = session.operation_time;
+    coll.count_documents_with_session(None, None, &mut session).await.unwrap();
+    test_func("aggregate", &client, &session, initial_operation_time, true);
+
+}
+
+/// Tests 1-4 of the causal consistency specs
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn test_causal_consistency() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = TestClient::new().await;
+    if client.is_standalone() {
+        return;
+    }
+
+    fn session_operation_time_test(
+        command_name: &str,
+        client: &EventClient,
+        session: &ClientSession,
+        initial_operation_time: Option<Timestamp>,
+        is_read: bool,
+    )
+    {
+        let (command_started, command_ended) =
+            client.get_successful_command_execution(command_name);
+
+        println!("{}", command_started.command);
+
+        // Assert that the sent readConcern.afterClusterTime matches the session.operationTime (on a read)
+       if is_read {
+            assert_eq!(
+                command_started
+                    .command
+                    .get_document("readConcern")
+                    .expect("no readConcern field found in command")
+                    .get_timestamp("afterClusterTime")
+                    .expect("no readConcern.afterClusterTime field found in command"),
+                initial_operation_time.unwrap(),
+            );
+        }
+
+        // Assert that after the command is completed, session.operationTime matches the
+        // operationTime field of the response
+        assert_eq!(
+            command_ended.reply.get_timestamp("operationTime").unwrap(),
+            session.operation_time.unwrap()
+        )
+    }
+
+    let client = EventClient::new().await;
+    let session = client.start_session(None).await.unwrap();
+    assert!(session.operation_time.is_none());
+
+
+
+    for_each_op_with_session(function_name!(), session_operation_time_test, client, session).await;
+
 }

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -1,0 +1,727 @@
+use bson::{doc, Document, Timestamp};
+use futures::{future::BoxFuture, FutureExt};
+use tokio::sync::RwLockReadGuard;
+
+use crate::{
+    client::options::{ClientOptions, SessionOptions},
+    coll::options::CollectionOptions,
+    error::Result,
+    options::ReadConcern,
+    test::{CommandEvent, EventClient, LOCK},
+    ClientSession,
+    Collection,
+};
+
+type OperationFn =
+    Box<dyn FnOnce(Collection<Document>, &mut ClientSession) -> BoxFuture<Result<()>>>;
+
+struct Operation {
+    name: &'static str,
+    fut: OperationFn,
+    is_read: bool,
+}
+
+impl Operation {
+    async fn execute<'a>(
+        self,
+        coll: Collection<Document>,
+        session: &'a mut ClientSession,
+    ) -> Result<()> {
+        (self.fut)(coll, session).await
+    }
+}
+
+fn for_each_op_with_session_gen() -> impl IntoIterator<Item = Operation> {
+    let mut ops = vec![];
+
+    let f: OperationFn = Box::new({
+        move |c, s| {
+            async move {
+                c.insert_one_with_session(doc! { "x": 1 }, None, s)
+                    .await
+                    .map(|_| ())
+            }
+            .boxed()
+        }
+    });
+    ops.push(Operation {
+        fut: f,
+        name: "insert",
+        is_read: false,
+    });
+
+    ops.push(Operation {
+        fut: Box::new({
+            move |coll, s| {
+                async move {
+                    coll.find_one_with_session(doc! { "x": 1 }, None, s)
+                        .await
+                        .map(|_| ())
+                }
+                .boxed()
+            }
+        }),
+        name: "find",
+        is_read: true,
+    });
+
+    ops
+}
+
+// // collection operations
+// let coll = client
+//     .database(test_name)
+//     .collection::<bson::Document>(test_name);
+// let initial_operation_time = session.operation_time;
+// coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("insert", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("insert", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("update", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("update", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("update", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("delete", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("delete", &client, &session, initial_operation_time, false);
+
+// let initial_operation_time = session.operation_time;
+// coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func(
+//     "findAndModify",
+//     &client,
+//     &session,
+//     initial_operation_time,
+//     false,
+// );
+
+// let initial_operation_time = session.operation_time;
+// coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func(
+//     "findAndModify",
+//     &client,
+//     &session,
+//     initial_operation_time,
+//     false,
+// );
+
+// let initial_operation_time = session.operation_time;
+// coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func(
+//     "findAndModify",
+//     &client,
+//     &session,
+//     initial_operation_time,
+//     false,
+// );
+
+// let initial_operation_time = session.operation_time;
+// coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
+//     .await
+//     .unwrap();
+// test_func(
+//     "aggregate",
+//     &client,
+//     &session,
+//     initial_operation_time,
+//     false,
+// );
+
+// let initial_operation_time = session.operation_time;
+// coll.find_with_session(doc! { "x": 1 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("find", &client, &session, initial_operation_time, true);
+
+// let initial_operation_time = session.operation_time;
+// coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("find", &client, &session, initial_operation_time, true);
+
+// let initial_operation_time = session.operation_time;
+// coll.distinct_with_session("x", None, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("distinct", &client, &session, initial_operation_time, true);
+
+// let initial_operation_time = session.operation_time;
+// coll.count_documents_with_session(None, None, &mut session)
+//     .await
+//     .unwrap();
+// test_func("aggregate", &client, &session, initial_operation_time, true);
+
+async fn for_each_op_with_session<F>(
+    test_name: &str,
+    test_func: F,
+    client: EventClient,
+    mut session: ClientSession,
+) where
+    F: Fn(&str, &EventClient, &ClientSession, Option<Timestamp>, bool) -> (),
+{
+    // collection operations
+    let coll = client
+        .database(test_name)
+        .collection::<bson::Document>(test_name);
+    let initial_operation_time = session.operation_time;
+    coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("insert", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
+        .await
+        .unwrap();
+    test_func("insert", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("update", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("update", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("update", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("delete", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("delete", &client, &session, initial_operation_time, false);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "findAndModify",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "findAndModify",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "findAndModify",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
+
+    let initial_operation_time = session.operation_time;
+    coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
+        .await
+        .unwrap();
+    test_func(
+        "aggregate",
+        &client,
+        &session,
+        initial_operation_time,
+        false,
+    );
+
+    let initial_operation_time = session.operation_time;
+    coll.find_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("find", &client, &session, initial_operation_time, true);
+
+    let initial_operation_time = session.operation_time;
+    coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
+        .await
+        .unwrap();
+    test_func("find", &client, &session, initial_operation_time, true);
+
+    let initial_operation_time = session.operation_time;
+    coll.distinct_with_session("x", None, None, &mut session)
+        .await
+        .unwrap();
+    test_func("distinct", &client, &session, initial_operation_time, true);
+
+    let initial_operation_time = session.operation_time;
+    coll.count_documents_with_session(None, None, &mut session)
+        .await
+        .unwrap();
+    test_func("aggregate", &client, &session, initial_operation_time, true);
+}
+
+/// Test 1 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn new_session_operation_time_null() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let session = client.start_session(None).await.unwrap();
+    assert!(session.operation_time().is_none());
+}
+
+/// Test 2 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn first_read_no_after_cluser_time() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let mut session = client
+        .start_session(Some(
+            SessionOptions::builder().causal_consistency(true).build(),
+        ))
+        .await
+        .unwrap();
+    assert!(session.operation_time().is_none());
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| o.is_read)
+    {
+        let name = op.name;
+        op.execute(
+            client
+                .database("causal_consistency_2")
+                .collection("causal_consistency_2"),
+            &mut session,
+        )
+        .await
+        .unwrap();
+        let (started, _) = client.get_successful_command_execution(name);
+
+        // assert that no read concern was set.
+        started.command.get_document("readConcern").unwrap_err();
+    }
+}
+
+/// Test 3 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn first_op_update_op_time() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let mut session = client
+        .start_session(Some(
+            SessionOptions::builder().causal_consistency(true).build(),
+        ))
+        .await
+        .unwrap();
+    assert!(session.operation_time().is_none());
+
+    for op in for_each_op_with_session_gen() {
+        let name = op.name;
+        op.execute(
+            client
+                .database("causal_consistency_3")
+                .collection("causal_consistency_3"),
+            &mut session,
+        )
+        .await
+        .unwrap();
+
+        let event = client
+            .get_command_events(&[name])
+            .into_iter()
+            .filter(|e| matches!(e, CommandEvent::Succeeded(_) | CommandEvent::Failed(_)))
+            .next()
+            .unwrap();
+
+        match event {
+            CommandEvent::Succeeded(s) => {
+                let op_time = s.reply.get_timestamp("operationTime").unwrap();
+                assert_eq!(session.operation_time().unwrap(), op_time);
+            }
+            CommandEvent::Failed(f) => {
+                assert!(session.operation_time().is_some());
+            }
+            _ => panic!("should have been succeeded or failed"),
+        }
+    }
+}
+
+/// Test 4 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn read_includes_after_cluster_time() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_4")
+        .collection::<Document>("causal_consistency_4");
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| o.is_read)
+    {
+        let command_name = op.name;
+        let mut session = client.start_session(None).await.unwrap();
+        coll.find_one_with_session(None, None, &mut session)
+            .await
+            .unwrap();
+        let op_time = session.operation_time().unwrap();
+        op.execute(coll.clone(), &mut session).await.unwrap();
+
+        let command_started = client
+            .get_command_started_events(&[command_name])
+            .pop()
+            .unwrap();
+
+        assert_eq!(
+            command_started
+                .command
+                .get_document("readConcern")
+                .expect("no readConcern field found in command")
+                .get_timestamp("afterClusterTime")
+                .expect("no readConcern.afterClusterTime field found in command"),
+            op_time,
+        );
+    }
+}
+
+/// Test 5 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn find_after_write_includes_after_cluster_time() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_5")
+        .collection::<Document>("causal_consistency_5");
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| !o.is_read)
+    {
+        let command_name = op.name;
+
+        let session_options = SessionOptions::builder().causal_consistency(true).build();
+        let mut session = client.start_session(Some(session_options)).await.unwrap();
+        op.execute(coll.clone(), &mut session).await.unwrap();
+        let op_time = session.operation_time().unwrap();
+        coll.find_one_with_session(None, None, &mut session)
+            .await
+            .unwrap();
+
+        let command_started = client.get_command_started_events(&["find"]).pop().unwrap();
+        assert_eq!(
+            command_started
+                .command
+                .get_document("readConcern")
+                .expect("no readConcern field found in command")
+                .get_timestamp("afterClusterTime")
+                .expect("no readConcern.afterClusterTime field found in command"),
+            op_time,
+        );
+    }
+}
+
+/// Test 6 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn not_causally_consitent_omits_after_cluster_time() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_6")
+        .collection::<Document>("causal_consistency_6");
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| o.is_read)
+    {
+        let command_name = op.name;
+
+        let session_options = SessionOptions::builder().causal_consistency(false).build();
+        let mut session = client.start_session(Some(session_options)).await.unwrap();
+        op.execute(coll.clone(), &mut session).await.unwrap();
+
+        let command_started = client
+            .get_command_started_events(&[command_name])
+            .pop()
+            .unwrap();
+        command_started
+            .command
+            .get_document("readConcern")
+            .unwrap_err();
+    }
+}
+
+/// Test 7 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn omit_after_cluster_time_standalone() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if !client.is_standalone() {
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_7")
+        .collection::<Document>("causal_consistency_7");
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| o.is_read)
+    {
+        let command_name = op.name;
+
+        let session_options = SessionOptions::builder().causal_consistency(true).build();
+        let mut session = client.start_session(Some(session_options)).await.unwrap();
+        op.execute(coll.clone(), &mut session).await.unwrap();
+
+        let command_started = client
+            .get_command_started_events(&[command_name])
+            .pop()
+            .unwrap();
+        command_started
+            .command
+            .get_document("readConcern")
+            .unwrap_err();
+    }
+}
+
+/// Test 8 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+#[function_name::named]
+async fn omit_default_read_concern_level() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+
+    if client.is_standalone() {
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_8")
+        .collection::<Document>("causal_consistency_8");
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| o.is_read)
+    {
+        let command_name = op.name;
+
+        let session_options = SessionOptions::builder().causal_consistency(true).build();
+        let mut session = client.start_session(Some(session_options)).await.unwrap();
+        coll.find_one_with_session(None, None, &mut session)
+            .await
+            .unwrap();
+        let op_time = session.operation_time().unwrap();
+        op.execute(coll.clone(), &mut session).await.unwrap();
+
+        let command_started = client
+            .get_command_started_events(&[command_name])
+            .pop()
+            .unwrap();
+        let rc_doc = command_started.command.get_document("readConcern").unwrap();
+
+        rc_doc.get_str("level").unwrap_err();
+        assert_eq!(rc_doc.get_timestamp("afterClusterTime").unwrap(), op_time);
+    }
+}
+
+/// Test 9 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn test_causal_consistency_read_concern_merge_gen() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let options = ClientOptions::builder()
+        .read_concern(ReadConcern::majority())
+        .build();
+    let client = EventClient::with_options(options).await;
+    if client.is_standalone() {
+        println!(
+            "skipping test_causal_consistency_read_concern_merge due to unsupported topology: \
+             standalone"
+        );
+        return;
+    }
+
+    let session_options = SessionOptions::builder().causal_consistency(true).build();
+    let mut session = client.start_session(Some(session_options)).await.unwrap();
+
+    let coll_options = CollectionOptions::builder()
+        .read_concern(ReadConcern::majority())
+        .build();
+    let coll = client
+        .database("causal_consistency_9")
+        .collection_with_options("causal_consistency_9", coll_options);
+
+    for op in for_each_op_with_session_gen()
+        .into_iter()
+        .filter(|o| o.is_read)
+    {
+        let initial_operation_time = session.operation_time();
+        let is_read = op.is_read;
+        let command_name = op.name;
+        coll.find_one_with_session(None, None, &mut session)
+            .await
+            .unwrap();
+        let op_time = session.operation_time().unwrap();
+        op.execute(coll.clone(), &mut session).await.unwrap();
+
+        let command_started = client
+            .get_command_started_events(&[command_name])
+            .pop()
+            .unwrap();
+        let rc_doc = command_started
+            .command
+            .get_document("readConcern")
+            .expect(format!("{} did not include read concern", command_name).as_str());
+
+        assert_eq!(rc_doc.get_str("level").unwrap(), "majority");
+        assert_eq!(rc_doc.get_timestamp("afterClusterTime").unwrap(), op_time);
+    }
+}
+
+/// Test 11 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn omit_cluster_time_standalone() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+    if !client.is_standalone() {
+        println!("skipping omit_cluster_time_standalone due to unsupported topology");
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_11")
+        .collection::<Document>("causal_consistency_11");
+
+    coll.find_one(None, None).await.unwrap();
+
+    let (started, _) = client.get_successful_command_execution("find");
+    started.command.get_document("$clusterTime").unwrap_err();
+}
+
+/// Test 12 from the causal consistency specification.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn cluster_time_send_in_commands() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+    if client.is_standalone() {
+        println!("skipping cluster_time_sent_in_commands due to unsupported topology");
+        return;
+    }
+
+    let coll = client
+        .database("causal_consistency_12")
+        .collection::<Document>("causal_consistency_12");
+
+    coll.find_one(None, None).await.unwrap();
+
+    let (started, _) = client.get_successful_command_execution("find");
+    started.command.get_document("$clusterTime").unwrap();
+}

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -186,12 +186,12 @@ async fn first_read_no_after_cluser_time() {
         let name = op.name;
         op.execute(
             client
-                .database("causal_consistency_2")
-                .collection("causal_consistency_2"),
+                .create_fresh_collection("causal_consistency_2", "causal_consistency_2", None)
+                .await,
             &mut session,
         )
         .await
-        .unwrap();
+        .unwrap_or_else(|e| panic!("{} failed: {}", name, e));
         let (started, _) = client.get_successful_command_execution(name);
 
         // assert that no read concern was set.
@@ -223,8 +223,8 @@ async fn first_op_update_op_time() {
         let name = op.name;
         op.execute(
             client
-                .database("causal_consistency_3")
-                .collection("causal_consistency_3"),
+                .create_fresh_collection("causal_consistency_3", "causal_consistency_3", None)
+                .await,
             &mut session,
         )
         .await
@@ -265,8 +265,8 @@ async fn read_includes_after_cluster_time() {
     }
 
     let coll = client
-        .database("causal_consistency_4")
-        .collection::<Document>("causal_consistency_4");
+        .create_fresh_collection("causal_consistency_4", "causal_consistency_4", None)
+        .await;
 
     for op in all_session_ops().into_iter().filter(|o| o.is_read) {
         let command_name = op.name;
@@ -312,8 +312,8 @@ async fn find_after_write_includes_after_cluster_time() {
     }
 
     let coll = client
-        .database("causal_consistency_5")
-        .collection::<Document>("causal_consistency_5");
+        .create_fresh_collection("causal_consistency_5", "causal_consistency_5", None)
+        .await;
 
     for op in all_session_ops().into_iter().filter(|o| !o.is_read) {
         let session_options = SessionOptions::builder().causal_consistency(true).build();
@@ -355,8 +355,8 @@ async fn not_causally_consistent_omits_after_cluster_time() {
     }
 
     let coll = client
-        .database("causal_consistency_6")
-        .collection::<Document>("causal_consistency_6");
+        .create_fresh_collection("causal_consistency_6", "causal_consistency_6", None)
+        .await;
 
     for op in all_session_ops().into_iter().filter(|o| o.is_read) {
         let command_name = op.name;
@@ -391,8 +391,8 @@ async fn omit_after_cluster_time_standalone() {
     }
 
     let coll = client
-        .database("causal_consistency_7")
-        .collection::<Document>("causal_consistency_7");
+        .create_fresh_collection("causal_consistency_7", "causal_consistency_7", None)
+        .await;
 
     for op in all_session_ops().into_iter().filter(|o| o.is_read) {
         let command_name = op.name;
@@ -429,8 +429,8 @@ async fn omit_default_read_concern_level() {
     }
 
     let coll = client
-        .database("causal_consistency_8")
-        .collection::<Document>("causal_consistency_8");
+        .create_fresh_collection("causal_consistency_8", "causal_consistency_8", None)
+        .await;
 
     for op in all_session_ops().into_iter().filter(|o| o.is_read) {
         let command_name = op.name;
@@ -475,6 +475,9 @@ async fn test_causal_consistency_read_concern_merge() {
     let coll_options = CollectionOptions::builder()
         .read_concern(ReadConcern::majority())
         .build();
+    let _ = client
+        .create_fresh_collection("causal_consistency_9", "causal_consistency_9", None)
+        .await;
     let coll = client
         .database("causal_consistency_9")
         .collection_with_options("causal_consistency_9", coll_options);

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -42,7 +42,7 @@ macro_rules! op {
     };
 }
 
-fn all_session_ops() -> impl IntoIterator<Item = Operation> {
+fn all_session_ops() -> impl Iterator<Item = Operation> {
     let mut ops = vec![];
 
     ops.push(op!("insert", false, |coll, session| {
@@ -138,7 +138,7 @@ fn all_session_ops() -> impl IntoIterator<Item = Operation> {
         s,
     )));
 
-    ops
+    ops.into_iter()
 }
 
 /// Test 1 from the causal consistency specification.
@@ -175,7 +175,7 @@ async fn first_read_no_after_cluser_time() {
         return;
     }
 
-    for op in all_session_ops().into_iter().filter(|o| o.is_read) {
+    for op in all_session_ops().filter(|o| o.is_read) {
         let mut session = client
             .start_session(Some(
                 SessionOptions::builder().causal_consistency(true).build(),
@@ -268,7 +268,7 @@ async fn read_includes_after_cluster_time() {
         .create_fresh_collection("causal_consistency_4", "causal_consistency_4", None)
         .await;
 
-    for op in all_session_ops().into_iter().filter(|o| o.is_read) {
+    for op in all_session_ops().filter(|o| o.is_read) {
         let command_name = op.name;
         let mut session = client.start_session(None).await.unwrap();
         coll.find_one_with_session(None, None, &mut session)
@@ -315,7 +315,7 @@ async fn find_after_write_includes_after_cluster_time() {
         .create_fresh_collection("causal_consistency_5", "causal_consistency_5", None)
         .await;
 
-    for op in all_session_ops().into_iter().filter(|o| !o.is_read) {
+    for op in all_session_ops().filter(|o| !o.is_read) {
         let session_options = SessionOptions::builder().causal_consistency(true).build();
         let mut session = client.start_session(Some(session_options)).await.unwrap();
         op.execute(coll.clone(), &mut session).await.unwrap();
@@ -358,7 +358,7 @@ async fn not_causally_consistent_omits_after_cluster_time() {
         .create_fresh_collection("causal_consistency_6", "causal_consistency_6", None)
         .await;
 
-    for op in all_session_ops().into_iter().filter(|o| o.is_read) {
+    for op in all_session_ops().filter(|o| o.is_read) {
         let command_name = op.name;
 
         let session_options = SessionOptions::builder().causal_consistency(false).build();
@@ -394,7 +394,7 @@ async fn omit_after_cluster_time_standalone() {
         .create_fresh_collection("causal_consistency_7", "causal_consistency_7", None)
         .await;
 
-    for op in all_session_ops().into_iter().filter(|o| o.is_read) {
+    for op in all_session_ops().filter(|o| o.is_read) {
         let command_name = op.name;
 
         let session_options = SessionOptions::builder().causal_consistency(true).build();
@@ -432,7 +432,7 @@ async fn omit_default_read_concern_level() {
         .create_fresh_collection("causal_consistency_8", "causal_consistency_8", None)
         .await;
 
-    for op in all_session_ops().into_iter().filter(|o| o.is_read) {
+    for op in all_session_ops().filter(|o| o.is_read) {
         let command_name = op.name;
 
         let session_options = SessionOptions::builder().causal_consistency(true).build();
@@ -482,7 +482,7 @@ async fn test_causal_consistency_read_concern_merge() {
         .database("causal_consistency_9")
         .collection_with_options("causal_consistency_9", coll_options);
 
-    for op in all_session_ops().into_iter().filter(|o| o.is_read) {
+    for op in all_session_ops().filter(|o| o.is_read) {
         let command_name = op.name;
         coll.find_one_with_session(None, None, &mut session)
             .await

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -1,4 +1,4 @@
-use bson::{doc, Document, Timestamp};
+use bson::{doc, Document};
 use futures::{future::BoxFuture, FutureExt};
 use tokio::sync::RwLockReadGuard;
 
@@ -22,11 +22,7 @@ struct Operation {
 }
 
 impl Operation {
-    async fn execute<'a>(
-        self,
-        coll: Collection<Document>,
-        session: &'a mut ClientSession,
-    ) -> Result<()> {
+    async fn execute(self, coll: Collection<Document>, session: &mut ClientSession) -> Result<()> {
         (self.fut)(coll, session).await
     }
 }
@@ -186,132 +182,132 @@ fn for_each_op_with_session_gen() -> impl IntoIterator<Item = Operation> {
 //     .unwrap();
 // test_func("aggregate", &client, &session, initial_operation_time, true);
 
-async fn for_each_op_with_session<F>(
-    test_name: &str,
-    test_func: F,
-    client: EventClient,
-    mut session: ClientSession,
-) where
-    F: Fn(&str, &EventClient, &ClientSession, Option<Timestamp>, bool) -> (),
-{
-    // collection operations
-    let coll = client
-        .database(test_name)
-        .collection::<bson::Document>(test_name);
-    let initial_operation_time = session.operation_time;
-    coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("insert", &client, &session, initial_operation_time, false);
+// async fn for_each_op_with_session<F>(
+//     test_name: &str,
+//     test_func: F,
+//     client: EventClient,
+//     mut session: ClientSession,
+// ) where
+//     F: Fn(&str, &EventClient, &ClientSession, Option<Timestamp>, bool),
+// {
+//     // collection operations
+//     let coll = client
+//         .database(test_name)
+//         .collection::<bson::Document>(test_name);
+//     let initial_operation_time = session.operation_time;
+//     coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("insert", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
-        .await
-        .unwrap();
-    test_func("insert", &client, &session, initial_operation_time, false);
+//     let initial_operation_time = session.operation_time;
+//     coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("insert", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("update", &client, &session, initial_operation_time, false);
+//     let initial_operation_time = session.operation_time;
+//     coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("update", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("update", &client, &session, initial_operation_time, false);
+//     let initial_operation_time = session.operation_time;
+//     coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("update", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("update", &client, &session, initial_operation_time, false);
+//     let initial_operation_time = session.operation_time;
+//     coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("update", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("delete", &client, &session, initial_operation_time, false);
+//     let initial_operation_time = session.operation_time;
+//     coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("delete", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("delete", &client, &session, initial_operation_time, false);
+//     let initial_operation_time = session.operation_time;
+//     coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("delete", &client, &session, initial_operation_time, false);
 
-    let initial_operation_time = session.operation_time;
-    coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func(
-        "findAndModify",
-        &client,
-        &session,
-        initial_operation_time,
-        false,
-    );
+//     let initial_operation_time = session.operation_time;
+//     coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func(
+//         "findAndModify",
+//         &client,
+//         &session,
+//         initial_operation_time,
+//         false,
+//     );
 
-    let initial_operation_time = session.operation_time;
-    coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session)
-        .await
-        .unwrap();
-    test_func(
-        "findAndModify",
-        &client,
-        &session,
-        initial_operation_time,
-        false,
-    );
+//     let initial_operation_time = session.operation_time;
+//     coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut
+// session)         .await
+//         .unwrap();
+//     test_func(
+//         "findAndModify",
+//         &client,
+//         &session,
+//         initial_operation_time,
+//         false,
+//     );
 
-    let initial_operation_time = session.operation_time;
-    coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
-        .await
-        .unwrap();
-    test_func(
-        "findAndModify",
-        &client,
-        &session,
-        initial_operation_time,
-        false,
-    );
+//     let initial_operation_time = session.operation_time;
+//     coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func(
+//         "findAndModify",
+//         &client,
+//         &session,
+//         initial_operation_time,
+//         false,
+//     );
 
-    let initial_operation_time = session.operation_time;
-    coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
-        .await
-        .unwrap();
-    test_func(
-        "aggregate",
-        &client,
-        &session,
-        initial_operation_time,
-        false,
-    );
+//     let initial_operation_time = session.operation_time;
+//     coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func(
+//         "aggregate",
+//         &client,
+//         &session,
+//         initial_operation_time,
+//         false,
+//     );
 
-    let initial_operation_time = session.operation_time;
-    coll.find_with_session(doc! { "x": 1 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("find", &client, &session, initial_operation_time, true);
+//     let initial_operation_time = session.operation_time;
+//     coll.find_with_session(doc! { "x": 1 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("find", &client, &session, initial_operation_time, true);
 
-    let initial_operation_time = session.operation_time;
-    coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
-        .await
-        .unwrap();
-    test_func("find", &client, &session, initial_operation_time, true);
+//     let initial_operation_time = session.operation_time;
+//     coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("find", &client, &session, initial_operation_time, true);
 
-    let initial_operation_time = session.operation_time;
-    coll.distinct_with_session("x", None, None, &mut session)
-        .await
-        .unwrap();
-    test_func("distinct", &client, &session, initial_operation_time, true);
+//     let initial_operation_time = session.operation_time;
+//     coll.distinct_with_session("x", None, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("distinct", &client, &session, initial_operation_time, true);
 
-    let initial_operation_time = session.operation_time;
-    coll.count_documents_with_session(None, None, &mut session)
-        .await
-        .unwrap();
-    test_func("aggregate", &client, &session, initial_operation_time, true);
-}
+//     let initial_operation_time = session.operation_time;
+//     coll.count_documents_with_session(None, None, &mut session)
+//         .await
+//         .unwrap();
+//     test_func("aggregate", &client, &session, initial_operation_time, true);
+// }
 
 /// Test 1 from the causal consistency specification.
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -403,8 +399,7 @@ async fn first_op_update_op_time() {
         let event = client
             .get_command_events(&[name])
             .into_iter()
-            .filter(|e| matches!(e, CommandEvent::Succeeded(_) | CommandEvent::Failed(_)))
-            .next()
+            .find(|e| matches!(e, CommandEvent::Succeeded(_) | CommandEvent::Failed(_)))
             .unwrap();
 
         match event {
@@ -412,7 +407,7 @@ async fn first_op_update_op_time() {
                 let op_time = s.reply.get_timestamp("operationTime").unwrap();
                 assert_eq!(session.operation_time().unwrap(), op_time);
             }
-            CommandEvent::Failed(f) => {
+            CommandEvent::Failed(_f) => {
                 assert!(session.operation_time().is_some());
             }
             _ => panic!("should have been succeeded or failed"),
@@ -486,8 +481,6 @@ async fn find_after_write_includes_after_cluster_time() {
         .into_iter()
         .filter(|o| !o.is_read)
     {
-        let command_name = op.name;
-
         let session_options = SessionOptions::builder().causal_consistency(true).build();
         let mut session = client.start_session(Some(session_options)).await.unwrap();
         op.execute(coll.clone(), &mut session).await.unwrap();
@@ -630,7 +623,7 @@ async fn omit_default_read_concern_level() {
 /// Test 9 from the causal consistency specification.
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn test_causal_consistency_read_concern_merge_gen() {
+async fn test_causal_consistency_read_concern_merge() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let options = ClientOptions::builder()
@@ -659,8 +652,6 @@ async fn test_causal_consistency_read_concern_merge_gen() {
         .into_iter()
         .filter(|o| o.is_read)
     {
-        let initial_operation_time = session.operation_time();
-        let is_read = op.is_read;
         let command_name = op.name;
         coll.find_one_with_session(None, None, &mut session)
             .await
@@ -675,7 +666,7 @@ async fn test_causal_consistency_read_concern_merge_gen() {
         let rc_doc = command_started
             .command
             .get_document("readConcern")
-            .expect(format!("{} did not include read concern", command_name).as_str());
+            .unwrap_or_else(|_| panic!("{} did not include read concern", command_name));
 
         assert_eq!(rc_doc.get_str("level").unwrap(), "majority");
         assert_eq!(rc_doc.get_timestamp("afterClusterTime").unwrap(), op_time);

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -3,7 +3,7 @@ use futures::{future::BoxFuture, FutureExt};
 use tokio::sync::RwLockReadGuard;
 
 use crate::{
-    client::options::{ClientOptions, SessionOptions},
+    client::options::SessionOptions,
     coll::options::CollectionOptions,
     error::Result,
     options::ReadConcern,

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -141,251 +141,6 @@ fn all_session_ops() -> impl IntoIterator<Item = Operation> {
     ops
 }
 
-// // collection operations
-// let coll = client
-//     .database(test_name)
-//     .collection::<bson::Document>(test_name);
-// let initial_operation_time = session.operation_time;
-// coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("insert", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("insert", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("update", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("update", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("update", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("delete", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("delete", &client, &session, initial_operation_time, false);
-
-// let initial_operation_time = session.operation_time;
-// coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func(
-//     "findAndModify",
-//     &client,
-//     &session,
-//     initial_operation_time,
-//     false,
-// );
-
-// let initial_operation_time = session.operation_time;
-// coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func(
-//     "findAndModify",
-//     &client,
-//     &session,
-//     initial_operation_time,
-//     false,
-// );
-
-// let initial_operation_time = session.operation_time;
-// coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func(
-//     "findAndModify",
-//     &client,
-//     &session,
-//     initial_operation_time,
-//     false,
-// );
-
-// let initial_operation_time = session.operation_time;
-// coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
-//     .await
-//     .unwrap();
-// test_func(
-//     "aggregate",
-//     &client,
-//     &session,
-//     initial_operation_time,
-//     false,
-// );
-
-// let initial_operation_time = session.operation_time;
-// coll.find_with_session(doc! { "x": 1 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("find", &client, &session, initial_operation_time, true);
-
-// let initial_operation_time = session.operation_time;
-// coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("find", &client, &session, initial_operation_time, true);
-
-// let initial_operation_time = session.operation_time;
-// coll.distinct_with_session("x", None, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("distinct", &client, &session, initial_operation_time, true);
-
-// let initial_operation_time = session.operation_time;
-// coll.count_documents_with_session(None, None, &mut session)
-//     .await
-//     .unwrap();
-// test_func("aggregate", &client, &session, initial_operation_time, true);
-
-// async fn for_each_op_with_session<F>(
-//     test_name: &str,
-//     test_func: F,
-//     client: EventClient,
-//     mut session: ClientSession,
-// ) where
-//     F: Fn(&str, &EventClient, &ClientSession, Option<Timestamp>, bool),
-// {
-//     // collection operations
-//     let coll = client
-//         .database(test_name)
-//         .collection::<bson::Document>(test_name);
-//     let initial_operation_time = session.operation_time;
-//     coll.insert_one_with_session(doc! { "x": 1 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("insert", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.insert_many_with_session(vec![doc! { "x": 1 }], None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("insert", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.replace_one_with_session(doc! { "x": 1 }, doc! { "x": 2 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("update", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.update_one_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("update", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.update_many_with_session(doc! {}, doc! { "$inc": {"x": 5 } }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("update", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.delete_one_with_session(doc! { "x": 1 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("delete", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.delete_many_with_session(doc! { "x": 1 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("delete", &client, &session, initial_operation_time, false);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.find_one_and_delete_with_session(doc! { "x": 1 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func(
-//         "findAndModify",
-//         &client,
-//         &session,
-//         initial_operation_time,
-//         false,
-//     );
-
-//     let initial_operation_time = session.operation_time;
-//     coll.find_one_and_update_with_session(doc! {}, doc! { "$inc": { "x": 1 } }, None, &mut
-// session)         .await
-//         .unwrap();
-//     test_func(
-//         "findAndModify",
-//         &client,
-//         &session,
-//         initial_operation_time,
-//         false,
-//     );
-
-//     let initial_operation_time = session.operation_time;
-//     coll.find_one_and_replace_with_session(doc! {}, doc! {"x": 1}, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func(
-//         "findAndModify",
-//         &client,
-//         &session,
-//         initial_operation_time,
-//         false,
-//     );
-
-//     let initial_operation_time = session.operation_time;
-//     coll.aggregate_with_session(vec![doc! { "$match": { "x": 1 } }], None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func(
-//         "aggregate",
-//         &client,
-//         &session,
-//         initial_operation_time,
-//         false,
-//     );
-
-//     let initial_operation_time = session.operation_time;
-//     coll.find_with_session(doc! { "x": 1 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("find", &client, &session, initial_operation_time, true);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.find_one_with_session(doc! { "x": 1 }, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("find", &client, &session, initial_operation_time, true);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.distinct_with_session("x", None, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("distinct", &client, &session, initial_operation_time, true);
-
-//     let initial_operation_time = session.operation_time;
-//     coll.count_documents_with_session(None, None, &mut session)
-//         .await
-//         .unwrap();
-//     test_func("aggregate", &client, &session, initial_operation_time, true);
-// }
-
 /// Test 1 from the causal consistency specification.
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
@@ -395,6 +150,9 @@ async fn new_session_operation_time_null() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!(
+            "skipping new_session_operation_time_null due to unsupported topology: standalone"
+        );
         return;
     }
 
@@ -411,6 +169,9 @@ async fn first_read_no_after_cluser_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!(
+            "skipping first_read_no_after_cluser_time due to unsupported topology: standalone"
+        );
         return;
     }
 
@@ -447,6 +208,7 @@ async fn first_op_update_op_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!("skipping first_op_update_op_time due to unsupported topology: standalone");
         return;
     }
 
@@ -496,6 +258,9 @@ async fn read_includes_after_cluster_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!(
+            "skipping read_includes_after_cluster_time due to unsupported topology: standalone"
+        );
         return;
     }
 
@@ -539,6 +304,10 @@ async fn find_after_write_includes_after_cluster_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!(
+            "skipping find_after_write_includes_after_cluster_time due to unsupported topology: \
+             standalone"
+        );
         return;
     }
 
@@ -572,12 +341,16 @@ async fn find_after_write_includes_after_cluster_time() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[function_name::named]
-async fn not_causally_consitent_omits_after_cluster_time() {
+async fn not_causally_consistent_omits_after_cluster_time() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!(
+            "skipping not_causally_consistent_omits_after_cluster_time due to unsupported \
+             topology: standalone"
+        );
         return;
     }
 
@@ -613,6 +386,7 @@ async fn omit_after_cluster_time_standalone() {
     let client = EventClient::new().await;
 
     if !client.is_standalone() {
+        println!("skipping omit_after_cluster_time_standalone due to unsupported topology");
         return;
     }
 
@@ -648,6 +422,9 @@ async fn omit_default_read_concern_level() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
+        println!(
+            "skipping omit_default_read_concern_level due to unsupported topology: standalone"
+        );
         return;
     }
 
@@ -683,10 +460,7 @@ async fn omit_default_read_concern_level() {
 async fn test_causal_consistency_read_concern_merge() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
-    let options = ClientOptions::builder()
-        .read_concern(ReadConcern::majority())
-        .build();
-    let client = EventClient::with_options(options).await;
+    let client = EventClient::new().await;
     if client.is_standalone() {
         println!(
             "skipping test_causal_consistency_read_concern_merge due to unsupported topology: \
@@ -752,7 +526,7 @@ async fn omit_cluster_time_standalone() {
 /// Test 12 from the causal consistency specification.
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn cluster_time_send_in_commands() {
+async fn cluster_time_sent_in_commands() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -2,26 +2,16 @@ mod causal_consistency;
 
 use std::{future::Future, time::Duration};
 
-use bson::{Document, Timestamp};
-use futures::{future::BoxFuture, stream::StreamExt, FutureExt};
+use bson::Document;
+use futures::stream::StreamExt;
 use tokio::sync::RwLockReadGuard;
 
 use crate::{
     bson::{doc, Bson},
-    client::options::{ClientOptions, SessionOptions},
-    coll::options::CollectionOptions,
     error::Result,
-    options::{
-        Acknowledgment,
-        FindOptions,
-        InsertOneOptions,
-        ReadConcern,
-        ReadPreference,
-        WriteConcern,
-    },
+    options::{Acknowledgment, FindOptions, InsertOneOptions, ReadPreference, WriteConcern},
     selection_criteria::SelectionCriteria,
-    test::{CommandEvent, EventClient, TestClient, CLIENT_OPTIONS, LOCK},
-    ClientSession,
+    test::{EventClient, TestClient, CLIENT_OPTIONS, LOCK},
     Collection,
     RUNTIME,
 };

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -3,7 +3,16 @@ use std::time::Duration;
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::wire::Message;
-use crate::{ClientSession, bson::Document, client::{options::ServerApi, ClusterTime, HELLO_COMMAND_NAMES, REDACTED_COMMANDS}, error::{Error, ErrorKind, Result}, is_master::{IsMasterCommandResponse, IsMasterReply}, operation::{CommandErrorBody, CommandResponse, Response}, options::{ReadConcernLevel, ReadConcernInternal, ServerAddress}, selection_criteria::ReadPreference};
+use crate::{
+    bson::Document,
+    client::{options::ServerApi, ClusterTime, HELLO_COMMAND_NAMES, REDACTED_COMMANDS},
+    error::{Error, ErrorKind, Result},
+    is_master::{IsMasterCommandResponse, IsMasterReply},
+    operation::{CommandErrorBody, CommandResponse, Response},
+    options::{ReadConcernInternal, ReadConcernLevel, ServerAddress},
+    selection_criteria::ReadPreference,
+    ClientSession,
+};
 
 /// A command that has been serialized to BSON.
 #[derive(Debug)]
@@ -130,10 +139,10 @@ impl<T> Command<T> {
 
     pub(crate) fn set_after_cluster_time(&mut self, session: &ClientSession) {
         let inner = self.read_concern.get_or_insert(ReadConcernInternal {
-                level: None,
-                at_cluster_time: None,
-                after_cluster_time: None,
-            });
+            level: None,
+            at_cluster_time: None,
+            after_cluster_time: None,
+        });
         inner.after_cluster_time = session.operation_time;
     }
 }

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -83,6 +83,28 @@ impl<T> Command<T> {
         }
     }
 
+    pub(crate) fn new_read(
+        name: String,
+        target_db: String,
+        read_concern: Option<ReadConcern>,
+        body: T,
+    ) -> Self {
+        Self {
+            name,
+            target_db,
+            body,
+            lsid: None,
+            cluster_time: None,
+            server_api: None,
+            read_preference: None,
+            txn_number: None,
+            start_transaction: None,
+            autocommit: None,
+            read_concern: read_concern.map(Into::into),
+            recovery_token: None,
+        }
+    }
+
     pub(crate) fn set_session(&mut self, session: &ClientSession) {
         self.lsid = Some(session.id().clone())
     }
@@ -113,16 +135,6 @@ impl<T> Command<T> {
 
     pub(crate) fn set_autocommit(&mut self) {
         self.autocommit = Some(false);
-    }
-
-    /// Sets the command's read concern to the provided read concern, overwriting any existing read
-    /// concern.
-    pub(crate) fn set_read_concern(&mut self, rc: ReadConcern) {
-        self.read_concern = Some(ReadConcernInternal {
-            level: Some(rc.level),
-            at_cluster_time: None,
-            after_cluster_time: None,
-        });
     }
 
     /// Sets the read concern level for this command according to the read concern specified on the

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -137,19 +137,15 @@ impl<T> Command<T> {
         self.autocommit = Some(false);
     }
 
-    /// Sets the read concern level for this command according to the read concern specified on the
-    /// transaction. This does not overwrite any other read concern options.
-    pub(crate) fn set_txn_read_concern(&mut self, session: &ClientSession) {
-        if let Some(ref options) = session.transaction.options {
-            if let Some(ref read_concern) = options.read_concern {
-                let inner = self.read_concern.get_or_insert(ReadConcernInternal {
-                    level: None,
-                    at_cluster_time: None,
-                    after_cluster_time: None,
-                });
-                inner.level = Some(read_concern.level.clone());
-            }
-        }
+    /// Sets the read concern level for this command.
+    /// This does not overwrite any other read concern options.
+    pub(crate) fn set_read_concern_level(&mut self, level: ReadConcernLevel) {
+        let inner = self.read_concern.get_or_insert(ReadConcernInternal {
+            level: None,
+            at_cluster_time: None,
+            after_cluster_time: None,
+        });
+        inner.level = Some(level);
     }
 
     /// Sets the read concern level for this command to "snapshot" and sets the `atClusterTime`

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -471,8 +471,7 @@ pub struct AggregateOptions {
     ///
     /// If none is specified, the read concern defined on the object executing this operation will
     /// be used.
-    #[builder(default)]
-    #[serde(default)]
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 
     /// The criteria used to select a server for this operation.
@@ -537,6 +536,7 @@ pub struct CountOptions {
     pub selection_criteria: Option<SelectionCriteria>,
 
     /// The level of the read concern.
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 }
 
@@ -572,6 +572,7 @@ pub struct EstimatedDocumentCountOptions {
     pub selection_criteria: Option<SelectionCriteria>,
 
     /// The level of the read concern.
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 }
 
@@ -602,6 +603,7 @@ pub struct DistinctOptions {
     pub selection_criteria: Option<SelectionCriteria>,
 
     /// The level of the read concern.
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 
     /// The collation to use for the operation.
@@ -691,6 +693,7 @@ pub struct FindOptions {
     /// The read concern to use for this find query.
     ///
     /// If none specified, the default set on the collection will be used.
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 
     /// Whether to return only the index keys in the documents.
@@ -811,6 +814,7 @@ pub struct FindOneOptions {
     /// The read concern to use for this find query.
     ///
     /// If none specified, the default set on the collection will be used.
+    #[serde(skip_serializing)]
     pub read_concern: Option<ReadConcern>,
 
     /// Whether to return only the index keys in the documents.

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -29,6 +29,8 @@ pub struct ReadConcern {
     pub level: ReadConcernLevel,
 }
 
+/// An internal-only read concern type that allows the omission of a "level" as well as
+/// specification of "atClusterTime" and "afterClusterTime".
 #[skip_serializing_none]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -100,6 +102,16 @@ impl ReadConcern {
             readconcernlevel: concern.level.as_str(),
         });
         state.serialize(serializer)
+    }
+}
+
+impl From<ReadConcern> for ReadConcernInternal {
+    fn from(rc: ReadConcern) -> Self {
+        ReadConcernInternal {
+            level: Some(rc.level),
+            at_cluster_time: None,
+            after_cluster_time: None,
+        }
     }
 }
 

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -105,7 +105,7 @@ impl ReadConcern {
 
 impl From<ReadConcernLevel> for ReadConcern {
     fn from(level: ReadConcernLevel) -> Self {
-        Self { level: level }
+        Self { level }
     }
 }
 

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -27,9 +27,23 @@ use crate::{
 pub struct ReadConcern {
     /// The level of the read concern.
     pub level: ReadConcernLevel,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[serde(rename = "readConcern")]
+pub(crate) struct ReadConcernInternal {
+
+    /// The level of the read concern.
+    pub(crate) level: Option<ReadConcernLevel>,
 
     /// The snapshot read timestamp.
     pub(crate) at_cluster_time: Option<Timestamp>,
+
+    /// The time of most recent operation using this session.
+    /// Used for providing causal consistency.
+    pub(crate) after_cluster_time: Option<Timestamp>,
 }
 
 impl ReadConcern {
@@ -93,8 +107,7 @@ impl ReadConcern {
 impl From<ReadConcernLevel> for ReadConcern {
     fn from(level: ReadConcernLevel) -> Self {
         Self {
-            level,
-            at_cluster_time: None,
+            level: level,
         }
     }
 }

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -34,7 +34,6 @@ pub struct ReadConcern {
 #[serde(rename_all = "camelCase")]
 #[serde(rename = "readConcern")]
 pub(crate) struct ReadConcernInternal {
-
     /// The level of the read concern.
     pub(crate) level: Option<ReadConcernLevel>,
 
@@ -106,9 +105,7 @@ impl ReadConcern {
 
 impl From<ReadConcernLevel> for ReadConcern {
     fn from(level: ReadConcernLevel) -> Self {
-        Self {
-            level: level,
-        }
+        Self { level: level }
     }
 }
 

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CursorBody, CursorResponse};
+use super::{CursorBody, CursorResponse, ReadConcernSupport};
 
 #[derive(Debug)]
 pub(crate) struct Aggregate {
@@ -46,10 +46,6 @@ impl Operation for Aggregate {
     type Response = CursorResponse<Document>;
 
     const NAME: &'static str = "aggregate";
-
-    fn supports_read_concern(&self) -> bool {
-        true
-    }
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
@@ -93,6 +89,14 @@ impl Operation for Aggregate {
         self.options
             .as_ref()
             .and_then(|opts| opts.selection_criteria.as_ref())
+    }
+
+    fn read_concern_support(&self) -> ReadConcernSupport<'_> {
+        ReadConcernSupport::Supported(
+            self.options
+                .as_ref()
+                .and_then(|opts| opts.read_concern.as_ref()),
+        )
     }
 
     fn write_concern(&self) -> Option<&WriteConcern> {

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CursorBody, CursorResponse, ReadConcernSupport, SERVER_4_2_0_WIRE_VERSION};
+use super::{CursorBody, CursorResponse, SERVER_4_2_0_WIRE_VERSION};
 
 #[derive(Debug)]
 pub(crate) struct Aggregate {
@@ -61,9 +61,10 @@ impl Operation for Aggregate {
             }
         }
 
-        Ok(Command::new(
+        Ok(Command::new_read(
             Self::NAME.to_string(),
             self.target.db_name().to_string(),
+            self.options.as_ref().and_then(|o| o.read_concern.clone()),
             body,
         ))
     }
@@ -91,19 +92,10 @@ impl Operation for Aggregate {
             .and_then(|opts| opts.selection_criteria.as_ref())
     }
 
-    fn read_concern_support(&self, description: &StreamDescription) -> ReadConcernSupport<'_> {
+    fn supports_read_concern(&self, description: &StreamDescription) -> bool {
         // for aggregates that write, read concern is only supported in MongoDB 4.2+.
-        if self.is_out_or_merge()
-            && description.max_wire_version.unwrap_or(0) < SERVER_4_2_0_WIRE_VERSION
-        {
-            ReadConcernSupport::Unsupported
-        } else {
-            ReadConcernSupport::Supported(
-                self.options
-                    .as_ref()
-                    .and_then(|opts| opts.read_concern.as_ref()),
-            )
-        }
+        !self.is_out_or_merge()
+            || description.max_wire_version.unwrap_or(0) >= SERVER_4_2_0_WIRE_VERSION
     }
 
     fn write_concern(&self) -> Option<&WriteConcern> {

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -47,6 +47,10 @@ impl Operation for Aggregate {
 
     const NAME: &'static str = "aggregate";
 
+    fn supports_read_concern(&self) -> bool {
+        true
+    }
+
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.target.to_bson(),

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -46,6 +46,10 @@ impl Operation for Count {
 
     const NAME: &'static str = "count";
 
+    fn supports_read_concern(&self) -> bool {
+        true
+    }
+
     fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         let mut name = Self::NAME.to_string();
         let mut body = match description.max_wire_version {

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::CommandResponse;
+use super::{CommandResponse, ReadConcernSupport};
 
 const SERVER_4_9_0_WIRE_VERSION: i32 = 12;
 
@@ -45,10 +45,6 @@ impl Operation for Count {
     type Response = CommandResponse<Response>;
 
     const NAME: &'static str = "count";
-
-    fn supports_read_concern(&self) -> bool {
-        true
-    }
 
     fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         let mut name = Self::NAME.to_string();
@@ -126,6 +122,14 @@ impl Operation for Count {
             return options.selection_criteria.as_ref();
         }
         None
+    }
+
+    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+        ReadConcernSupport::Supported(
+            self.options
+                .as_ref()
+                .and_then(|opts| opts.read_concern.as_ref()),
+        )
     }
 
     fn retryability(&self) -> Retryability {

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -13,9 +13,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::{CommandResponse, ReadConcernSupport};
-
-const SERVER_4_9_0_WIRE_VERSION: i32 = 12;
+use super::{CommandResponse, ReadConcernSupport, SERVER_4_9_0_WIRE_VERSION};
 
 pub(crate) struct Count {
     ns: Namespace,
@@ -124,7 +122,10 @@ impl Operation for Count {
         None
     }
 
-    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+    fn read_concern_support(
+        &self,
+        _description: &StreamDescription,
+    ) -> super::ReadConcernSupport<'_> {
         ReadConcernSupport::Supported(
             self.options
                 .as_ref()

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -127,4 +127,8 @@ impl Operation for CountDocuments {
     fn retryability(&self) -> Retryability {
         Retryability::Read
     }
+
+    fn supports_read_concern(&self) -> bool {
+        self.aggregate.supports_read_concern()
+    }
 }

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -128,7 +128,10 @@ impl Operation for CountDocuments {
         Retryability::Read
     }
 
-    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
-        self.aggregate.read_concern_support()
+    fn read_concern_support(
+        &self,
+        description: &StreamDescription,
+    ) -> super::ReadConcernSupport<'_> {
+        self.aggregate.read_concern_support(description)
     }
 }

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -128,10 +128,7 @@ impl Operation for CountDocuments {
         Retryability::Read
     }
 
-    fn read_concern_support(
-        &self,
-        description: &StreamDescription,
-    ) -> super::ReadConcernSupport<'_> {
-        self.aggregate.read_concern_support(description)
+    fn supports_read_concern(&self, description: &StreamDescription) -> bool {
+        self.aggregate.supports_read_concern(description)
     }
 }

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -128,7 +128,7 @@ impl Operation for CountDocuments {
         Retryability::Read
     }
 
-    fn supports_read_concern(&self) -> bool {
-        self.aggregate.supports_read_concern()
+    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+        self.aggregate.read_concern_support()
     }
 }

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::CommandResponse;
+use super::{CommandResponse, ReadConcernSupport};
 
 pub(crate) struct Distinct {
     ns: Namespace,
@@ -57,10 +57,6 @@ impl Operation for Distinct {
 
     const NAME: &'static str = "distinct";
 
-    fn supports_read_concern(&self) -> bool {
-        true
-    }
-
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body: Document = doc! {
             Self::NAME: self.ns.coll.clone(),
@@ -96,6 +92,14 @@ impl Operation for Distinct {
 
     fn retryability(&self) -> Retryability {
         Retryability::Read
+    }
+
+    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+        ReadConcernSupport::Supported(
+            self.options
+                .as_ref()
+                .and_then(|opts| opts.read_concern.as_ref()),
+        )
     }
 }
 

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -94,7 +94,10 @@ impl Operation for Distinct {
         Retryability::Read
     }
 
-    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+    fn read_concern_support(
+        &self,
+        _description: &StreamDescription,
+    ) -> super::ReadConcernSupport<'_> {
         ReadConcernSupport::Supported(
             self.options
                 .as_ref()

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::{CommandResponse, ReadConcernSupport};
+use super::CommandResponse;
 
 pub(crate) struct Distinct {
     ns: Namespace,
@@ -69,9 +69,10 @@ impl Operation for Distinct {
 
         append_options(&mut body, self.options.as_ref())?;
 
-        Ok(Command::new(
+        Ok(Command::new_read(
             Self::NAME.to_string(),
             self.ns.db.clone(),
+            self.options.as_ref().and_then(|o| o.read_concern.clone()),
             body,
         ))
     }
@@ -94,15 +95,8 @@ impl Operation for Distinct {
         Retryability::Read
     }
 
-    fn read_concern_support(
-        &self,
-        _description: &StreamDescription,
-    ) -> super::ReadConcernSupport<'_> {
-        ReadConcernSupport::Supported(
-            self.options
-                .as_ref()
-                .and_then(|opts| opts.read_concern.as_ref()),
-        )
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
+        true
     }
 }
 

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -57,6 +57,10 @@ impl Operation for Distinct {
 
     const NAME: &'static str = "distinct";
 
+    fn supports_read_concern(&self) -> bool {
+        true
+    }
+
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body: Document = doc! {
             Self::NAME: self.ns.coll.clone(),

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CursorResponse, ReadConcernSupport};
+use super::CursorResponse;
 
 #[derive(Debug)]
 pub(crate) struct Find<T> {
@@ -98,9 +98,10 @@ impl<T: DeserializeOwned> Operation for Find<T> {
             body.insert("filter", filter.clone());
         }
 
-        Ok(Command::new(
+        Ok(Command::new_read(
             Self::NAME.to_string(),
             self.ns.db.clone(),
+            self.options.as_ref().and_then(|o| o.read_concern.clone()),
             body,
         ))
     }
@@ -118,15 +119,8 @@ impl<T: DeserializeOwned> Operation for Find<T> {
         ))
     }
 
-    fn read_concern_support(
-        &self,
-        _description: &StreamDescription,
-    ) -> super::ReadConcernSupport<'_> {
-        ReadConcernSupport::Supported(
-            self.options
-                .as_ref()
-                .and_then(|opts| opts.read_concern.as_ref()),
-        )
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
+        true
     }
 
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     Namespace,
 };
 
-use super::CursorResponse;
+use super::{CursorResponse, ReadConcernSupport};
 
 #[derive(Debug)]
 pub(crate) struct Find<T> {
@@ -57,10 +57,6 @@ impl<T: DeserializeOwned> Operation for Find<T> {
     type Command = Document;
     type Response = CursorResponse<T>;
     const NAME: &'static str = "find";
-
-    fn supports_read_concern(&self) -> bool {
-        true
-    }
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
@@ -120,6 +116,14 @@ impl<T: DeserializeOwned> Operation for Find<T> {
             self.options.as_ref().and_then(|opts| opts.batch_size),
             self.options.as_ref().and_then(|opts| opts.max_await_time),
         ))
+    }
+
+    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+        ReadConcernSupport::Supported(
+            self.options
+                .as_ref()
+                .and_then(|opts| opts.read_concern.as_ref()),
+        )
     }
 
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -118,7 +118,10 @@ impl<T: DeserializeOwned> Operation for Find<T> {
         ))
     }
 
-    fn read_concern_support(&self) -> super::ReadConcernSupport<'_> {
+    fn read_concern_support(
+        &self,
+        _description: &StreamDescription,
+    ) -> super::ReadConcernSupport<'_> {
         ReadConcernSupport::Supported(
             self.options
                 .as_ref()

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -58,6 +58,10 @@ impl<T: DeserializeOwned> Operation for Find<T> {
     type Response = CursorResponse<T>;
     const NAME: &'static str = "find";
 
+    fn supports_read_concern(&self) -> bool {
+        true
+    }
+
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body = doc! {
             Self::NAME: self.ns.coll.clone(),

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -43,7 +43,7 @@ use crate::{
         WriteConcernError,
         WriteFailure,
     },
-    options::{ReadConcern, WriteConcern},
+    options::WriteConcern,
     selection_criteria::SelectionCriteria,
     Namespace,
 };
@@ -129,8 +129,8 @@ pub(crate) trait Operation {
 
     /// Returns whether or not this command supports the `readConcern` field, and if so, the read
     /// concern's value.
-    fn read_concern_support(&self, _description: &StreamDescription) -> ReadConcernSupport<'_> {
-        ReadConcernSupport::Unsupported
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
+        false
     }
 
     /// Whether this operation supports sessions or not.
@@ -455,16 +455,4 @@ pub(crate) enum Retryability {
     Write,
     Read,
     None,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum ReadConcernSupport<'a> {
-    Unsupported,
-    Supported(Option<&'a ReadConcern>),
-}
-
-impl<'a> ReadConcernSupport<'a> {
-    pub(crate) fn is_supported(self) -> bool {
-        matches!(self, Self::Supported(_))
-    }
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -127,8 +127,7 @@ pub(crate) trait Operation {
         None
     }
 
-    /// Returns whether or not this command supports the `readConcern` field, and if so, the read
-    /// concern's value.
+    /// Returns whether or not this command supports the `readConcern` field.
     fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
         false
     }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -70,6 +70,9 @@ pub(crate) use list_indexes::ListIndexes;
 pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;
 
+const SERVER_4_9_0_WIRE_VERSION: i32 = 12;
+const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
+
 /// A trait modeling the behavior of a server side operation.
 pub(crate) trait Operation {
     /// The output type of this operation.
@@ -126,7 +129,7 @@ pub(crate) trait Operation {
 
     /// Returns whether or not this command supports the `readConcern` field, and if so, the read
     /// concern's value.
-    fn read_concern_support(&self) -> ReadConcernSupport<'_> {
+    fn read_concern_support(&self, _description: &StreamDescription) -> ReadConcernSupport<'_> {
         ReadConcernSupport::Unsupported
     }
 

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -150,6 +150,10 @@ impl super::Response for Response {
         self.recovery_token.as_ref()
     }
 
+    fn operation_time(&self) -> Option<Timestamp> {
+        self.doc.get_timestamp("operationTime").ok()
+    }
+
     fn into_body(self) -> Self::Body {
         self.doc
     }

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -7,9 +7,19 @@ use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use crate::{
     bson::{doc, Bson},
     error::{CommandError, Error, ErrorKind},
-    options::{AuthMechanism, ClientOptions, Credential, ListDatabasesOptions, ServerAddress},
+    operation::Operation,
+    options::{
+        Acknowledgment,
+        AuthMechanism,
+        ClientOptions,
+        Credential,
+        ListDatabasesOptions,
+        ReadConcern,
+        ServerAddress,
+        WriteConcern,
+    },
     selection_criteria::{ReadPreference, ReadPreferenceOptions, SelectionCriteria},
-    test::{util::TestClient, CLIENT_OPTIONS, LOCK},
+    test::{util::TestClient, EventClient, CLIENT_OPTIONS, LOCK},
     Client,
     RUNTIME,
 };
@@ -656,4 +666,60 @@ async fn plain_auth() {
             authenticated: "yeah".into()
         }
     );
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn client_options_inherited() {
+    async fn assert_options_inherited(client: &EventClient, command_name: &str) {
+        let events = client.get_command_started_events(&[command_name]);
+        let event = events.iter().last().unwrap();
+
+        let read_concern_doc = event.command.get_document("readConcern").unwrap();
+        assert_eq!(read_concern_doc.get_str("level").unwrap(), "majority");
+
+        let write_concern_doc = event.command.get_document("writeConcern").unwrap();
+        assert_eq!(read_concern_doc.get_str("w").unwrap(), "majority");
+
+        if client.is_standalone() {
+            let read_pref_doc = event.command.get_document("$readPreference").unwrap();
+            assert_eq!(read_pref_doc.get_str("mode").unwrap(), "primaryPreferred");
+        }
+    }
+
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let wc = WriteConcern::builder().w(Acknowledgment::Majority).build();
+    let rc = ReadConcern::majority();
+    let rp = SelectionCriteria::ReadPreference(ReadPreference::PrimaryPreferred {
+        options: Default::default(),
+    });
+
+    let options = ClientOptions::builder()
+        .selection_criteria(rp)
+        .write_concern(wc)
+        .read_concern(rc)
+        .build();
+    let client = EventClient::with_options(options).await;
+
+    let mut session = client.start_session(None).await.unwrap();
+
+    let coll = client
+        .database("client_opts_inherited")
+        .collection::<Document>("client_opts_inherited");
+
+    coll.find_with_session(None, None, &mut session)
+        .await
+        .unwrap();
+    assert_options_inherited(&client, "find").await;
+
+    coll.find_one_with_session(None, None, &mut session)
+        .await
+        .unwrap();
+    assert_options_inherited(&client, "find").await;
+
+    coll.count_documents_with_session(None, None, &mut session)
+        .await
+        .unwrap();
+    assert_options_inherited(&client, "aggregate").await;
 }

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -325,7 +325,7 @@ impl TestClient {
         if self.server_info.msg.as_deref() == Some("isdbgrid") {
             return Topology::Sharded;
         }
-        if self.options.repl_set_name.is_some() {
+        if self.server_info.set_name.is_some() {
             return Topology::ReplicaSet;
         }
         Topology::Single


### PR DESCRIPTION
This PR provides support for [causal consistency](https://github.com/mongodb/specifications/blob/master/source/causal-consistency/causal-consistency.rst).

The change that is needed to support causally consistent sessions is that `readConcern.afterClusterTime` now needs to be included in all commands that are part of a causally consistent session that take a `readConcern`.  `readConcern.afterClusterTime` must be set to the `operationTime` field of the `ClientSession` struct (initialized to `None`).  The `operationTime` field of the `ClientSession` struct must get updated to the `operationTime` field of the server's response to any command that is part of a causally consistent session (this field is included on success or error).

The main difficulty is that `readConcern.level` now is not always included when `readConcern` is included.  To address that I introduced a new type `readConcernInternal` that takes the role of `readConcern` in certain cases (when `level` is optional).  

Currently there is a bug in this implementation where there are duplicate `readConcern` fields being included.  Most likely this is because the readConcern in `FindOptions` (for example) and the `readConcern` that is set on the session are both being serialized.