### PR TITLE
RUST-1133 Update driver to use the raw BSON API

### DIFF
--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -187,7 +187,6 @@ where
 
 /// The size in bytes of the provided document's entry in a BSON array at the given index.
 pub(crate) fn array_entry_size_bytes(index: usize, doc_len: usize) -> u64 {
-    // 
     //   * type (1 byte)
     //   * number of decimal digits in key
     //   * null terminator for the key (1 byte)

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -103,7 +103,7 @@ impl<'a, T: Serialize> Operation for Insert<'a, T> {
             }
         }
 
-        if docs.as_bytes().len() == 5 {
+        if docs.is_empty() {
             return Err(ErrorKind::InvalidArgument {
                 message: "document exceeds maxBsonObjectSize".to_string(),
             }

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -74,9 +74,8 @@ async fn build() {
     let mut cmd_docs: Vec<Document> = cmd
         .body
         .documents
-        .documents
-        .iter()
-        .map(|b| Document::from_reader(b.as_slice()).unwrap())
+        .into_iter()
+        .map(|b| Document::from_reader(b.unwrap().as_document().unwrap().as_bytes()).unwrap())
         .collect();
     assert_eq!(cmd_docs.len(), fixtures.documents.len());
 
@@ -197,8 +196,8 @@ async fn generate_ids() {
     assert_eq!(docs[1].x, 2);
 
     // ensure the _id was prepended to the document
-    let docs: Documents<Document> = bson::from_slice(serialized.as_slice()).unwrap();
-    assert_eq!(docs.documents[0].iter().next().unwrap().0, "_id")
+    // let docs: Documents<Document> = bson::from_slice(serialized.as_slice()).unwrap();
+    // assert_eq!(docs.documents[0].iter().next().unwrap().0, "_id")
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -196,8 +196,8 @@ async fn generate_ids() {
     assert_eq!(docs[1].x, 2);
 
     // ensure the _id was prepended to the document
-    // let docs: Documents<Document> = bson::from_slice(serialized.as_slice()).unwrap();
-    // assert_eq!(docs.documents[0].iter().next().unwrap().0, "_id")
+    let docs: Documents<Document> = bson::from_slice(serialized.as_slice()).unwrap();
+    assert_eq!(docs.documents[0].iter().next().unwrap().0, "_id")
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]


### PR DESCRIPTION
RUST-1133

We implemented some of the raw BSON functionality in the driver itself as a temporary measure until the BSON library had its own support for it. Now that it does, we can remove these driver-only implementations and update to use the BSON library's versions instead.