### PR TITLE
RUST-1103 Update microbenchmarks to use raw BSON

### DIFF
--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -20,6 +20,6 @@ cargo run \
       --release \
       --no-default-features \
       --features ${FEATURES} \
-      -- --output="../benchmark-results.json" --single --multi --parallel
+      -- --output="../benchmark-results.json" --driver
 
 cat ../benchmark-results.json

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -30,3 +30,4 @@ async-std = { version = "1.9.0", optional = true, features = ["attributes", "uns
 futures = "0.3.8"
 anyhow = "1.0.34"
 serde = "1"
+num_enum = "0.5"

--- a/benchmarks/src/bench/find_many.rs
+++ b/benchmarks/src/bench/find_many.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use crate::{
     bench::{drop_database, Benchmark, COLL_NAME, DATABASE_NAME},
     fs::read_to_string,
-    models::tweet::{Tweet, TweetRef},
+    models::tweet::Tweet,
 };
 
 pub struct FindManyBenchmark {
@@ -36,7 +36,6 @@ pub enum Mode {
     Document,
     RawBson,
     Serde,
-    SerdeBorrowed,
 }
 
 #[async_trait::async_trait]
@@ -91,13 +90,6 @@ impl Benchmark for FindManyBenchmark {
             }
             Mode::Serde => {
                 execute::<Tweet>(self).await?;
-            }
-            Mode::SerdeBorrowed => {
-                let mut cursor = self.coll.find(None, None).await?;
-                while let Some(doc) = cursor.next().await {
-                    let doc = doc?;
-                    let _t: TweetRef = mongodb::bson::from_slice(doc.as_bytes())?;
-                }
             }
         }
 

--- a/benchmarks/src/bench/find_one.rs
+++ b/benchmarks/src/bench/find_one.rs
@@ -2,7 +2,7 @@ use std::{convert::TryInto, path::PathBuf};
 
 use anyhow::{bail, Result};
 use mongodb::{
-    bson::{doc, Bson, Document},
+    bson::{doc, Bson, Document, RawDocumentBuf},
     Client,
     Collection,
     Database,
@@ -17,8 +17,9 @@ use crate::{
 pub struct FindOneBenchmark {
     db: Database,
     num_iter: usize,
-    coll: Collection<Document>,
+    coll: Collection<RawDocumentBuf>,
     uri: String,
+    raw: bool,
 }
 
 // Specifies the options to a `FindOneBenchmark::setup` operation.
@@ -26,6 +27,7 @@ pub struct Options {
     pub num_iter: usize,
     pub path: PathBuf,
     pub uri: String,
+    pub raw: bool,
 }
 
 #[async_trait::async_trait]
@@ -56,16 +58,24 @@ impl Benchmark for FindOneBenchmark {
         Ok(FindOneBenchmark {
             db,
             num_iter,
-            coll,
+            coll: coll.clone_with_type(),
             uri: options.uri,
+            raw: options.raw,
         })
     }
 
     async fn do_task(&self) -> Result<()> {
-        for i in 0..self.num_iter {
-            self.coll
-                .find_one(Some(doc! { "_id": i as i32 }), None)
-                .await?;
+        if self.raw {
+            for i in 0..self.num_iter {
+                self.coll
+                    .find_one(Some(doc! { "_id": i as i32 }), None)
+                    .await?;
+            }
+        } else {
+            let coll = self.coll.clone_with_type::<Document>();
+            for i in 0..self.num_iter {
+                coll.find_one(Some(doc! { "_id": i as i32 }), None).await?;
+            }
         }
 
         Ok(())

--- a/benchmarks/src/bench/json_multi_export.rs
+++ b/benchmarks/src/bench/json_multi_export.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use futures::stream::TryStreamExt;
 use mongodb::{
-    bson::{doc, Document},
+    bson::{doc, Document, RawDocumentBuf},
     Client,
     Collection,
     Database,
@@ -22,7 +22,7 @@ const TOTAL_FILES: usize = 100;
 pub struct JsonMultiExportBenchmark {
     uri: String,
     db: Database,
-    coll: Collection<Document>,
+    coll: Collection<RawDocumentBuf>,
 }
 
 // Specifies the options to a `JsonMultiExportBenchmark::setup` operation.
@@ -71,7 +71,7 @@ impl Benchmark for JsonMultiExportBenchmark {
         Ok(JsonMultiExportBenchmark {
             uri: options.uri,
             db,
-            coll,
+            coll: coll.clone_with_type(),
         })
     }
 
@@ -79,7 +79,7 @@ impl Benchmark for JsonMultiExportBenchmark {
         let mut tasks = Vec::new();
 
         for i in 0..TOTAL_FILES {
-            let coll_ref = self.coll.clone_with_type::<Tweet>();
+            let coll_ref = self.coll.clone();
             let path = std::env::temp_dir();
 
             tasks.push(crate::spawn(async move {

--- a/benchmarks/src/bench/json_multi_export.rs
+++ b/benchmarks/src/bench/json_multi_export.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use futures::stream::TryStreamExt;
 use mongodb::{
-    bson::{doc, Document, RawDocumentBuf},
+    bson::{doc, RawDocumentBuf},
     Client,
     Collection,
     Database,
@@ -12,7 +12,6 @@ use mongodb::{
 use crate::{
     bench::{parse_json_file_to_documents, Benchmark, COLL_NAME, DATABASE_NAME},
     fs::File,
-    models::tweet::Tweet,
 };
 
 use super::drop_database;

--- a/benchmarks/src/bench/json_multi_export.rs
+++ b/benchmarks/src/bench/json_multi_export.rs
@@ -12,7 +12,7 @@ use mongodb::{
 use crate::{
     bench::{parse_json_file_to_documents, Benchmark, COLL_NAME, DATABASE_NAME},
     fs::File,
-    models::json_multi::Tweet,
+    models::tweet::Tweet,
 };
 
 use super::drop_database;

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -7,7 +7,7 @@ use mongodb::{options::InsertManyOptions, Client, Collection, Database};
 use crate::{
     bench::{Benchmark, COLL_NAME, DATABASE_NAME},
     fs::{BufReader, File},
-    models::json_multi::Tweet,
+    models::tweet::Tweet,
 };
 
 use super::drop_database;

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -151,7 +151,7 @@ const BSON_BENCHES: &[&'static str] = &[
 /// Benchmarkes included in the "SingleBench" composite.
 /// This consists of all the single-doc benchmarks except Run Command.
 const SINGLE_BENCHES: &[&'static str] = &[
-    FIND_MANY_BENCH_RAW,
+    FIND_ONE_BENCH,
     SMALL_DOC_INSERT_ONE_BENCH,
     LARGE_DOC_INSERT_ONE_BENCH,
 ];
@@ -175,7 +175,7 @@ const PARALLEL_BENCHES: &[&'static str] = &[
 
 /// Benchmarks included in the "ReadBench" composite.
 const READ_BENCHES: &[&'static str] = &[
-    FIND_MANY_BENCH_RAW,
+    FIND_ONE_BENCH,
     FIND_MANY_BENCH_RAW,
     GRIDFS_DOWNLOAD_BENCH,
     LDJSON_MULTI_EXPORT_BENCH,

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -193,7 +193,7 @@ const WRITE_BENCHES: &[&'static str] = &[
     GRIDFS_MULTI_UPLOAD_BENCH,
 ];
 
-const MAX_ID: usize = 17;
+const MAX_ID: u8 = BenchmarkId::FindManySerde as u8;
 
 async fn run_benchmarks(
     uri: &str,
@@ -529,6 +529,12 @@ fn parse_ids(matches: ArgMatches) -> HashSet<BenchmarkId> {
 #[cfg_attr(feature = "tokio-runtime", tokio::main)]
 #[cfg_attr(feature = "async-std-runtime", async_std::main)]
 async fn main() {
+    // ensure MAX_ID is kept up to date.
+    assert!(
+        BenchmarkId::try_from(MAX_ID + 1).is_err(),
+        "MAX_ID not up to date"
+    );
+
     let matches = App::new("RustDriverBenchmark")
         .version(env!("CARGO_PKG_VERSION"))
         .about("Runs performance micro-bench")

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -81,8 +81,6 @@ const FIND_ONE_BENCH: &'static str = "Find one";
 const FIND_MANY_BENCH: &'static str = "Find many and empty cursor";
 const FIND_MANY_BENCH_RAW: &'static str = "Find many and empty cursor (raw BSON)";
 const FIND_MANY_BENCH_SERDE: &'static str = "Find many and empty cursor (serde structs)";
-const FIND_MANY_BENCH_SERDE_BORROWED: &'static str =
-    "Find many and empty cursor (serde structs with borrowed fields)";
 const GRIDFS_DOWNLOAD_BENCH: &'static str = "GridFS download";
 const LDJSON_MULTI_EXPORT_BENCH: &'static str = "LDJSON multi-file export";
 const GRIDFS_MULTI_DOWNLOAD_BENCH: &'static str = "GridFS multi-file download";
@@ -114,7 +112,6 @@ enum BenchmarkId {
     BsonFullDocumentEncode,
     FindManyRawBson,
     FindManySerde,
-    FindManySerdeBorrowed,
 }
 
 impl BenchmarkId {
@@ -137,7 +134,6 @@ impl BenchmarkId {
             BenchmarkId::BsonFullDocumentEncode => FULL_BSON_ENCODING,
             BenchmarkId::FindManyRawBson => FIND_MANY_BENCH_RAW,
             BenchmarkId::FindManySerde => FIND_MANY_BENCH_SERDE,
-            BenchmarkId::FindManySerdeBorrowed => FIND_MANY_BENCH_SERDE_BORROWED,
         }
     }
 }
@@ -197,7 +193,7 @@ const WRITE_BENCHES: &[&'static str] = &[
     GRIDFS_MULTI_UPLOAD_BENCH,
 ];
 
-const MAX_ID: usize = 18;
+const MAX_ID: usize = 17;
 
 async fn run_benchmarks(
     uri: &str,
@@ -440,15 +436,11 @@ async fn run_benchmarks(
             }
 
             // Find many and empty the cursor
-            BenchmarkId::FindManyRawBson
-            | BenchmarkId::FindMany
-            | BenchmarkId::FindManySerde
-            | BenchmarkId::FindManySerdeBorrowed => {
+            BenchmarkId::FindManyRawBson | BenchmarkId::FindMany | BenchmarkId::FindManySerde => {
                 let mode = match id {
                     BenchmarkId::FindMany => bench::find_many::Mode::Document,
                     BenchmarkId::FindManyRawBson => bench::find_many::Mode::RawBson,
                     BenchmarkId::FindManySerde => bench::find_many::Mode::Serde,
-                    BenchmarkId::FindManySerdeBorrowed => bench::find_many::Mode::SerdeBorrowed,
                     _ => unreachable!(),
                 };
                 let find_many_options = bench::find_many::Options {

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -513,7 +513,7 @@ fn parse_ids(matches: ArgMatches) -> HashSet<BenchmarkId> {
     ids
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::main(flavor = "current_thread"))]
+#[cfg_attr(feature = "tokio-runtime", tokio::main)]
 #[cfg_attr(feature = "async-std-runtime", async_std::main)]
 async fn main() {
     let matches = App::new("RustDriverBenchmark")

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -576,7 +576,6 @@ Run benchmarks by id number (comma-separated):
     15: BSON full document encode
     16: Find many and empty the cursor (raw BSON)
     17: Find many and empty the cursor (serde structs)
-    18: Find many and empty the cursor (serde structs with references)
     all: All benchmarks
                     ",
                 ),

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -502,6 +502,19 @@ fn parse_ids(matches: ArgMatches) -> HashSet<BenchmarkId> {
         ids.insert(BenchmarkId::BsonFullDocumentDecode);
         ids.insert(BenchmarkId::BsonFullDocumentEncode);
     }
+    if matches.is_present("driver") {
+        ids.insert(BenchmarkId::RunCommand);
+        ids.insert(BenchmarkId::FindOneById);
+        ids.insert(BenchmarkId::SmallDocInsertOne);
+        ids.insert(BenchmarkId::LargeDocInsertOne);
+        ids.insert(BenchmarkId::FindMany);
+        ids.insert(BenchmarkId::FindManyRawBson);
+        ids.insert(BenchmarkId::FindManySerde);
+        ids.insert(BenchmarkId::SmallDocBulkInsert);
+        ids.insert(BenchmarkId::LargeDocBulkInsert);
+        ids.insert(BenchmarkId::LdJsonMultiFileImport);
+        ids.insert(BenchmarkId::LdJsonMultiFileExport);
+    }
 
     // if none were enabled, that means no arguments were provided and all should be enabled.
     if ids.is_empty() {
@@ -543,6 +556,12 @@ async fn main() {
                 .short("b")
                 .long("bson")
                 .help("Run BSON-only benchmarks"),
+        )
+        .arg(
+            Arg::with_name("driver")
+                .short("d")
+                .long("driver")
+                .help("Run driver-only benchmarks"),
         )
         .arg(
             Arg::with_name("verbose")

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -1,5 +1,5 @@
 pub(crate) mod tweet {
-    use mongodb::bson::{Document, RawDocument};
+    use mongodb::bson::Document;
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -55,63 +55,5 @@ pub(crate) mod tweet {
         profile_background_color: String,
         listed_count: i32,
         lang: String,
-    }
-
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub(crate) struct TweetRef<'a> {
-        text: &'a str,
-        in_reply_to_status_id: i64,
-        retweet_count: Option<i32>,
-        contributors: Option<i32>,
-        created_at: &'a str,
-        geo: Option<&'a str>,
-        source: &'a str,
-        coordinates: Option<&'a str>,
-        in_reply_to_screen_name: Option<&'a str>,
-        truncated: bool,
-        #[serde(borrow)]
-        entities: EntitiesRef<'a>,
-        retweeted: bool,
-        place: Option<&'a str>,
-        user: User,
-    }
-
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub(crate) struct EntitiesRef<'a> {
-        #[serde(borrow)]
-        user_mentions: Vec<MentionRef<'a>>,
-        urls: Vec<&'a str>,
-        hashtags: Vec<&'a str>,
-    }
-
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub(crate) struct MentionRef<'a> {
-        indices: Vec<i32>,
-        screen_name: &'a str,
-        name: &'a str,
-        id: i64,
-    }
-
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub(crate) struct UserRef<'a> {
-        friends_count: i32,
-        profile_sidebar_fill_color: &'a str,
-        location: &'a str,
-        verified: bool,
-        follow_request_sent: Option<bool>,
-        favourites_count: i32,
-        profile_sidebar_border_color: &'a str,
-        profile_image_url: &'a str,
-        geo_enabled: bool,
-        created_at: &'a str,
-        description: &'a str,
-        time_zone: &'a str,
-        url: &'a str,
-        screen_name: &'a str,
-        #[serde(borrow)]
-        notifications: Option<Vec<&'a RawDocument>>,
-        profile_background_color: &'a str,
-        listed_count: i32,
-        lang: &'a str,
     }
 }

--- a/benchmarks/src/models.rs
+++ b/benchmarks/src/models.rs
@@ -1,5 +1,5 @@
-pub(crate) mod json_multi {
-    use mongodb::bson::Document;
+pub(crate) mod tweet {
+    use mongodb::bson::{Document, RawDocument};
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -55,5 +55,63 @@ pub(crate) mod json_multi {
         profile_background_color: String,
         listed_count: i32,
         lang: String,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct TweetRef<'a> {
+        text: &'a str,
+        in_reply_to_status_id: i64,
+        retweet_count: Option<i32>,
+        contributors: Option<i32>,
+        created_at: &'a str,
+        geo: Option<&'a str>,
+        source: &'a str,
+        coordinates: Option<&'a str>,
+        in_reply_to_screen_name: Option<&'a str>,
+        truncated: bool,
+        #[serde(borrow)]
+        entities: EntitiesRef<'a>,
+        retweeted: bool,
+        place: Option<&'a str>,
+        user: User,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct EntitiesRef<'a> {
+        #[serde(borrow)]
+        user_mentions: Vec<MentionRef<'a>>,
+        urls: Vec<&'a str>,
+        hashtags: Vec<&'a str>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct MentionRef<'a> {
+        indices: Vec<i32>,
+        screen_name: &'a str,
+        name: &'a str,
+        id: i64,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub(crate) struct UserRef<'a> {
+        friends_count: i32,
+        profile_sidebar_fill_color: &'a str,
+        location: &'a str,
+        verified: bool,
+        follow_request_sent: Option<bool>,
+        favourites_count: i32,
+        profile_sidebar_border_color: &'a str,
+        profile_image_url: &'a str,
+        geo_enabled: bool,
+        created_at: &'a str,
+        description: &'a str,
+        time_zone: &'a str,
+        url: &'a str,
+        screen_name: &'a str,
+        #[serde(borrow)]
+        notifications: Option<Vec<&'a RawDocument>>,
+        profile_background_color: &'a str,
+        listed_count: i32,
+        lang: &'a str,
     }
 }


### PR DESCRIPTION
RUST-1103

This PR introduces two new benchmarks: find many (raw BSON) and find many (serde struct). It also updates the multi export benchmark to use raw BSON, resulting in a speedup.

I didn't include any new versions of the find one by id benchmark, since using raw BSON didn't actually change anything there. I believe this is due to the test being bottlenecked by network I/O rather than BSON serialization. 

I also didn't include any borrowed deserialization benchmarks for any case, since it also didn't make any noticeable difference. I think we'd need to use a data set that has documents much larger than the tweet one provided with the microbenchmarks.

Lastly, I didn't update the multi-import benchmark to use raw documents, since it currently doesn't result in a speedup due to RUST-1132.

example patch: https://evergreen.mongodb.com/version/61bbc5421e2d177b9452baf4

Some numbers from my machine:
| benchmark                | median iteration time |
|:------------------------:|:---------------------:|
| find many (Document)     | 0.166s                |
| find many (raw BSON)     | 0.022s                |
| find many (serde struct) | 0.068s                |
| find many (C, raw BSON)            | 0.019                 |
| find many (Go, raw BSON)           | 0.012                 |
| find many (Go, bson.M)   | 0.366                 |

So overall, performance is quite good (especially serde struct, which used to be 0.15ish but improved due to the internal use of `RawDocumentBuf`), but we are a bit slower than Go and C in the raw BSON case. This is likely due to extra copies incurred by going through `serde` and could be avoided, but it didn't seem like a high enough priority to focus on now.