### PR TITLE
minor: fix external crate links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! This crate contains the officially supported MongoDB Rust driver, a
 //! client side library that can be used to interact with MongoDB deployments
 //! in Rust applications. It uses the [`bson`] crate for BSON support.
-//! The driver contains a fully async API that supports either [`tokio`] (default)
-//! or [`async_std`], depending on the feature flags set. The driver also has
+//! The driver contains a fully async API that supports either [`tokio`](https://docs.rs/tokio) (default)
+//! or [`async_std`](https://docs.rs/async_std), depending on the feature flags set. The driver also has
 //! a sync API that may be enabled via the `"sync"` feature flag.
 //!
 //! # Installation
@@ -56,8 +56,8 @@
 //! | `async-std-runtime` | Enable support for the `async-std` runtime                                                                                            | `async-std` 1.0                     | no      |
 //! | `sync`              | Expose the synchronous API (`mongodb::sync`). This flag cannot be used in conjunction with either of the async runtime feature flags. | `async-std` 1.0                     | no      |
 //! | `aws-auth`          | Enable support for the MONGODB-AWS authentication mechanism.                                                                          | `reqwest` 0.11                      | no      |
-//! | `bson-uuid-0_8`     | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API of the re-exported `bson` crate.                    | n/a                                 | no      |
-//! | `bson-chrono-0_4`   | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API of the re-exported `bson` crate.                | n/a                                 | no      |
+//! | `bson-uuid-0_8`     | Enable support for v0.8 of the [`uuid`] crate in the public API of the re-exported `bson` crate.                                      | n/a                                 | no      |
+//! | `bson-chrono-0_4`   | Enable support for v0.4 of the [`chrono`] crate in the public API of the re-exported `bson` crate.                                    | n/a                                 | no      |
 //! | `zlib-compression`]  | Enable support for compressing messages with [`zlib`](https://zlib.net/).                                                            | `flate2` 1.0                        | no      |
 //! | `zstd-compression`  | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).  This flag requires Rust version 1.54.        | `zstd` 0.9.0                        | no      |
 //! | `snappy-compression` | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/).                                            | `snap` 1.0.5                        | no      |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! This crate contains the officially supported MongoDB Rust driver, a
 //! client side library that can be used to interact with MongoDB deployments
 //! in Rust applications. It uses the [`bson`] crate for BSON support.
-//! The driver contains a fully async API that supports either [`tokio`](https://docs.rs/tokio) (default)
-//! or [`async_std`](https://docs.rs/async_std), depending on the feature flags set. The driver also has
+//! The driver contains a fully async API that supports either [`tokio`] (default)
+//! or [`async-std`](https://docs.rs/async_std), depending on the feature flags set. The driver also has
 //! a sync API that may be enabled via the `"sync"` feature flag.
 //!
 //! # Installation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! This crate contains the officially supported MongoDB Rust driver, a
 //! client side library that can be used to interact with MongoDB deployments
-//! in Rust applications. It uses the [`bson`](docs.rs/bson) crate for BSON support.
-//! The driver contains a fully async API that supports either [`tokio`](docs.rs/tokio) (default)
-//! or [`async-std`](docs.rs/async-std), depending on the feature flags set. The driver also has
+//! in Rust applications. It uses the [`bson`] crate for BSON support.
+//! The driver contains a fully async API that supports either [`tokio`] (default)
+//! or [`async_std`], depending on the feature flags set. The driver also has
 //! a sync API that may be enabled via the `"sync"` feature flag.
 //!
 //! # Installation


### PR DESCRIPTION
Fixes the links to external crates on our [docs.rs page](https://docs.rs/mongodb/latest/mongodb/) that are currently broken.