### PR TITLE
RUST-1039 Support deserializing `RawDocumentBuf` in cursors

### DIFF
--- a/benchmarks/src/bench/find_many.rs
+++ b/benchmarks/src/bench/find_many.rs
@@ -2,7 +2,12 @@ use std::{convert::TryInto, path::PathBuf};
 
 use anyhow::{bail, Result};
 use futures::stream::StreamExt;
-use mongodb::{Client, Collection, Database, bson::{self, Bson, Document, RawDocumentBuf}};
+use mongodb::{
+    bson::{Bson, Document},
+    Client,
+    Collection,
+    Database,
+};
 use serde_json::Value;
 
 use crate::{
@@ -12,7 +17,7 @@ use crate::{
 
 pub struct FindManyBenchmark {
     db: Database,
-    coll: Collection<RawDocumentBuf>,
+    coll: Collection<Document>,
     uri: String,
 }
 
@@ -48,7 +53,7 @@ impl Benchmark for FindManyBenchmark {
 
         Ok(FindManyBenchmark {
             db,
-            coll: coll.clone_with_type(),
+            coll,
             uri: options.uri,
         })
     }
@@ -56,7 +61,7 @@ impl Benchmark for FindManyBenchmark {
     async fn do_task(&self) -> Result<()> {
         let mut cursor = self.coll.find(None, None).await?;
         while let Some(doc) = cursor.next().await {
-            let _d: Document = bson::from_slice(doc?.as_bytes())?;
+            doc?;
         }
 
         Ok(())

--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use bson::{RawBson, spec::ElementType};
+use bson::{spec::ElementType, RawBson};
 use serde::{de::Error as SerdeDeError, ser, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -28,9 +28,9 @@ pub(crate) fn get_int(val: &Bson) -> Option<i64> {
 /// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
 pub(crate) fn get_int_raw<'a>(val: RawBson<'a>) -> Option<i64> {
     match val {
-        RawBson::Int32(i) => Some(i64::from(i)),
-        RawBson::Int64(i) => Some(i),
-        RawBson::Double(f) if (f - (f as i64 as f64)).abs() <= f64::EPSILON => Some(f as i64),
+        RawBson::Int32(i) => get_int(&Bson::Int32(i)),
+        RawBson::Int64(i) => get_int(&Bson::Int64(i)),
+        RawBson::Double(i) => get_int(&Bson::Double(i)),
         _ => None,
     }
 }
@@ -48,9 +48,9 @@ pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
 
 pub(crate) fn get_u64_raw<'a>(val: RawBson<'a>) -> Option<u64> {
     match val {
-        RawBson::Int32(i) => u64::try_from(i).ok(),
-        RawBson::Int64(i) => u64::try_from(i).ok(),
-        RawBson::Double(f) if (f - (f as u64 as f64)).abs() <= f64::EPSILON => Some(f as u64),
+        RawBson::Int32(i) => get_u64(&Bson::Int32(i)),
+        RawBson::Int64(i) => get_u64(&Bson::Int64(i)),
+        RawBson::Double(i) => get_u64(&Bson::Double(i)),
         _ => None,
     }
 }

--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -26,7 +26,7 @@ pub(crate) fn get_int(val: &Bson) -> Option<i64> {
 
 /// Coerce numeric types into an `i64` if it would be lossless to do so. If this Bson is not numeric
 /// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
-pub(crate) fn get_int_raw<'a>(val: RawBson<'a>) -> Option<i64> {
+pub(crate) fn get_int_raw(val: RawBson<'_>) -> Option<i64> {
     match val {
         RawBson::Int32(i) => get_int(&Bson::Int32(i)),
         RawBson::Int64(i) => get_int(&Bson::Int64(i)),
@@ -46,7 +46,7 @@ pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
     }
 }
 
-pub(crate) fn get_u64_raw<'a>(val: RawBson<'a>) -> Option<u64> {
+pub(crate) fn get_u64_raw(val: RawBson<'_>) -> Option<u64> {
     match val {
         RawBson::Int32(i) => get_u64(&Bson::Int32(i)),
         RawBson::Int64(i) => get_u64(&Bson::Int64(i)),

--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use bson::spec::ElementType;
+use bson::{RawBson, spec::ElementType};
 use serde::{de::Error as SerdeDeError, ser, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -24,6 +24,17 @@ pub(crate) fn get_int(val: &Bson) -> Option<i64> {
     }
 }
 
+/// Coerce numeric types into an `i64` if it would be lossless to do so. If this Bson is not numeric
+/// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
+pub(crate) fn get_int_raw<'a>(val: RawBson<'a>) -> Option<i64> {
+    match val {
+        RawBson::Int32(i) => Some(i64::from(i)),
+        RawBson::Int64(i) => Some(i),
+        RawBson::Double(f) if (f - (f as i64 as f64)).abs() <= f64::EPSILON => Some(f as i64),
+        _ => None,
+    }
+}
+
 /// Coerce numeric types into an `u64` if it would be lossless to do so. If this Bson is not numeric
 /// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
 pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
@@ -31,6 +42,15 @@ pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
         Bson::Int32(i) => u64::try_from(i).ok(),
         Bson::Int64(i) => u64::try_from(i).ok(),
         Bson::Double(f) if (f - (f as u64 as f64)).abs() <= f64::EPSILON => Some(f as u64),
+        _ => None,
+    }
+}
+
+pub(crate) fn get_u64_raw<'a>(val: RawBson<'a>) -> Option<u64> {
+    match val {
+        RawBson::Int32(i) => u64::try_from(i).ok(),
+        RawBson::Int64(i) => u64::try_from(i).ok(),
+        RawBson::Double(f) if (f - (f as u64 as f64)).abs() <= f64::EPSILON => Some(f as u64),
         _ => None,
     }
 }

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -1,49 +1,22 @@
-use bson::doc;
+use bson::{RawBson, RawDocument, Timestamp, doc};
 use lazy_static::lazy_static;
 use serde::de::DeserializeOwned;
 
 use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use super::{session::TransactionState, Client, ClientSession};
-use crate::{
-    bson::Document,
-    cmap::{
-        conn::PinnedConnectionHandle,
-        Connection,
-        ConnectionPool,
-        RawCommand,
-        RawCommandResponse,
-    },
-    cursor::{session::SessionCursor, Cursor, CursorSpecification},
-    error::{
-        Error,
-        ErrorKind,
-        Result,
-        RETRYABLE_WRITE_ERROR,
-        TRANSIENT_TRANSACTION_ERROR,
+use crate::{ClusterTime, bson::Document, cmap::{
+        conn::PinnedConnectionHandle, Connection, ConnectionPool, RawCommand, RawCommandResponse,
+    }, cursor::{session::SessionCursor, Cursor, CursorSpecification}, error::{
+        Error, ErrorKind, Result, RETRYABLE_WRITE_ERROR, TRANSIENT_TRANSACTION_ERROR,
         UNKNOWN_TRANSACTION_COMMIT_RESULT,
-    },
-    event::command::{CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent},
-    operation::{
-        AbortTransaction,
-        CommandErrorBody,
-        CommandResponse,
-        CommitTransaction,
-        Operation,
-        Response,
-        Retryability,
-    },
-    options::SelectionCriteria,
-    sdam::{
-        HandshakePhase,
-        SelectedServer,
-        ServerType,
-        SessionSupportStatus,
-        TopologyType,
+    }, event::command::{CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent}, operation::{
+        AbortTransaction, CommandErrorBody, CommandResponse, CommitTransaction, Operation,
+        Response, Retryability,
+    }, options::SelectionCriteria, sdam::{
+        HandshakePhase, SelectedServer, ServerType, SessionSupportStatus, TopologyType,
         TransactionSupportStatus,
-    },
-    selection_criteria::ReadPreference,
-};
+    }, selection_criteria::ReadPreference};
 
 lazy_static! {
     pub(crate) static ref REDACTED_COMMANDS: HashSet<&'static str> = {
@@ -139,7 +112,7 @@ impl Client {
     /// Server selection be will performed using the criteria specified on the operation, if any.
     pub(crate) async fn execute_cursor_operation<Op, T>(&self, op: Op) -> Result<Cursor<T>>
     where
-        Op: Operation<O = CursorSpecification<T>>,
+        Op: Operation<O = CursorSpecification>,
         T: DeserializeOwned + Unpin + Send + Sync,
     {
         Box::pin(async {
@@ -161,7 +134,7 @@ impl Client {
         session: &mut ClientSession,
     ) -> Result<SessionCursor<T>>
     where
-        Op: Operation<O = CursorSpecification<T>>,
+        Op: Operation<O = CursorSpecification>,
         T: DeserializeOwned + Unpin + Send + Sync,
     {
         let mut details = self
@@ -185,12 +158,12 @@ impl Client {
         self.inner.options.load_balanced.unwrap_or(false)
     }
 
-    fn pin_connection_for_cursor<Op, T>(
+    fn pin_connection_for_cursor<Op>(
         &self,
         details: &mut ExecutionOutput<Op>,
     ) -> Result<Option<PinnedConnectionHandle>>
     where
-        Op: Operation<O = CursorSpecification<T>>,
+        Op: Operation<O = CursorSpecification>,
     {
         if self.is_load_balanced() && details.operation_output.info.id != 0 {
             Ok(Some(details.connection.pin()?))
@@ -530,82 +503,148 @@ impl Client {
         let start_time = Instant::now();
         let command_result = match connection.send_raw_command(raw_cmd, request_id).await {
             Ok(response) => {
-                match T::Response::deserialize_response(&response) {
-                    Ok(r) => {
-                        if let (Some(session), Some(ts)) = (session.as_mut(), r.operation_time()) {
-                            session.advance_operation_time(ts);
-                        }
-                        self.update_cluster_time(&r, session).await;
-                        if r.is_success() {
-                            // Retrieve recovery token from successful response.
-                            Client::update_recovery_token(is_sharded, &r, session).await;
+                async fn handle_response(
+                    client: &Client,
+                    session: &mut Option<&mut ClientSession>,
+                    is_sharded: bool,
+                    response: RawCommandResponse,
+                ) -> Result<RawCommandResponse> {
+                    let raw_doc = RawDocument::new(response.as_bytes())?;
 
-                            Ok(CommandResult {
-                                raw: response,
-                                deserialized: r.into_body(),
-                            })
-                        } else {
-                            // if command was ok: 0, try to deserialize the command error.
-                            // if that fails, return a generic error.
-                            Err(response
-                                .body::<CommandErrorBody>()
-                                .map(|error_response| error_response.into())
-                                .unwrap_or_else(|e| {
-                                    Error::from(ErrorKind::InvalidResponse {
-                                        message: format!(
-                                            "error deserializing command error: {}",
-                                            e
-                                        ),
-                                    })
-                                }))
-                        }
-                    }
-                    Err(deserialize_error) => {
-                        // if we failed to deserialize the whole response, try deserializing
-                        // a generic command response without the operation's body.
-                        match response.body::<CommandResponse<Option<CommandErrorBody>>>() {
-                            Ok(error_response) => {
-                                if let (Some(session), Some(ts)) =
-                                    (session.as_mut(), error_response.operation_time())
-                                {
-                                    session.advance_operation_time(ts);
-                                }
-                                self.update_cluster_time(&error_response, session).await;
-                                match error_response.body {
-                                    // if the response was ok: 0, return the command error.
-                                    Some(command_error_response)
-                                        if !error_response.is_success() =>
-                                    {
-                                        Err(command_error_response.into())
-                                    }
-                                    // if the response was ok: 0 but we couldnt deserialize the
-                                    // command error,
-                                    // return a generic error indicating so.
-                                    None if !error_response.is_success() => {
-                                        Err(Error::from(ErrorKind::InvalidResponse {
-                                            message: "got command error but failed to deserialize \
-                                                      response"
-                                                .to_string(),
-                                        }))
-                                    }
-                                    // for ok: 1 just return the original deserialization error.
-                                    _ => {
-                                        Client::update_recovery_token(
-                                            is_sharded,
-                                            &error_response,
-                                            session,
-                                        )
-                                        .await;
-                                        Err(deserialize_error)
-                                    }
-                                }
+                    let ok = match raw_doc.get("ok")? {
+                        Some(b) => crate::bson_util::get_int_raw(b).ok_or_else(|| {
+                            ErrorKind::InvalidResponse {
+                                message: format!(
+                                    "expected ok value to be a number, instead got {:?}",
+                                    b
+                                ),
                             }
-                            // We failed to deserialize even that, so just return the original
-                            // deserialization error.
-                            Err(_) => Err(deserialize_error),
+                        })?,
+                        None => {
+                            return Err(ErrorKind::InvalidResponse {
+                                message: "missing 'ok' value in response".to_string(),
+                            }
+                            .into())
                         }
+                    };
+
+                    let cluster_time: Option<ClusterTime> = raw_doc
+                        .get("clusterTime")?
+                        .and_then(RawBson::as_document)
+                        .map(|d| bson::from_slice(d.as_bytes()))
+                        .transpose()?;
+
+                    let at_cluster_time: Option<Timestamp> = raw_doc
+                        .get("atClusterTime")?
+                        .and_then(RawBson::as_timestamp);
+
+                    client
+                        .update_cluster_time_1(cluster_time, at_cluster_time, session)
+                        .await;
+
+                    if ok == 1 {
+                        if let Some(ref mut session) = session {
+                            if is_sharded && session.in_transaction() {
+                                let recovery_token = raw_doc
+                                    .get("recoveryToken")?
+                                    .and_then(RawBson::as_document)
+                                    .map(|d| bson::from_slice(d.as_bytes()))
+                                    .transpose()?;
+                                session.transaction.recovery_token = recovery_token;
+                            }
+                        }
+
+                        Ok(response)
+                    } else {
+                        Err(response
+                            .body::<CommandErrorBody>()
+                            .map(|error_response| error_response.into())
+                            .unwrap_or_else(|e| {
+                                Error::from(ErrorKind::InvalidResponse {
+                                    message: format!("error deserializing command error: {}", e),
+                                })
+                            }))
                     }
                 }
+
+                handle_response(self, session, is_sharded, response).await
+                // match T::Response::deserialize_response(&response) {
+                //     Ok(r) => {
+
+                //         if let (Some(session), Some(ts)) = (session.as_mut(), r.operation_time()) {
+                //             session.advance_operation_time(ts);
+                //         }
+                //         self.update_cluster_time(&r, session).await;
+                //         if r.is_success() {
+                //             // Retrieve recovery token from successful response.
+                //             Client::update_recovery_token(is_sharded, &r, session).await;
+
+                //             Ok(CommandResult {
+                //                 raw: response,
+                //                 deserialized: r.into_body(),
+                //             })
+                //         } else {
+                //             // if command was ok: 0, try to deserialize the command error.
+                //             // if that fails, return a generic error.
+                //             Err(response
+                //                 .body::<CommandErrorBody>()
+                //                 .map(|error_response| error_response.into())
+                //                 .unwrap_or_else(|e| {
+                //                     Error::from(ErrorKind::InvalidResponse {
+                //                         message: format!(
+                //                             "error deserializing command error: {}",
+                //                             e
+                //                         ),
+                //                     })
+                //                 }))
+                //         }
+                //     }
+                //     Err(deserialize_error) => {
+                //         // if we failed to deserialize the whole response, try deserializing
+                //         // a generic command response without the operation's body.
+                //         match response.body::<CommandResponse<Option<CommandErrorBody>>>() {
+                //             Ok(error_response) => {
+                //                 if let (Some(session), Some(ts)) =
+                //                     (session.as_mut(), error_response.operation_time())
+                //                 {
+                //                     session.advance_operation_time(ts);
+                //                 }
+                //                 self.update_cluster_time(&error_response, session).await;
+                //                 match error_response.body {
+                //                     // if the response was ok: 0, return the command error.
+                //                     Some(command_error_response)
+                //                         if !error_response.is_success() =>
+                //                     {
+                //                         Err(command_error_response.into())
+                //                     }
+                //                     // if the response was ok: 0 but we couldnt deserialize the
+                //                     // command error,
+                //                     // return a generic error indicating so.
+                //                     None if !error_response.is_success() => {
+                //                         Err(Error::from(ErrorKind::InvalidResponse {
+                //                             message: "got command error but failed to deserialize \
+                //                                       response"
+                //                                 .to_string(),
+                //                         }))
+                //                     }
+                //                     // for ok: 1 just return the original deserialization error.
+                //                     _ => {
+                //                         Client::update_recovery_token(
+                //                             is_sharded,
+                //                             &error_response,
+                //                             session,
+                //                         )
+                //                         .await;
+                //                         Err(deserialize_error)
+                //                     }
+                //                 }
+                //             }
+                //             // We failed to deserialize even that, so just return the original
+                //             // deserialization error.
+                //             Err(_) => Err(deserialize_error),
+                //         }
+                //     }
+                // }
             }
             Err(err) => Err(err),
         };
@@ -642,7 +681,6 @@ impl Client {
                         Document::new()
                     } else {
                         response
-                            .raw
                             .body()
                             .unwrap_or_else(|e| doc! { "deserialization error": e.to_string() })
                     };
@@ -658,7 +696,7 @@ impl Client {
                     handler.handle_command_succeeded_event(command_succeeded_event);
                 });
 
-                match op.handle_response(response.deserialized, connection.stream_description()?) {
+                match op.handle_raw_response(response, connection.stream_description()?) {
                     Ok(response) => Ok(response),
                     Err(mut err) => {
                         err.add_labels_and_update_pin(
@@ -761,6 +799,26 @@ impl Client {
             }
         }
         Ok(Retryability::None)
+    }
+
+    async fn update_cluster_time_1(
+        &self,
+        cluster_time: Option<ClusterTime>,
+        at_cluster_time: Option<Timestamp>,
+        session: &mut Option<&mut ClientSession>,
+    ) {
+        if let Some(ref cluster_time) = cluster_time {
+            self.inner.topology.advance_cluster_time(cluster_time).await;
+            if let Some(ref mut session) = session {
+                session.advance_cluster_time(cluster_time)
+            }
+        }
+
+        if let Some(timestamp) = at_cluster_time {
+            if let Some(ref mut session) = session {
+                session.snapshot_time = Some(timestamp);
+            }
+        }
     }
 
     async fn update_cluster_time<T: Response>(

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -555,7 +555,7 @@ impl Client {
                         .map(|d| bson::from_slice(d.as_bytes()))
                         .transpose()?;
 
-                    let at_cluster_time = op.extract_at_cluster_time(&raw_doc)?;
+                    let at_cluster_time = op.extract_at_cluster_time(raw_doc)?;
 
                     client
                         .update_cluster_time(cluster_time, at_cluster_time, session)

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -557,7 +557,7 @@ impl Client {
                     };
 
                     let cluster_time: Option<ClusterTime> = raw_doc
-                        .get("clusterTime")?
+                        .get("$clusterTime")?
                         .and_then(RawBson::as_document)
                         .map(|d| bson::from_slice(d.as_bytes()))
                         .transpose()?;

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -24,15 +24,7 @@ use crate::{
         UNKNOWN_TRANSACTION_COMMIT_RESULT,
     },
     event::command::{CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent},
-    operation::{
-        AbortTransaction,
-        CommandErrorBody,
-        CommandResponse,
-        CommitTransaction,
-        Operation,
-        Response,
-        Retryability,
-    },
+    operation::{AbortTransaction, CommandErrorBody, CommitTransaction, Operation, Retryability},
     options::SelectionCriteria,
     sdam::{
         HandshakePhase,
@@ -873,11 +865,6 @@ impl Error {
 
         Ok(())
     }
-}
-
-struct CommandResult<T> {
-    raw: RawCommandResponse,
-    deserialized: T,
 }
 
 struct ExecutionDetails<T: Operation> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -5,7 +5,6 @@ pub mod session;
 
 use std::{sync::Arc, time::Duration};
 
-use bson::Bson;
 use derivative::Derivative;
 use std::time::Instant;
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -189,7 +189,9 @@ impl Client {
         let op = ListDatabases::new(filter.into(), false, options.into());
         self.execute_operation(op, session).await.and_then(|dbs| {
             dbs.into_iter()
-                .map(|db_spec| bson::from_document(db_spec).map_err(crate::error::Error::from))
+                .map(|db_spec| {
+                    bson::from_slice(db_spec.as_bytes()).map_err(crate::error::Error::from)
+                })
                 .collect()
         })
     }
@@ -226,13 +228,13 @@ impl Client {
             Ok(databases) => databases
                 .into_iter()
                 .map(|doc| {
-                    let name = doc.get("name").and_then(Bson::as_str).ok_or_else(|| {
-                        ErrorKind::InvalidResponse {
+                    let name = doc
+                        .get_str("name")
+                        .map_err(|_| ErrorKind::InvalidResponse {
                             message: "Expected \"name\" field in server response, but it was not \
                                       found"
                                 .to_string(),
-                        }
-                    })?;
+                        })?;
                     Ok(name.to_string())
                 })
                 .collect(),

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use bson::{RawDocument, RawDocumentBuf};
+use bson::RawDocumentBuf;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::wire::Message;

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -9,7 +9,7 @@ use crate::{
     client::{options::ServerApi, ClusterTime, HELLO_COMMAND_NAMES, REDACTED_COMMANDS},
     error::{Error, ErrorKind, Result},
     is_master::{IsMasterCommandResponse, IsMasterReply},
-    operation::{CommandErrorBody, CommandResponse, Response},
+    operation::{CommandErrorBody, CommandResponse},
     options::{ReadConcern, ReadConcernInternal, ReadConcernLevel, ServerAddress},
     selection_criteria::ReadPreference,
     ClientSession,

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use bson::{RawDocument, RawDocumentBuf};
 use serde::{de::DeserializeOwned, Serialize};
 
 use super::wire::Message;
@@ -174,7 +175,7 @@ impl<T> Command<T> {
 #[derive(Debug, Clone)]
 pub(crate) struct RawCommandResponse {
     pub(crate) source: ServerAddress,
-    raw: Vec<u8>,
+    raw: RawDocumentBuf,
 }
 
 impl RawCommandResponse {
@@ -182,7 +183,7 @@ impl RawCommandResponse {
     pub(crate) fn with_document_and_address(source: ServerAddress, doc: Document) -> Result<Self> {
         let mut raw = Vec::new();
         doc.to_writer(&mut raw)?;
-        Ok(Self { source, raw })
+        Ok(Self { source, raw: RawDocumentBuf::new(raw)? })
     }
 
     /// Initialize a response from a document.
@@ -199,15 +200,19 @@ impl RawCommandResponse {
 
     pub(crate) fn new(source: ServerAddress, message: Message) -> Result<Self> {
         let raw = message.single_document_response()?;
-        Ok(Self { source, raw })
+        Ok(Self { source, raw: RawDocumentBuf::new(raw)? })
     }
 
     pub(crate) fn body<T: DeserializeOwned>(&self) -> Result<T> {
-        bson::from_slice(self.raw.as_slice()).map_err(|e| {
+        bson::from_slice(self.raw.as_bytes()).map_err(|e| {
             Error::from(ErrorKind::InvalidResponse {
                 message: format!("{}", e),
             })
         })
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.raw.as_bytes()
     }
 
     /// Deserialize the body of this response, returning an authentication error if it fails.
@@ -247,5 +252,9 @@ impl RawCommandResponse {
     /// The address of the server that sent this response.
     pub(crate) fn source_address(&self) -> &ServerAddress {
         &self.source
+    }
+
+    pub(crate) fn into_raw_document_buf(self) -> RawDocumentBuf {
+        self.raw
     }
 }

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -803,7 +803,7 @@ where
         let mut options = options.into();
         resolve_options!(self, options, [read_concern, selection_criteria]);
 
-        let find = Find::<T>::new(self.namespace(), filter.into(), options);
+        let find = Find::new(self.namespace(), filter.into(), options);
         let client = self.client();
 
         client.execute_cursor_operation(find).await
@@ -820,7 +820,7 @@ where
         resolve_read_concern_with_session!(self, options, Some(&mut *session))?;
         resolve_selection_criteria_with_session!(self, options, Some(&mut *session))?;
 
-        let find = Find::<T>::new(self.namespace(), filter.into(), options);
+        let find = Find::new(self.namespace(), filter.into(), options);
         let client = self.client();
 
         client.execute_session_cursor_operation(find, session).await

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -1,4 +1,10 @@
-use std::{collections::VecDeque, marker::PhantomData, pin::Pin, task::{Context, Poll}, time::Duration};
+use std::{
+    collections::VecDeque,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use bson::RawDocumentBuf;
 use derivative::Derivative;
@@ -126,9 +132,7 @@ where
 
             match self.buffer.pop_front() {
                 Some(doc) => {
-                    // todo!()
-                    // // return Poll::Ready(Some(Ok(doc)));
-                    return Poll::Ready(Some(Ok(bson::from_slice(doc.as_bytes())?)))
+                    return Poll::Ready(Some(Ok(bson::from_slice(doc.as_bytes())?)));
                 }
                 None if !self.exhausted && !self.pinned_connection.is_invalid() => {
                     self.start_get_more();

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -1,10 +1,6 @@
-use std::{
-    collections::VecDeque,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
+use std::{collections::VecDeque, marker::PhantomData, pin::Pin, task::{Context, Poll}, time::Duration};
 
+use bson::RawDocumentBuf;
 use derivative::Derivative;
 use futures_core::{Future, Stream};
 use serde::de::DeserializeOwned;
@@ -28,25 +24,26 @@ use crate::{
 #[derivative(Debug)]
 pub(super) struct GenericCursor<P, T>
 where
-    P: GetMoreProvider<DocumentType = T>,
+    P: GetMoreProvider,
 {
     #[derivative(Debug = "ignore")]
     provider: P,
     client: Client,
     info: CursorInformation,
-    buffer: VecDeque<T>,
+    buffer: VecDeque<RawDocumentBuf>,
     exhausted: bool,
     pinned_connection: PinnedConnection,
+    _phantom: PhantomData<T>,
 }
 
 impl<P, T> GenericCursor<P, T>
 where
-    P: GetMoreProvider<DocumentType = T>,
+    P: GetMoreProvider,
     T: DeserializeOwned,
 {
     pub(super) fn new(
         client: Client,
-        spec: CursorSpecification<T>,
+        spec: CursorSpecification,
         pinned_connection: PinnedConnection,
         get_more_provider: P,
     ) -> Self {
@@ -58,10 +55,11 @@ where
             buffer: spec.initial_buffer,
             info: spec.info,
             pinned_connection,
+            _phantom: Default::default(),
         }
     }
 
-    pub(super) fn take_buffer(&mut self) -> VecDeque<T> {
+    pub(super) fn take_buffer(&mut self) -> VecDeque<RawDocumentBuf> {
         std::mem::take(&mut self.buffer)
     }
 
@@ -91,7 +89,7 @@ where
 
 impl<P, T> Stream for GenericCursor<P, T>
 where
-    P: GetMoreProvider<DocumentType = T>,
+    P: GetMoreProvider,
     T: DeserializeOwned + Unpin,
 {
     type Item = Result<T>;
@@ -128,7 +126,9 @@ where
 
             match self.buffer.pop_front() {
                 Some(doc) => {
-                    return Poll::Ready(Some(Ok(doc)));
+                    // todo!()
+                    // // return Poll::Ready(Some(Ok(doc)));
+                    return Poll::Ready(Some(Ok(bson::from_slice(doc.as_bytes())?)))
                 }
                 None if !self.exhausted && !self.pinned_connection.is_invalid() => {
                     self.start_get_more();
@@ -142,11 +142,8 @@ where
 /// A trait implemented by objects that can provide batches of documents to a cursor via the getMore
 /// command.
 pub(super) trait GetMoreProvider: Unpin {
-    /// The type that the invididual documents will be deserialized to.
-    type DocumentType;
-
     /// The result type that the future running the getMore evaluates to.
-    type ResultType: GetMoreProviderResult<DocumentType = Self::DocumentType>;
+    type ResultType: GetMoreProviderResult;
 
     /// The type of future created by this provider when running a getMore.
     type GetMoreFuture: Future<Output = Self::ResultType> + Unpin;
@@ -173,11 +170,10 @@ pub(super) trait GetMoreProvider: Unpin {
 /// Trait describing results returned from a `GetMoreProvider`.
 pub(crate) trait GetMoreProviderResult {
     type Session;
-    type DocumentType;
 
-    fn as_ref(&self) -> std::result::Result<&GetMoreResult<Self::DocumentType>, &Error>;
+    fn as_ref(&self) -> std::result::Result<&GetMoreResult, &Error>;
 
-    fn into_parts(self) -> (Result<GetMoreResult<Self::DocumentType>>, Self::Session);
+    fn into_parts(self) -> (Result<GetMoreResult>, Self::Session);
 
     /// Whether the response from the server indicated the cursor was exhausted or not.
     fn exhausted(&self) -> bool {
@@ -192,14 +188,14 @@ pub(crate) trait GetMoreProviderResult {
 
 /// Specification used to create a new cursor.
 #[derive(Debug, Clone)]
-pub(crate) struct CursorSpecification<T> {
+pub(crate) struct CursorSpecification {
     pub(crate) info: CursorInformation,
-    pub(crate) initial_buffer: VecDeque<T>,
+    pub(crate) initial_buffer: VecDeque<RawDocumentBuf>,
 }
 
-impl<T> CursorSpecification<T> {
+impl CursorSpecification {
     pub(crate) fn new(
-        info: operation::CursorInfo<T>,
+        info: operation::CursorInfo,
         address: ServerAddress,
         batch_size: impl Into<Option<u32>>,
         max_time: impl Into<Option<Duration>>,

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -1,4 +1,9 @@
-use std::{collections::VecDeque, marker::PhantomData, pin::Pin, task::{Context, Poll}};
+use std::{
+    collections::VecDeque,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use bson::RawDocumentBuf;
 use futures_core::{future::BoxFuture, Stream};
@@ -290,8 +295,7 @@ impl<'session> ExplicitSessionGetMoreProvider<'session> {
     }
 }
 
-impl<'session> GetMoreProvider for ExplicitSessionGetMoreProvider<'session>
-{
+impl<'session> GetMoreProvider for ExplicitSessionGetMoreProvider<'session> {
     type ResultType = ExecutionResult<'session>;
     type GetMoreFuture = BoxFuture<'session, ExecutionResult<'session>>;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,8 +91,6 @@ impl Error {
         Error::authentication_error(mechanism_name, "invalid server response")
     }
 
-
-
     pub(crate) fn internal(message: impl Into<String>) -> Error {
         ErrorKind::Internal {
             message: message.into(),
@@ -105,10 +103,6 @@ impl Error {
             message: message.into(),
         }
         .into()
-    }
-
-    pub(crate) fn invalid_response(message: impl std::fmt::Display) -> Error {
-        ErrorKind::InvalidResponse { message: message.to_string() }.into()
     }
 
     pub(crate) fn is_state_change_error(&self) -> bool {

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,8 @@ impl Error {
         Error::authentication_error(mechanism_name, "invalid server response")
     }
 
+
+
     pub(crate) fn internal(message: impl Into<String>) -> Error {
         ErrorKind::Internal {
             message: message.into(),
@@ -103,6 +105,10 @@ impl Error {
             message: message.into(),
         }
         .into()
+    }
+
+    pub(crate) fn invalid_response(message: impl std::fmt::Display) -> Error {
+        ErrorKind::InvalidResponse { message: message.to_string() }.into()
     }
 
     pub(crate) fn is_state_change_error(&self) -> bool {
@@ -335,6 +341,12 @@ impl From<bson::de::Error> for ErrorKind {
 impl From<bson::ser::Error> for ErrorKind {
     fn from(err: bson::ser::Error) -> Self {
         Self::BsonSerialization(err)
+    }
+}
+
+impl From<bson::raw::Error> for ErrorKind {
+    fn from(err: bson::raw::Error) -> Self {
+        Self::InvalidResponse { message: err.to_string() }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -340,7 +340,9 @@ impl From<bson::ser::Error> for ErrorKind {
 
 impl From<bson::raw::Error> for ErrorKind {
     fn from(err: bson::raw::Error) -> Self {
-        Self::InvalidResponse { message: err.to_string() }
+        Self::InvalidResponse {
+            message: err.to_string(),
+        }
     }
 }
 

--- a/src/operation/abort_transaction/mod.rs
+++ b/src/operation/abort_transaction/mod.rs
@@ -3,7 +3,7 @@ use bson::Document;
 use crate::{
     bson::doc,
     client::session::TransactionPin,
-    cmap::{conn::PinnedConnectionHandle, Command, StreamDescription},
+    cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{Operation, Retryability},
     options::WriteConcern,
@@ -29,7 +29,6 @@ impl AbortTransaction {
 impl Operation for AbortTransaction {
     type O = ();
     type Command = Document;
-    type Response = CommandResponse<WriteConcernOnlyBody>;
 
     const NAME: &'static str = "abortTransaction";
 
@@ -50,9 +49,10 @@ impl Operation for AbortTransaction {
 
     fn handle_response(
         &self,
-        response: <Self::Response as Response>::Body,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteConcernOnlyBody = response.body()?;
         response.validate()
     }
 

--- a/src/operation/abort_transaction/mod.rs
+++ b/src/operation/abort_transaction/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::{CommandResponse, Response, WriteConcernOnlyBody};
+use super::WriteConcernOnlyBody;
 
 pub(crate) struct AbortTransaction {
     write_concern: Option<WriteConcern>,

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -41,9 +41,9 @@ impl Aggregate {
 }
 
 impl Operation for Aggregate {
-    type O = CursorSpecification<Document>;
+    type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse<Document>;
+    type Response = CursorResponse;
 
     const NAME: &'static str = "aggregate";
 
@@ -71,7 +71,7 @@ impl Operation for Aggregate {
 
     fn handle_response(
         &self,
-        response: CursorBody<Document>,
+        response: CursorBody,
         description: &StreamDescription,
     ) -> Result<Self::O> {
         if self.is_out_or_merge() {

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -68,6 +68,13 @@ impl Operation for Aggregate {
         ))
     }
 
+    fn extract_at_cluster_time(
+        &self,
+        response: &bson::RawDocument,
+    ) -> Result<Option<bson::Timestamp>> {
+        CursorBody::extract_at_cluster_time(response)
+    }
+
     fn handle_response(
         &self,
         response: RawCommandResponse,

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -4,7 +4,7 @@ mod test;
 use crate::{
     bson::{doc, Bson, Document},
     bson_util,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
     operation::{append_options, Operation, Retryability},
@@ -43,7 +43,6 @@ impl Aggregate {
 impl Operation for Aggregate {
     type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse;
 
     const NAME: &'static str = "aggregate";
 
@@ -71,9 +70,11 @@ impl Operation for Aggregate {
 
     fn handle_response(
         &self,
-        response: CursorBody,
+        response: RawCommandResponse,
         description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: CursorBody = response.body()?;
+
         if self.is_out_or_merge() {
             response.write_concern_info.validate()?;
         };

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CursorBody, CursorResponse, SERVER_4_2_0_WIRE_VERSION};
+use super::{CursorBody, SERVER_4_2_0_WIRE_VERSION};
 
 #[derive(Debug)]
 pub(crate) struct Aggregate {

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -1,5 +1,7 @@
 use std::{collections::VecDeque, time::Duration};
 
+use bson::RawDocumentBuf;
+
 use super::AggregateTarget;
 use crate::{
     bson::{doc, Document},
@@ -201,13 +203,16 @@ async fn handle_success() {
 
     let aggregate = Aggregate::new(ns.clone(), Vec::new(), None);
 
-    let first_batch = VecDeque::from(vec![doc! {"_id": 1}, doc! {"_id": 2}]);
+    let first_batch = VecDeque::from(vec![
+        RawDocumentBuf::from_document(&doc! {"_id": 1}).unwrap(),
+        RawDocumentBuf::from_document(&doc! {"_id": 2}).unwrap(),
+    ]);
     let response = doc! {
         "ok": 1.0,
         "cursor": {
             "id": 123,
             "ns": "test_db.test_coll",
-            "firstBatch": Vec::from(first_batch.clone()),
+            "firstBatch": bson::to_bson(&first_batch).unwrap(),
         }
     };
 

--- a/src/operation/commit_transaction/mod.rs
+++ b/src/operation/commit_transaction/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     options::{Acknowledgment, TransactionOptions, WriteConcern},
 };
 
-use super::{CommandResponse, WriteConcernOnlyBody};
+use super::WriteConcernOnlyBody;
 
 pub(crate) struct CommitTransaction {
     options: Option<TransactionOptions>,

--- a/src/operation/commit_transaction/mod.rs
+++ b/src/operation/commit_transaction/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bson::{doc, Document};
 
 use crate::{
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, Retryability},
     options::{Acknowledgment, TransactionOptions, WriteConcern},
@@ -24,7 +24,6 @@ impl CommitTransaction {
 impl Operation for CommitTransaction {
     type O = ();
     type Command = Document;
-    type Response = CommandResponse<WriteConcernOnlyBody>;
 
     const NAME: &'static str = "commitTransaction";
 
@@ -44,9 +43,10 @@ impl Operation for CommitTransaction {
 
     fn handle_response(
         &self,
-        response: WriteConcernOnlyBody,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteConcernOnlyBody = response.body()?;
         response.validate()
     }
 

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -93,7 +93,7 @@ impl Operation for Count {
                     .cursor
                     .first_batch
                     .pop_front()
-                    .and_then(|doc| bson::from_document(doc).ok())
+                    .and_then(|doc| bson::from_slice(doc.as_bytes()).ok())
                     .ok_or_else(|| {
                         Error::from(ErrorKind::InvalidResponse {
                             message: "invalid server response to count operation".into(),
@@ -139,7 +139,7 @@ impl Operation for Count {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum Response {
-    Aggregate(Box<CursorBody<Document>>),
+    Aggregate(Box<CursorBody>),
     Count(ResponseBody),
 }
 

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -90,16 +90,11 @@ impl Operation for Count {
 
         let response_body: ResponseBody = match (description.max_wire_version, response) {
             (Some(v), Response::Aggregate(mut cursor_body)) if v >= SERVER_4_9_0_WIRE_VERSION => {
-                cursor_body
-                    .cursor
-                    .first_batch
-                    .pop_front()
-                    .and_then(|doc| bson::from_slice(doc.as_bytes()).ok())
-                    .ok_or_else(|| {
-                        Error::from(ErrorKind::InvalidResponse {
-                            message: "invalid server response to count operation".into(),
-                        })
-                    })?
+                cursor_body.cursor.first_batch.pop_front().ok_or_else(|| {
+                    Error::from(ErrorKind::InvalidResponse {
+                        message: "invalid server response to count operation".into(),
+                    })
+                })?
             }
             (_, Response::Count(body)) => body,
             _ => {
@@ -140,7 +135,7 @@ impl Operation for Count {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum Response {
-    Aggregate(Box<CursorBody>),
+    Aggregate(Box<CursorBody<ResponseBody>>),
     Count(ResponseBody),
 }
 

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::{CommandResponse, SERVER_4_9_0_WIRE_VERSION};
+use super::SERVER_4_9_0_WIRE_VERSION;
 
 pub(crate) struct Count {
     ns: Namespace,

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 
 use bson::{doc, Document, RawDocument};
 
-use super::{CursorBody, CursorResponse, Operation, Retryability};
+use super::{CursorBody, Operation, Retryability};
 use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -85,6 +85,10 @@ impl Operation for CountDocuments {
         self.aggregate.build(description)
     }
 
+    fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<bson::Timestamp>> {
+        self.aggregate.extract_at_cluster_time(response)
+    }
+
     fn handle_response(
         &self,
         response: RawCommandResponse,

--- a/src/operation/create/mod.rs
+++ b/src/operation/create/mod.rs
@@ -5,7 +5,7 @@ use bson::Document;
 
 use crate::{
     bson::doc,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, WriteConcernOnlyBody},
     options::{CreateCollectionOptions, WriteConcern},
@@ -40,7 +40,6 @@ impl Create {
 impl Operation for Create {
     type O = ();
     type Command = Document;
-    type Response = CommandResponse<WriteConcernOnlyBody>;
 
     const NAME: &'static str = "create";
 
@@ -59,9 +58,10 @@ impl Operation for Create {
 
     fn handle_response(
         &self,
-        response: WriteConcernOnlyBody,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteConcernOnlyBody = response.body()?;
         response.validate()
     }
 

--- a/src/operation/create/mod.rs
+++ b/src/operation/create/mod.rs
@@ -12,8 +12,6 @@ use crate::{
     Namespace,
 };
 
-use super::CommandResponse;
-
 #[derive(Debug)]
 pub(crate) struct Create {
     ns: Namespace,

--- a/src/operation/create_indexes/mod.rs
+++ b/src/operation/create_indexes/mod.rs
@@ -3,7 +3,7 @@ mod test;
 
 use crate::{
     bson::{doc, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::{ErrorKind, Result},
     index::IndexModel,
     operation::{append_options, Operation},
@@ -50,7 +50,6 @@ impl CreateIndexes {
 impl Operation for CreateIndexes {
     type O = CreateIndexesResult;
     type Command = Document;
-    type Response = CommandResponse<WriteConcernOnlyBody>;
     const NAME: &'static str = "createIndexes";
 
     fn build(&mut self, description: &StreamDescription) -> Result<Command> {
@@ -86,9 +85,10 @@ impl Operation for CreateIndexes {
 
     fn handle_response(
         &self,
-        response: WriteConcernOnlyBody,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteConcernOnlyBody = response.body()?;
         response.validate()?;
         let index_names = self.indexes.iter().filter_map(|i| i.get_name()).collect();
         Ok(CreateIndexesResult { index_names })

--- a/src/operation/create_indexes/mod.rs
+++ b/src/operation/create_indexes/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CommandResponse, WriteConcernOnlyBody};
+use super::WriteConcernOnlyBody;
 
 #[derive(Debug)]
 pub(crate) struct CreateIndexes {

--- a/src/operation/delete/mod.rs
+++ b/src/operation/delete/mod.rs
@@ -12,8 +12,6 @@ use crate::{
     results::DeleteResult,
 };
 
-use super::CommandResponse;
-
 #[derive(Debug)]
 pub(crate) struct Delete {
     ns: Namespace,

--- a/src/operation/delete/mod.rs
+++ b/src/operation/delete/mod.rs
@@ -3,7 +3,7 @@ mod test;
 
 use crate::{
     bson::{doc, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     coll::Namespace,
     collation::Collation,
     error::{convert_bulk_errors, Result},
@@ -58,7 +58,6 @@ impl Delete {
 impl Operation for Delete {
     type O = DeleteResult;
     type Command = Document;
-    type Response = CommandResponse<WriteResponseBody>;
 
     const NAME: &'static str = "delete";
 
@@ -93,9 +92,10 @@ impl Operation for Delete {
 
     fn handle_response(
         &self,
-        response: WriteResponseBody,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteResponseBody = response.body()?;
         response.validate().map_err(convert_bulk_errors)?;
 
         Ok(DeleteResult {

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod test;
 
+use bson::RawBson;
 use serde::Deserialize;
 
 use crate::{
@@ -73,6 +74,16 @@ impl Operation for Distinct {
             body,
         ))
     }
+
+    fn extract_at_cluster_time(
+        &self,
+        response: &bson::RawDocument,
+    ) -> Result<Option<bson::Timestamp>> {
+        Ok(response
+            .get("atClusterTime")?
+            .and_then(RawBson::as_timestamp))
+    }
+
     fn handle_response(
         &self,
         response: RawCommandResponse,

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -12,8 +12,6 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-use super::CommandResponse;
-
 pub(crate) struct Distinct {
     ns: Namespace,
     field_name: String,

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::{
     bson::{doc, Bson, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     coll::{options::DistinctOptions, Namespace},
     error::Result,
     operation::{append_options, Operation, Retryability},
@@ -53,7 +53,6 @@ impl Distinct {
 impl Operation for Distinct {
     type O = Vec<Bson>;
     type Command = Document;
-    type Response = CommandResponse<Response>;
 
     const NAME: &'static str = "distinct";
 
@@ -78,9 +77,10 @@ impl Operation for Distinct {
     }
     fn handle_response(
         &self,
-        response: Response,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: Response = response.body()?;
         Ok(response.values)
     }
 

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -12,8 +12,6 @@ use crate::{
     Namespace,
 };
 
-use super::CommandResponse;
-
 #[derive(Debug)]
 pub(crate) struct DropCollection {
     ns: Namespace,

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -5,7 +5,7 @@ use bson::Document;
 
 use crate::{
     bson::doc,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
     operation::{append_options, Operation, WriteConcernOnlyBody},
     options::{DropCollectionOptions, WriteConcern},
@@ -40,7 +40,6 @@ impl DropCollection {
 impl Operation for DropCollection {
     type O = ();
     type Command = Document;
-    type Response = CommandResponse<WriteConcernOnlyBody>;
 
     const NAME: &'static str = "drop";
 
@@ -60,9 +59,10 @@ impl Operation for DropCollection {
 
     fn handle_response(
         &self,
-        response: WriteConcernOnlyBody,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteConcernOnlyBody = response.body()?;
         response.validate()
     }
 

--- a/src/operation/drop_database/mod.rs
+++ b/src/operation/drop_database/mod.rs
@@ -5,7 +5,7 @@ use bson::Document;
 
 use crate::{
     bson::doc,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, WriteConcernOnlyBody},
     options::{DropDatabaseOptions, WriteConcern},
@@ -33,7 +33,6 @@ impl DropDatabase {
 impl Operation for DropDatabase {
     type O = ();
     type Command = Document;
-    type Response = CommandResponse<WriteConcernOnlyBody>;
 
     const NAME: &'static str = "dropDatabase";
 
@@ -53,9 +52,10 @@ impl Operation for DropDatabase {
 
     fn handle_response(
         &self,
-        response: WriteConcernOnlyBody,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteConcernOnlyBody = response.body()?;
         response.validate()
     }
 

--- a/src/operation/drop_database/mod.rs
+++ b/src/operation/drop_database/mod.rs
@@ -11,8 +11,6 @@ use crate::{
     options::{DropDatabaseOptions, WriteConcern},
 };
 
-use super::CommandResponse;
-
 #[derive(Debug)]
 pub(crate) struct DropDatabase {
     target_db: String,

--- a/src/operation/drop_indexes/mod.rs
+++ b/src/operation/drop_indexes/mod.rs
@@ -10,8 +10,6 @@ use crate::{
     Namespace,
 };
 
-use super::{CommandResponse, EmptyBody};
-
 pub(crate) struct DropIndexes {
     ns: Namespace,
     name: String,

--- a/src/operation/drop_indexes/mod.rs
+++ b/src/operation/drop_indexes/mod.rs
@@ -3,7 +3,7 @@ mod test;
 
 use crate::{
     bson::{doc, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation},
     options::DropIndexOptions,
@@ -39,7 +39,6 @@ impl DropIndexes {
 impl Operation for DropIndexes {
     type O = ();
     type Command = Document;
-    type Response = CommandResponse<EmptyBody>;
     const NAME: &'static str = "dropIndexes";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
@@ -58,7 +57,7 @@ impl Operation for DropIndexes {
 
     fn handle_response(
         &self,
-        _response: EmptyBody,
+        _response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
         Ok(())

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -6,19 +6,26 @@ use std::marker::PhantomData;
 use bson::RawDocumentBuf;
 use serde::de::DeserializeOwned;
 
-use crate::{Namespace, bson::{doc, Document}, cmap::{Command, RawCommandResponse, StreamDescription}, cursor::CursorSpecification, error::{Error, ErrorKind, Result}, operation::{append_options, CursorBody, Operation, Retryability}, options::{CursorType, FindOptions, SelectionCriteria}};
+use crate::{
+    bson::{doc, Document},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    cursor::CursorSpecification,
+    error::{Error, ErrorKind, Result},
+    operation::{append_options, CursorBody, Operation, Retryability},
+    options::{CursorType, FindOptions, SelectionCriteria},
+    Namespace,
+};
 
 use super::{CursorInfo, CursorResponse};
 
 #[derive(Debug)]
-pub(crate) struct Find<T> {
+pub(crate) struct Find {
     ns: Namespace,
     filter: Option<Document>,
     options: Option<Box<FindOptions>>,
-    _phantom: PhantomData<T>,
 }
 
-impl<T> Find<T> {
+impl Find {
     #[cfg(test)]
     fn empty() -> Self {
         Self::new(
@@ -40,15 +47,13 @@ impl<T> Find<T> {
             ns,
             filter,
             options: options.map(Box::new),
-            _phantom: Default::default(),
         }
     }
 }
 
-impl<T: DeserializeOwned> Operation for Find<T> {
+impl Operation for Find {
     type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse;
     const NAME: &'static str = "find";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
@@ -100,14 +105,6 @@ impl<T: DeserializeOwned> Operation for Find<T> {
     }
 
     fn handle_response(
-        &self,
-        response: <Self::Response as super::Response>::Body,
-        description: &StreamDescription,
-    ) -> Result<Self::O> {
-        todo!()
-    }
-
-    fn handle_raw_response(
         &self,
         response: RawCommandResponse,
         description: &StreamDescription,

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -97,6 +97,13 @@ impl Operation for Find {
         ))
     }
 
+    fn extract_at_cluster_time(
+        &self,
+        response: &bson::RawDocument,
+    ) -> Result<Option<bson::Timestamp>> {
+        CursorBody::extract_at_cluster_time(response)
+    }
+
     fn handle_response(
         &self,
         response: RawCommandResponse,

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -1,22 +1,15 @@
 #[cfg(test)]
 mod test;
 
-use std::marker::PhantomData;
-
-use bson::RawDocumentBuf;
-use serde::de::DeserializeOwned;
-
 use crate::{
     bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
-    error::{Error, ErrorKind, Result},
+    error::{ErrorKind, Result},
     operation::{append_options, CursorBody, Operation, Retryability},
     options::{CursorType, FindOptions, SelectionCriteria},
     Namespace,
 };
-
-use super::{CursorInfo, CursorResponse};
 
 #[derive(Debug)]
 pub(crate) struct Find {

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -109,14 +109,10 @@ impl Operation for Find {
         response: RawCommandResponse,
         description: &StreamDescription,
     ) -> Result<Self::O> {
-        let raw_doc = response.into_raw_document_buf();
-        let info = raw_doc
-            .get_document("cursor")
-            .map_err(Error::invalid_response)?;
-        let cursor_info: CursorInfo = bson::from_slice(info.as_bytes())?;
+        let response: CursorBody = response.body()?;
 
         Ok(CursorSpecification::new(
-            cursor_info,
+            response.cursor,
             description.server_address.clone(),
             self.options.as_ref().and_then(|opts| opts.batch_size),
             self.options.as_ref().and_then(|opts| opts.max_await_time),

--- a/src/operation/find_and_modify/mod.rs
+++ b/src/operation/find_and_modify/mod.rs
@@ -25,8 +25,6 @@ use crate::{
     options::WriteConcern,
 };
 
-use super::CommandResponse;
-
 pub(crate) struct FindAndModify<T = Document>
 where
     T: DeserializeOwned,

--- a/src/operation/find_and_modify/mod.rs
+++ b/src/operation/find_and_modify/mod.rs
@@ -10,7 +10,7 @@ use self::options::FindAndModifyOptions;
 use crate::{
     bson::{doc, from_document, Bson, Document},
     bson_util,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     coll::{
         options::{
             FindOneAndDeleteOptions,
@@ -103,7 +103,6 @@ where
 {
     type O = Option<T>;
     type Command = Document;
-    type Response = CommandResponse<Response>;
     const NAME: &'static str = "findAndModify";
 
     fn build(&mut self, description: &StreamDescription) -> Result<Command> {
@@ -132,9 +131,11 @@ where
 
     fn handle_response(
         &self,
-        response: Response,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: Response = response.body()?;
+
         match response.value {
             Bson::Document(doc) => Ok(Some(from_document(doc)?)),
             Bson::Null => Ok(None),

--- a/src/operation/get_more/mod.rs
+++ b/src/operation/get_more/mod.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod test;
 
-use std::{collections::VecDeque, marker::PhantomData, time::Duration};
+use std::{collections::VecDeque, time::Duration};
 
 use bson::{Document, RawDocumentBuf};
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::Deserialize;
 
 use crate::{
     bson::doc,
@@ -16,8 +16,6 @@ use crate::{
     results::GetMoreResult,
     Namespace,
 };
-
-use super::CommandResponse;
 
 #[derive(Debug)]
 pub(crate) struct GetMore<'conn> {

--- a/src/operation/get_more/mod.rs
+++ b/src/operation/get_more/mod.rs
@@ -48,7 +48,6 @@ impl<'conn> GetMore<'conn> {
 impl<'conn> Operation for GetMore<'conn> {
     type O = GetMoreResult;
     type Command = Document;
-    type Response = CommandResponse<GetMoreResponseBody>;
 
     const NAME: &'static str = "getMore";
 
@@ -82,18 +81,10 @@ impl<'conn> Operation for GetMore<'conn> {
 
     fn handle_response(
         &self,
-        response: <Self::Response as super::Response>::Body,
-        description: &StreamDescription,
-    ) -> Result<Self::O> {
-        todo!()
-    }
-
-    fn handle_raw_response(
-        &self,
         response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
-        let response: GetMoreResponseBody = bson::from_slice(response.as_bytes())?;
+        let response: GetMoreResponseBody = response.body()?;
 
         Ok(GetMoreResult {
             batch: response.cursor.next_batch,

--- a/src/operation/get_more/test.rs
+++ b/src/operation/get_more/test.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, time::Duration};
+use std::time::Duration;
 
 use bson::RawDocumentBuf;
 

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CommandBody, CommandResponse};
+use super::CommandBody;
 
 #[derive(Debug)]
 pub(crate) struct Insert<'a, T> {

--- a/src/operation/list_collections/mod.rs
+++ b/src/operation/list_collections/mod.rs
@@ -17,15 +17,14 @@ use crate::{
 use super::CursorResponse;
 
 #[derive(Debug)]
-pub(crate) struct ListCollections<T> {
+pub(crate) struct ListCollections {
     db: String,
     filter: Option<Document>,
     name_only: bool,
     options: Option<ListCollectionsOptions>,
-    _phantom: PhantomData<T>,
 }
 
-impl<T> ListCollections<T> {
+impl ListCollections {
     #[cfg(test)]
     fn empty() -> Self {
         Self::new(String::new(), None, false, None)
@@ -42,18 +41,14 @@ impl<T> ListCollections<T> {
             filter,
             name_only,
             options,
-            _phantom: PhantomData::default(),
         }
     }
 }
 
-impl<T> Operation for ListCollections<T>
-where
-    T: DeserializeOwned + Unpin + Send + Sync,
-{
-    type O = CursorSpecification<T>;
+impl Operation for ListCollections {
+    type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse<T>;
+    type Response = CursorResponse;
 
     const NAME: &'static str = "listCollections";
 
@@ -79,7 +74,7 @@ where
 
     fn handle_response(
         &self,
-        response: CursorBody<T>,
+        response: CursorBody,
         description: &StreamDescription,
     ) -> Result<Self::O> {
         Ok(CursorSpecification::new(

--- a/src/operation/list_collections/mod.rs
+++ b/src/operation/list_collections/mod.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 
 use crate::{
     bson::{doc, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
     operation::{append_options, CursorBody, Operation, Retryability},
@@ -48,7 +48,6 @@ impl ListCollections {
 impl Operation for ListCollections {
     type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse;
 
     const NAME: &'static str = "listCollections";
 
@@ -74,9 +73,10 @@ impl Operation for ListCollections {
 
     fn handle_response(
         &self,
-        response: CursorBody,
+        raw_response: RawCommandResponse,
         description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: CursorBody = raw_response.body()?;
         Ok(CursorSpecification::new(
             response.cursor,
             description.server_address.clone(),

--- a/src/operation/list_collections/mod.rs
+++ b/src/operation/list_collections/mod.rs
@@ -1,10 +1,6 @@
 #[cfg(test)]
 mod test;
 
-use std::marker::PhantomData;
-
-use serde::de::DeserializeOwned;
-
 use crate::{
     bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
@@ -13,8 +9,6 @@ use crate::{
     operation::{append_options, CursorBody, Operation, Retryability},
     options::{ListCollectionsOptions, ReadPreference, SelectionCriteria},
 };
-
-use super::CursorResponse;
 
 #[derive(Debug)]
 pub(crate) struct ListCollections {

--- a/src/operation/list_collections/test.rs
+++ b/src/operation/list_collections/test.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::{
     bson::{doc, Document},
     bson_util,
@@ -7,11 +9,7 @@ use crate::{
     Namespace,
 };
 
-fn build_test(
-    db_name: &str,
-    mut list_collections: ListCollections<Document>,
-    mut expected_body: Document,
-) {
+fn build_test(db_name: &str, mut list_collections: ListCollections, mut expected_body: Document) {
     let mut cmd = list_collections
         .build(&StreamDescription::new_testing())
         .expect("build should succeed");
@@ -128,7 +126,7 @@ async fn build_batch_size() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn op_selection_criteria() {
-    assert!(ListCollections::<Document>::empty()
+    assert!(ListCollections::empty()
         .selection_criteria()
         .expect("should have criteria")
         .is_read_pref_primary());
@@ -183,6 +181,7 @@ async fn handle_success() {
         cursor_spec
             .initial_buffer
             .into_iter()
+            .map(|d| d.try_into().unwrap())
             .collect::<Vec<Document>>(),
         first_batch
     );
@@ -204,6 +203,7 @@ async fn handle_success() {
         cursor_spec
             .initial_buffer
             .into_iter()
+            .map(|d| d.try_into().unwrap())
             .collect::<Vec<Document>>(),
         first_batch
     );
@@ -243,6 +243,7 @@ async fn handle_success_name_only() {
         cursor_spec
             .initial_buffer
             .into_iter()
+            .map(|d| d.try_into().unwrap())
             .collect::<Vec<Document>>(),
         first_batch
     );
@@ -251,7 +252,7 @@ async fn handle_success_name_only() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn handle_invalid_response() {
-    let list_collections = ListCollections::<Document>::empty();
+    let list_collections = ListCollections::empty();
 
     let garbled = doc! { "asdfasf": "ASdfasdf" };
     handle_response_test(&list_collections, garbled).expect_err("garbled response should fail");

--- a/src/operation/list_databases/mod.rs
+++ b/src/operation/list_databases/mod.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod test;
 
+use bson::RawDocumentBuf;
 use serde::Deserialize;
 
 use crate::{
     bson::{doc, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{append_options, Operation, Retryability},
     options::ListDatabasesOptions,
@@ -45,9 +46,8 @@ impl ListDatabases {
 }
 
 impl Operation for ListDatabases {
-    type O = Vec<Document>;
+    type O = Vec<RawDocumentBuf>;
     type Command = Document;
-    type Response = CommandResponse<Response>;
 
     const NAME: &'static str = "listDatabases";
 
@@ -72,9 +72,10 @@ impl Operation for ListDatabases {
 
     fn handle_response(
         &self,
-        response: Response,
+        raw_response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: Response = raw_response.body()?;
         Ok(response.databases)
     }
 
@@ -89,5 +90,5 @@ impl Operation for ListDatabases {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Response {
-    databases: Vec<Document>,
+    databases: Vec<RawDocumentBuf>,
 }

--- a/src/operation/list_databases/mod.rs
+++ b/src/operation/list_databases/mod.rs
@@ -13,8 +13,6 @@ use crate::{
     selection_criteria::{ReadPreference, SelectionCriteria},
 };
 
-use super::CommandResponse;
-
 #[derive(Debug)]
 pub(crate) struct ListDatabases {
     filter: Option<Document>,

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -1,8 +1,7 @@
 use bson::RawDocumentBuf;
 
 use crate::{
-    bson::{doc, Bson, Document},
-    bson_util,
+    bson::{doc, Bson},
     cmap::StreamDescription,
     error::ErrorKind,
     operation::{test::handle_response_test, ListDatabases, Operation},

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -1,3 +1,5 @@
+use bson::RawDocumentBuf;
+
 use crate::{
     bson::{doc, Bson, Document},
     bson_util,
@@ -92,7 +94,7 @@ async fn build_with_options() {
 async fn handle_success() {
     let total_size = 251658240;
 
-    let databases: Vec<Document> = vec![
+    let databases = vec![
         doc! {
            "name" : "admin",
            "sizeOnDisk" : 83886080,
@@ -110,17 +112,22 @@ async fn handle_success() {
         },
     ];
 
+    let raw_databases = databases
+        .iter()
+        .map(|d| RawDocumentBuf::from_document(&d).unwrap())
+        .collect::<Vec<_>>();
+
     let actual_values = handle_response_test(
         &ListDatabases::empty(),
         doc! {
-           "databases" : bson_util::to_bson_array(&databases),
+           "databases" : databases,
            "totalSize" : total_size,
            "ok" : 1
         },
     )
     .expect("should succeed");
 
-    assert_eq!(actual_values, databases);
+    assert_eq!(actual_values, raw_databases);
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -113,7 +113,7 @@ async fn handle_success() {
 
     let raw_databases = databases
         .iter()
-        .map(|d| RawDocumentBuf::from_document(&d).unwrap())
+        .map(|d| RawDocumentBuf::from_document(d).unwrap())
         .collect::<Vec<_>>();
 
     let actual_values = handle_response_test(

--- a/src/operation/list_indexes/mod.rs
+++ b/src/operation/list_indexes/mod.rs
@@ -3,14 +3,13 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    index::IndexModel,
     operation::{append_options, Operation},
     options::ListIndexesOptions,
     selection_criteria::{ReadPreference, SelectionCriteria},
     Namespace,
 };
 
-use super::{CursorBody, CursorResponse, Retryability};
+use super::{CursorBody, Retryability};
 
 #[cfg(test)]
 mod test;

--- a/src/operation/list_indexes/mod.rs
+++ b/src/operation/list_indexes/mod.rs
@@ -38,9 +38,9 @@ impl ListIndexes {
 }
 
 impl Operation for ListIndexes {
-    type O = CursorSpecification<IndexModel>;
+    type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse<IndexModel>;
+    type Response = CursorResponse;
 
     const NAME: &'static str = "listIndexes";
 
@@ -62,7 +62,7 @@ impl Operation for ListIndexes {
 
     fn handle_response(
         &self,
-        response: CursorBody<IndexModel>,
+        response: CursorBody,
         description: &StreamDescription,
     ) -> Result<Self::O> {
         Ok(CursorSpecification::new(

--- a/src/operation/list_indexes/mod.rs
+++ b/src/operation/list_indexes/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bson::{doc, Document},
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
     index::IndexModel,
@@ -40,7 +40,6 @@ impl ListIndexes {
 impl Operation for ListIndexes {
     type O = CursorSpecification;
     type Command = Document;
-    type Response = CursorResponse;
 
     const NAME: &'static str = "listIndexes";
 
@@ -62,9 +61,10 @@ impl Operation for ListIndexes {
 
     fn handle_response(
         &self,
-        response: CursorBody,
+        raw_response: RawCommandResponse,
         description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: CursorBody = raw_response.body()?;
         Ok(CursorSpecification::new(
             response.cursor,
             description.server_address.clone(),

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -8,7 +8,7 @@ use bson::RawBson;
 use super::{CursorBody, Operation};
 use crate::{
     bson::Document,
-    client::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS},
+    client::SESSIONS_UNSUPPORTED_COMMANDS,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::{ErrorKind, Result},
     options::WriteConcern,
@@ -110,11 +110,4 @@ impl<'conn> Operation for RunCommand<'conn> {
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.pinned_connection
     }
-}
-
-#[derive(Debug)]
-pub(crate) struct Response {
-    doc: Document,
-    cluster_time: Option<ClusterTime>,
-    recovery_token: Option<Document>,
 }

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -3,9 +3,9 @@ mod test;
 
 use std::convert::TryInto;
 
-use bson::{Bson, Timestamp};
+use bson::RawBson;
 
-use super::Operation;
+use super::{CursorBody, Operation};
 use crate::{
     bson::Document,
     client::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS},
@@ -72,6 +72,17 @@ impl<'conn> Operation for RunCommand<'conn> {
         ))
     }
 
+    fn extract_at_cluster_time(
+        &self,
+        response: &bson::RawDocument,
+    ) -> Result<Option<bson::Timestamp>> {
+        if let Some(RawBson::Timestamp(ts)) = response.get("atClusterTime")? {
+            Ok(Some(ts))
+        } else {
+            CursorBody::extract_at_cluster_time(response)
+        }
+    }
+
     fn handle_response(
         &self,
         response: RawCommandResponse,
@@ -106,56 +117,4 @@ pub(crate) struct Response {
     doc: Document,
     cluster_time: Option<ClusterTime>,
     recovery_token: Option<Document>,
-}
-
-impl super::Response for Response {
-    type Body = Document;
-
-    fn deserialize_response(raw: &RawCommandResponse) -> Result<Self> {
-        let doc: Document = raw.body()?;
-
-        let cluster_time = doc
-            .get_document("$clusterTime")
-            .ok()
-            .and_then(|doc| bson::from_document(doc.clone()).ok());
-
-        let recovery_token = doc.get_document("recoveryToken").ok().cloned();
-
-        Ok(Self {
-            doc,
-            cluster_time,
-            recovery_token,
-        })
-    }
-
-    fn ok(&self) -> Option<&Bson> {
-        self.doc.get("ok")
-    }
-
-    fn cluster_time(&self) -> Option<&ClusterTime> {
-        self.cluster_time.as_ref()
-    }
-
-    fn at_cluster_time(&self) -> Option<Timestamp> {
-        self.doc
-            .get_timestamp("atClusterTime")
-            .or_else(|_| {
-                self.doc
-                    .get_document("cursor")
-                    .and_then(|subdoc| subdoc.get_timestamp("atClusterTime"))
-            })
-            .ok()
-    }
-
-    fn recovery_token(&self) -> Option<&Document> {
-        self.recovery_token.as_ref()
-    }
-
-    fn operation_time(&self) -> Option<Timestamp> {
-        self.doc.get_timestamp("operationTime").ok()
-    }
-
-    fn into_body(self) -> Self::Body {
-        self.doc
-    }
 }

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod test;
 
+use std::convert::TryInto;
+
 use bson::{Bson, Timestamp};
 
 use super::Operation;
@@ -51,7 +53,6 @@ impl<'conn> RunCommand<'conn> {
 impl<'conn> Operation for RunCommand<'conn> {
     type O = Document;
     type Command = Document;
-    type Response = Response;
 
     // Since we can't actually specify a string statically here, we just put a descriptive string
     // that should fail loudly if accidentally passed to the server.
@@ -73,10 +74,10 @@ impl<'conn> Operation for RunCommand<'conn> {
 
     fn handle_response(
         &self,
-        response: Document,
+        response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
-        Ok(response)
+        Ok(response.into_raw_document_buf().try_into()?)
     }
 
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -3,9 +3,8 @@ use bson::Timestamp;
 use super::RunCommand;
 use crate::{
     bson::doc,
-    client::ClusterTime,
-    cmap::{RawCommandResponse, StreamDescription},
-    operation::{test::handle_response_test, Operation, Response},
+    cmap::StreamDescription,
+    operation::{test::handle_response_test, Operation},
 };
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -47,32 +47,3 @@ async fn handle_success() {
     let result_doc = handle_response_test(&op, doc.clone()).unwrap();
     assert_eq!(result_doc, doc);
 }
-
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn response() {
-    let cluster_timestamp = Timestamp {
-        time: 123,
-        increment: 345,
-    };
-    let doc = doc! {
-        "ok": 1,
-        "some": "field",
-        "other": true,
-        "$clusterTime": {
-            "clusterTime": cluster_timestamp,
-            "signature": {}
-        }
-    };
-    let raw = RawCommandResponse::with_document(doc).unwrap();
-    let response = <RunCommand as Operation>::Response::deserialize_response(&raw).unwrap();
-
-    assert!(response.is_success());
-    assert_eq!(
-        response.cluster_time(),
-        Some(&ClusterTime {
-            cluster_time: cluster_timestamp,
-            signature: doc! {},
-        })
-    );
-}

--- a/src/operation/test.rs
+++ b/src/operation/test.rs
@@ -11,8 +11,7 @@ use crate::{
 
 pub(crate) fn handle_response_test<T: Operation>(op: &T, response_doc: Document) -> Result<T::O> {
     let raw = RawCommandResponse::with_document(response_doc).unwrap();
-    let response = T::Response::deserialize_response(&raw)?;
-    op.handle_response(response.into_body(), &StreamDescription::new_testing())
+    op.handle_response(raw, &StreamDescription::new_testing())
 }
 
 pub(crate) fn handle_response_test_with_wire_version<T: Operation>(
@@ -21,11 +20,7 @@ pub(crate) fn handle_response_test_with_wire_version<T: Operation>(
     wire_version: i32,
 ) -> Result<T::O> {
     let raw = RawCommandResponse::with_document(response_doc).unwrap();
-    let response = T::Response::deserialize_response(&raw)?;
-    op.handle_response(
-        response.into_body(),
-        &StreamDescription::with_wire_version(wire_version),
-    )
+    op.handle_response(raw, &StreamDescription::with_wire_version(wire_version))
 }
 
 pub(crate) fn op_selection_criteria<F, T>(constructor: F)

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -14,8 +14,6 @@ use crate::{
     Namespace,
 };
 
-use super::CommandResponse;
-
 #[derive(Debug)]
 pub(crate) struct Update {
     ns: Namespace,

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use crate::{
     bson::{doc, Bson, Document},
     bson_util,
-    cmap::{Command, StreamDescription},
+    cmap::{Command, RawCommandResponse, StreamDescription},
     error::{convert_bulk_errors, Result},
     operation::{Operation, Retryability, WriteResponseBody},
     options::{UpdateModifications, UpdateOptions, WriteConcern},
@@ -60,7 +60,6 @@ impl Update {
 impl Operation for Update {
     type O = UpdateResult;
     type Command = Document;
-    type Response = CommandResponse<WriteResponseBody<UpdateBody>>;
 
     const NAME: &'static str = "update";
 
@@ -116,9 +115,10 @@ impl Operation for Update {
 
     fn handle_response(
         &self,
-        response: WriteResponseBody<UpdateBody>,
+        raw_response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
+        let response: WriteResponseBody<UpdateBody> = raw_response.body()?;
         response.validate().map_err(convert_bulk_errors)?;
 
         let modified_count = response.n_modified;

--- a/src/results.rs
+++ b/src/results.rs
@@ -8,7 +8,7 @@ use crate::{
     db::options::CreateCollectionOptions,
 };
 
-use bson::Binary;
+use bson::{Binary, RawDocumentBuf};
 use serde::{Deserialize, Serialize};
 
 /// The result of a [`Collection::insert_one`](../struct.Collection.html#method.insert_one)
@@ -103,8 +103,8 @@ impl CreateIndexesResult {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct GetMoreResult<T> {
-    pub(crate) batch: VecDeque<T>,
+pub(crate) struct GetMoreResult {
+    pub(crate) batch: VecDeque<RawDocumentBuf>,
     pub(crate) exhausted: bool,
 }
 

--- a/src/test/documentation_examples/mod.rs
+++ b/src/test/documentation_examples/mod.rs
@@ -1508,7 +1508,7 @@ async fn aggregation_examples() -> GenericResult<()> {
     db.drop(None).await?;
     aggregation_data::populate(&db).await?;
 
-    // Each example is within its own scope to allow the example to include 
+    // Each example is within its own scope to allow the example to include
     // `use futures::TryStreamExt;` without causing multiple definition errors.
 
     {


### PR DESCRIPTION
RUST-1039

This PR updates the internals of the driver to support using `RawDocumentBuf` as the generic parameter of a cursor, thereby providing support for raw BSON cursors. From initial benchmarking, these cursors are _really_ fast, nearly C fast. Furthermore, users can now perform borrowed deserialization from the values retrieved from these cursors, which seems to be much faster than owned deserialization. I filed a follow up ticket for creating benchmarks for these cases to ensure we have an actual measurement of the performance differences.

It also seems that regular `Document` cursors may have been sped up by this change, though it's not immediately clear why. My guess is that we stopped using `#[serde(flatten)]`, which may be doing extra copies under the hood.

Note that the way this is implemented involves copying the results, so it's not truly zero-copy (the deserialization part from `RawDocumentBuf` to `T` can be, but iterating the cursor involves copies). I opted for this more straightforward path after doing some benchmarking that showed a true-zero-copy approach netted very little benefit when doing no deserialization at all and essentially zero benefit when doing borrowed deserialization. If we want to revisit this in the future we certainly can, though.