### PR TITLE
RUST-1100 Fix `find_and_getmore_share_session` test

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -428,4 +428,9 @@ impl Client {
     pub(crate) async fn sync_workers(&self) {
         self.inner.topology.sync_workers().await;
     }
+
+    #[cfg(test)]
+    pub(crate) async fn topology_description(&self) -> crate::sdam::TopologyDescription {
+        self.inner.topology.description().await
+    }
 }

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -1,6 +1,6 @@
 mod causal_consistency;
 
-use std::{future::Future, time::Duration};
+use std::{future::Future, sync::Arc, time::Duration};
 
 use bson::Document;
 use futures::stream::StreamExt;
@@ -8,12 +8,14 @@ use tokio::sync::RwLockReadGuard;
 
 use crate::{
     bson::{doc, Bson},
-    coll::options::InsertManyOptions,
+    coll::options::{CountOptions, InsertManyOptions},
     error::Result,
     options::{Acknowledgment, FindOptions, ReadPreference, WriteConcern},
+    sdam::ServerInfo,
     selection_criteria::SelectionCriteria,
     test::{EventClient, TestClient, CLIENT_OPTIONS, LOCK},
     Collection,
+    ServerType,
     RUNTIME,
 };
 
@@ -459,21 +461,8 @@ async fn find_and_getmore_share_session() {
         .init_db_and_coll(function_name!(), function_name!())
         .await;
 
-    // ensure writes are propagated to all nodes in replica set.
-    let topology_description = client.topology_description().await;
-    let w = match topology_description.topology_type() {
-        crate::TopologyType::ReplicaSetWithPrimary => Acknowledgment::Nodes(
-            topology_description
-                .servers
-                .iter()
-                .filter(|s| s.1.server_type.is_data_bearing())
-                .count() as u32,
-        ),
-        _ => Acknowledgment::Majority,
-    };
-
     let options = InsertManyOptions::builder()
-        .write_concern(WriteConcern::builder().w(w).build())
+        .write_concern(WriteConcern::builder().w(Acknowledgment::Majority).build())
         .build();
     coll.insert_many(vec![doc! {}; 3], options).await.unwrap();
 
@@ -539,6 +528,40 @@ async fn find_and_getmore_share_session() {
             .get("lsid")
             .expect("count documents should use implicit session");
         assert_eq!(getmore_session_id, session_id);
+    }
+
+    let topology_description = client.topology_description().await;
+    for (addr, server) in topology_description.servers {
+        if matches!(server.server_type, ServerType::RsArbiter) {
+            continue;
+        }
+
+        let a = addr.clone();
+        let rp = Arc::new(move |si: &ServerInfo| si.address() == &a);
+        let options = CountOptions::builder()
+            .selection_criteria(SelectionCriteria::Predicate(rp))
+            .build();
+
+        loop {
+            let count = match coll.count_documents(None, options.clone()).await {
+                Ok(c) => c,
+                Err(e) => {
+                    let desc = client.topology_description().await;
+                    if matches!(
+                        desc.servers.get(&addr).unwrap().server_type,
+                        ServerType::RsArbiter
+                    ) {
+                        break;
+                    } else {
+                        panic!("{:?}", e);
+                    }
+                }
+            };
+
+            if count == 3 {
+                break;
+            }
+        }
     }
 
     for read_pref in read_preferences {

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -10,13 +10,12 @@ use crate::{
     bson::{doc, Bson},
     coll::options::{CountOptions, InsertManyOptions},
     error::Result,
+    operation::Operation,
     options::{Acknowledgment, FindOptions, ReadPreference, WriteConcern},
     sdam::ServerInfo,
     selection_criteria::SelectionCriteria,
     test::{EventClient, TestClient, CLIENT_OPTIONS, LOCK},
-    Collection,
-    ServerType,
-    RUNTIME,
+    Collection, ServerType, RUNTIME,
 };
 
 /// Macro defining a closure that returns a future populated by an operation on the
@@ -531,38 +530,12 @@ async fn find_and_getmore_share_session() {
     }
 
     let topology_description = client.topology_description().await;
-    for (addr, server) in topology_description.servers {
-        if matches!(server.server_type, ServerType::RsArbiter) {
-            continue;
-        }
 
-        let a = addr.clone();
-        let rp = Arc::new(move |si: &ServerInfo| si.address() == &a);
-        let options = CountOptions::builder()
-            .selection_criteria(SelectionCriteria::Predicate(rp))
-            .build();
-
-        loop {
-            let count = match coll.count_documents(None, options.clone()).await {
-                Ok(c) => c,
-                Err(e) => {
-                    let desc = client.topology_description().await;
-                    if matches!(
-                        desc.servers.get(&addr).unwrap().server_type,
-                        ServerType::RsArbiter
-                    ) {
-                        break;
-                    } else {
-                        panic!("{:?}", e);
-                    }
-                }
-            };
-
-            if count == 3 {
-                break;
-            }
-        }
-    }
+    // ensure documents have propagated to the secondaries
+    let options = CountOptions::builder().selection_criteria(
+        SelectionCriteria::ReadPreference(ReadPreference::Secondary).build(),
+    );
+    while coll.count_documents(None, options.clone()).await? != 3 {}
 
     for read_pref in read_preferences {
         run_test(&client, &coll, read_pref).await;

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -462,9 +462,13 @@ async fn find_and_getmore_share_session() {
     // ensure writes are propagated to all nodes in replica set.
     let topology_description = client.topology_description().await;
     let w = match topology_description.topology_type() {
-        crate::TopologyType::ReplicaSetWithPrimary => {
-            Acknowledgment::Nodes(topology_description.servers.len() as u32)
-        }
+        crate::TopologyType::ReplicaSetWithPrimary => Acknowledgment::Nodes(
+            topology_description
+                .servers
+                .iter()
+                .filter(|s| s.1.server_type.is_data_bearing())
+                .count() as u32,
+        ),
         _ => Acknowledgment::Majority,
     };
 

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -531,6 +531,7 @@ async fn find_and_getmore_share_session() {
     }
 
     for host in CLIENT_OPTIONS.hosts.iter() {
+        println!("counting {}", host);
         let rp = Arc::new(move |si: &ServerInfo| si.address() == host);
         let options = CountOptions::builder()
             .selection_criteria(SelectionCriteria::Predicate(rp))

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -300,8 +300,9 @@ impl ConnectionPoolWorker {
                     } => {
                         self.clear(cause, service_id);
                     }
-                    PoolManagementRequest::MarkAsReady { .. } => {
+                    PoolManagementRequest::MarkAsReady { _completion_handler } => {
                         self.mark_as_ready();
+                        _completion_handler.acknowledge(());
                     }
                     PoolManagementRequest::HandleConnectionSucceeded(conn) => {
                         self.handle_connection_succeeded(conn);

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -300,7 +300,9 @@ impl ConnectionPoolWorker {
                     } => {
                         self.clear(cause, service_id);
                     }
-                    PoolManagementRequest::MarkAsReady { _completion_handler } => {
+                    PoolManagementRequest::MarkAsReady {
+                        _completion_handler,
+                    } => {
                         self.mark_as_ready();
                         _completion_handler.acknowledge(());
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ pub(crate) use crate::{
     db::Database,
 };
 
-pub use {coll::Namespace, index::IndexModel, client::session::ClusterTime};
+pub use {coll::Namespace, index::IndexModel, client::session::ClusterTime, sdam::public::*};
 
 #[cfg(all(
     feature = "tokio-runtime",

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -14,22 +14,41 @@ const DRIVER_MIN_DB_VERSION: &str = "3.6";
 const DRIVER_MIN_WIRE_VERSION: i32 = 6;
 const DRIVER_MAX_WIRE_VERSION: i32 = 14;
 
+/// Enum representing the possible types of servers that the driver can connect to.
 #[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ServerType {
+    /// A single, non-replica set mongod.
     Standalone,
+
+    /// A router used in sharded deployments.
     Mongos,
+
+    /// The primary node in a replica set.
     #[serde(rename = "RSPrimary")]
     RsPrimary,
+
+    /// A secondary node in a replica set.
     #[serde(rename = "RSSecondary")]
     RsSecondary,
+
+    /// A non-data bearing node in a replica set which can participate in elections.
     #[serde(rename = "RSArbiter")]
     RsArbiter,
+
+    /// Hidden, starting up, or recovering nodes in a replica set.
     #[serde(rename = "RSOther")]
     RsOther,
+
+    /// A member of an uninitialized replica set or a member that has been removed from the replica
+    /// set config.
     #[serde(rename = "RSGhost")]
     RsGhost,
+
+    /// A load-balancing proxy between the driver and the MongoDB deployment.
     LoadBalancer,
+
+    /// A server that the driver hasn't yet communicated with or can't connect to.
     #[serde(alias = "PossiblePrimary")]
     Unknown,
 }

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -119,11 +119,7 @@ impl TopologyDescription {
             SelectionCriteria::Predicate(ref filter) => self
                 .servers
                 .values()
-                .filter(|s| {
-                    s.is_available()
-                        && !matches!(s.server_type, ServerType::RsArbiter)
-                        && filter(&ServerInfo::new_borrowed(s))
-                })
+                .filter(|s| s.server_type.is_data_bearing() && filter(&ServerInfo::new_borrowed(s)))
                 .collect(),
         };
 

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -119,7 +119,11 @@ impl TopologyDescription {
             SelectionCriteria::Predicate(ref filter) => self
                 .servers
                 .values()
-                .filter(|s| s.is_available() && filter(&ServerInfo::new_borrowed(s)))
+                .filter(|s| {
+                    s.is_available()
+                        && !matches!(s.server_type, ServerType::RsArbiter)
+                        && filter(&ServerInfo::new_borrowed(s))
+                })
                 .collect(),
         };
 

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -119,7 +119,7 @@ impl TopologyDescription {
             SelectionCriteria::Predicate(ref filter) => self
                 .servers
                 .values()
-                .filter(|s| filter(&ServerInfo::new_borrowed(s)))
+                .filter(|s| s.is_available() && filter(&ServerInfo::new_borrowed(s)))
                 .collect(),
         };
 

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -65,8 +65,7 @@ async fn run_test(test_file: TestFile) {
 
     let topology_description = test_file
         .topology_description
-        .into_topology_description(None)
-        .unwrap();
+        .into_topology_description(None);
 
     let read_pref = ReadPreference::Nearest {
         options: Default::default(),

--- a/src/sdam/description/topology/server_selection/test/logic.rs
+++ b/src/sdam/description/topology/server_selection/test/logic.rs
@@ -66,13 +66,9 @@ async fn run_test(test_file: TestFile) {
         None => return,
     };
 
-    let topology = match test_file
+    let topology = test_file
         .topology_description
-        .into_topology_description(test_file.heartbeat_frequency_ms.map(Duration::from_millis))
-    {
-        Some(t) => t,
-        None => return,
-    };
+        .into_topology_description(test_file.heartbeat_frequency_ms.map(Duration::from_millis));
 
     if let Some(ref expected_suitable_servers) = test_file.suitable_servers {
         let mut actual_servers: Vec<_> = topology.suitable_servers(&read_pref).unwrap();

--- a/src/sdam/description/topology/server_selection/test/mod.rs
+++ b/src/sdam/description/topology/server_selection/test/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use serde::Deserialize;
 
@@ -12,7 +12,7 @@ use crate::{
         ServerType,
         TopologyDescription,
     },
-    selection_criteria::TagSet,
+    selection_criteria::{SelectionCriteria, TagSet},
 };
 
 mod in_window;
@@ -29,7 +29,7 @@ impl TestTopologyDescription {
     fn into_topology_description(
         self,
         heartbeat_frequency: Option<Duration>,
-    ) -> Option<TopologyDescription> {
+    ) -> TopologyDescription {
         let servers: HashMap<ServerAddress, ServerDescription> = self
             .servers
             .into_iter()
@@ -53,7 +53,6 @@ impl TestTopologyDescription {
             heartbeat_freq: heartbeat_frequency,
             servers,
         }
-        .into()
     }
 }
 
@@ -183,4 +182,73 @@ fn is_master_response_from_server_type(server_type: ServerType) -> Option<IsMast
     };
 
     Some(response)
+}
+
+#[test]
+fn predicate_omits_unavailable() {
+    let criteria = SelectionCriteria::Predicate(Arc::new(|si| {
+        si.address()
+            == &ServerAddress::Tcp {
+                host: "localhost".to_string(),
+                port: Some(27018),
+            }
+    }));
+
+    let desc = TestTopologyDescription {
+        topology_type: TopologyType::ReplicaSetWithPrimary,
+        servers: vec![
+            TestServerDescription {
+                address: "localhost:27017".to_string(),
+                avg_rtt_ms: Some(12.0),
+                server_type: TestServerType::RsPrimary,
+                tags: None,
+                last_update_time: None,
+                last_write: None,
+                _max_wire_version: None,
+            },
+            TestServerDescription {
+                address: "localhost:27018".to_string(),
+                avg_rtt_ms: Some(12.0),
+                server_type: TestServerType::Unknown,
+                tags: None,
+                last_update_time: None,
+                last_write: None,
+                _max_wire_version: None,
+            },
+        ],
+    }
+    .into_topology_description(None);
+    assert_eq!(
+        desc.suitable_servers_in_latency_window(&criteria).unwrap(),
+        Vec::<&ServerDescription>::new()
+    );
+
+    let desc = TestTopologyDescription {
+        topology_type: TopologyType::ReplicaSetWithPrimary,
+        servers: vec![
+            TestServerDescription {
+                address: "localhost:27017".to_string(),
+                avg_rtt_ms: Some(12.0),
+                server_type: TestServerType::RsPrimary,
+                tags: None,
+                last_update_time: None,
+                last_write: None,
+                _max_wire_version: None,
+            },
+            TestServerDescription {
+                address: "localhost:27018".to_string(),
+                avg_rtt_ms: Some(12.0),
+                server_type: TestServerType::RsArbiter,
+                tags: None,
+                last_update_time: None,
+                last_write: None,
+                _max_wire_version: None,
+            },
+        ],
+    }
+    .into_topology_description(None);
+    assert_eq!(
+        desc.suitable_servers_in_latency_window(&criteria).unwrap(),
+        Vec::<&ServerDescription>::new()
+    );
 }

--- a/src/sdam/description/topology/server_selection/test/mod.rs
+++ b/src/sdam/description/topology/server_selection/test/mod.rs
@@ -187,11 +187,7 @@ fn is_master_response_from_server_type(server_type: ServerType) -> Option<IsMast
 #[test]
 fn predicate_omits_unavailable() {
     let criteria = SelectionCriteria::Predicate(Arc::new(|si| {
-        si.address()
-            == &ServerAddress::Tcp {
-                host: "localhost".to_string(),
-                port: Some(27018),
-            }
+        !matches!(si.server_type(), ServerType::RsPrimary)
     }));
 
     let desc = TestTopologyDescription {
@@ -215,28 +211,8 @@ fn predicate_omits_unavailable() {
                 last_write: None,
                 _max_wire_version: None,
             },
-        ],
-    }
-    .into_topology_description(None);
-    assert_eq!(
-        desc.suitable_servers_in_latency_window(&criteria).unwrap(),
-        Vec::<&ServerDescription>::new()
-    );
-
-    let desc = TestTopologyDescription {
-        topology_type: TopologyType::ReplicaSetWithPrimary,
-        servers: vec![
             TestServerDescription {
-                address: "localhost:27017".to_string(),
-                avg_rtt_ms: Some(12.0),
-                server_type: TestServerType::RsPrimary,
-                tags: None,
-                last_update_time: None,
-                last_write: None,
-                _max_wire_version: None,
-            },
-            TestServerDescription {
-                address: "localhost:27018".to_string(),
+                address: "localhost:27019".to_string(),
                 avg_rtt_ms: Some(12.0),
                 server_type: TestServerType::RsArbiter,
                 tags: None,
@@ -244,10 +220,28 @@ fn predicate_omits_unavailable() {
                 last_write: None,
                 _max_wire_version: None,
             },
+            TestServerDescription {
+                address: "localhost:27020".to_string(),
+                avg_rtt_ms: Some(12.0),
+                server_type: TestServerType::RsGhost,
+                tags: None,
+                last_update_time: None,
+                last_write: None,
+                _max_wire_version: None,
+            },
+            TestServerDescription {
+                address: "localhost:27021".to_string(),
+                avg_rtt_ms: Some(12.0),
+                server_type: TestServerType::RsOther,
+                tags: None,
+                last_update_time: None,
+                last_write: None,
+                _max_wire_version: None,
+            },
         ],
     }
     .into_topology_description(None);
-    assert_eq!(
+    pretty_assertions::assert_eq!(
         desc.suitable_servers_in_latency_window(&criteria).unwrap(),
         Vec::<&ServerDescription>::new()
     );


### PR DESCRIPTION
RUST-1100

This PR fixes a test that was occasionally failing due to a race between replication and the test. It also fixes a bug in server selection wherein unavailable servers and arbiters could be selected via predicate-based selection criteria (RUST-1113). Additionally, this PR exports the types defined in `sdam::public` (RUST-1114).