### PR TITLE
RUST-1060 Omit non-pub fields from debug output of ClientOptions (1.2)

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -290,6 +290,7 @@ pub struct ClientOptions {
     pub app_name: Option<String>,
 
     #[builder(default)]
+    #[derivative(Debug = "ignore")]
     pub(crate) compressors: Option<Vec<String>>,
 
     /// The handler that should process all Connection Monitoring and Pooling events. See the
@@ -404,6 +405,7 @@ pub struct ClientOptions {
     ///
     /// The default value is to have no declared API version
     #[builder(default, skip)]
+    #[derivative(Debug = "ignore")]
     pub(crate) server_api: Option<ServerApi>,
 
     /// The amount of time the Client should attempt to select a server for an operation before
@@ -414,6 +416,7 @@ pub struct ClientOptions {
     pub server_selection_timeout: Option<Duration>,
 
     #[builder(default)]
+    #[derivative(Debug = "ignore")]
     pub(crate) socket_timeout: Option<Duration>,
 
     /// The TLS configuration for the Client to use in its connections with the server.
@@ -439,9 +442,11 @@ pub struct ClientOptions {
     pub(crate) zlib_compression: Option<i32>,
 
     #[builder(default)]
+    #[derivative(Debug = "ignore")]
     pub(crate) original_srv_hostname: Option<String>,
 
     #[builder(default)]
+    #[derivative(Debug = "ignore")]
     pub(crate) original_uri: Option<String>,
 
     /// Configuration of the trust-dns resolver used for SRV and TXT lookups.
@@ -451,10 +456,12 @@ pub struct ClientOptions {
     /// configuration, so a custom configuration is recommended.
     #[builder(default)]
     #[serde(skip)]
+    #[derivative(Debug = "ignore")]
     pub(crate) resolver_config: Option<ResolverConfig>,
 
     /// Used by tests to override MIN_HEARTBEAT_FREQUENCY.
     #[builder(default)]
+    #[derivative(Debug = "ignore")]
     pub(crate) heartbeat_freq_test: Option<Duration>,
 }
 

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -372,3 +372,15 @@ async fn parse_unknown_options() {
     .await;
     parse_uri("maxstalenessms", Some("maxstalenessseconds")).await;
 }
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn options_debug_omits_uri() {
+    let uri = "mongodb://username:password@localhost/";
+    let options = ClientOptions::parse(uri).await.unwrap();
+
+    let debug_output = format!("{:?}", options);
+    assert!(!debug_output.contains("username"));
+    assert!(!debug_output.contains("password"));
+    assert!(!debug_output.contains("uri"));
+}


### PR DESCRIPTION
Bacports RUST-1060 to 1.2.4.