### PR TITLE
RUST-844 Fix flaky speculative authentication test

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,31 +12,19 @@ use derivative::Derivative;
 
 #[cfg(test)]
 use crate::options::ServerAddress;
-use crate::{
-    bson::Document,
-    change_stream::{
+use crate::{ClientSession, bson::Document, change_stream::{
         event::ChangeStreamEvent,
         options::ChangeStreamOptions,
         session::SessionChangeStream,
         ChangeStream,
-    },
-    concern::{ReadConcern, WriteConcern},
-    db::Database,
-    error::{ErrorKind, Result},
-    event::command::CommandEventHandler,
-    operation::ListDatabases,
-    options::{
+    }, concern::{ReadConcern, WriteConcern}, db::Database, error::{ErrorKind, Result}, event::command::CommandEventHandler, operation::ListDatabases, options::{
         ClientOptions,
         DatabaseOptions,
         ListDatabasesOptions,
         ReadPreference,
         SelectionCriteria,
         SessionOptions,
-    },
-    results::DatabaseSpecification,
-    sdam::{SelectedServer, SessionSupportStatus, Topology},
-    ClientSession,
-};
+    }, results::DatabaseSpecification, sdam::{SelectedServer, SessionSupportStatus, Topology, TopologyDescription}};
 pub(crate) use executor::{HELLO_COMMAND_NAMES, REDACTED_COMMANDS};
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 
@@ -427,5 +415,10 @@ impl Client {
     #[cfg(test)]
     pub(crate) async fn sync_workers(&self) {
         self.inner.topology.sync_workers().await;
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn topology_description(&self) -> TopologyDescription {
+        self.inner.topology.description().await
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -24,7 +24,7 @@ use crate::{ClientSession, bson::Document, change_stream::{
         ReadPreference,
         SelectionCriteria,
         SessionOptions,
-    }, results::DatabaseSpecification, sdam::{SelectedServer, SessionSupportStatus, Topology, TopologyDescription}};
+    }, results::DatabaseSpecification, sdam::{SelectedServer, SessionSupportStatus, Topology}};
 pub(crate) use executor::{HELLO_COMMAND_NAMES, REDACTED_COMMANDS};
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 
@@ -418,7 +418,7 @@ impl Client {
     }
 
     #[cfg(test)]
-    pub(crate) async fn topology_description(&self) -> TopologyDescription {
+    pub(crate) async fn topology_description(&self) -> crate::sdam::TopologyDescription {
         self.inner.topology.description().await
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,19 +12,31 @@ use derivative::Derivative;
 
 #[cfg(test)]
 use crate::options::ServerAddress;
-use crate::{ClientSession, bson::Document, change_stream::{
+use crate::{
+    bson::Document,
+    change_stream::{
         event::ChangeStreamEvent,
         options::ChangeStreamOptions,
         session::SessionChangeStream,
         ChangeStream,
-    }, concern::{ReadConcern, WriteConcern}, db::Database, error::{ErrorKind, Result}, event::command::CommandEventHandler, operation::ListDatabases, options::{
+    },
+    concern::{ReadConcern, WriteConcern},
+    db::Database,
+    error::{ErrorKind, Result},
+    event::command::CommandEventHandler,
+    operation::ListDatabases,
+    options::{
         ClientOptions,
         DatabaseOptions,
         ListDatabasesOptions,
         ReadPreference,
         SelectionCriteria,
         SessionOptions,
-    }, results::DatabaseSpecification, sdam::{SelectedServer, SessionSupportStatus, Topology}};
+    },
+    results::DatabaseSpecification,
+    sdam::{SelectedServer, SessionSupportStatus, Topology},
+    ClientSession,
+};
 pub(crate) use executor::{HELLO_COMMAND_NAMES, REDACTED_COMMANDS};
 pub(crate) use session::{ClusterTime, SESSIONS_UNSUPPORTED_COMMANDS};
 

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -48,14 +48,12 @@ async fn speculative_auth_test(
     // if running against a replica set, use the primary to ensure the user creation has propagated.
     let addr = match description.topology_type {
         TopologyType::Sharded => Default::default(),
-        TopologyType::ReplicaSetWithPrimary => {
-            description
-                .servers_with_type(&[ServerType::RsPrimary])
-                .next()
-                .unwrap()
-                .address
-                .clone()
-        }
+        TopologyType::ReplicaSetWithPrimary => description
+            .servers_with_type(&[ServerType::RsPrimary])
+            .next()
+            .unwrap()
+            .address
+            .clone(),
         _ => panic!(),
     };
 

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -47,14 +47,13 @@ async fn speculative_auth_test(
 
     // if running against a replica set, use the primary to ensure the user creation has propagated.
     let addr = match description.topology_type {
-        TopologyType::Sharded => Default::default(),
         TopologyType::ReplicaSetWithPrimary => description
             .servers_with_type(&[ServerType::RsPrimary])
             .next()
             .unwrap()
             .address
             .clone(),
-        _ => panic!(),
+        _ => Default::default(),
     };
 
     let handshaker = Handshaker::new(Some(pool_options.clone().into()));

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -42,6 +42,8 @@ async fn speculative_auth_test(
     );
     pool_options.tls_options = CLIENT_OPTIONS.tls_options();
 
+    let description = client.topology_description().await;
+
     let handshaker = Handshaker::new(Some(pool_options.clone().into()));
 
     let mut conn = Connection::new_testing(1, Default::default(), 1, Some(pool_options.into()))

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -5,6 +5,7 @@ use crate::{
     cmap::{establish::Handshaker, Command, Connection, ConnectionPoolOptions},
     operation::CommandResponse,
     options::{AuthMechanism, ClientOptions, Credential, ReadPreference},
+    sdam::{ServerType, TopologyType},
     test::{TestClient, CLIENT_OPTIONS, LOCK},
 };
 
@@ -44,9 +45,23 @@ async fn speculative_auth_test(
 
     let description = client.topology_description().await;
 
+    // if running against a replica set, use the primary to ensure the user creation has propagated.
+    let addr = match description.topology_type {
+        TopologyType::Sharded => Default::default(),
+        TopologyType::ReplicaSetWithPrimary => {
+            description
+                .servers_with_type(&[ServerType::RsPrimary])
+                .next()
+                .unwrap()
+                .address
+                .clone()
+        }
+        _ => panic!(),
+    };
+
     let handshaker = Handshaker::new(Some(pool_options.clone().into()));
 
-    let mut conn = Connection::new_testing(1, Default::default(), 1, Some(pool_options.into()))
+    let mut conn = Connection::new_testing(1, addr, 1, Some(pool_options.into()))
         .await
         .unwrap();
 

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -175,7 +175,7 @@ impl TopologyDescription {
         });
     }
 
-    fn servers_with_type<'a>(
+    pub(crate) fn servers_with_type<'a>(
         &'a self,
         types: &'a [ServerType],
     ) -> impl Iterator<Item = &'a ServerDescription> {

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -119,7 +119,7 @@ impl TopologyDescription {
             SelectionCriteria::Predicate(ref filter) => self
                 .servers
                 .values()
-                .filter(|s| filter(&ServerInfo::new_borrowed(s)))
+                .filter(|s| s.is_available() && filter(&ServerInfo::new_borrowed(s)))
                 .collect(),
         };
 

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -119,7 +119,7 @@ impl TopologyDescription {
             SelectionCriteria::Predicate(ref filter) => self
                 .servers
                 .values()
-                .filter(|s| s.is_available() && filter(&ServerInfo::new_borrowed(s)))
+                .filter(|s| filter(&ServerInfo::new_borrowed(s)))
                 .collect(),
         };
 


### PR DESCRIPTION
RUST-844

This PR fixes an issue which I think occurs when the test attempts to authenticate against a node that the credentials haven't replicated to yet. The fix is to just always run the test against the primary on replica sets.