### PR TITLE
RUST-1162 Fix "unpin after transient error within a txn and commit" test failure

### DIFF
--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -1,10 +1,7 @@
 use serde::Deserialize;
 use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 
-use super::{
-    event::{Event, EventHandler},
-    EVENT_TIMEOUT,
-};
+use super::event::{Event, EventHandler};
 use crate::{
     bson::{doc, Document},
     cmap::{options::ConnectionPoolOptions, Command, ConnectionPool},
@@ -12,7 +9,15 @@ use crate::{
     operation::CommandResponse,
     sdam::ServerUpdateSender,
     selection_criteria::ReadPreference,
-    test::{FailCommandOptions, FailPoint, FailPointMode, TestClient, CLIENT_OPTIONS, LOCK},
+    test::{
+        FailCommandOptions,
+        FailPoint,
+        FailPointMode,
+        TestClient,
+        CLIENT_OPTIONS,
+        EVENT_TIMEOUT,
+        LOCK,
+    },
     RUNTIME,
 };
 use semver::VersionReq;

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -26,6 +26,7 @@ use crate::{
         MatchErrExt,
         Matchable,
         CLIENT_OPTIONS,
+        EVENT_TIMEOUT,
         LOCK,
         SERVER_API,
     },
@@ -42,16 +43,6 @@ const TEST_DESCRIPTIONS_TO_SKIP: &[&str] = &[
     // TODO DRIVERS-1785 remove this skip when test event order is fixed
     "error during minPoolSize population clears pool",
 ];
-
-/// Many different types of CMAP events are emitted from tasks spawned in the drop
-/// implementations of various types (Connections, pools, etc.). Sometimes it takes
-/// a longer amount of time for these tasks to get scheduled and thus their associated
-/// events to get emitted, requiring the runner to wait for a little bit before asserting
-/// the events were actually fired.
-///
-/// This value was purposefully chosen to be large to prevent test failures, though it is not
-/// expected that the 3s timeout will regularly or ever be hit.
-const EVENT_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug)]
 struct Executor {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -42,9 +42,19 @@ use crate::{
     },
     options::{ClientOptions, Compressor},
 };
-use std::{fs::read_to_string, str::FromStr};
+use std::{fs::read_to_string, str::FromStr, time::Duration};
 
 const MAX_POOL_SIZE: u32 = 100;
+
+/// Many different types of events are emitted from tasks spawned in the drop
+/// implementations of various types (Connections, pools, etc.). Sometimes it takes
+/// a longer amount of time for these tasks to get scheduled and thus their associated
+/// events to get emitted, requiring the runner to wait for a little bit before asserting
+/// the events were actually fired.
+///
+/// This value was purposefully chosen to be large to prevent test failures, though it is not
+/// expected that the 3s timeout will regularly or ever be hit.
+pub(crate) const EVENT_TIMEOUT: Duration = Duration::from_secs(3);
 
 lazy_static! {
     pub(crate) static ref CLIENT_OPTIONS: ClientOptions = {

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -16,9 +16,7 @@ use crate::{
     test::{
         assert_matches,
         util::{get_default_name, FailPointGuard},
-        EventClient,
-        TestClient,
-        SERVERLESS,
+        EventClient, TestClient, SERVERLESS,
     },
     RUNTIME,
 };
@@ -306,7 +304,12 @@ pub async fn run_v2_test(test_file: TestFile) {
                             assert!(message.contains(&error_contains));
                         }
                         if let Some(error_code_name) = operation_error.error_code_name {
-                            let code_name = error.code_name().unwrap();
+                            let code_name = error.code_name().unwrap_or_else(|| {
+                                panic!(
+                                    "expected to get code name \"{}\", got none from error {:#?}",
+                                    error_code_name, error
+                                )
+                            });
                             assert_eq!(error_code_name, code_name);
                         }
                         if let Some(error_code) = operation_error.error_code {


### PR DESCRIPTION
RUST-1162

This PR fixes a race in the v2 runner between events being emitted and the runner asserting that they have been received. It does so by waiting on a channel with a given timeout instead of checking once that all the events are there after executing all the operations.