### PR TITLE
RUST-928 Respect serverless clauses in crud v1 tests

### DIFF
--- a/src/test/spec/crud_v1/aggregate.rs
+++ b/src/test/spec/crud_v1/aggregate.rs
@@ -2,11 +2,11 @@ use futures::stream::TryStreamExt;
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{AggregateOptions, Collation},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -94,5 +94,5 @@ async fn run_aggregate_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "read"], run_aggregate_test).await;
+    run_crud_v1_test(&["crud", "v1", "read"], run_aggregate_test).await;
 }

--- a/src/test/spec/crud_v1/count.rs
+++ b/src/test/spec/crud_v1/count.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, CountOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -76,5 +76,5 @@ async fn run_count_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "read"], run_count_test).await;
+    run_crud_v1_test(&["crud", "v1", "read"], run_count_test).await;
 }

--- a/src/test/spec/crud_v1/delete_many.rs
+++ b/src/test/spec/crud_v1/delete_many.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, DeleteOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -88,5 +88,5 @@ async fn run_delete_many_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_delete_many_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_delete_many_test).await;
 }

--- a/src/test/spec/crud_v1/delete_one.rs
+++ b/src/test/spec/crud_v1/delete_one.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, DeleteOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -88,5 +88,5 @@ async fn run_delete_one_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_delete_one_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_delete_one_test).await;
 }

--- a/src/test/spec/crud_v1/distinct.rs
+++ b/src/test/spec/crud_v1/distinct.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, DistinctOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -64,5 +64,5 @@ async fn run_distinct_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "read"], run_distinct_test).await;
+    run_crud_v1_test(&["crud", "v1", "read"], run_distinct_test).await;
 }

--- a/src/test/spec/crud_v1/find.rs
+++ b/src/test/spec/crud_v1/find.rs
@@ -2,11 +2,11 @@ use futures::stream::TryStreamExt;
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, FindOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -75,5 +75,5 @@ async fn run_find_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "read"], run_find_test).await;
+    run_crud_v1_test(&["crud", "v1", "read"], run_find_test).await;
 }

--- a/src/test/spec/crud_v1/find_one_and_delete.rs
+++ b/src/test/spec/crud_v1/find_one_and_delete.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, FindOneAndDeleteOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -81,5 +81,5 @@ async fn run_find_one_and_delete_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_find_one_and_delete_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_find_one_and_delete_test).await;
 }

--- a/src/test/spec/crud_v1/find_one_and_replace.rs
+++ b/src/test/spec/crud_v1/find_one_and_replace.rs
@@ -3,11 +3,11 @@ use std::cmp;
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, FindOneAndReplaceOptions, ReturnDocument},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -100,5 +100,5 @@ async fn run_find_one_and_replace_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_find_one_and_replace_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_find_one_and_replace_test).await;
 }

--- a/src/test/spec/crud_v1/find_one_and_update.rs
+++ b/src/test/spec/crud_v1/find_one_and_update.rs
@@ -3,11 +3,11 @@ use std::cmp;
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, FindOneAndUpdateOptions, ReturnDocument},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -103,5 +103,5 @@ async fn run_find_one_and_update_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_find_one_and_update_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_find_one_and_update_test).await;
 }

--- a/src/test/spec/crud_v1/insert_many.rs
+++ b/src/test/spec/crud_v1/insert_many.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::InsertManyOptions,
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -106,5 +106,5 @@ async fn run_insert_many_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_insert_many_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_insert_many_test).await;
 }

--- a/src/test/spec/crud_v1/insert_one.rs
+++ b/src/test/spec/crud_v1/insert_one.rs
@@ -1,10 +1,10 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -79,5 +79,5 @@ async fn run_insert_one_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_insert_one_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_insert_one_test).await;
 }

--- a/src/test/spec/crud_v1/replace_one.rs
+++ b/src/test/spec/crud_v1/replace_one.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, ReplaceOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -111,5 +111,5 @@ async fn run_replace_one_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_replace_one_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_replace_one_test).await;
 }

--- a/src/test/spec/crud_v1/update_many.rs
+++ b/src/test/spec/crud_v1/update_many.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, UpdateOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -112,5 +112,5 @@ async fn run_update_many_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_update_many_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_update_many_test).await;
 }

--- a/src/test/spec/crud_v1/update_one.rs
+++ b/src/test/spec/crud_v1/update_one.rs
@@ -1,11 +1,11 @@
 use serde::Deserialize;
 use tokio::sync::RwLockReadGuard;
 
-use super::{Outcome, TestFile};
+use super::{run_crud_v1_test, Outcome, TestFile};
 use crate::{
     bson::{Bson, Document},
     options::{Collation, UpdateOptions},
-    test::{run_spec_test, util::TestClient, LOCK},
+    test::{util::TestClient, LOCK},
 };
 
 #[derive(Debug, Deserialize)]
@@ -112,5 +112,5 @@ async fn run_update_one_test(test_file: TestFile) {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
-    run_spec_test(&["crud", "v1", "write"], run_update_one_test).await;
+    run_crud_v1_test(&["crud", "v1", "write"], run_update_one_test).await;
 }

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -42,7 +42,7 @@ pub use self::{
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
 
-use crate::bson::Bson;
+use crate::{bson::Bson, test::SERVERLESS};
 
 pub(crate) async fn run_spec_test<T, F, G>(spec: &[&str], run_test_file: F)
 where
@@ -117,4 +117,14 @@ pub(crate) enum Serverless {
     Require,
     Forbid,
     Allow,
+}
+
+impl Serverless {
+    pub(crate) fn can_run(&self) -> bool {
+        match self {
+            Self::Forbid if *SERVERLESS => false,
+            Self::Require if !*SERVERLESS => false,
+            _ => true,
+        }
+    }
 }

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -20,7 +20,7 @@ use crate::{
         SelectionCriteria,
         WriteConcern,
     },
-    test::{Serverless, TestClient, DEFAULT_URI, SERVERLESS},
+    test::{Serverless, TestClient, DEFAULT_URI},
 };
 
 #[derive(Debug, Deserialize)]
@@ -107,10 +107,8 @@ impl RunOnRequirement {
             }
         }
         if let Some(ref serverless) = self.serverless {
-            match serverless {
-                Serverless::Forbid if *SERVERLESS => return false,
-                Serverless::Require if !*SERVERLESS => return false,
-                _ => (),
+            if !serverless.can_run() {
+                return false;
             }
         }
         if let Some(ref auth) = self.auth {

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -8,15 +8,7 @@ use serde::{Deserialize, Deserializer};
 use crate::{
     bson::Document,
     options::{FindOptions, ReadPreference, SelectionCriteria, SessionOptions},
-    test::{
-        spec::merge_uri_options,
-        EventClient,
-        FailPoint,
-        Serverless,
-        TestClient,
-        DEFAULT_URI,
-        SERVERLESS,
-    },
+    test::{spec::merge_uri_options, EventClient, FailPoint, Serverless, TestClient, DEFAULT_URI},
 };
 
 use super::{operation::Operation, test_event::CommandStartedEvent};
@@ -62,10 +54,8 @@ impl RunOn {
             }
         }
         if let Some(ref serverless) = self.serverless {
-            match serverless {
-                Serverless::Forbid if *SERVERLESS => return false,
-                Serverless::Require if !*SERVERLESS => return false,
-                _ => (),
+            if !serverless.can_run() {
+                return false;
             }
         }
         true


### PR DESCRIPTION
RUST-928

The test runners for crud v1 were ignoring the `serverless` field; this brings them in line with the v2/unified runners.