### PR TITLE
RUST-1076 Remove conditional module definition

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1479,7 +1479,7 @@ impl ClientOptionsParser {
                     credential.source = options
                         .auth_source
                         .clone()
-                        .or(db.clone())
+                        .or_else(|| db.clone())
                         .or_else(|| Some("admin".into()));
                 } else if authentication_requested {
                     return Err(ErrorKind::InvalidArgument {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,73 +304,57 @@
 #[cfg(all(feature = "aws-auth", feature = "async-std-runtime"))]
 compile_error!("The `aws-auth` feature flag is only supported on the tokio runtime.");
 
-macro_rules! define_if_single_runtime_enabled {
-    ( $( $def:item )+ ) => {
-        $(
-            #[cfg(any(
-                all(feature = "tokio-runtime", not(feature = "async-std-runtime")),
-                all(not(feature = "tokio-runtime"), feature = "async-std-runtime")
-            ))]
-            $def
-        )+
-    }
-}
+#[macro_use]
+pub mod options;
 
-// In the case that neither tokio nor async-std is enabled, we want to disable all compiler errors
-// and warnings other than our custom ones.
-define_if_single_runtime_enabled! {
-    #[macro_use]
-    pub mod options;
+pub use ::bson;
 
-    pub use ::bson;
+mod bson_util;
+mod client;
+mod cmap;
+mod coll;
+mod collation;
+mod compression;
+mod concern;
+mod cursor;
+mod db;
+pub mod error;
+pub mod event;
+mod index;
+mod is_master;
+mod operation;
+pub mod results;
+pub(crate) mod runtime;
+mod sdam;
+mod selection_criteria;
+mod srv;
+#[cfg(any(feature = "sync", docsrs))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+pub mod sync;
+#[cfg(test)]
+mod test;
 
-    mod bson_util;
-    mod client;
-    mod cmap;
-    mod coll;
-    mod collation;
-    mod compression;
-    mod concern;
-    mod cursor;
-    mod db;
-    pub mod error;
-    pub mod event;
-    mod index;
-    mod is_master;
-    mod operation;
-    pub mod results;
-    pub(crate) mod runtime;
-    mod sdam;
-    mod selection_criteria;
-    mod srv;
-    #[cfg(any(feature = "sync", docsrs))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
-    pub mod sync;
-    #[cfg(test)]
-    mod test;
+#[cfg(test)]
+#[macro_use]
+extern crate derive_more;
 
-    #[cfg(test)]
-    #[macro_use]
-    extern crate derive_more;
+#[cfg(not(feature = "sync"))]
+pub use crate::{
+    client::{Client, session::ClientSession},
+    coll::Collection,
+    cursor::{Cursor, session::{SessionCursor, SessionCursorStream}},
+    db::Database,
+};
 
-    #[cfg(not(feature = "sync"))]
-    pub use crate::{
-        client::{Client, session::ClientSession},
-        coll::Collection,
-        cursor::{Cursor, session::{SessionCursor, SessionCursorStream}},
-        db::Database,
-    };
+#[cfg(feature = "sync")]
+pub(crate) use crate::{
+    client::{Client, session::ClientSession},
+    coll::Collection,
+    cursor::{Cursor, session::{SessionCursor, SessionCursorStream}},
+    db::Database,
+};
 
-    #[cfg(feature = "sync")]
-    pub(crate) use crate::{
-        client::{Client, session::ClientSession},
-        coll::Collection,
-        cursor::{Cursor, session::{SessionCursor, SessionCursorStream}},
-        db::Database,
-    };
-
-    pub use {coll::Namespace, index::IndexModel, client::session::ClusterTime};
-}
+pub use {coll::Namespace, index::IndexModel, client::session::ClusterTime};
 
 #[cfg(all(
     feature = "tokio-runtime",

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -323,8 +323,6 @@ impl ReadPreference {
     where
         S: serde::Serializer,
     {
-        use serde::ser::Serialize;
-
         #[derive(serde::Serialize)]
         struct ReadPreferenceHelper<'a> {
             readpreference: &'a str,


### PR DESCRIPTION
RUST-1076

This PR removes the macro that conditionally defines all of the drivers modules. Its intent was to make the compile error issued when a user selects more than one async runtime more readable, but it has the side effect of making the docs.rs page for the crate very noisy. After removing the defines, the compile error is still readable, though it does have some extra distracting info.

example:

```
cargo check --no-default-features
    Checking mongodb v2.0.0 (/home/patrick/mongo-rust-driver)
error: one of `tokio-runtime`, `async-std-runtime`, or `sync` must be enabled; either enable `default-features`, or enable one of those features specifically in your Cargo.toml
   --> src/lib.rs:376:1
    |
376 | / compile_error!(
377 | |     "one of `tokio-runtime`, `async-std-runtime`, or `sync` must be enabled; either enable \
378 | |      `default-features`, or enable one of those features specifically in your Cargo.toml"
379 | | );
    | |__^

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/client/session/mod.rs:24:5
   |
24 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/cmap/worker.rs:37:5
   |
37 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/cursor/common.rs:23:5
   |
23 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/runtime/stream.rs:19:5
   |
19 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
 --> src/sdam/message_manager.rs:5:5
  |
5 | use crate::RUNTIME;
  |     ^^^^^^^^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/sdam/monitor.rs:17:5
   |
17 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/sdam/srv_polling/mod.rs:15:5
   |
15 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0432]: unresolved import `crate::RUNTIME`
  --> src/sdam/state/mod.rs:48:5
   |
48 |     RUNTIME,
   |     ^^^^^^^ no `RUNTIME` in the root

error[E0425]: cannot find value `RUNTIME_NAME` in this scope
   --> src/cmap/establish/handshake/mod.rs:133:82
    |
133 |                 Some(format!("rustc {} {} ({}) with {}", version, channel, date, RUNTIME_NAME));
    |                                                                                  ^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `resolver` in this scope
  --> src/runtime/resolver.rs:41:19
   |
41 |         Ok(Self { resolver })
   |                   ^^^^^^^^ not found in this scope

error[E0412]: cannot find type `Interval` in this scope
   --> src/runtime/mod.rs:150:57
    |
150 |     pub(crate) fn interval(self, duration: Duration) -> Interval {
    |                                                         ^^^^^^^^ not found in this scope
    |
help: consider importing this struct
    |
11  | use tokio::time::Interval;
    |

warning: unused import: `net::SocketAddr`
 --> src/runtime/stream.rs:2:5
  |
2 |     net::SocketAddr,
  |     ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0392]: parameter `T` is never used
  --> src/runtime/join_handle.rs:13:33
   |
13 | pub(crate) enum AsyncJoinHandle<T> {
   |                                 ^ unused parameter
   |
   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`

error: aborting due to 13 previous errors; 1 warning emitted

Some errors have detailed explanations: E0392, E0412, E0425, E0432.
For more information about an error, try `rustc --explain E0392`.
error: could not compile `mongodb`

To learn more, run the command again with --verbose.
```