### PR TITLE
Updated readme reference to driver version to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository contains the officially supported MongoDB Rust driver, a client 
 The driver is available on [crates.io](https://crates.io/crates/mongodb). To use the driver in your application, simply add it to your project's `Cargo.toml`.
 ```toml
 [dependencies]
-mongodb = "2.0.0"
+mongodb = "2.1.0"
 ```
 
 #### Configuring the async runtime
@@ -45,7 +45,7 @@ The driver supports both of the most popular async runtime crates, namely [`toki
 For example, to instruct the driver to work with [`async-std`](https://crates.io/crates/async-std), add the following to your `Cargo.toml`:
 ```toml
 [dependencies.mongodb]
-version = "2.0.0"
+version = "2.1.0"
 default-features = false
 features = ["async-std-runtime"]
 ```
@@ -54,7 +54,7 @@ features = ["async-std-runtime"]
 The driver also provides a blocking sync API. To enable this, add the `"sync"` feature to your `Cargo.toml`:
 ```toml
 [dependencies.mongodb]
-version = "2.0.0"
+version = "2.1.0"
 default-features = false
 features = ["sync"]
 ```


### PR DESCRIPTION
The latest version always needs to be reflected in the README because, for better or worse, the [MongoDB Rust Driver official documentation section "Installation"](https://docs.mongodb.com/drivers/rust/#installation), delegates to this repo's "master" branch README for user installation instructions and we of course don't want to be encouraging users to use old versions of the driver by default.