### PR TITLE
RUST-519 Implement (but do not expose) the public change streams API

### DIFF
--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -1,4 +1,4 @@
-//! Contains documents related to a ChangeStream event.
+//! Contains the types related to a `ChangeStream` event.
 use crate::coll::Namespace;
 use bson::{Bson, Document};
 use serde::{Deserialize, Serialize};
@@ -37,10 +37,10 @@ pub struct ChangeStreamEvent<T> {
     /// Describes the type of operation represented in this change notification.
     pub operation_type: OperationType,
 
-    /// Identifies which collection or database where the event occurred.
+    /// Identifies the collection or database on which the event occurred.
     pub ns: Option<ChangeStreamEventSource>,
 
-    /// The new name for the ns collection.  Only included for `OperationType::Rename`.
+    /// The new name for the `ns` collection.  Only included for `OperationType::Rename`.
     pub to: Option<Namespace>,
 
     /// For unsharded collections this contains a single field, id, with the value of the id of the
@@ -48,7 +48,8 @@ pub struct ChangeStreamEvent<T> {
     /// shard key in order, followed by the id if the id isn’t part of the shard key.
     pub document_key: Option<Document>,
 
-    /// Contains a description of updated and removed fields in this operation.
+    /// A `Document` describing the fields that were updated or removed by the update operation.
+    /// Only specified if `operation_type` is `OperationType::Update`.
     pub update_description: Option<UpdateDescription>,
 
     /// For operations of type "insert" and "replace", this key will contain the document being
@@ -105,7 +106,7 @@ pub enum OperationType {
     Invalidate,
 }
 
-/// Identifies which collection or database where an event occurred.
+/// Identifies the collection or database on which an event occurred.
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
 #[non_exhaustive]
@@ -114,6 +115,6 @@ pub enum ChangeStreamEventSource {
     /// the change happened.
     Namespace(Namespace),
 
-    // Contains the name of the dabatase in which the change happened.
+    // Contains the name of the database in which the change happened.
     Database(String),
 }

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -4,12 +4,11 @@ use bson::{Bson, Document};
 use serde::{Deserialize, Serialize};
 
 /// An opaque token used for resuming an interrupted
-/// [`ChangeStream`](../struct.ChangeStream.html).
+/// [`ChangeStream`](crate::change_stream::ChangeStream).
 ///
 /// When starting a new change stream,
-/// [`start_after`](../option/struct.ChangeStreamOptions.html#structfield.start_after)
-/// and [`resume_after`](../option/struct.ChangeStreamOptions.html#structfield.resume_after) fields
-/// on [`ChangeStreamOptions`](../option/struct.ChangeStreamOptions.html) can be specified
+/// [`crate::options::ChangeStreamOptions::start_after`] and
+/// [`crate::options::ChangeStreamOptions::resume_after`] fields can be specified
 /// with instances of `ResumeToken`.
 ///
 /// See the documentation
@@ -109,6 +108,7 @@ pub enum OperationType {
 /// Identifies which collection or database where an event occurred.
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ChangeStreamEventSource {
     /// Contains two fields: "db" and "coll" containing the database and collection name in which
     /// the change happened.

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -118,6 +118,6 @@ pub enum ChangeStreamEventSource {
     /// The [`Namespace`] containing the database and collection in which the change occurred.
     Namespace(Namespace),
 
-    // Contains the name of the database in which the change happened.
+    /// Contains the name of the database in which the change happened.
     Database(String),
 }

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -1,0 +1,119 @@
+//! Contains documents related to a ChangeStream event.
+use crate::coll::Namespace;
+use bson::{Bson, Document};
+use serde::{Deserialize, Serialize};
+
+/// An opaque token used for resuming an interrupted
+/// [`ChangeStream`](../struct.ChangeStream.html).
+///
+/// When starting a new change stream,
+/// [`start_after`](../option/struct.ChangeStreamOptions.html#structfield.start_after)
+/// and [`resume_after`](../option/struct.ChangeStreamOptions.html#structfield.resume_after) fields
+/// on [`ChangeStreamOptions`](../option/struct.ChangeStreamOptions.html) can be specified
+/// with instances of `ResumeToken`.
+///
+/// See the documentation
+/// [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-token) for more
+/// information on resume tokens.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ResumeToken(pub(crate) Bson);
+
+/// A `ChangeStreamEvent` represents a
+/// [change event](https://docs.mongodb.com/manual/reference/change-events/) in the associated change stream.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct ChangeStreamEvent<T> {
+    /// An opaque token for use when resuming an interrupted `ChangeStream`.
+    ///
+    /// See the documentation
+    /// [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-token) for
+    /// more information on resume tokens.
+    ///
+    /// Also see the documentation on [resuming a change
+    /// stream](https://docs.mongodb.com/manual/changeStreams/#resume-a-change-stream).
+    #[serde(rename = "_id")]
+    pub id: ResumeToken,
+
+    /// Describes the type of operation represented in this change notification.
+    pub operation_type: OperationType,
+
+    /// Identifies which collection or database where the event occurred.
+    pub ns: Option<ChangeStreamEventSource>,
+
+    /// The new name for the ns collection.  Only included for `OperationType::Rename`.
+    pub to: Option<Namespace>,
+
+    /// For unsharded collections this contains a single field, id, with the value of the id of the
+    /// document updated.  For sharded collections, this will contain all the components of the
+    /// shard key in order, followed by the id if the id isn’t part of the shard key.
+    pub document_key: Option<Document>,
+
+    /// Contains a description of updated and removed fields in this operation.
+    pub update_description: Option<UpdateDescription>,
+
+    /// For operations of type "insert" and "replace", this key will contain the document being
+    /// inserted, or the new version of the document that is replacing the existing
+    /// document, respectively.
+    ///
+    /// For operations of type "update", when the `ChangeStream's` full document type is
+    /// `UpdateLookup`, this key will contain a copy of the full version of the document from
+    /// some point after the update occurred. If the document was deleted since the updated
+    /// happened, it will be `None`.
+    pub full_document: Option<T>,
+}
+
+/// Describes which fields have been updated or removed from a document.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct UpdateDescription {
+    /// A `Document` containing key:value pairs of names of the fields that were changed, and the
+    /// new value for those fields.
+    pub updated_fields: Document,
+
+    /// An array of field names that were removed from the `Document`.
+    pub removed_fields: Vec<String>,
+}
+
+/// The operation type represented in a given change notification.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum OperationType {
+    /// See [insert-event](https://docs.mongodb.com/manual/reference/change-events/#insert-event)
+    Insert,
+
+    /// See [update-event](https://docs.mongodb.com/manual/reference/change-events/#update-event)
+    Update,
+
+    /// See [replace-event](https://docs.mongodb.com/manual/reference/change-events/#replace-event)
+    Replace,
+
+    /// See [delete-event](https://docs.mongodb.com/manual/reference/change-events/#delete-event)
+    Delete,
+
+    /// See [drop-event](https://docs.mongodb.com/manual/reference/change-events/#drop-event)
+    Drop,
+
+    /// See [rename-event](https://docs.mongodb.com/manual/reference/change-events/#rename-event)
+    Rename,
+
+    /// See [dropdatabase-event](https://docs.mongodb.com/manual/reference/change-events/#dropdatabase-event)
+    DropDatabase,
+
+    /// See [invalidate-event](https://docs.mongodb.com/manual/reference/change-events/#invalidate-event)
+    Invalidate,
+}
+
+/// Identifies which collection or database where an event occurred.
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum ChangeStreamEventSource {
+    /// Contains two fields: "db" and "coll" containing the database and collection name in which
+    /// the change happened.
+    Namespace(Namespace),
+
+    // Contains the name of the dabatase in which the change happened.
+    Database(String),
+}

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -43,23 +43,27 @@ pub struct ChangeStreamEvent<T> {
     /// The new name for the `ns` collection.  Only included for `OperationType::Rename`.
     pub to: Option<Namespace>,
 
-    /// For unsharded collections this contains a single field, id, with the value of the id of the
-    /// document updated.  For sharded collections, this will contain all the components of the
-    /// shard key in order, followed by the id if the id isn’t part of the shard key.
+    /// A `Document` that contains the `_id` of the document created or modified by the `insert`,
+    /// `replace`, `delete`, `update` operations (i.e. CRUD operations). For sharded collections,
+    /// also displays the full shard key for the document. The `_id` field is not repeated if it is
+    /// already a part of the shard key.
     pub document_key: Option<Document>,
 
-    /// A `Document` describing the fields that were updated or removed by the update operation.
+    /// A description of the fields that were updated or removed by the update operation.
     /// Only specified if `operation_type` is `OperationType::Update`.
     pub update_description: Option<UpdateDescription>,
 
-    /// For operations of type "insert" and "replace", this key will contain the document being
-    /// inserted, or the new version of the document that is replacing the existing
-    /// document, respectively.
+    /// The `Document` created or modified by the `insert`, `replace`, `delete`, `update`
+    /// operations (i.e. CRUD operations).
     ///
-    /// For operations of type "update", when the `ChangeStream's` full document type is
-    /// `UpdateLookup`, this key will contain a copy of the full version of the document from
-    /// some point after the update occurred. If the document was deleted since the updated
-    /// happened, it will be `None`.
+    /// For `insert` and `replace` operations, this represents the new document created by the
+    /// operation.  For `delete` operations, this field is `None`.
+    ///
+    /// For `update` operations, this field only appears if you configured the change stream with
+    /// [`full_document`](crate::options::ChangeStreamOptions::full_document) set to
+    /// [`UpdateLookup`](crate::options::FullDocumentType::UpdateLookup). This field then
+    /// represents the most current majority-committed version of the document modified by the
+    /// update operation.
     pub full_document: Option<T>,
 }
 
@@ -111,8 +115,7 @@ pub enum OperationType {
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum ChangeStreamEventSource {
-    /// Contains two fields: "db" and "coll" containing the database and collection name in which
-    /// the change happened.
+    /// The [`Namespace`] containing the database and collection in which the change occurred.
     Namespace(Namespace),
 
     // Contains the name of the database in which the change happened.

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -128,6 +128,11 @@ where
     pub fn resume_token(&self) -> Option<&ResumeToken> {
         todo!()
     }
+
+    /// Update the type streamed values will be parsed as.
+    pub fn with_type<D: DeserializeOwned + Unpin + Send + Sync>(self) -> ChangeStream<D> {
+        todo!()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -1,4 +1,4 @@
-//! Contains the functionality for ChangeStreams.
+//! Contains the functionality for change streams.
 pub mod event;
 pub(crate) mod options;
 pub mod session;
@@ -31,7 +31,7 @@ use crate::{
 /// deployment. `ChangeStream` instances should be created with method `watch` or
 /// `watch_with_pipeline` against the relevant target.
 ///
-/// `ChangeStream`'s are "resumable", meaning that they can be restarted at a given place in the
+/// `ChangeStream`s are "resumable", meaning that they can be restarted at a given place in the
 /// stream of events. This is done automatically when the `ChangeStream` encounters certain
 /// ["resumable"](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error)
 /// errors, such as transient network failures. It can also be done manually by passing

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -34,21 +34,20 @@ use crate::{
 /// stream of events. This is done automatically when the `ChangeStream` encounters certain
 /// ["resumable"](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error)
 /// errors, such as transient network failures. It can also be done manually by passing
-/// a [`ResumeToken`](document/struct.ResumeToken.html) retrieved from a past event
-/// into either the
-/// [`resume_after`](option/struct.ChangeStreamOptions.html#structfield.resume_after)
-/// or [`start_after`](option/struct.ChangeStreamOptions.html#structfield.start_after)
-/// (4.2+) options used to create the `ChangeStream`. Issuing a raw change stream aggregation is
-/// discouraged unless users wish to explicitly opt out of resumability.
+/// a [`ResumeToken`] retrieved from a past event into either the
+/// [`resume_after`](ChangeStreamOptions::resume_after) or
+/// [`start_after`](ChangeStreamOptions::start_after) (4.2+) options used to create the
+/// `ChangeStream`. Issuing a raw change stream aggregation is discouraged unless users wish to
+/// explicitly opt out of resumability.
 ///
 /// A `ChangeStream` can be iterated to return batches of instances of the result type.  For
-/// `watch`, this will be [`ChangeStreamEvent`](document/struct.ChangeStreamEvent.html)
-/// wrapping the value type (for `Collection::watch`) or a `Document` (for `Client::watch` and
-/// `Database::watch`).  For `watch_with_pipeline`, a deserializable type must be specified that
-/// matches the result of the aggregation pipeline; if the pipeline does not alter the event
-/// structure it may be convenient to reuse `ChangeStreamEvent` for that type.
+/// `watch`, this will be [`ChangeStreamEvent`] wrapping the value type (for [`Collection::watch`])
+/// or a [`Document`] (for [`Client::watch`] and [`Database::watch`]).  For `watch_with_pipeline`,
+/// a deserializable type must be specified that matches the result of the aggregation pipeline; if
+/// the pipeline does not alter the event structure it may be convenient to reuse
+/// [`ChangeStreamEvent`] for that type.
 ///
-/// A `ChangeStream` can be iterated like any other `Stream`:
+/// A `ChangeStream` can be iterated like any other [`Stream`]:
 ///
 /// ```rust
 /// # #[cfg(not(feature = "sync"))]
@@ -126,7 +125,7 @@ where
     /// See the documentation
     /// [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-token) for more
     /// information on change stream resume tokens.
-    pub fn resume_token(&self) -> Option<ResumeToken> {
+    pub fn resume_token(&self) -> Option<&ResumeToken> {
         todo!()
     }
 }

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -1,0 +1,150 @@
+//! Contains the functionality for ChangeStreams.
+pub mod event;
+pub(crate) mod options;
+
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use bson::Document;
+use futures_core::Stream;
+use serde::{de::DeserializeOwned, Deserialize};
+
+use crate::{
+    change_stream::{
+        event::{ChangeStreamEvent, ResumeToken},
+        options::ChangeStreamOptions,
+    },
+    error::Result,
+    options::AggregateOptions,
+    selection_criteria::ReadPreference,
+    Client,
+    Collection,
+    Cursor,
+    Database,
+};
+
+/// A `ChangeStream` streams the ongoing changes of its associated collection, database or
+/// deployment. `ChangeStream` instances should be created with method `watch` or
+/// `watch_with_pipeline` against the relevant target.
+///
+/// `ChangeStream`'s are "resumable", meaning that they can be restarted at a given place in the
+/// stream of events. This is done automatically when the `ChangeStream` encounters certain
+/// ["resumable"](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error)
+/// errors, such as transient network failures. It can also be done manually by passing
+/// a [`ResumeToken`](document/struct.ResumeToken.html) retrieved from a past event
+/// into either the
+/// [`resume_after`](option/struct.ChangeStreamOptions.html#structfield.resume_after)
+/// or [`start_after`](option/struct.ChangeStreamOptions.html#structfield.start_after)
+/// (4.2+) options used to create the `ChangeStream`. Issuing a raw change stream aggregation is
+/// discouraged unless users wish to explicitly opt out of resumability.
+///
+/// A `ChangeStream` can be iterated to return batches of instances of the result type.  For
+/// `watch`, this will be [`ChangeStreamEvent`](document/struct.ChangeStreamEvent.html)
+/// wrapping the value type (for `Collection::watch`) or a `Document` (for `Client::watch` and
+/// `Database::watch`).  For `watch_with_pipeline`, a deserializable type must be specified that
+/// matches the result of the aggregation pipeline; if the pipeline does not alter the event
+/// structure it may be convenient to reuse `ChangeStreamEvent` for that type.
+///
+/// A `ChangeStream` can be iterated like any other `Stream`:
+///
+/// ```rust
+/// # #[cfg(not(feature = "sync"))]
+/// # use futures::stream::StreamExt;
+/// # use mongodb::{Client, error::Result, bson::doc,
+/// # change_stream::document::ChangeStreamEventDocument};
+/// # #[cfg(feature = "async-std-runtime")]
+/// # use async_std::task;
+/// # #[cfg(feature = "tokio-runtime")]
+/// # use tokio::task;
+/// #
+/// # async fn func() -> Result<()> {
+/// # let client = Client::with_uri_str("mongodb://example.com").await?;
+/// # let coll = client.database("foo").collection("bar");
+/// let mut change_stream = coll.watch(None).await?;
+/// let coll_ref = coll.clone();
+/// task::spawn(async move {
+///     coll_ref.insert_one(doc! { "x": 1 }, None).await;
+/// });
+/// while let Some(event) = change_stream.next().await {
+///     println!("operation performed: {:?}, document: {:?}", event.operation_type, event.full_document);
+///     // operation performed: Insert, document: Some(Document({"x": Int32(1)}))
+/// }
+/// #
+/// # Ok(())
+/// # }
+/// ```
+///
+/// See the documentation [here](https://docs.mongodb.com/manual/changeStreams) for more
+/// details. Also see the documentation on [usage recommendations](https://docs.mongodb.com/manual/administration/change-streams-production-recommendations/).
+pub struct ChangeStream<T>
+where
+    T: DeserializeOwned + Unpin + Send + Sync,
+{
+    /// The cursor to iterate over event instances.
+    cursor: Cursor<T>,
+
+    /// The pipeline of stages to append to an initial `$changeStream` stage.
+    pipeline: Vec<Document>,
+
+    /// The client that was used for the initial `$changeStream` aggregation, used for server
+    /// selection during an automatic resume.
+    client: Client,
+
+    /// The original target of the change stream, used for re-issuing the aggregation during
+    /// an automatic resume.
+    target: ChangeStreamTarget<T>,
+
+    /// The cached resume token.
+    resume_token: Option<ResumeToken>,
+
+    /// The options provided to the initial `$changeStream` stage.
+    options: Option<ChangeStreamOptions>,
+
+    /// The read preference for the initial `$changeStream` aggregation, used for server selection
+    /// during an automatic resume.
+    read_preference: Option<ReadPreference>,
+
+    /// Whether or not the change stream has attempted a resume, used to attempt a resume only
+    /// once.
+    resume_attempted: bool,
+
+    /// Whether or not the change stream has returned a document, used to update resume token
+    /// during an automatic resume.
+    document_returned: bool,
+}
+
+impl<T> ChangeStream<T>
+where
+    T: DeserializeOwned + Unpin + Send + Sync,
+{
+    /// Returns the cached resume token that can be used to resume after the most recently returned
+    /// change.
+    ///
+    /// See the documentation
+    /// [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-token) for more
+    /// information on change stream resume tokens.
+    pub fn resume_token(&self) -> Option<ResumeToken> {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ChangeStreamTarget<T> {
+    Collection(Collection<T>),
+    Database(Database),
+    Cluster(Database),
+}
+
+impl<T> Stream for ChangeStream<T>
+where
+    T: DeserializeOwned + Unpin + Send + Sync,
+{
+    type Item = Result<T>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        todo!()
+    }
+}

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -43,11 +43,11 @@ use crate::{
 ///
 /// A `ChangeStream` can be iterated like any other [`Stream`]:
 ///
-/// ```rust
+/// ```ignore
 /// # #[cfg(not(feature = "sync"))]
 /// # use futures::stream::StreamExt;
 /// # use mongodb::{Client, error::Result, bson::doc,
-/// # change_stream::document::ChangeStreamEventDocument};
+/// # change_stream::event::ChangeStreamEvent};
 /// # #[cfg(feature = "async-std-runtime")]
 /// # use async_std::task;
 /// # #[cfg(feature = "tokio-runtime")]
@@ -56,12 +56,12 @@ use crate::{
 /// # async fn func() -> Result<()> {
 /// # let client = Client::with_uri_str("mongodb://example.com").await?;
 /// # let coll = client.database("foo").collection("bar");
-/// let mut change_stream = coll.watch(None).await?;
+/// let mut change_stream = coll.watch(None, None).await?;
 /// let coll_ref = coll.clone();
 /// task::spawn(async move {
 ///     coll_ref.insert_one(doc! { "x": 1 }, None).await;
 /// });
-/// while let Some(event) = change_stream.next().await {
+/// while let Some(event) = change_stream.next().await.transpose()? {
 ///     println!("operation performed: {:?}, document: {:?}", event.operation_type, event.full_document);
 ///     // operation performed: Insert, document: Some(Document({"x": Int32(1)}))
 /// }

--- a/src/change_stream/options.rs
+++ b/src/change_stream/options.rs
@@ -4,7 +4,12 @@ use serde_with::skip_serializing_none;
 use std::time::Duration;
 use typed_builder::TypedBuilder;
 
-use crate::{change_stream::event::ResumeToken, collation::Collation, options::AggregateOptions};
+use crate::{
+    bson::Timestamp,
+    change_stream::event::ResumeToken,
+    collation::Collation,
+    options::AggregateOptions,
+};
 
 /// These are the valid options that can be passed to the `watch` method for creating a
 /// [`ChangeStream`](crate::change_stream::ChangeStream).
@@ -13,9 +18,10 @@ use crate::{change_stream::event::ResumeToken, collation::Collation, options::Ag
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ChangeStreamOptions {
+    #[rustfmt::skip]
     /// When set to [`FullDocumentType::UpdateLookup`], the
-    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::
-    /// full_document`) field  will be populated with a copy of the entire document that was
+    /// [`ChangeStreamEvent::full_document`](crate::change_stream::event::ChangeStreamEvent::full_document)
+    /// field  will be populated with a copy of the entire document that was
     /// updated from some time after the change occurred when an "update" event occurs. By
     /// default, the `full_document` field will be empty for updates.
     #[builder(default)]
@@ -49,7 +55,7 @@ pub struct ChangeStreamOptions {
     /// timestamp. Any command run against the server will return an operation time that can be
     /// used here.
     #[builder(default)]
-    pub start_at_operation_time: Option<i64>,
+    pub start_at_operation_time: Option<Timestamp>,
 
     /// Takes a resume token and starts a new change stream returning the first notification after
     /// the token. This will allow users to watch collections that have been dropped and
@@ -63,16 +69,17 @@ pub struct ChangeStreamOptions {
     pub start_after: Option<ResumeToken>,
 }
 
+#[rustfmt::skip]
 /// Describes the modes for configuring the
-/// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::
-/// full_document`) field.
+/// [`ChangeStreamEvent::full_document`](crate::change_stream::event::ChangeStreamEvent::full_document)
+/// field.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub enum FullDocumentType {
+    #[rustfmt::skip]
     /// The
-    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::
-    /// full_document`) field will be populated with a copy of the entire document that was
-    /// updated.
+    /// [`ChangeStreamEvent::full_document`](crate::change_stream::event::ChangeStreamEvent::full_document)
+    /// field will be populated with a copy of the entire document that was updated.
     UpdateLookup,
 
     /// User-defined other types for forward compatibility.

--- a/src/change_stream/options.rs
+++ b/src/change_stream/options.rs
@@ -14,10 +14,10 @@ use crate::{change_stream::event::ResumeToken, collation::Collation, options::Ag
 #[non_exhaustive]
 pub struct ChangeStreamOptions {
     /// When set to [`FullDocumentType::UpdateLookup`], the
-    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::full_document`)
-    /// field  will be populated with a copy of the entire document that was updated from some time
-    /// after the change occurred when an "update" event occurs. By default, the `full_document`
-    /// field will be empty for updates.
+    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::
+    /// full_document`) field  will be populated with a copy of the entire document that was
+    /// updated from some time after the change occurred when an "update" event occurs. By
+    /// default, the `full_document` field will be empty for updates.
     #[builder(default)]
     pub full_document: Option<FullDocumentType>,
 
@@ -64,14 +64,15 @@ pub struct ChangeStreamOptions {
 }
 
 /// Describes the modes for configuring the
-/// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::full_document`)
-/// field.
+/// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::
+/// full_document`) field.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
 pub enum FullDocumentType {
     /// The
-    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::full_document`)
-    /// field will be populated with a copy of the entire document that was updated.
+    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::
+    /// full_document`) field will be populated with a copy of the entire document that was
+    /// updated.
     UpdateLookup,
 
     /// User-defined other types for forward compatibility.

--- a/src/change_stream/options.rs
+++ b/src/change_stream/options.rs
@@ -1,0 +1,77 @@
+//! Contains options for ChangeStreams.
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use std::time::Duration;
+use typed_builder::TypedBuilder;
+
+use crate::{change_stream::event::ResumeToken, collation::Collation, options::AggregateOptions};
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+/// These are the valid options that can be passed to the `watch` method for creating a
+/// [`ChangeStream`](../struct.ChangeStream.html).
+pub struct ChangeStreamOptions {
+    /// When set to FullDocumentType::UpdateLookup, the `full_document` field of the
+    /// `ChangeStreamEvent` will be populated with a copy of the entire document that was updated
+    /// from some time after the change occurred when an "update" event occurs. By default, the
+    /// `full_document` field will be empty for updates.
+    #[builder(default)]
+    pub full_document: Option<FullDocumentType>,
+
+    /// Specifies the logical starting point for the new change stream. Note that if a watched
+    /// collection is dropped and recreated or newly renamed, `start_after` should be set instead.
+    /// `resume_after` and `start_after` cannot be set simultaneously.
+    ///
+    /// For more information on resuming a change stream see the documentation [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-after)
+    #[builder(default)]
+    pub resume_after: Option<ResumeToken>,
+
+    /// The maximum amount of time for the server to wait on new documents to satisfy a change
+    /// stream query.
+    #[builder(default)]
+    #[serde(skip_serializing)]
+    pub max_await_time: Option<Duration>,
+
+    /// The number of documents to return per batch.
+    #[builder(default)]
+    #[serde(skip_serializing)]
+    pub batch_size: Option<i32>,
+
+    /// Specifies a collation.
+    #[builder(default)]
+    #[serde(skip_serializing)]
+    pub collation: Option<Collation>,
+
+    /// The change stream will only provide changes that occurred at or after the specified
+    /// timestamp. Any command run against the server will return an operation time that can be
+    /// used here.
+    #[builder(default)]
+    pub start_at_operation_time: Option<i64>,
+
+    /// Takes a resume token and starts a new change stream returning the first notification after
+    /// the token. This will allow users to watch collections that have been dropped and
+    /// recreated or newly renamed collections without missing any notifications.
+    ///
+    /// This feature is only available on MongoDB 4.2+.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/master/changeStreams/#change-stream-start-after) for more
+    /// information.
+    #[builder(default)]
+    pub start_after: Option<ResumeToken>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+/// Describes the modes for configuring the `full_document` field of a
+/// [`ChangeStreamEventDocument`](../document/struct.ChangeStreamEventDocument.html)
+pub enum FullDocumentType {
+    /// The `full_document` field of the
+    /// [`ChangeStreamEventDocument`](../document/struct.ChangeStreamEventDocument.html) will be
+    /// populated with a copy of the entire document that was updated.
+    UpdateLookup,
+
+    /// User-defined other types for forward compatibility.
+    Other(String),
+}

--- a/src/change_stream/options.rs
+++ b/src/change_stream/options.rs
@@ -6,17 +6,18 @@ use typed_builder::TypedBuilder;
 
 use crate::{change_stream::event::ResumeToken, collation::Collation, options::AggregateOptions};
 
+/// These are the valid options that can be passed to the `watch` method for creating a
+/// [`ChangeStream`](crate::change_stream::ChangeStream).
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-/// These are the valid options that can be passed to the `watch` method for creating a
-/// [`ChangeStream`](../struct.ChangeStream.html).
 pub struct ChangeStreamOptions {
-    /// When set to FullDocumentType::UpdateLookup, the `full_document` field of the
-    /// `ChangeStreamEvent` will be populated with a copy of the entire document that was updated
-    /// from some time after the change occurred when an "update" event occurs. By default, the
-    /// `full_document` field will be empty for updates.
+    /// When set to [`FullDocumentType::UpdateLookup`], the
+    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::full_document`)
+    /// field  will be populated with a copy of the entire document that was updated from some time
+    /// after the change occurred when an "update" event occurs. By default, the `full_document`
+    /// field will be empty for updates.
     #[builder(default)]
     pub full_document: Option<FullDocumentType>,
 
@@ -62,14 +63,15 @@ pub struct ChangeStreamOptions {
     pub start_after: Option<ResumeToken>,
 }
 
+/// Describes the modes for configuring the
+/// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::full_document`)
+/// field.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
-/// Describes the modes for configuring the `full_document` field of a
-/// [`ChangeStreamEventDocument`](../document/struct.ChangeStreamEventDocument.html)
 pub enum FullDocumentType {
-    /// The `full_document` field of the
-    /// [`ChangeStreamEventDocument`](../document/struct.ChangeStreamEventDocument.html) will be
-    /// populated with a copy of the entire document that was updated.
+    /// The
+    /// [`ChangeStreamEvent::full_document`](`crate::change_stream::event::ChangeStreamEvent::full_document`)
+    /// field will be populated with a copy of the entire document that was updated.
     UpdateLookup,
 
     /// User-defined other types for forward compatibility.

--- a/src/change_stream/session.rs
+++ b/src/change_stream/session.rs
@@ -1,13 +1,13 @@
 use bson::Document;
 use serde::de::DeserializeOwned;
 
-use crate::{ClientSession, SessionCursor, SessionCursorStream, error::Result};
+use crate::{error::Result, ClientSession, SessionCursor, SessionCursorStream};
 
-use super::{ChangeStreamData, event::ResumeToken};
+use super::{event::ResumeToken, ChangeStreamData};
 
-/// A [`SessionChangeStream`] is a change stream that was created with a [`ClientSession`] that must be iterated
-/// using one. To iterate, use [`SessionChangeStream::next`] or retrieve a [`SessionCursorStream`] using
-/// [`SessionChangeStream::stream`]:
+/// A [`SessionChangeStream`] is a change stream that was created with a [`ClientSession`] that must
+/// be iterated using one. To iterate, use [`SessionChangeStream::next`] or retrieve a
+/// [`SessionCursorStream`] using [`SessionChangeStream::stream`]:
 ///
 /// ```rust
 /// # use mongodb::{bson::Document, Client, error::Result, ClientSession, SessionCursor};
@@ -59,12 +59,12 @@ where
         todo!()
     }
 
-    /// Retrieves a [`SessionCursorStream`] to iterate this change stream. The session provided must be the
-    /// same session used to create the cursor.
+    /// Retrieves a [`SessionCursorStream`] to iterate this change stream. The session provided must
+    /// be the same session used to create the cursor.
     ///
     /// Note that the borrow checker will not allow the session to be reused in between iterations
-    /// of this stream. In order to do that, either use [`SessionChangeStream::next`] instead or drop
-    /// the stream before using the session.
+    /// of this stream. In order to do that, either use [`SessionChangeStream::next`] instead or
+    /// drop the stream before using the session.
     ///
     /// ```
     /// # use bson::{doc, Document};

--- a/src/change_stream/session.rs
+++ b/src/change_stream/session.rs
@@ -1,4 +1,10 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 use bson::Document;
+use futures_core::Stream;
 use serde::de::DeserializeOwned;
 
 use crate::{error::Result, ClientSession, SessionCursor, SessionCursorStream};
@@ -101,10 +107,10 @@ where
     /// # };
     /// # }
     /// ```
-    pub fn stream<'session>(
+    pub fn values<'session>(
         &mut self,
         session: &'session mut ClientSession,
-    ) -> SessionCursorStream<'_, 'session, T> {
+    ) -> SessionChangeStreamValues<'_, 'session, T> {
         todo!()
     }
 
@@ -132,6 +138,30 @@ where
     /// # }
     /// ```
     pub async fn next(&mut self, session: &mut ClientSession) -> Option<Result<T>> {
+        todo!()
+    }
+}
+
+/// A type that implements [`Stream`](https://docs.rs/futures/latest/futures/stream/index.html) which can be used to
+/// stream the results of a [`SessionChangeStream`]. Returned from [`SessionChangeStream::values`].
+///
+/// This updates the buffer of the parent [`SessionChangeStream`] when dropped.
+/// [`SessionChangeStream::next`] or any further streams created from
+/// [`SessionChangeStream::values`] will pick up where this one left off.
+pub struct SessionChangeStreamValues<'cursor, 'session, T>
+where
+    T: DeserializeOwned + Unpin + Send + Sync,
+{
+    stream: SessionCursorStream<'cursor, 'session, T>,
+}
+
+impl<'cursor, 'session, T> Stream for SessionChangeStreamValues<'cursor, 'session, T>
+where
+    T: DeserializeOwned + Unpin + Send + Sync,
+{
+    type Item = Result<T>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         todo!()
     }
 }

--- a/src/change_stream/session.rs
+++ b/src/change_stream/session.rs
@@ -1,0 +1,137 @@
+use bson::Document;
+use serde::de::DeserializeOwned;
+
+use crate::{ClientSession, SessionCursor, SessionCursorStream, error::Result};
+
+use super::{ChangeStreamData, event::ResumeToken};
+
+/// A [`SessionChangeStream`] is a change stream that was created with a [`ClientSession`] that must be iterated
+/// using one. To iterate, use [`SessionChangeStream::next`] or retrieve a [`SessionCursorStream`] using
+/// [`SessionChangeStream::stream`]:
+///
+/// ```rust
+/// # use mongodb::{bson::Document, Client, error::Result, ClientSession, SessionCursor};
+/// #
+/// # async fn do_stuff() -> Result<()> {
+/// # let client = Client::with_uri_str("mongodb://example.com").await?;
+/// # let mut session = client.start_session(None).await?;
+/// # let coll = client.database("foo").collection::<Document>("bar");
+/// #
+/// // iterate using next()
+/// let mut cs = coll.watch_with_session(None, None, &mut session).await?;
+/// while let Some(doc) = cursor.next(&mut session).await.transpose()? {
+///     println!("{}", doc)
+/// }
+///
+/// // iterate using `Stream`:
+/// use futures::stream::TryStreamExt;
+///
+/// let mut cs = coll.watch_with_session(None, None, &mut session).await?;
+/// let results: Vec<_> = cursor.stream(&mut session).try_collect().await?;
+/// #
+/// # Ok(())
+/// # }
+/// ```
+pub struct SessionChangeStream<T>
+where
+    T: DeserializeOwned + Unpin,
+{
+    cursor: SessionCursor<T>,
+    data: ChangeStreamData,
+}
+
+impl<T> SessionChangeStream<T>
+where
+    T: DeserializeOwned + Unpin + Send + Sync,
+{
+    /// Returns the cached resume token that can be used to resume after the most recently returned
+    /// change.
+    ///
+    /// See the documentation
+    /// [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-token) for more
+    /// information on change stream resume tokens.
+    pub fn resume_token(&self) -> Option<&ResumeToken> {
+        todo!()
+    }
+
+    /// Update the type streamed values will be parsed as.
+    pub fn with_type<D: DeserializeOwned + Unpin + Send + Sync>(self) -> SessionChangeStream<D> {
+        todo!()
+    }
+
+    /// Retrieves a [`SessionCursorStream`] to iterate this change stream. The session provided must be the
+    /// same session used to create the cursor.
+    ///
+    /// Note that the borrow checker will not allow the session to be reused in between iterations
+    /// of this stream. In order to do that, either use [`SessionChangeStream::next`] instead or drop
+    /// the stream before using the session.
+    ///
+    /// ```
+    /// # use bson::{doc, Document};
+    /// # use mongodb::{Client, error::Result};
+    /// # fn main() {
+    /// # async {
+    /// # let client = Client::with_uri_str("foo").await?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let other_coll = coll.clone();
+    /// # let mut session = client.start_session(None).await?;
+    /// #
+    /// use futures::stream::TryStreamExt;
+    ///
+    /// // iterate over the results
+    /// let mut cs = coll.watch_with_session(None, None, &mut session).await?;
+    /// while let Some(doc) = cs.stream(&mut session).try_next().await? {
+    ///     println!("{}", doc);
+    /// }
+    ///
+    /// // collect the results
+    /// let mut cs1 = coll.watch_with_session(None, None, &mut session).await?;
+    /// let v: Vec<Document> = cs1.stream(&mut session).try_collect().await?;
+    ///
+    /// // use session between iterations
+    /// let mut cs2 = coll.watch_with_session(None, None, &mut session).await?;
+    /// loop {
+    ///     let doc = match cs2.stream(&mut session).try_next().await? {
+    ///         Some(d) => d,
+    ///         None => break,
+    ///     };
+    ///     other_coll.insert_one_with_session(doc, None, &mut session).await?;
+    /// }
+    /// # Ok::<(), mongodb::error::Error>(())
+    /// # };
+    /// # }
+    /// ```
+    pub fn stream<'session>(
+        &mut self,
+        session: &'session mut ClientSession,
+    ) -> SessionCursorStream<'_, 'session, T> {
+        todo!()
+    }
+
+    /// Retrieve the next result from the change stream.
+    /// The session provided must be the same session used to create the change stream.
+    ///
+    /// Use this method when the session needs to be used again between iterations or when the added
+    /// functionality of `Stream` is not needed.
+    ///
+    /// ```
+    /// # use bson::{doc, Document};
+    /// # use mongodb::Client;
+    /// # fn main() {
+    /// # async {
+    /// # let client = Client::with_uri_str("foo").await?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let other_coll = coll.clone();
+    /// # let mut session = client.start_session(None).await?;
+    /// let mut cs = coll.watch_with_session(None, None, &mut session).await?;
+    /// while let Some(doc) = cs.next(&mut session).await.transpose()? {
+    ///     other_coll.insert_one_with_session(doc, None, &mut session).await?;
+    /// }
+    /// # Ok::<(), mongodb::error::Error>(())
+    /// # };
+    /// # }
+    /// ```
+    pub async fn next(&mut self, session: &mut ClientSession) -> Option<Result<T>> {
+        todo!()
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,14 +13,31 @@ use derivative::Derivative;
 
 #[cfg(test)]
 use crate::options::ServerAddress;
-use crate::{ClientSession, bson::Document, change_stream::{ChangeStream, event::ChangeStreamEvent, options::ChangeStreamOptions, session::SessionChangeStream}, concern::{ReadConcern, WriteConcern}, db::Database, error::{ErrorKind, Result}, event::command::CommandEventHandler, operation::ListDatabases, options::{
+use crate::{
+    bson::Document,
+    change_stream::{
+        event::ChangeStreamEvent,
+        options::ChangeStreamOptions,
+        session::SessionChangeStream,
+        ChangeStream,
+    },
+    concern::{ReadConcern, WriteConcern},
+    db::Database,
+    error::{ErrorKind, Result},
+    event::command::CommandEventHandler,
+    operation::ListDatabases,
+    options::{
         ClientOptions,
         DatabaseOptions,
         ListDatabasesOptions,
         ReadPreference,
         SelectionCriteria,
         SessionOptions,
-    }, results::DatabaseSpecification, sdam::{SelectedServer, SessionSupportStatus, Topology}};
+    },
+    results::DatabaseSpecification,
+    sdam::{SelectedServer, SessionSupportStatus, Topology},
+    ClientSession,
+};
 pub(crate) use executor::{HELLO_COMMAND_NAMES, REDACTED_COMMANDS};
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -13,26 +13,14 @@ use derivative::Derivative;
 
 #[cfg(test)]
 use crate::options::ServerAddress;
-use crate::{
-    bson::Document,
-    change_stream::{event::ChangeStreamEvent, options::ChangeStreamOptions, ChangeStream},
-    concern::{ReadConcern, WriteConcern},
-    db::Database,
-    error::{ErrorKind, Result},
-    event::command::CommandEventHandler,
-    operation::ListDatabases,
-    options::{
+use crate::{ClientSession, bson::Document, change_stream::{ChangeStream, event::ChangeStreamEvent, options::ChangeStreamOptions, session::SessionChangeStream}, concern::{ReadConcern, WriteConcern}, db::Database, error::{ErrorKind, Result}, event::command::CommandEventHandler, operation::ListDatabases, options::{
         ClientOptions,
         DatabaseOptions,
         ListDatabasesOptions,
         ReadPreference,
         SelectionCriteria,
         SessionOptions,
-    },
-    results::DatabaseSpecification,
-    sdam::{SelectedServer, SessionSupportStatus, Topology},
-    ClientSession,
-};
+    }, results::DatabaseSpecification, sdam::{SelectedServer, SessionSupportStatus, Topology}};
 pub(crate) use executor::{HELLO_COMMAND_NAMES, REDACTED_COMMANDS};
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 
@@ -282,6 +270,16 @@ impl Client {
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
     ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
+        todo!()
+    }
+
+    #[allow(unused)]
+    pub(crate) async fn watch_with_session(
+        &self,
+        pipeline: impl IntoIterator<Item = Document>,
+        options: impl Into<Option<ChangeStreamOptions>>,
+        session: &mut ClientSession,
+    ) -> Result<SessionChangeStream<ChangeStreamEvent<Document>>> {
         todo!()
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,16 +3,20 @@ mod executor;
 pub mod options;
 pub mod session;
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use bson::Bson;
 use derivative::Derivative;
-use std::time::Instant;
+use serde::de::DeserializeOwned;
 
 #[cfg(test)]
 use crate::options::ServerAddress;
 use crate::{
     bson::Document,
+    change_stream::{event::ChangeStreamEvent, options::ChangeStreamOptions, ChangeStream},
     concern::{ReadConcern, WriteConcern},
     db::Database,
     error::{ErrorKind, Result},
@@ -253,6 +257,52 @@ impl Client {
                 .await),
             _ => Err(ErrorKind::SessionsNotSupported.into()),
         }
+    }
+
+    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
+    /// for all changes in the cluster. The stream does not observe changes from system
+    /// collections or the "config", "local" or "admin" databases. Note that this method
+    /// (`watch` on a cluster) is only supported in MongoDB 4.0 or greater.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
+    /// streams.
+    ///
+    /// Change streams require either a "majority" read concern or no read
+    /// concern. Anything else will cause a server error.
+    #[allow(unused)]
+    pub(crate) async fn watch(
+        &self,
+        options: impl Into<Option<ChangeStreamOptions>>,
+    ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
+        todo!()
+    }
+
+    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
+    /// for all changes in the cluster and processes them via the given aggregation pipeline. The
+    /// stream does not observe changes from system collections or the "config", "local" or "admin"
+    /// databases. Note that this method (`watch` on a cluster) is only supported in MongoDB 4.0 or
+    /// greater.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
+    /// streams.
+    ///
+    /// Change streams require either a "majority" read concern or no read
+    /// concern. Anything else will cause a server error.
+    ///
+    /// Note that using a `$project` stage to remove any of the `_id` `operationType` or `ns` fields
+    /// will cause an error. The driver requires these fields to support resumability. For
+    /// more information on resumability, see the documentation for
+    /// [`ChangeStream`](change_stream/struct.ChangeStream.html)
+    #[allow(unused)]
+    pub(crate) async fn watch_with_pipeline<D>(
+        &self,
+        pipeline: impl IntoIterator<Item = Document>,
+        options: impl Into<Option<ChangeStreamOptions>>,
+    ) -> Result<ChangeStream<D>>
+    where
+        D: DeserializeOwned + Unpin + Send + Sync,
+    {
+        todo!()
     }
 
     /// Check in a server session to the server session pool.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -10,7 +10,6 @@ use std::{
 
 use bson::Bson;
 use derivative::Derivative;
-use serde::de::DeserializeOwned;
 
 #[cfg(test)]
 use crate::options::ServerAddress;
@@ -259,29 +258,10 @@ impl Client {
         }
     }
 
-    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
-    /// for all changes in the cluster. The stream does not observe changes from system
-    /// collections or the "config", "local" or "admin" databases. Note that this method
-    /// (`watch` on a cluster) is only supported in MongoDB 4.0 or greater.
-    ///
-    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
-    /// streams.
-    ///
-    /// Change streams require either a "majority" read concern or no read
-    /// concern. Anything else will cause a server error.
-    #[allow(unused)]
-    pub(crate) async fn watch(
-        &self,
-        options: impl Into<Option<ChangeStreamOptions>>,
-    ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
-        todo!()
-    }
-
-    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
-    /// for all changes in the cluster and processes them via the given aggregation pipeline. The
-    /// stream does not observe changes from system collections or the "config", "local" or "admin"
-    /// databases. Note that this method (`watch` on a cluster) is only supported in MongoDB 4.0 or
-    /// greater.
+    /// Starts a new [`ChangeStream`] that receives events for all changes in the cluster. The
+    /// stream does not observe changes from system collections or the "config", "local" or
+    /// "admin" databases. Note that this method (`watch` on a cluster) is only supported in
+    /// MongoDB 4.0 or greater.
     ///
     /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
     /// streams.
@@ -293,15 +273,15 @@ impl Client {
     /// will cause an error. The driver requires these fields to support resumability. For
     /// more information on resumability, see the documentation for
     /// [`ChangeStream`](change_stream/struct.ChangeStream.html)
+    ///
+    /// If the pipeline alters the structure of the returned events, the parsed type will need to be
+    /// changed via [`ChangeStream::with_type`].
     #[allow(unused)]
-    pub(crate) async fn watch_with_pipeline<D>(
+    pub(crate) async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
-    ) -> Result<ChangeStream<D>>
-    where
-        D: DeserializeOwned + Unpin + Send + Sync,
-    {
+    ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
         todo!()
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -290,6 +290,8 @@ impl Client {
         todo!()
     }
 
+    /// Starts a new [`SessionChangeStream`] that receives events for all changes in the cluster
+    /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
     #[allow(unused)]
     pub(crate) async fn watch_with_session(
         &self,

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -14,7 +14,21 @@ use serde::{
 };
 
 use self::options::*;
-use crate::{Client, ClientSession, Cursor, Database, SessionCursor, bson::{doc, to_document, Bson, Document}, bson_util, change_stream::{ChangeStream, event::ChangeStreamEvent, options::ChangeStreamOptions, session::SessionChangeStream}, client::session::TransactionState, cmap::conn::PinnedConnectionHandle, concern::{ReadConcern, WriteConcern}, error::{convert_bulk_errors, BulkWriteError, BulkWriteFailure, Error, ErrorKind, Result}, index::IndexModel, operation::{
+use crate::{
+    bson::{doc, to_document, Bson, Document},
+    bson_util,
+    change_stream::{
+        event::ChangeStreamEvent,
+        options::ChangeStreamOptions,
+        session::SessionChangeStream,
+        ChangeStream,
+    },
+    client::session::TransactionState,
+    cmap::conn::PinnedConnectionHandle,
+    concern::{ReadConcern, WriteConcern},
+    error::{convert_bulk_errors, BulkWriteError, BulkWriteFailure, Error, ErrorKind, Result},
+    index::IndexModel,
+    operation::{
         Aggregate,
         Count,
         CountDocuments,
@@ -28,14 +42,22 @@ use crate::{Client, ClientSession, Cursor, Database, SessionCursor, bson::{doc, 
         Insert,
         ListIndexes,
         Update,
-    }, results::{
+    },
+    results::{
         CreateIndexResult,
         CreateIndexesResult,
         DeleteResult,
         InsertManyResult,
         InsertOneResult,
         UpdateResult,
-    }, selection_criteria::SelectionCriteria};
+    },
+    selection_criteria::SelectionCriteria,
+    Client,
+    ClientSession,
+    Cursor,
+    Database,
+    SessionCursor,
+};
 
 /// `Collection` is the client-side abstraction of a MongoDB Collection. It can be used to
 /// perform collection-level operations such as CRUD operations. A `Collection` can be obtained

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -800,40 +800,22 @@ impl<T> Collection<T> {
     ///
     /// Change streams require either a "majority" read concern or no read concern. Anything else
     /// will cause a server error.
-    #[allow(unused)]
-    pub(crate) async fn watch(
-        &self,
-        options: impl Into<Option<ChangeStreamOptions>>,
-    ) -> Result<ChangeStream<ChangeStreamEvent<T>>>
-    where
-        T: DeserializeOwned + Unpin + Send + Sync,
-    {
-        todo!()
-    }
-
-    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
-    /// for all changes in this collection and processes them via the given aggregation pipeline. A
-    /// [`ChangeStream`](change_stream/struct.ChangeStream.html) cannot be started on system
-    /// collections.
-    ///
-    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
-    /// streams.
-    ///
-    /// Change streams require either a "majority" read concern or no read concern. Anything else
-    /// will cause a server error.
     ///
     /// Also note that using a `$project` stage to remove any of the `_id`, `operationType` or `ns`
     /// fields will cause an error. The driver requires these fields to support resumability. For
     /// more information on resumability, see the documentation for
     /// [`ChangeStream`](change_stream/struct.ChangeStream.html)
+    ///
+    /// If the pipeline alters the structure of the returned events, the parsed type will need to be
+    /// changed via [`ChangeStream::with_type`].
     #[allow(unused)]
-    pub(crate) async fn watch_with_pipeline<D>(
+    pub(crate) async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
-    ) -> Result<ChangeStream<D>>
+    ) -> Result<ChangeStream<ChangeStreamEvent<T>>>
     where
-        D: DeserializeOwned + Unpin + Send + Sync,
+        T: DeserializeOwned + Unpin + Send + Sync,
     {
         todo!()
     }

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -825,6 +825,8 @@ impl<T> Collection<T> {
         todo!()
     }
 
+    /// Starts a new [`SessionChangeStream`] that receives events for all changes in this collection
+    /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
     #[allow(unused)]
     pub(crate) async fn watch_with_session(
         &self,

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -14,16 +14,7 @@ use serde::{
 };
 
 use self::options::*;
-use crate::{
-    bson::{doc, to_document, Bson, Document},
-    bson_util,
-    change_stream::{event::ChangeStreamEvent, options::ChangeStreamOptions, ChangeStream},
-    client::session::TransactionState,
-    cmap::conn::PinnedConnectionHandle,
-    concern::{ReadConcern, WriteConcern},
-    error::{convert_bulk_errors, BulkWriteError, BulkWriteFailure, Error, ErrorKind, Result},
-    index::IndexModel,
-    operation::{
+use crate::{Client, ClientSession, Cursor, Database, SessionCursor, bson::{doc, to_document, Bson, Document}, bson_util, change_stream::{ChangeStream, event::ChangeStreamEvent, options::ChangeStreamOptions, session::SessionChangeStream}, client::session::TransactionState, cmap::conn::PinnedConnectionHandle, concern::{ReadConcern, WriteConcern}, error::{convert_bulk_errors, BulkWriteError, BulkWriteFailure, Error, ErrorKind, Result}, index::IndexModel, operation::{
         Aggregate,
         Count,
         CountDocuments,
@@ -37,22 +28,14 @@ use crate::{
         Insert,
         ListIndexes,
         Update,
-    },
-    results::{
+    }, results::{
         CreateIndexResult,
         CreateIndexesResult,
         DeleteResult,
         InsertManyResult,
         InsertOneResult,
         UpdateResult,
-    },
-    selection_criteria::SelectionCriteria,
-    Client,
-    ClientSession,
-    Cursor,
-    Database,
-    SessionCursor,
-};
+    }, selection_criteria::SelectionCriteria};
 
 /// `Collection` is the client-side abstraction of a MongoDB Collection. It can be used to
 /// perform collection-level operations such as CRUD operations. A `Collection` can be obtained
@@ -814,6 +797,19 @@ impl<T> Collection<T> {
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
     ) -> Result<ChangeStream<ChangeStreamEvent<T>>>
+    where
+        T: DeserializeOwned + Unpin + Send + Sync,
+    {
+        todo!()
+    }
+
+    #[allow(unused)]
+    pub(crate) async fn watch_with_session(
+        &self,
+        pipeline: impl IntoIterator<Item = Document>,
+        options: impl Into<Option<ChangeStreamOptions>>,
+        session: &mut ClientSession,
+    ) -> Result<SessionChangeStream<ChangeStreamEvent<T>>>
     where
         T: DeserializeOwned + Unpin + Send + Sync,
     {

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -17,6 +17,7 @@ use self::options::*;
 use crate::{
     bson::{doc, to_document, Bson, Document},
     bson_util,
+    change_stream::{event::ChangeStreamEvent, options::ChangeStreamOptions, ChangeStream},
     client::session::TransactionState,
     cmap::conn::PinnedConnectionHandle,
     concern::{ReadConcern, WriteConcern},
@@ -787,6 +788,54 @@ impl<T> Collection<T> {
             )
             .await?;
         Ok(())
+    }
+
+    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
+    /// for all changes in this collection. A
+    /// [`ChangeStream`](change_stream/struct.ChangeStream.html) cannot be started on system
+    /// collections.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
+    /// streams.
+    ///
+    /// Change streams require either a "majority" read concern or no read concern. Anything else
+    /// will cause a server error.
+    #[allow(unused)]
+    pub(crate) async fn watch(
+        &self,
+        options: impl Into<Option<ChangeStreamOptions>>,
+    ) -> Result<ChangeStream<ChangeStreamEvent<T>>>
+    where
+        T: DeserializeOwned + Unpin + Send + Sync,
+    {
+        todo!()
+    }
+
+    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
+    /// for all changes in this collection and processes them via the given aggregation pipeline. A
+    /// [`ChangeStream`](change_stream/struct.ChangeStream.html) cannot be started on system
+    /// collections.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
+    /// streams.
+    ///
+    /// Change streams require either a "majority" read concern or no read concern. Anything else
+    /// will cause a server error.
+    ///
+    /// Also note that using a `$project` stage to remove any of the `_id`, `operationType` or `ns`
+    /// fields will cause an error. The driver requires these fields to support resumability. For
+    /// more information on resumability, see the documentation for
+    /// [`ChangeStream`](change_stream/struct.ChangeStream.html)
+    #[allow(unused)]
+    pub(crate) async fn watch_with_pipeline<D>(
+        &self,
+        pipeline: impl IntoIterator<Item = Document>,
+        options: impl Into<Option<ChangeStreamOptions>>,
+    ) -> Result<ChangeStream<D>>
+    where
+        D: DeserializeOwned + Unpin + Send + Sync,
+    {
+        todo!()
     }
 }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -472,6 +472,8 @@ impl Database {
         todo!()
     }
 
+    /// Starts a new [`SessionChangeStream`] that receives events for all changes in this database
+    /// using the provided [`ClientSession`].  See [`Database::watch`] for more information.
     #[allow(unused)]
     pub(crate) async fn watch_with_session(
         &self,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,9 +3,11 @@ pub mod options;
 use std::{fmt::Debug, sync::Arc};
 
 use futures_util::stream::TryStreamExt;
+use serde::de::DeserializeOwned;
 
 use crate::{
     bson::{Bson, Document},
+    change_stream::{event::ChangeStreamEvent, options::ChangeStreamOptions, ChangeStream},
     client::session::TransactionState,
     cmap::conn::PinnedConnectionHandle,
     concern::{ReadConcern, WriteConcern},
@@ -438,5 +440,49 @@ impl Database {
         client
             .execute_session_cursor_operation(aggregate, session)
             .await
+    }
+
+    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
+    /// for all changes in this database. The stream does not observe changes from system
+    /// collections and cannot be started on "config", "local" or "admin" databases.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
+    /// streams.
+    ///
+    /// Change streams require either a "majority" read concern or no read
+    /// concern. Anything else will cause a server error.
+    #[allow(unused)]
+    pub(crate) async fn watch(
+        &self,
+        options: impl Into<Option<ChangeStreamOptions>>,
+    ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
+        todo!()
+    }
+
+    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
+    /// for all changes in this database and processes them via the given aggregation pipeline. The
+    /// stream does not observe changes from system collections and cannot be started on "config",
+    /// "local" or "admin" databases.
+    ///
+    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
+    /// streams.
+    ///
+    /// Change streams require either a "majority" read concern or no read
+    /// concern. Anything else will cause a server error.
+    ///
+    /// Note that using a `$project` stage to remove any of the `_id`, `operationType` or `ns`
+    /// fields will cause an error. The driver requires these fields to support resumability. For
+    /// more information on resumability, see the documentation for
+    /// [`ChangeStream`](change_stream/struct.ChangeStream.html)
+    #[allow(unused)]
+    pub(crate) async fn watch_with_pipeline<D>(
+        &self,
+        pipeline: impl IntoIterator<Item = Document>,
+        options: impl Into<Option<ChangeStreamOptions>>,
+    ) -> Result<ChangeStream<D>>
+    where
+        D: DeserializeOwned + Unpin + Send + Sync,
+    {
+        todo!()
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,14 +4,36 @@ use std::{fmt::Debug, sync::Arc};
 
 use futures_util::stream::TryStreamExt;
 
-use crate::{Client, ClientSession, Collection, Namespace, SessionCursor, bson::{Bson, Document}, change_stream::{ChangeStream, event::ChangeStreamEvent, options::ChangeStreamOptions, session::SessionChangeStream}, client::session::TransactionState, cmap::conn::PinnedConnectionHandle, concern::{ReadConcern, WriteConcern}, cursor::Cursor, error::{Error, ErrorKind, Result}, operation::{Aggregate, Create, DropDatabase, ListCollections, RunCommand}, options::{
+use crate::{
+    bson::{Bson, Document},
+    change_stream::{
+        event::ChangeStreamEvent,
+        options::ChangeStreamOptions,
+        session::SessionChangeStream,
+        ChangeStream,
+    },
+    client::session::TransactionState,
+    cmap::conn::PinnedConnectionHandle,
+    concern::{ReadConcern, WriteConcern},
+    cursor::Cursor,
+    error::{Error, ErrorKind, Result},
+    operation::{Aggregate, Create, DropDatabase, ListCollections, RunCommand},
+    options::{
         AggregateOptions,
         CollectionOptions,
         CreateCollectionOptions,
         DatabaseOptions,
         DropDatabaseOptions,
         ListCollectionsOptions,
-    }, results::CollectionSpecification, selection_criteria::SelectionCriteria};
+    },
+    results::CollectionSpecification,
+    selection_criteria::SelectionCriteria,
+    Client,
+    ClientSession,
+    Collection,
+    Namespace,
+    SessionCursor,
+};
 
 /// `Database` is the client-side abstraction of a MongoDB database. It can be used to perform
 /// database-level operations or to obtain handles to specific collections within the database. A

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,31 +4,14 @@ use std::{fmt::Debug, sync::Arc};
 
 use futures_util::stream::TryStreamExt;
 
-use crate::{
-    bson::{Bson, Document},
-    change_stream::{event::ChangeStreamEvent, options::ChangeStreamOptions, ChangeStream},
-    client::session::TransactionState,
-    cmap::conn::PinnedConnectionHandle,
-    concern::{ReadConcern, WriteConcern},
-    cursor::Cursor,
-    error::{Error, ErrorKind, Result},
-    operation::{Aggregate, Create, DropDatabase, ListCollections, RunCommand},
-    options::{
+use crate::{Client, ClientSession, Collection, Namespace, SessionCursor, bson::{Bson, Document}, change_stream::{ChangeStream, event::ChangeStreamEvent, options::ChangeStreamOptions, session::SessionChangeStream}, client::session::TransactionState, cmap::conn::PinnedConnectionHandle, concern::{ReadConcern, WriteConcern}, cursor::Cursor, error::{Error, ErrorKind, Result}, operation::{Aggregate, Create, DropDatabase, ListCollections, RunCommand}, options::{
         AggregateOptions,
         CollectionOptions,
         CreateCollectionOptions,
         DatabaseOptions,
         DropDatabaseOptions,
         ListCollectionsOptions,
-    },
-    results::CollectionSpecification,
-    selection_criteria::SelectionCriteria,
-    Client,
-    ClientSession,
-    Collection,
-    Namespace,
-    SessionCursor,
-};
+    }, results::CollectionSpecification, selection_criteria::SelectionCriteria};
 
 /// `Database` is the client-side abstraction of a MongoDB database. It can be used to perform
 /// database-level operations or to obtain handles to specific collections within the database. A
@@ -464,6 +447,16 @@ impl Database {
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
     ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
+        todo!()
+    }
+
+    #[allow(unused)]
+    pub(crate) async fn watch_with_session(
+        &self,
+        pipeline: impl IntoIterator<Item = Document>,
+        options: impl Into<Option<ChangeStreamOptions>>,
+        session: &mut ClientSession,
+    ) -> Result<SessionChangeStream<ChangeStreamEvent<Document>>> {
         todo!()
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,7 +3,6 @@ pub mod options;
 use std::{fmt::Debug, sync::Arc};
 
 use futures_util::stream::TryStreamExt;
-use serde::de::DeserializeOwned;
 
 use crate::{
     bson::{Bson, Document},
@@ -451,38 +450,20 @@ impl Database {
     ///
     /// Change streams require either a "majority" read concern or no read
     /// concern. Anything else will cause a server error.
-    #[allow(unused)]
-    pub(crate) async fn watch(
-        &self,
-        options: impl Into<Option<ChangeStreamOptions>>,
-    ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
-        todo!()
-    }
-
-    /// Starts a new [`ChangeStream`](change_stream/struct.ChangeStream.html) that receives events
-    /// for all changes in this database and processes them via the given aggregation pipeline. The
-    /// stream does not observe changes from system collections and cannot be started on "config",
-    /// "local" or "admin" databases.
-    ///
-    /// See the documentation [here](https://docs.mongodb.com/manual/changeStreams/) on change
-    /// streams.
-    ///
-    /// Change streams require either a "majority" read concern or no read
-    /// concern. Anything else will cause a server error.
     ///
     /// Note that using a `$project` stage to remove any of the `_id`, `operationType` or `ns`
     /// fields will cause an error. The driver requires these fields to support resumability. For
     /// more information on resumability, see the documentation for
     /// [`ChangeStream`](change_stream/struct.ChangeStream.html)
+    ///
+    /// If the pipeline alters the structure of the returned events, the parsed type will need to be
+    /// changed via [`ChangeStream::with_type`].
     #[allow(unused)]
-    pub(crate) async fn watch_with_pipeline<D>(
+    pub(crate) async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
-    ) -> Result<ChangeStream<D>>
-    where
-        D: DeserializeOwned + Unpin + Send + Sync,
-    {
+    ) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
         todo!()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,8 @@ pub mod options;
 pub use ::bson;
 
 mod bson_util;
+#[allow(unused)]
+pub(crate) mod change_stream;
 mod client;
 mod cmap;
 mod coll;

--- a/src/options.rs
+++ b/src/options.rs
@@ -26,6 +26,9 @@ pub use crate::{
     selection_criteria::*,
 };
 
+#[allow(unused)]
+pub(crate) use crate::change_stream::options::*;
+
 /// Updates an options struct with the read preference/read concern/write concern of a
 /// client/database/collection.
 macro_rules! resolve_options {

--- a/src/test/documentation_examples/mod.rs
+++ b/src/test/documentation_examples/mod.rs
@@ -1508,7 +1508,7 @@ async fn aggregation_examples() -> GenericResult<()> {
     db.drop(None).await?;
     aggregation_data::populate(&db).await?;
 
-    // Each example is within its own scope to allow the example to include 
+    // Each example is within its own scope to allow the example to include
     // `use futures::TryStreamExt;` without causing multiple definition errors.
 
     {


### PR DESCRIPTION
RUST-519

This is largely a directly transliteration of the [spec](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst), and is heavily based on [the PR](https://github.com/mongodb/mongo-rust-driver/commit/2f16ab6600457cbf6d24a90603301b3554f5d71f) implementing this in the change-streams branch.  Notable changes from that PR:
* `ChangeStreamEvent` is generic over the document type.
* `ChangeStream` is generic over the item type.
* `watch` assumes a `ChangeStreamEvent<_>` as the returned stream item type, and notes in documentation that if the structure is changed it'll need a `with_type` call.