### PR TITLE
minor: fix publish release evergreen config

### DIFF
--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -6,6 +6,30 @@ functions:
       type: system
       params:
         directory: "src"
+    # Make an evergreen exapanstion file with dynamic values
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
+           export PROJECT_DIRECTORY="$(pwd)"
+
+           cat <<EOT > expansion.yml
+           PROJECT_DIRECTORY: "$PROJECT_DIRECTORY"
+           PREPARE_SHELL: |
+              set -o errexit
+              set -o xtrace
+              export PROJECT_DIRECTORY="$PROJECT_DIRECTORY"
+
+              export PROJECT="${project}"
+
+           EOT
+           # See what we've done
+           cat expansion.yml
+
+    # Load the expansion file to make an evergreen variable with the current unique version
+    - command: expansions.update
+      params:
+        file: src/expansion.yml
 
   "install dependencies":
     command: shell.exec

--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -6,7 +6,7 @@ functions:
       type: system
       params:
         directory: "src"
-    # Make an evergreen exapanstion file with dynamic values
+    # Make an evergreen expansion file with dynamic values
     - command: shell.exec
       params:
         working_dir: "src"


### PR DESCRIPTION
This PR fixes the release publishing config, which is currently broken because the `install-node.sh` script can't find the `$PROJECT_DIRECTORY` variable.