### PR TITLE
RUST-395 Log skipped tests

### DIFF
--- a/.evergreen/run-async-std-tests.sh
+++ b/.evergreen/run-async-std-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 source ./.evergreen/env.sh
 
-OPTIONS="-- -Z unstable-options --format json --report-time"
+OPTIONS="-- -Z unstable-options --format json --report-time --nocapture"
 
 if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"

--- a/.evergreen/run-async-std-tests.sh
+++ b/.evergreen/run-async-std-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 source ./.evergreen/env.sh
 
-OPTIONS="-- -Z unstable-options --format json --report-time --nocapture"
+OPTIONS="-- -Z unstable-options --format json --report-time"
 
 if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"

--- a/.evergreen/run-tokio-tests.sh
+++ b/.evergreen/run-tokio-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 source ./.evergreen/env.sh
 
-OPTIONS="-- -Z unstable-options --format json --report-time"
+OPTIONS="-- -Z unstable-options --format json --report-time --nocapture"
 
 if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"

--- a/.evergreen/run-tokio-tests.sh
+++ b/.evergreen/run-tokio-tests.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 source ./.evergreen/env.sh
 
-OPTIONS="-- -Z unstable-options --format json --report-time --nocapture"
+OPTIONS="-- -Z unstable-options --format json --report-time"
 
 if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -7,7 +7,7 @@ use crate::{
     coll::options::CollectionOptions,
     error::Result,
     options::ReadConcern,
-    test::{CommandEvent, EventClient, LOCK},
+    test::{log_uncaptured, CommandEvent, EventClient, LOCK},
     ClientSession,
     Collection,
 };
@@ -150,8 +150,8 @@ async fn new_session_operation_time_null() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!(
-            "skipping new_session_operation_time_null due to unsupported topology: standalone"
+        log_uncaptured(
+            "skipping new_session_operation_time_null due to unsupported topology: standalone",
         );
         return;
     }
@@ -169,8 +169,8 @@ async fn first_read_no_after_cluser_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!(
-            "skipping first_read_no_after_cluser_time due to unsupported topology: standalone"
+        log_uncaptured(
+            "skipping first_read_no_after_cluser_time due to unsupported topology: standalone",
         );
         return;
     }
@@ -208,7 +208,7 @@ async fn first_op_update_op_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!("skipping first_op_update_op_time due to unsupported topology: standalone");
+        log_uncaptured("skipping first_op_update_op_time due to unsupported topology: standalone");
         return;
     }
 
@@ -258,8 +258,8 @@ async fn read_includes_after_cluster_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!(
-            "skipping read_includes_after_cluster_time due to unsupported topology: standalone"
+        log_uncaptured(
+            "skipping read_includes_after_cluster_time due to unsupported topology: standalone",
         );
         return;
     }
@@ -303,9 +303,9 @@ async fn find_after_write_includes_after_cluster_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!(
+        log_uncaptured(
             "skipping find_after_write_includes_after_cluster_time due to unsupported topology: \
-             standalone"
+             standalone",
         );
         return;
     }
@@ -345,9 +345,9 @@ async fn not_causally_consistent_omits_after_cluster_time() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!(
+        log_uncaptured(
             "skipping not_causally_consistent_omits_after_cluster_time due to unsupported \
-             topology: standalone"
+             topology: standalone",
         );
         return;
     }
@@ -383,7 +383,7 @@ async fn omit_after_cluster_time_standalone() {
     let client = EventClient::new().await;
 
     if !client.is_standalone() {
-        println!("skipping omit_after_cluster_time_standalone due to unsupported topology");
+        log_uncaptured("skipping omit_after_cluster_time_standalone due to unsupported topology");
         return;
     }
 
@@ -418,8 +418,8 @@ async fn omit_default_read_concern_level() {
     let client = EventClient::new().await;
 
     if client.is_standalone() {
-        println!(
-            "skipping omit_default_read_concern_level due to unsupported topology: standalone"
+        log_uncaptured(
+            "skipping omit_default_read_concern_level due to unsupported topology: standalone",
         );
         return;
     }
@@ -458,9 +458,9 @@ async fn test_causal_consistency_read_concern_merge() {
 
     let client = EventClient::new().await;
     if client.is_standalone() {
-        println!(
+        log_uncaptured(
             "skipping test_causal_consistency_read_concern_merge due to unsupported topology: \
-             standalone"
+             standalone",
         );
         return;
     }
@@ -508,7 +508,7 @@ async fn omit_cluster_time_standalone() {
 
     let client = EventClient::new().await;
     if !client.is_standalone() {
-        println!("skipping omit_cluster_time_standalone due to unsupported topology");
+        log_uncaptured("skipping omit_cluster_time_standalone due to unsupported topology");
         return;
     }
 
@@ -530,7 +530,7 @@ async fn cluster_time_sent_in_commands() {
 
     let client = EventClient::new().await;
     if client.is_standalone() {
-        println!("skipping cluster_time_sent_in_commands due to unsupported topology");
+        log_uncaptured("skipping cluster_time_sent_in_commands due to unsupported topology");
         return;
     }
 

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     options::{Acknowledgment, FindOptions, ReadConcern, ReadPreference, WriteConcern},
     sdam::ServerInfo,
     selection_criteria::SelectionCriteria,
-    test::{EventClient, TestClient, CLIENT_OPTIONS, LOCK},
+    test::{log_uncaptured, EventClient, TestClient, CLIENT_OPTIONS, LOCK},
     Collection,
     RUNTIME,
 };
@@ -452,7 +452,9 @@ async fn find_and_getmore_share_session() {
 
     let client = EventClient::new().await;
     if client.is_standalone() {
-        println!("skipping find_and_getmore_share_session due to unsupported topology: Standalone");
+        log_uncaptured(
+            "skipping find_and_getmore_share_session due to unsupported topology: Standalone",
+        );
         return;
     }
 

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -12,7 +12,15 @@ use crate::{
     operation::CommandResponse,
     sdam::ServerUpdateSender,
     selection_criteria::ReadPreference,
-    test::{FailCommandOptions, FailPoint, FailPointMode, TestClient, CLIENT_OPTIONS, LOCK},
+    test::{
+        log_uncaptured,
+        FailCommandOptions,
+        FailPoint,
+        FailPointMode,
+        TestClient,
+        CLIENT_OPTIONS,
+        LOCK,
+    },
     RUNTIME,
 };
 use semver::VersionReq;
@@ -79,7 +87,7 @@ async fn concurrent_connections() {
 
     let mut options = CLIENT_OPTIONS.clone();
     if options.load_balanced.unwrap_or(false) {
-        println!("skipping concurrent_connections test due to load-balanced topology");
+        log_uncaptured("skipping concurrent_connections test due to load-balanced topology");
         return;
     }
     options.direct_connection = Some(true);
@@ -89,8 +97,8 @@ async fn concurrent_connections() {
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
     if !version.matches(&client.server_version) {
-        println!(
-            "skipping concurrent_connections test due to server not supporting failpoint option"
+        log_uncaptured(
+            "skipping concurrent_connections test due to server not supporting failpoint option",
         );
         return;
     }
@@ -169,8 +177,8 @@ async fn connection_error_during_establishment() {
 
     let mut client_options = CLIENT_OPTIONS.clone();
     if client_options.load_balanced.unwrap_or(false) {
-        println!(
-            "skipping connection_error_during_establishment test due to load-balanced topology"
+        log_uncaptured(
+            "skipping connection_error_during_establishment test due to load-balanced topology",
         );
         return;
     }
@@ -181,10 +189,10 @@ async fn connection_error_during_establishment() {
 
     let client = TestClient::with_options(Some(client_options.clone())).await;
     if !client.supports_fail_command() {
-        println!(
+        log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",
             function_name!()
-        );
+        ));
         return;
     }
 
@@ -236,10 +244,10 @@ async fn connection_error_during_operation() {
 
     let client = TestClient::with_options(options.into()).await;
     if !client.supports_fail_command() {
-        println!(
+        log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",
             function_name!()
-        );
+        ));
         return;
     }
 

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -432,7 +432,10 @@ async fn cmap_spec_tests() {
 
         let mut options = CLIENT_OPTIONS.clone();
         if options.load_balanced.unwrap_or(false) {
-            log_uncaptured("skipping due to load balanced topology");
+            log_uncaptured(format!(
+                "skipping {:?} due to load balanced topology",
+                test_file.description
+            ));
             return;
         }
         options.hosts.drain(1..);

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     test::{
         assert_matches,
         eq_matches,
+        log_uncaptured,
         run_spec_test,
         EventClient,
         MatchErrExt,
@@ -431,7 +432,7 @@ async fn cmap_spec_tests() {
 
         let mut options = CLIENT_OPTIONS.clone();
         if options.load_balanced.unwrap_or(false) {
-            println!("skipping due to load balanced topology");
+            log_uncaptured("skipping due to load balanced topology");
             return;
         }
         options.hosts.drain(1..);
@@ -440,7 +441,7 @@ async fn cmap_spec_tests() {
         if let Some(ref run_on) = test_file.run_on {
             let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));
             if !can_run_on {
-                println!("skipping due to runOn requirements");
+                log_uncaptured("skipping due to runOn requirements");
                 return;
             }
         }

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -12,6 +12,7 @@ use crate::{
     sdam::{description::topology::server_selection, Server},
     selection_criteria::ReadPreference,
     test::{
+        log_uncaptured,
         run_spec_test,
         Event,
         EventHandler,
@@ -118,12 +119,12 @@ async fn load_balancing_test() {
     let mut setup_client_options = CLIENT_OPTIONS.clone();
 
     if setup_client_options.load_balanced.unwrap_or(false) {
-        println!("skipping load_balancing_test test due to load-balanced topology");
+        log_uncaptured("skipping load_balancing_test test due to load-balanced topology");
         return;
     }
 
     if setup_client_options.credential.is_some() {
-        println!("skipping load_balancing_test test due to auth being enabled");
+        log_uncaptured("skipping load_balancing_test test due to auth being enabled");
         return;
     }
 
@@ -134,19 +135,19 @@ async fn load_balancing_test() {
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
     if !version.matches(&setup_client.server_version) {
-        println!(
-            "skipping load_balancing_test test due to server not supporting blockConnection option"
+        log_uncaptured(
+            "skipping load_balancing_test test due to server not supporting blockConnection option",
         );
         return;
     }
 
     if !setup_client.is_sharded() {
-        println!("skipping load_balancing_test test due to topology not being sharded");
+        log_uncaptured("skipping load_balancing_test test due to topology not being sharded");
         return;
     }
 
     if CLIENT_OPTIONS.hosts.len() != 2 {
-        println!("skipping load_balancing_test test due to topology not having 2 mongoses");
+        log_uncaptured("skipping load_balancing_test test due to topology not having 2 mongoses");
         return;
     }
 

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -644,7 +644,7 @@ async fn direct_connection() {
 
     let test_client = TestClient::new().await;
     if !test_client.is_replica_set() {
-        log_uncaptured("Skipping due to non-replica set topology");
+        log_uncaptured("Skipping direct_connection test due to non-replica set topology");
         return;
     }
 

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     selection_criteria::TagSet,
     test::{
+        log_uncaptured,
         run_spec_test,
         Event,
         EventClient,
@@ -240,7 +241,7 @@ async fn run_test(test_file: TestFile) {
 
     // TODO: RUST-360 unskip tests that rely on topology version
     if test_description.contains("topologyVersion") {
-        println!("Skipping {} (RUST-360)", test_description);
+        log_uncaptured(format!("Skipping {} (RUST-360)", test_description));
         return;
     }
 
@@ -597,7 +598,7 @@ async fn heartbeat_events() {
     .await;
 
     if client.is_load_balanced() {
-        println!("skipping heartbeat_events tests due to load-balanced topology");
+        log_uncaptured("skipping heartbeat_events tests due to load-balanced topology");
         return;
     }
 
@@ -643,7 +644,7 @@ async fn direct_connection() {
 
     let test_client = TestClient::new().await;
     if !test_client.is_replica_set() {
-        println!("Skipping due to non-replica set topology");
+        log_uncaptured("Skipping due to non-replica set topology");
         return;
     }
 

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -11,6 +11,7 @@ use crate::{
     error::ErrorKind,
     sdam::ServerType,
     test::{
+        log_uncaptured,
         CmapEvent,
         Event,
         EventClient,
@@ -34,7 +35,7 @@ async fn min_heartbeat_frequency() {
 
     let mut setup_client_options = CLIENT_OPTIONS.clone();
     if setup_client_options.load_balanced.unwrap_or(false) {
-        println!("skipping min_heartbeat_frequency test due to load-balanced topology");
+        log_uncaptured("skipping min_heartbeat_frequency test due to load-balanced topology");
         return;
     }
     setup_client_options.hosts.drain(1..);
@@ -43,12 +44,16 @@ async fn min_heartbeat_frequency() {
     let setup_client = TestClient::with_options(Some(setup_client_options.clone())).await;
 
     if !setup_client.supports_fail_command() {
-        println!("skipping min_heartbeat_frequency test due to server not supporting fail points");
+        log_uncaptured(
+            "skipping min_heartbeat_frequency test due to server not supporting fail points",
+        );
         return;
     }
 
     if setup_client.server_version_lt(4, 9) {
-        println!("skipping min_heartbeat_frequency test due to server version being less than 4.9");
+        log_uncaptured(
+            "skipping min_heartbeat_frequency test due to server version being less than 4.9",
+        );
         return;
     }
 
@@ -96,7 +101,7 @@ async fn sdam_pool_management() {
 
     let mut options = CLIENT_OPTIONS.clone();
     if options.load_balanced.unwrap_or(false) {
-        println!("skipping sdam_pool_management test due to load-balanced topology");
+        log_uncaptured("skipping sdam_pool_management test due to load-balanced topology");
         return;
     }
     options.hosts.drain(1..);
@@ -119,8 +124,8 @@ async fn sdam_pool_management() {
         .unwrap()
         .matches(&client.server_version)
     {
-        println!(
-            "skipping sdam_pool_management test due to server not supporting appName failCommand"
+        log_uncaptured(
+            "skipping sdam_pool_management test due to server not supporting appName failCommand",
         );
         return;
     }
@@ -189,7 +194,7 @@ async fn sdam_min_pool_size_error() {
 
     let mut setup_client_options = CLIENT_OPTIONS.clone();
     if setup_client_options.load_balanced.unwrap_or(false) {
-        println!("skipping sdam_min_pool_size_error test due to load-balanced topology");
+        log_uncaptured("skipping sdam_min_pool_size_error test due to load-balanced topology");
         return;
     }
     setup_client_options.hosts.drain(1..);
@@ -201,8 +206,8 @@ async fn sdam_min_pool_size_error() {
         .unwrap()
         .matches(&setup_client.server_version)
     {
-        println!(
-            "skipping sdam_pool_management test due to server not supporting appName failCommand"
+        log_uncaptured(
+            "skipping sdam_pool_management test due to server not supporting appName failCommand",
         );
         return;
     }
@@ -284,12 +289,12 @@ async fn auth_error() {
         .unwrap()
         .matches(&setup_client.server_version)
     {
-        println!("skipping auth_error test due to server not supporting appName failCommand");
+        log_uncaptured("skipping auth_error test due to server not supporting appName failCommand");
         return;
     }
 
     if !setup_client.auth_enabled() {
-        println!("skipping auth_error test due to auth not being enabled");
+        log_uncaptured("skipping auth_error test due to auth not being enabled");
         return;
     }
 

--- a/src/test/atlas_connectivity.rs
+++ b/src/test/atlas_connectivity.rs
@@ -5,7 +5,10 @@ use super::log_uncaptured;
 
 async fn run_test(uri_env_var: &str, resolver_config: Option<ResolverConfig>) {
     if std::env::var_os("MONGO_ATLAS_TESTS").is_none() {
-        log_uncaptured("skipping test due to undefined environment variable MONGO_ATLAS_TESTS");
+        log_uncaptured(
+            "skipping atlas_connectivity test due to undefined environment variable \
+             MONGO_ATLAS_TESTS",
+        );
         return;
     }
 

--- a/src/test/atlas_connectivity.rs
+++ b/src/test/atlas_connectivity.rs
@@ -1,9 +1,11 @@
 use crate::{bson::doc, client::options::ResolverConfig, options::ClientOptions, Client};
 use bson::Document;
 
+use super::log_uncaptured;
+
 async fn run_test(uri_env_var: &str, resolver_config: Option<ResolverConfig>) {
     if std::env::var_os("MONGO_ATLAS_TESTS").is_none() {
-        println!("skipping test due to undefined environment variable MONGO_ATLAS_TESTS");
+        log_uncaptured("skipping test due to undefined environment variable MONGO_ATLAS_TESTS");
         return;
     }
 

--- a/src/test/atlas_connectivity.rs
+++ b/src/test/atlas_connectivity.rs
@@ -3,6 +3,7 @@ use bson::Document;
 
 async fn run_test(uri_env_var: &str, resolver_config: Option<ResolverConfig>) {
     if std::env::var_os("MONGO_ATLAS_TESTS").is_none() {
+        println!("skipping test due to undefined environment variable MONGO_ATLAS_TESTS");
         return;
     }
 

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -13,7 +13,7 @@ use crate::{
     Collection,
 };
 
-use super::{EventClient, TestClient, CLIENT_OPTIONS, LOCK};
+use super::{log_uncaptured, EventClient, TestClient, CLIENT_OPTIONS, LOCK};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -29,11 +29,11 @@ async fn init_stream(
 > {
     let init_client = TestClient::new().await;
     if !init_client.is_replica_set() && !init_client.is_sharded() {
-        println!("skipping change stream test on unsupported topology");
+        log_uncaptured("skipping change stream test on unsupported topology");
         return Ok(None);
     }
     if !init_client.supports_fail_command() {
-        println!("skipping change stream test on version without fail commands");
+        log_uncaptured("skipping change stream test on version without fail commands");
         return Ok(None);
     }
 
@@ -468,17 +468,17 @@ async fn aggregate_batch() -> Result<()> {
         None => return Ok(()),
     };
     if client.is_sharded() {
-        println!("skipping change stream test on unsupported topology");
+        log_uncaptured("skipping change stream test on unsupported topology");
         return Ok(());
     }
     if !VersionReq::parse(">=4.2")
         .unwrap()
         .matches(&client.server_version)
     {
-        println!(
+        log_uncaptured(format!(
             "skipping change stream test on unsupported version {:?}",
             client.server_version
-        );
+        ));
         return Ok(());
     }
 

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -9,7 +9,7 @@ use crate::{
     error::{CommandError, Error, ErrorKind},
     options::{AuthMechanism, ClientOptions, Credential, ListDatabasesOptions, ServerAddress},
     selection_criteria::{ReadPreference, ReadPreferenceOptions, SelectionCriteria},
-    test::{util::TestClient, CLIENT_OPTIONS, LOCK},
+    test::{log_uncaptured, util::TestClient, CLIENT_OPTIONS, LOCK},
     Client,
     RUNTIME,
 };
@@ -115,7 +115,7 @@ async fn server_selection_timeout_message() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     if CLIENT_OPTIONS.repl_set_name.is_none() {
-        println!("skipping server_selection_timeout_message due to missing replica set name");
+        log_uncaptured("skipping server_selection_timeout_message due to missing replica set name");
         return;
     }
 
@@ -241,7 +241,7 @@ async fn list_authorized_databases() {
 
     let client = TestClient::new().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
-        println!("skipping list_authorized_databases due to test configuration");
+        log_uncaptured("skipping list_authorized_databases due to test configuration");
         return;
     }
 
@@ -430,7 +430,7 @@ async fn scram_sha1() {
 
     let client = TestClient::new().await;
     if !client.auth_enabled() {
-        println!("skipping scram_sha1 due to missing authentication");
+        log_uncaptured("skipping scram_sha1 due to missing authentication");
         return;
     }
 
@@ -454,7 +454,7 @@ async fn scram_sha256() {
 
     let client = TestClient::new().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
-        println!("skipping scram_sha256 due to test configuration");
+        log_uncaptured("skipping scram_sha256 due to test configuration");
         return;
     }
     client
@@ -477,7 +477,7 @@ async fn scram_both() {
 
     let client = TestClient::new().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
-        println!("skipping scram_both due to test configuration");
+        log_uncaptured("skipping scram_both due to test configuration");
         return;
     }
     client
@@ -506,7 +506,7 @@ async fn scram_missing_user_uri() {
 
     let client = TestClient::new().await;
     if !client.auth_enabled() {
-        println!("skipping scram_missing_user_uri due to missing authentication");
+        log_uncaptured("skipping scram_missing_user_uri due to missing authentication");
         return;
     }
     auth_test_uri("adsfasdf", "ASsdfsadf", None, false).await;
@@ -519,7 +519,7 @@ async fn scram_missing_user_options() {
 
     let client = TestClient::new().await;
     if !client.auth_enabled() {
-        println!("skipping scram_missing_user_options due to missing authentication");
+        log_uncaptured("skipping scram_missing_user_options due to missing authentication");
         return;
     }
     auth_test_options("sadfasdf", "fsdadsfasdf", None, false).await;
@@ -533,7 +533,7 @@ async fn saslprep() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
-        println!("skipping saslprep due to test configuration");
+        log_uncaptured("skipping saslprep due to test configuration");
         return;
     }
 
@@ -626,7 +626,7 @@ async fn plain_auth() {
     let _guard: RwLockReadGuard<_> = LOCK.run_concurrently().await;
 
     if std::env::var("MONGO_PLAIN_AUTH_TEST").is_err() {
-        println!("skipping plain_auth due to environment variable MONGO_PLAIN_AUTH_TEST");
+        log_uncaptured("skipping plain_auth due to environment variable MONGO_PLAIN_AUTH_TEST");
         return;
     }
 

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -115,6 +115,7 @@ async fn server_selection_timeout_message() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     if CLIENT_OPTIONS.repl_set_name.is_none() {
+        println!("skipping server_selection_timeout_message due to missing replica set name");
         return;
     }
 
@@ -240,6 +241,7 @@ async fn list_authorized_databases() {
 
     let client = TestClient::new().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
+        println!("skipping list_authorized_databases due to test configuration");
         return;
     }
 
@@ -428,6 +430,7 @@ async fn scram_sha1() {
 
     let client = TestClient::new().await;
     if !client.auth_enabled() {
+        println!("skipping scram_sha1 due to missing authentication");
         return;
     }
 
@@ -451,6 +454,7 @@ async fn scram_sha256() {
 
     let client = TestClient::new().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
+        println!("skipping scram_sha256 due to test configuration");
         return;
     }
     client
@@ -473,6 +477,7 @@ async fn scram_both() {
 
     let client = TestClient::new().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
+        println!("skipping scram_both due to test configuration");
         return;
     }
     client
@@ -501,6 +506,7 @@ async fn scram_missing_user_uri() {
 
     let client = TestClient::new().await;
     if !client.auth_enabled() {
+        println!("skipping scram_missing_user_uri due to missing authentication");
         return;
     }
     auth_test_uri("adsfasdf", "ASsdfsadf", None, false).await;
@@ -513,6 +519,7 @@ async fn scram_missing_user_options() {
 
     let client = TestClient::new().await;
     if !client.auth_enabled() {
+        println!("skipping scram_missing_user_options due to missing authentication");
         return;
     }
     auth_test_options("sadfasdf", "fsdadsfasdf", None, false).await;
@@ -526,6 +533,7 @@ async fn saslprep() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
+        println!("skipping saslprep due to test configuration");
         return;
     }
 
@@ -618,6 +626,7 @@ async fn plain_auth() {
     let _guard: RwLockReadGuard<_> = LOCK.run_concurrently().await;
 
     if std::env::var("MONGO_PLAIN_AUTH_TEST").is_err() {
+        println!("skipping plain_auth due to environment variable MONGO_PLAIN_AUTH_TEST");
         return;
     }
 

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -28,6 +28,7 @@ use crate::{
     },
     results::DeleteResult,
     test::{
+        log_uncaptured,
         util::{drop_collection, EventClient, TestClient},
         CLIENT_OPTIONS,
         LOCK,
@@ -47,7 +48,7 @@ async fn insert_err_details() {
         .init_db_and_coll(function_name!(), function_name!())
         .await;
     if client.server_version_lt(4, 0) || !client.is_replica_set() {
-        println!("skipping insert_err_details due to test configuration");
+        log_uncaptured("skipping insert_err_details due to test configuration");
         return;
     }
     client
@@ -402,7 +403,7 @@ lazy_static! {
 #[function_name::named]
 async fn large_insert() {
     if std::env::consts::OS != "linux" {
-        println!("skipping large_insert due to unsupported OS");
+        log_uncaptured("skipping large_insert due to unsupported OS");
         return;
     }
 
@@ -452,7 +453,7 @@ fn multibatch_documents_with_duplicate_keys() -> Vec<Document> {
 #[function_name::named]
 async fn large_insert_unordered_with_errors() {
     if std::env::consts::OS != "linux" {
-        println!("skipping large_insert_unordered_with_errors due to unsupported OS");
+        log_uncaptured("skipping large_insert_unordered_with_errors due to unsupported OS");
         return;
     }
 
@@ -493,7 +494,7 @@ async fn large_insert_unordered_with_errors() {
 #[function_name::named]
 async fn large_insert_ordered_with_errors() {
     if std::env::consts::OS != "linux" {
-        println!("skipping large_insert_ordered_with_errors due to unsupported OS");
+        log_uncaptured("skipping large_insert_ordered_with_errors due to unsupported OS");
         return;
     }
 
@@ -579,7 +580,7 @@ async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>)
 
     let event_client = EventClient::new().await;
     if event_client.server_version_lt(4, 3) {
-        println!("skipping allow_disk_use_test due to server version < 4.3");
+        log_uncaptured("skipping allow_disk_use_test due to server version < 4.3");
         return;
     }
     let coll = event_client
@@ -658,7 +659,7 @@ async fn find_one_and_delete_hint_test(options: Option<FindOneAndDeleteOptions>,
 
     let req = VersionReq::parse(">= 4.2").unwrap();
     if options.is_some() && !req.matches(&client.server_version) {
-        println!("skipping find_one_and_delete_hint_test due to test configuration");
+        log_uncaptured("skipping find_one_and_delete_hint_test due to test configuration");
         return;
     }
 
@@ -738,7 +739,7 @@ async fn no_read_preference_to_standalone() {
     let client = EventClient::new().await;
 
     if !client.is_standalone() {
-        println!("skipping no_read_preference_to_standalone due to test topology");
+        log_uncaptured("skipping no_read_preference_to_standalone due to test topology");
         return;
     }
 
@@ -1076,7 +1077,7 @@ async fn cursor_batch_size() {
 
     // test session cursors
     if client.is_standalone() {
-        println!("skipping cursor_batch_size due to standalone topology");
+        log_uncaptured("skipping cursor_batch_size due to standalone topology");
         return;
     }
     let mut session = client.start_session(None).await.unwrap();

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -47,6 +47,7 @@ async fn insert_err_details() {
         .init_db_and_coll(function_name!(), function_name!())
         .await;
     if client.server_version_lt(4, 0) || !client.is_replica_set() {
+        println!("skipping insert_err_details due to test configuration");
         return;
     }
     client
@@ -401,6 +402,7 @@ lazy_static! {
 #[function_name::named]
 async fn large_insert() {
     if std::env::consts::OS != "linux" {
+        println!("skipping large_insert due to unsupported OS");
         return;
     }
 
@@ -450,6 +452,7 @@ fn multibatch_documents_with_duplicate_keys() -> Vec<Document> {
 #[function_name::named]
 async fn large_insert_unordered_with_errors() {
     if std::env::consts::OS != "linux" {
+        println!("skipping large_insert_unordered_with_errors due to unsupported OS");
         return;
     }
 
@@ -490,6 +493,7 @@ async fn large_insert_unordered_with_errors() {
 #[function_name::named]
 async fn large_insert_ordered_with_errors() {
     if std::env::consts::OS != "linux" {
+        println!("skipping large_insert_ordered_with_errors due to unsupported OS");
         return;
     }
 
@@ -575,6 +579,7 @@ async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>)
 
     let event_client = EventClient::new().await;
     if event_client.server_version_lt(4, 3) {
+        println!("skipping allow_disk_use_test due to server version < 4.3");
         return;
     }
     let coll = event_client
@@ -653,6 +658,7 @@ async fn find_one_and_delete_hint_test(options: Option<FindOneAndDeleteOptions>,
 
     let req = VersionReq::parse(">= 4.2").unwrap();
     if options.is_some() && !req.matches(&client.server_version) {
+        println("skipping find_one_and_delete_hint_test due to test configuration");
         return;
     }
 
@@ -732,6 +738,7 @@ async fn no_read_preference_to_standalone() {
     let client = EventClient::new().await;
 
     if !client.is_standalone() {
+        println!("skipping no_read_preference_to_standalone due to test topology");
         return;
     }
 
@@ -1069,6 +1076,7 @@ async fn cursor_batch_size() {
 
     // test session cursors
     if client.is_standalone() {
+        println!("skipping cursor_batch_size due to standalone topology");
         return;
     }
     let mut session = client.start_session(None).await.unwrap();

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -658,7 +658,7 @@ async fn find_one_and_delete_hint_test(options: Option<FindOneAndDeleteOptions>,
 
     let req = VersionReq::parse(">= 4.2").unwrap();
     if options.is_some() && !req.matches(&client.server_version) {
-        println("skipping find_one_and_delete_hint_test due to test configuration");
+        println!("skipping find_one_and_delete_hint_test due to test configuration");
         return;
     }
 

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -24,6 +24,8 @@ use crate::{
     Database,
 };
 
+use super::log_uncaptured;
+
 #[derive(Deserialize)]
 struct IsMasterReply {
     ismaster: bool,
@@ -266,7 +268,7 @@ async fn db_aggregate() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) {
-        println!("skipping db_aggregate due to server version < 4.0");
+        log_uncaptured("skipping db_aggregate due to server version < 4.0");
         return;
     }
 
@@ -311,7 +313,7 @@ async fn db_aggregate_disk_use() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) {
-        println!("skipping db_aggregate_disk_use due to server version < 4.0");
+        log_uncaptured("skipping db_aggregate_disk_use due to server version < 4.0");
         return;
     }
 

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -266,6 +266,7 @@ async fn db_aggregate() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) {
+        println!("skipping db_aggregate due to server version < 4.0");
         return;
     }
 
@@ -310,6 +311,7 @@ async fn db_aggregate_disk_use() {
     let client = TestClient::new().await;
 
     if client.server_version_lt(4, 0) {
+        println!("skipping db_aggregate_disk_use due to server version < 4.0");
         return;
     }
 

--- a/src/test/documentation_examples/mod.rs
+++ b/src/test/documentation_examples/mod.rs
@@ -1376,18 +1376,18 @@ type GenericResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 async fn versioned_api_examples() -> GenericResult<()> {
     let setup_client = TestClient::new().await;
     if setup_client.server_version_lt(4, 9) {
-        println!("skipping versioned API examples due to unsupported server version");
+        log_uncaptured("skipping versioned API examples due to unsupported server version");
         return Ok(());
     }
     if setup_client.is_sharded() && setup_client.server_version <= Version::new(5, 0, 2) {
         // See SERVER-58794.
-        println!(
-            "skipping versioned API examples due to unsupported server version on sharded topology"
+        log_uncaptured(
+            "skipping versioned API examples due to unsupported server version on sharded topology",
         );
         return Ok(());
     }
     if setup_client.is_load_balanced() {
-        println!("skipping versioned API examples due to load-balanced topology");
+        log_uncaptured("skipping versioned API examples due to load-balanced topology");
         return Ok(());
     }
 
@@ -1440,6 +1440,8 @@ async fn versioned_api_examples() -> GenericResult<()> {
     db.collection::<Document>("sales").drop(None).await?;
 
     use std::{error::Error, result::Result};
+
+    use crate::test::log_uncaptured;
     // Start Versioned API Example 5
     // With the `bson-chrono-0_4` feature enabled, this function can be dropped in favor of using
     // `chrono::DateTime` values directly.

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -286,6 +286,7 @@ async fn commit_quorum_error() {
 
     let client = TestClient::new().await;
     if client.is_standalone() {
+        println!("skipping commit_quorum_error due to standalone topology");
         return;
     }
 

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -6,6 +6,7 @@ use crate::{
     error::ErrorKind,
     options::{CommitQuorum, CreateIndexOptions, IndexOptions},
     test::{
+        log_uncaptured,
         util::{EventClient, TestClient},
         LOCK,
     },
@@ -286,7 +287,7 @@ async fn commit_quorum_error() {
 
     let client = TestClient::new().await;
     if client.is_standalone() {
-        println!("skipping commit_quorum_error due to standalone topology");
+        log_uncaptured("skipping commit_quorum_error due to standalone topology");
         return;
     }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use self::{
     util::{
         assert_matches,
         eq_matches,
+        log_uncaptured,
         CmapEvent,
         CommandEvent,
         Event,

--- a/src/test/spec/command_monitoring/mod.rs
+++ b/src/test/spec/command_monitoring/mod.rs
@@ -11,7 +11,7 @@ use self::{event::TestEvent, operation::*};
 use crate::{
     bson::{Bson, Document},
     options::ClientOptions,
-    test::{assert_matches, util::TestClient, EventClient, CLIENT_OPTIONS, LOCK},
+    test::{assert_matches, log_uncaptured, util::TestClient, EventClient, CLIENT_OPTIONS, LOCK},
 };
 
 #[derive(Deserialize)]
@@ -52,14 +52,14 @@ async fn run_command_monitoring_test(test_file: TestFile) {
 
     for test_case in test_file.tests {
         if skipped_tests.iter().any(|st| st == &test_case.description) {
-            println!("Skipping {}", test_case.description);
+            log_uncaptured(format!("Skipping {}", test_case.description));
             continue;
         }
 
         if let Some(ref max_version) = test_case.max_version {
             let req = VersionReq::parse(&format!("<= {}", &max_version)).unwrap();
             if !req.matches(&client.server_version) {
-                println!("Skipping {}", test_case.description);
+                log_uncaptured(format!("Skipping {}", test_case.description));
                 continue;
             }
         }
@@ -67,7 +67,7 @@ async fn run_command_monitoring_test(test_file: TestFile) {
         if let Some(ref min_version) = test_case.min_version {
             let req = VersionReq::parse(&format!(">= {}", &min_version)).unwrap();
             if !req.matches(&client.server_version) {
-                println!("Skipping {}", test_case.description);
+                log_uncaptured(format!("Skipping {}", test_case.description));
                 continue;
             }
         }

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -31,7 +31,10 @@ async fn run_test<F: Future>(
     let client = EventClient::with_additional_options(Some(options), None, None, None).await;
 
     if !client.is_replica_set() {
-        log_uncaptured("skipping test due to not running on a replica set");
+        log_uncaptured(format!(
+            "skipping test {:?} due to not running on a replica set",
+            name
+        ));
         return;
     }
 

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -31,6 +31,7 @@ async fn run_test<F: Future>(
     let client = EventClient::with_additional_options(Some(options), None, None, None).await;
 
     if !client.is_replica_set() {
+        println!("skipping test due to not running on a replica set");
         return;
     }
 
@@ -70,6 +71,7 @@ async fn get_more() {
     async fn get_more_test(client: EventClient, _db: Database, coll: Collection<Document>) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
+            println!("skipping get_more due to server version < 4.2");
             return;
         }
 
@@ -122,6 +124,7 @@ async fn not_master_keep_pool() {
     ) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
+            println!("skipping not_master_keep_pool due to server version < 4.2");
             return;
         }
 
@@ -172,6 +175,7 @@ async fn not_master_reset_pool() {
     ) {
         // This test must only run on 4.0 servers.
         if !client.server_version_eq(4, 0) {
+            println!("skipping not_master_reset_pool due to unsupported server version");
             return;
         }
 
@@ -221,6 +225,7 @@ async fn shutdown_in_progress() {
         coll: Collection<Document>,
     ) {
         if client.server_version_lt(4, 0) {
+            println!("skipping shutdown_in_progress due to server version < 4.0");
             return;
         }
 
@@ -270,6 +275,7 @@ async fn interrupted_at_shutdown() {
         coll: Collection<Document>,
     ) {
         if client.server_version_lt(4, 0) {
+            println!("skipping interrupted_at_shutdown due to server version < 4.2");
             return;
         }
 

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -15,7 +15,7 @@ use crate::{
         InsertManyOptions,
         WriteConcern,
     },
-    test::{util::EventClient, LOCK},
+    test::{log_uncaptured, util::EventClient, LOCK},
     Collection,
     Database,
     RUNTIME,
@@ -31,7 +31,7 @@ async fn run_test<F: Future>(
     let client = EventClient::with_additional_options(Some(options), None, None, None).await;
 
     if !client.is_replica_set() {
-        println!("skipping test due to not running on a replica set");
+        log_uncaptured("skipping test due to not running on a replica set");
         return;
     }
 
@@ -71,7 +71,7 @@ async fn get_more() {
     async fn get_more_test(client: EventClient, _db: Database, coll: Collection<Document>) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
-            println!("skipping get_more due to server version < 4.2");
+            log_uncaptured("skipping get_more due to server version < 4.2");
             return;
         }
 
@@ -124,7 +124,7 @@ async fn not_master_keep_pool() {
     ) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
-            println!("skipping not_master_keep_pool due to server version < 4.2");
+            log_uncaptured("skipping not_master_keep_pool due to server version < 4.2");
             return;
         }
 
@@ -175,7 +175,7 @@ async fn not_master_reset_pool() {
     ) {
         // This test must only run on 4.0 servers.
         if !client.server_version_eq(4, 0) {
-            println!("skipping not_master_reset_pool due to unsupported server version");
+            log_uncaptured("skipping not_master_reset_pool due to unsupported server version");
             return;
         }
 
@@ -225,7 +225,7 @@ async fn shutdown_in_progress() {
         coll: Collection<Document>,
     ) {
         if client.server_version_lt(4, 0) {
-            println!("skipping shutdown_in_progress due to server version < 4.0");
+            log_uncaptured("skipping shutdown_in_progress due to server version < 4.0");
             return;
         }
 
@@ -275,7 +275,7 @@ async fn interrupted_at_shutdown() {
         coll: Collection<Document>,
     ) {
         if client.server_version_lt(4, 0) {
-            println!("skipping interrupted_at_shutdown due to server version < 4.2");
+            log_uncaptured("skipping interrupted_at_shutdown due to server version < 4.2");
             return;
         }
 

--- a/src/test/spec/crud_v1/mod.rs
+++ b/src/test/spec/crud_v1/mod.rs
@@ -18,7 +18,7 @@ use std::future::Future;
 use futures::stream::TryStreamExt;
 use serde::Deserialize;
 
-use crate::{bson::Document, Collection};
+use crate::{bson::Document, test::log_uncaptured, Collection};
 
 use super::{run_spec_test, Serverless};
 
@@ -74,7 +74,7 @@ where
     run_spec_test(spec, |t: TestFile| async {
         if let Some(ref serverless) = t.serverless {
             if !serverless.can_run() {
-                println!("skipping crud_v1_test");
+                log_uncaptured("skipping crud_v1_test");
                 return;
             }
         }

--- a/src/test/spec/crud_v1/mod.rs
+++ b/src/test/spec/crud_v1/mod.rs
@@ -74,6 +74,7 @@ where
     run_spec_test(spec, |t: TestFile| async {
         if let Some(ref serverless) = t.serverless {
             if !serverless.can_run() {
+                println!("skipping crud_v1_test");
                 return;
             }
         }

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -164,7 +164,7 @@ async fn run_test(mut test_file: TestFile) {
             RUNTIME.delay_for(Duration::from_millis(500)).await;
         }
     } else {
-        println!("skipping test due to test configuration");
+        println!("skipping test due to test topology");
     }
 
     if let Some(ref mut resolved_options) = test_file.options {

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -65,6 +65,19 @@ async fn run_test(mut test_file: TestFile) {
         return;
     }
 
+    // TODO RUST-980 unskip these tests
+    if test_file
+        .options
+        .as_ref()
+        .and_then(|o| o.load_balanced)
+        .unwrap_or(false)
+    {
+        log_uncaptured(
+            "skipping initial_dns_seedlist_discovery due to load-balanced test configuration",
+        );
+        return;
+    }
+
     // "encoded-userinfo-and-db.json" specifies a database name with a question mark which is
     // disallowed on Windows. See
     // <https://docs.mongodb.com/manual/reference/limits/#restrictions-on-db-names>

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -58,7 +58,10 @@ struct ParsedOptions {
 async fn run_test(mut test_file: TestFile) {
     // TODO DRIVERS-796: unskip this test
     if test_file.uri == "mongodb+srv://test5.test.build.10gen.cc/?authSource=otherDB" {
-        println!("skipping initial_dns_seedlist_discovery due to authSource being specified without credentials");
+        println!(
+            "skipping initial_dns_seedlist_discovery due to authSource being specified without \
+             credentials"
+        );
         return;
     }
 

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -7,7 +7,7 @@ use crate::{
     bson::doc,
     client::{auth::AuthMechanism, Client},
     options::{ClientOptions, ResolverConfig},
-    test::{run_spec_test, TestClient, CLIENT_OPTIONS, LOCK},
+    test::{log_uncaptured, run_spec_test, TestClient, CLIENT_OPTIONS, LOCK},
     RUNTIME,
 };
 
@@ -58,9 +58,9 @@ struct ParsedOptions {
 async fn run_test(mut test_file: TestFile) {
     // TODO DRIVERS-796: unskip this test
     if test_file.uri == "mongodb+srv://test5.test.build.10gen.cc/?authSource=otherDB" {
-        println!(
+        log_uncaptured(
             "skipping initial_dns_seedlist_discovery due to authSource being specified without \
-             credentials"
+             credentials",
         );
         return;
     }
@@ -167,7 +167,7 @@ async fn run_test(mut test_file: TestFile) {
             RUNTIME.delay_for(Duration::from_millis(500)).await;
         }
     } else {
-        println!("skipping test due to test topology");
+        log_uncaptured("skipping test due to test topology");
     }
 
     if let Some(ref mut resolved_options) = test_file.options {

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -58,16 +58,7 @@ struct ParsedOptions {
 async fn run_test(mut test_file: TestFile) {
     // TODO DRIVERS-796: unskip this test
     if test_file.uri == "mongodb+srv://test5.test.build.10gen.cc/?authSource=otherDB" {
-        return;
-    }
-
-    // TODO RUST-980 unskip these tests
-    if test_file
-        .options
-        .as_ref()
-        .and_then(|o| o.load_balanced)
-        .unwrap_or(false)
-    {
+        println!("skipping initial_dns_seedlist_discovery due to authSource being specified without credentials");
         return;
     }
 
@@ -115,7 +106,6 @@ async fn run_test(mut test_file: TestFile) {
         None => true,
     };
     let client = TestClient::new().await;
-    // TODO RUST-395: log this test skip
     if requires_tls == client.options.tls_options().is_some()
         && client.is_replica_set()
         && client.options.repl_set_name.as_deref() == Some("repl0")
@@ -173,6 +163,8 @@ async fn run_test(mut test_file: TestFile) {
 
             RUNTIME.delay_for(Duration::from_millis(500)).await;
         }
+    } else {
+        println!("skipping test due to test configuration");
     }
 
     if let Some(ref mut resolved_options) = test_file.options {

--- a/src/test/spec/load_balancers.rs
+++ b/src/test/spec/load_balancers.rs
@@ -44,6 +44,7 @@ async fn run() {
         run_unified_format_test_filtered(test_file, |tc| {
             // TODO RUST-142 unskip this when change streams are implemented.
             if tc.description == "change streams pin to a connection" {
+                println!("skipping due to change streams not being implemented");
                 return false;
             }
             true

--- a/src/test/spec/load_balancers.rs
+++ b/src/test/spec/load_balancers.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use tokio::sync::RwLockWriteGuard;
 
 use crate::test::{
+    log_uncaptured,
     run_spec_test_with_path,
     spec::{
         unified_runner::{ExpectedCmapEvent, ExpectedEvent, TestFile},
@@ -44,7 +45,7 @@ async fn run() {
         run_unified_format_test_filtered(test_file, |tc| {
             // TODO RUST-142 unskip this when change streams are implemented.
             if tc.description == "change streams pin to a connection" {
-                println!("skipping due to change streams not being implemented");
+                log_uncaptured("skipping due to change streams not being implemented");
                 return false;
             }
             true

--- a/src/test/spec/ocsp.rs
+++ b/src/test/spec/ocsp.rs
@@ -4,7 +4,7 @@ use bson::doc;
 use tokio::sync::RwLockWriteGuard;
 
 use crate::{
-    test::{CLIENT_OPTIONS, LOCK},
+    test::{log_uncaptured, CLIENT_OPTIONS, LOCK},
     Client,
 };
 
@@ -12,7 +12,7 @@ use crate::{
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
     if std::env::var_os("MONGO_OCSP_TESTS").is_none() {
-        println!("skipping test due to missing environment variable MONGO_OCSP_TESTS");
+        log_uncaptured("skipping test due to missing environment variable MONGO_OCSP_TESTS");
         return;
     }
 

--- a/src/test/spec/ocsp.rs
+++ b/src/test/spec/ocsp.rs
@@ -12,6 +12,7 @@ use crate::{
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
     if std::env::var_os("MONGO_OCSP_TESTS").is_none() {
+        println!("skipping test due to missing environment variable MONGO_OCSP_TESTS");
         return;
     }
 

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     runtime::AsyncJoinHandle,
     test::{
+        log_uncaptured,
         run_spec_test,
         CmapEvent,
         Event,
@@ -48,7 +49,7 @@ async fn retry_releases_connection() {
 
     let client = TestClient::with_options(Some(client_options)).await;
     if !client.supports_fail_command() {
-        println!("skipping retry_releases_connection due to failCommand not being supported");
+        log_uncaptured("skipping retry_releases_connection due to failCommand not being supported");
         return;
     }
 
@@ -88,11 +89,13 @@ async fn retry_read_pool_cleared() {
 
     let client = TestClient::with_options(Some(client_options.clone())).await;
     if !client.supports_block_connection() {
-        println!("skipping retry_read_pool_cleared due to blockConnection not being supported");
+        log_uncaptured(
+            "skipping retry_read_pool_cleared due to blockConnection not being supported",
+        );
         return;
     }
     if client.is_load_balanced() {
-        println!("skipping retry_read_pool_cleared due to load-balanced topology");
+        log_uncaptured("skipping retry_read_pool_cleared due to load-balanced topology");
         return;
     }
 

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -376,7 +376,9 @@ async fn label_not_added(retry_reads: bool) {
     if client.is_sharded() && !sharded_req.matches(&client.server_version)
         || !req.matches(&client.server_version)
     {
-        println!("skipping label_not_added due to unsupported replica set or sharded cluster version");
+        println!(
+            "skipping label_not_added due to unsupported replica set or sharded cluster version"
+        );
         return;
     }
 

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     runtime::AsyncJoinHandle,
     test::{
         assert_matches,
+        log_uncaptured,
         run_spec_test,
         util::get_default_name,
         CmapEvent,
@@ -68,7 +69,7 @@ async fn run_legacy() {
             if let Some(ref run_on) = test_file.run_on {
                 let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));
                 if !can_run_on {
-                    println!("Skipping {}", test_case.description);
+                    log_uncaptured(format!("Skipping {}", test_case.description));
                     continue;
                 }
             }
@@ -197,7 +198,7 @@ async fn transaction_ids_excluded() {
     let client = EventClient::new().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
-        println!("skipping transaction_ids_excluded due to test topology");
+        log_uncaptured("skipping transaction_ids_excluded due to test topology");
         return;
     }
 
@@ -251,7 +252,7 @@ async fn transaction_ids_included() {
     let client = EventClient::new().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
-        println!("skipping transaction_ids_included due to test topology");
+        log_uncaptured("skipping transaction_ids_included due to test topology");
         return;
     }
 
@@ -314,7 +315,7 @@ async fn mmapv1_error_raised() {
 
     let req = semver::VersionReq::parse("<=4.0").unwrap();
     if !req.matches(&client.server_version) || !client.is_replica_set() {
-        println!("skipping mmapv1_error_raised due to test topology");
+        log_uncaptured("skipping mmapv1_error_raised due to test topology");
         return;
     }
 
@@ -331,7 +332,7 @@ async fn mmapv1_error_raised() {
         .get_str("name")
         .unwrap();
     if name != "mmapv1" {
-        println!("skipping mmapv1_error_raised due to unsupported storage engine");
+        log_uncaptured("skipping mmapv1_error_raised due to unsupported storage engine");
         return;
     }
 
@@ -376,8 +377,8 @@ async fn label_not_added(retry_reads: bool) {
     if client.is_sharded() && !sharded_req.matches(&client.server_version)
         || !req.matches(&client.server_version)
     {
-        println!(
-            "skipping label_not_added due to unsupported replica set or sharded cluster version"
+        log_uncaptured(
+            "skipping label_not_added due to unsupported replica set or sharded cluster version",
         );
         return;
     }
@@ -425,17 +426,19 @@ async fn retry_write_pool_cleared() {
 
     let client = TestClient::with_options(Some(client_options.clone())).await;
     if !client.supports_block_connection() {
-        println!("skipping retry_write_pool_cleared due to blockConnection not being supported");
+        log_uncaptured(
+            "skipping retry_write_pool_cleared due to blockConnection not being supported",
+        );
         return;
     }
 
     if client.is_standalone() {
-        println!("skipping retry_write_pool_cleared due standalone topology");
+        log_uncaptured("skipping retry_write_pool_cleared due standalone topology");
         return;
     }
 
     if client.is_load_balanced() {
-        println!("skipping retry_write_pool_cleared due to load-balanced topology");
+        log_uncaptured("skipping retry_write_pool_cleared due to load-balanced topology");
         return;
     }
 

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -197,7 +197,7 @@ async fn transaction_ids_excluded() {
     let client = EventClient::new().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
-        println!("skipping transaction_ids_excluded due to test configuration");
+        println!("skipping transaction_ids_excluded due to test topology");
         return;
     }
 
@@ -251,7 +251,7 @@ async fn transaction_ids_included() {
     let client = EventClient::new().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
-        println!("skipping transaction_ids_included due to test configuration");
+        println!("skipping transaction_ids_included due to test topology");
         return;
     }
 
@@ -314,7 +314,7 @@ async fn mmapv1_error_raised() {
 
     let req = semver::VersionReq::parse("<=4.0").unwrap();
     if !req.matches(&client.server_version) || !client.is_replica_set() {
-        println!("skipping mmapv1_error_raised due to test configuration");
+        println!("skipping mmapv1_error_raised due to test topology");
         return;
     }
 
@@ -331,7 +331,7 @@ async fn mmapv1_error_raised() {
         .get_str("name")
         .unwrap();
     if name != "mmapv1" {
-        println!("skipping mmapv1_error_raised due to incorrect storage engine");
+        println!("skipping mmapv1_error_raised due to unsupported storage engine");
         return;
     }
 

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -197,6 +197,7 @@ async fn transaction_ids_excluded() {
     let client = EventClient::new().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
+        println!("skipping transaction_ids_excluded due to test configuration");
         return;
     }
 
@@ -250,6 +251,7 @@ async fn transaction_ids_included() {
     let client = EventClient::new().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
+        println!("skipping transaction_ids_included due to test configuration");
         return;
     }
 
@@ -312,6 +314,7 @@ async fn mmapv1_error_raised() {
 
     let req = semver::VersionReq::parse("<=4.0").unwrap();
     if !req.matches(&client.server_version) || !client.is_replica_set() {
+        println!("skipping mmapv1_error_raised due to test configuration");
         return;
     }
 
@@ -328,6 +331,7 @@ async fn mmapv1_error_raised() {
         .get_str("name")
         .unwrap();
     if name != "mmapv1" {
+        println!("skipping mmapv1_error_raised due to incorrect storage engine");
         return;
     }
 
@@ -372,6 +376,7 @@ async fn label_not_added(retry_reads: bool) {
     if client.is_sharded() && !sharded_req.matches(&client.server_version)
         || !req.matches(&client.server_version)
     {
+        println!("skipping label_not_added due to unsupported replica set or sharded cluster version");
         return;
     }
 

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -4,7 +4,7 @@ use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 use crate::{
     bson::{doc, serde_helpers::serialize_u64_as_i32, Document},
     client::session::TransactionState,
-    test::{run_spec_test, TestClient, LOCK},
+    test::{log_uncaptured, run_spec_test, TestClient, LOCK},
     Collection,
 };
 
@@ -43,7 +43,7 @@ async fn client_errors() {
 
     let client = TestClient::new().await;
     if !client.is_replica_set() || client.server_version_lt(4, 0) {
-        println!("skipping client_errors due to test topology");
+        log_uncaptured("skipping client_errors due to test topology");
         return;
     }
 
@@ -106,7 +106,7 @@ async fn deserialize_recovery_token() {
 
     let client = TestClient::new().await;
     if !client.is_sharded() || client.server_version_lt(4, 2) {
-        println!("skipping deserialize_recovery_token due to test topology");
+        log_uncaptured("skipping deserialize_recovery_token due to test topology");
         return;
     }
 

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -43,6 +43,7 @@ async fn client_errors() {
 
     let client = TestClient::new().await;
     if !client.is_replica_set() || client.server_version_lt(4, 0) {
+        println!("skipping client_errors due to test configuration");
         return;
     }
 
@@ -105,6 +106,7 @@ async fn deserialize_recovery_token() {
 
     let client = TestClient::new().await;
     if !client.is_sharded() || client.server_version_lt(4, 2) {
+        println!("skipping deserialize_recovery_token due to test configuration");
         return;
     }
 

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -43,7 +43,7 @@ async fn client_errors() {
 
     let client = TestClient::new().await;
     if !client.is_replica_set() || client.server_version_lt(4, 0) {
-        println!("skipping client_errors due to test configuration");
+        println!("skipping client_errors due to test topology");
         return;
     }
 
@@ -106,7 +106,7 @@ async fn deserialize_recovery_token() {
 
     let client = TestClient::new().await;
     if !client.is_sharded() || client.server_version_lt(4, 2) {
-        println!("skipping deserialize_recovery_token due to test configuration");
+        println!("skipping deserialize_recovery_token due to test topology");
         return;
     }
 

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -14,7 +14,7 @@ use tokio::sync::RwLockWriteGuard;
 use crate::{
     bson::{doc, Document},
     options::{CollectionOptions, FindOptions, ReadConcern, ReadPreference, SelectionCriteria},
-    test::{run_single_test, run_spec_test, LOCK},
+    test::{log_uncaptured, run_single_test, run_spec_test, LOCK},
     RUNTIME,
 };
 
@@ -89,14 +89,17 @@ pub async fn run_unified_format_test_filtered(
             }
         }
         if !can_run_on {
-            println!("Client topology not compatible with test");
+            log_uncaptured("Client topology not compatible with test");
             return;
         }
     }
 
     for test_case in test_file.tests {
         if let Some(skip_reason) = test_case.skip_reason {
-            println!("Skipping {}: {}", &test_case.description, skip_reason);
+            log_uncaptured(format!(
+                "Skipping {}: {}",
+                &test_case.description, skip_reason
+            ));
             continue;
         }
 
@@ -105,16 +108,16 @@ pub async fn run_unified_format_test_filtered(
             .iter()
             .any(|op| SKIPPED_OPERATIONS.contains(&op.name.as_str()))
         {
-            println!("Skipping {}", &test_case.description);
+            log_uncaptured(format!("Skipping {}", &test_case.description));
             continue;
         }
 
         if !pred(&test_case) {
-            println!("Skipping {}", test_case.description);
+            log_uncaptured(format!("Skipping {}", test_case.description));
             continue;
         }
 
-        println!("Running {}", &test_case.description);
+        log_uncaptured(format!("Running {}", &test_case.description));
 
         if let Some(requirements) = test_case.run_on_requirements {
             let mut can_run_on = false;
@@ -124,10 +127,10 @@ pub async fn run_unified_format_test_filtered(
                 }
             }
             if !can_run_on {
-                println!(
+                log_uncaptured(format!(
                     "{}: client topology not compatible with test",
                     &test_case.description
-                );
+                ));
                 return;
             }
         }
@@ -373,7 +376,7 @@ async fn invalid() {
             .iter()
             .any(|skip| *skip == test_file_str)
         {
-            println!("Skipping {}", test_file_str);
+            log_uncaptured(format!("Skipping {}", test_file_str));
             continue;
         }
         let path = path.join(&test_file_path);

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
     test::{
         assert_matches,
+        log_uncaptured,
         util::{get_default_name, FailPointGuard},
         EventClient,
         TestClient,
@@ -46,7 +47,7 @@ pub async fn run_v2_test(test_file: TestFile) {
             .iter()
             .any(|run_on| run_on.can_run_on(&internal_client));
         if !can_run_on {
-            println!("Client topology not compatible with test");
+            log_uncaptured("Client topology not compatible with test");
             return;
         }
     }
@@ -63,7 +64,7 @@ pub async fn run_v2_test(test_file: TestFile) {
         }
 
         if let Some(skip_reason) = test.skip_reason {
-            println!("skipping {}: {}", test.description, skip_reason);
+            log_uncaptured(format!("skipping {}: {}", test.description, skip_reason));
             continue;
         }
 

--- a/src/test/spec/versioned_api.rs
+++ b/src/test/spec/versioned_api.rs
@@ -44,6 +44,7 @@ async fn run_transaction_handling_spec_test() {
 
 async fn run_non_transaction_handling_test(path: PathBuf, file: TestFile) {
     if path.ends_with("transaction-handling.json") {
+        println!("skipping run_non_transaction_handling_test");
         return;
     }
     run_unified_format_test(file).await
@@ -63,6 +64,7 @@ async fn transaction_handling() {
     options.server_api = Some(version);
     let client = EventClient::with_options(options).await;
     if !client.is_replica_set() || client.server_version_lt(5, 0) {
+        println!("skipping transaction_handling due to test configuration");
         return;
     }
 

--- a/src/test/spec/versioned_api.rs
+++ b/src/test/spec/versioned_api.rs
@@ -64,7 +64,7 @@ async fn transaction_handling() {
     options.server_api = Some(version);
     let client = EventClient::with_options(options).await;
     if !client.is_replica_set() || client.server_version_lt(5, 0) {
-        println!("skipping transaction_handling due to test configuration");
+        println!("skipping transaction_handling due to test topology");
         return;
     }
 

--- a/src/test/spec/versioned_api.rs
+++ b/src/test/spec/versioned_api.rs
@@ -6,6 +6,7 @@ use crate::{
     bson::doc,
     options::{ServerApi, ServerApiVersion},
     test::{
+        log_uncaptured,
         run_single_test,
         run_spec_test_with_path,
         spec::unified_runner::TestFile,
@@ -44,7 +45,7 @@ async fn run_transaction_handling_spec_test() {
 
 async fn run_non_transaction_handling_test(path: PathBuf, file: TestFile) {
     if path.ends_with("transaction-handling.json") {
-        println!("skipping run_non_transaction_handling_test");
+        log_uncaptured("skipping run_non_transaction_handling_test");
         return;
     }
     run_unified_format_test(file).await
@@ -64,7 +65,7 @@ async fn transaction_handling() {
     options.server_api = Some(version);
     let client = EventClient::with_options(options).await;
     if !client.is_replica_set() || client.server_version_lt(5, 0) {
-        println!("skipping transaction_handling due to test topology");
+        log_uncaptured("skipping transaction_handling due to test topology");
         return;
     }
 

--- a/src/test/spec/write_error.rs
+++ b/src/test/spec/write_error.rs
@@ -2,7 +2,7 @@ use crate::{
     bson::{doc, Document},
     error::{ErrorKind, WriteFailure},
     options::CreateCollectionOptions,
-    test::{EventClient, LOCK},
+    test::{log_uncaptured, EventClient, LOCK},
     Collection,
 };
 
@@ -14,7 +14,7 @@ async fn details() {
 
     if client.server_version_lt(5, 0) {
         // SERVER-58399
-        println!("skipping write_error_details test due to server version");
+        log_uncaptured("skipping write_error_details test due to server version");
         return;
     }
 

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -450,3 +450,12 @@ pub fn get_default_name(description: &str) -> String {
     db_name.truncate(37);
     db_name
 }
+
+/// Log a message on stderr that won't be captured by `cargo test`.  Panics if the write fails.
+pub fn log_uncaptured<S: AsRef<str>>(text: S) {
+    use std::io::Write;
+
+    let mut stderr = std::io::stderr();
+    stderr.write_all(text.as_ref().as_bytes()).unwrap();
+    stderr.write_all(b"\n").unwrap();
+}


### PR DESCRIPTION
[RUST-395](https://jira.mongodb.org/browse/RUST-395)

This PR adds logging to test cases that are skipped and enables the `--nocapture` flag to allow the test framework to print output for skipped tests.