### PR TITLE
minor: derive `TypedBuilder` for `TimeseriesOptions`

### DIFF
--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -144,7 +144,7 @@ pub struct IndexOptionDefaults {
 }
 
 /// Specifies options for creating a timeseries collection.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct TimeseriesOptions {


### PR DESCRIPTION
Our `TimeseriesOptions` struct does not derive `TypedBuilder`, so users currently do not have a way to construct these options (see #556). Thank you to @fuwaneko for pointing out this issue!