### PR TITLE
RUST-1122 Fix x509 auth for pkcs8 keys and Atlas free tier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ md-5 = "0.9.1"
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.7.2", features = ["small_rng"] }
+rustls-pemfile = "0.2.1"
 serde_with = "1.3.1"
 sha-1 = "0.9.4"
 sha2 = "0.9.3"

--- a/src/client/auth/x509.rs
+++ b/src/client/auth/x509.rs
@@ -51,8 +51,8 @@ pub(super) async fn authenticate_stream(
     server_api: Option<&ServerApi>,
     server_first: impl Into<Option<Document>>,
 ) -> Result<()> {
-    let server_response = match server_first.into() {
-        Some(server_first) => server_first,
+    let server_response: Document = match server_first.into() {
+        Some(_) => return Ok(()),
         None => {
             send_client_first(conn, credential, server_api)
                 .await?
@@ -60,7 +60,11 @@ pub(super) async fn authenticate_stream(
         }
     };
 
-    if server_response.get_str("dbname") != Ok("$external") {
+    if server_response
+        .get("ok")
+        .and_then(crate::bson_util::get_int)
+        != Some(1)
+    {
         return Err(Error::authentication_error(
             "MONGODB-X509",
             "Authentication failed",


### PR DESCRIPTION
This backports RUST-1122 to 1.2.x.