### PR TITLE
RUST-1060 Omit non-pub fields from debug output of ClientOptions (2.0.x)

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -484,6 +484,7 @@ pub struct ClientOptions {
     pub server_selection_timeout: Option<Duration>,
 
     #[builder(default, setter(skip))]
+    #[derivative(Debug = "ignore")]
     pub(crate) socket_timeout: Option<Duration>,
 
     /// The TLS configuration for the Client to use in its connections with the server.
@@ -503,9 +504,11 @@ pub struct ClientOptions {
     /// Information from the SRV URI that generated these client options, if applicable.
     #[builder(default, setter(skip))]
     #[serde(skip)]
+    #[derivative(Debug = "ignore")]
     pub(crate) original_srv_info: Option<OriginalSrvInfo>,
 
     #[builder(default, setter(skip))]
+    #[derivative(Debug = "ignore")]
     pub(crate) original_uri: Option<String>,
 
     /// Configuration of the trust-dns resolver used for SRV and TXT lookups.
@@ -515,6 +518,7 @@ pub struct ClientOptions {
     /// configuration, so a custom configuration is recommended.
     #[builder(default, setter(skip))]
     #[serde(skip)]
+    #[derivative(Debug = "ignore")]
     pub(crate) resolver_config: Option<ResolverConfig>,
 
     /// Used by tests to override MIN_HEARTBEAT_FREQUENCY.

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -189,3 +189,15 @@ async fn parse_unknown_options() {
     .await;
     parse_uri("maxstalenessms", Some("maxstalenessseconds")).await;
 }
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn options_debug_omits_uri() {
+    let uri = "mongodb://username:password@localhost/";
+    let options = ClientOptions::parse(uri).await.unwrap();
+
+    let debug_output = format!("{:?}", options);
+    assert!(!debug_output.contains("username"));
+    assert!(!debug_output.contains("password"));
+    assert!(!debug_output.contains("uri"));
+}


### PR DESCRIPTION
Backport of RUST-1060 to 2.0.2.