### PR TITLE
RUST-1149 Prose tests for change streams.

### DIFF
--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 /// See the documentation
 /// [here](https://docs.mongodb.com/manual/changeStreams/#change-stream-resume-token) for more
 /// information on resume tokens.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ResumeToken(pub(crate) RawBson);
 
 impl ResumeToken {
@@ -52,7 +52,7 @@ impl ResumeToken {
 
 /// A `ChangeStreamEvent` represents a
 /// [change event](https://docs.mongodb.com/manual/reference/change-events/) in the associated change stream.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ChangeStreamEvent<T> {
@@ -104,7 +104,7 @@ pub struct ChangeStreamEvent<T> {
 }
 
 /// Describes which fields have been updated or removed from a document.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct UpdateDescription {
@@ -117,7 +117,7 @@ pub struct UpdateDescription {
 }
 
 /// The operation type represented in a given change notification.
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum OperationType {
@@ -147,7 +147,7 @@ pub enum OperationType {
 }
 
 /// Identifies the collection or database on which an event occurred.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct ChangeStreamEventSource {
     /// The name of the database in which the change occurred.
     pub db: String,

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -143,12 +143,10 @@ pub enum OperationType {
 
 /// Identifies the collection or database on which an event occurred.
 #[derive(Deserialize, Debug)]
-#[serde(untagged)]
-#[non_exhaustive]
-pub enum ChangeStreamEventSource {
-    /// The [`Namespace`] containing the database and collection in which the change occurred.
-    Namespace(Namespace),
+pub struct ChangeStreamEventSource {
+    /// The name of the database in which the change occurred.
+    pub db: String,
 
-    /// Contains the name of the database in which the change happened.
-    Database(String),
+    /// The name of the collection in which the change occurred.
+    pub coll: Option<String>,
 }

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -43,6 +43,11 @@ impl ResumeToken {
     pub(crate) fn from_raw(doc: Option<RawDocumentBuf>) -> Option<ResumeToken> {
         doc.map(|doc| ResumeToken(RawBson::Document(doc)))
     }
+
+    #[cfg(test)]
+    pub fn parsed(self) -> std::result::Result<Bson, bson::raw::Error> {
+        self.0.try_into()
+    }
 }
 
 /// A `ChangeStreamEvent` represents a

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -148,6 +148,7 @@ pub enum OperationType {
 
 /// Identifies the collection or database on which an event occurred.
 #[derive(Deserialize, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ChangeStreamEventSource {
     /// The name of the database in which the change occurred.
     pub db: String,

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -240,50 +240,55 @@ where
     T: DeserializeOwned + Unpin + Send + Sync,
 {
     fn poll_next_in_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<BatchValue>> {
-        if let Some(mut pending) = self.pending_resume.take() {
-            match Pin::new(&mut pending).poll(cx) {
-                Poll::Pending => {
-                    self.pending_resume = Some(pending);
-                    return Poll::Pending;
+        loop {
+            if let Some(mut pending) = self.pending_resume.take() {
+                match Pin::new(&mut pending).poll(cx) {
+                    Poll::Pending => {
+                        self.pending_resume = Some(pending);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(Ok(new_stream)) => {
+                        // Ensure that the old cursor is killed on the server selected for the new one.
+                        self.cursor
+                            .set_drop_address(new_stream.cursor.address().clone());
+                        self.cursor = new_stream.cursor;
+                        self.args = new_stream.args;
+                        continue;
+                    }
+                    Poll::Ready(Err(e)) => {
+                        return Poll::Ready(Err(e))
+                    },
                 }
-                Poll::Ready(Ok(new_stream)) => {
-                    // Ensure that the old cursor is killed on the server selected for the new one.
-                    self.cursor
-                        .set_drop_address(new_stream.cursor.address().clone());
-                    self.cursor = new_stream.cursor;
-                    self.args = new_stream.args;
-                    return Poll::Pending;
-                }
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
             }
+            let out = self.cursor.poll_next_in_batch(cx);
+            match &out {
+                Poll::Ready(Ok(bv)) => {
+                    if let Some(token) = get_resume_token(bv, self.cursor.post_batch_resume_token())? {
+                        self.data.resume_token = Some(token);
+                    }
+                    if matches!(bv, BatchValue::Some { .. }) {
+                        self.data.document_returned = true;
+                    }
+                }
+                Poll::Ready(Err(e)) if e.is_resumable() && !self.data.resume_attempted => {
+                    self.data.resume_attempted = true;
+                    let client = self.cursor.client().clone();
+                    let args = self.args.clone();
+                    let mut data = self.data.take();
+                    data.implicit_session = self.cursor.take_implicit_session();
+                    self.pending_resume = Some(Box::pin(async move {
+                        let new_stream: Result<ChangeStream<ChangeStreamEvent<()>>> = client
+                            .execute_watch(args.pipeline, args.options, args.target, Some(data))
+                            .await;
+                        new_stream.map(|cs| cs.with_type::<T>())
+                    }));
+                    // Iterate the loop so the new future gets polled and can register wakers.
+                    continue;
+                }
+                _ => { }
+            }
+            return out;
         }
-        let out = self.cursor.poll_next_in_batch(cx);
-        match &out {
-            Poll::Ready(Ok(bv)) => {
-                if let Some(token) = get_resume_token(bv, self.cursor.post_batch_resume_token())? {
-                    self.data.resume_token = Some(token);
-                }
-                if matches!(bv, BatchValue::Some { .. }) {
-                    self.data.document_returned = true;
-                }
-            }
-            Poll::Ready(Err(e)) if e.is_resumable() && !self.data.resume_attempted => {
-                self.data.resume_attempted = true;
-                let client = self.cursor.client().clone();
-                let args = self.args.clone();
-                let mut data = self.data.take();
-                data.implicit_session = self.cursor.take_implicit_session();
-                self.pending_resume = Some(Box::pin(async move {
-                    let new_stream: Result<ChangeStream<ChangeStreamEvent<()>>> = client
-                        .execute_watch(args.pipeline, args.options, args.target, Some(data))
-                        .await;
-                    new_stream.map(|cs| cs.with_type::<T>())
-                }));
-                return Poll::Pending;
-            }
-            _ => {}
-        }
-        out
     }
 }
 

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -596,7 +596,7 @@ impl Client {
 
         let should_redact = cmd.should_redact();
 
-        let cmd_name = cmd.name.clone();
+        let cmd_name = dbg!(cmd.name.clone());
         let target_db = cmd.target_db.clone();
 
         let serialized = op.serialize_command(cmd)?;
@@ -628,6 +628,7 @@ impl Client {
         let start_time = Instant::now();
         let command_result = match connection.send_raw_command(raw_cmd, request_id).await {
             Ok(response) => {
+                let _ = dbg!(response.body::<Document>());
                 async fn handle_response<T: Operation>(
                     client: &Client,
                     op: &T,

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -596,7 +596,7 @@ impl Client {
 
         let should_redact = cmd.should_redact();
 
-        let cmd_name = dbg!(cmd.name.clone());
+        let cmd_name = cmd.name.clone();
         let target_db = cmd.target_db.clone();
 
         let serialized = op.serialize_command(cmd)?;
@@ -628,7 +628,6 @@ impl Client {
         let start_time = Instant::now();
         let command_result = match connection.send_raw_command(raw_cmd, request_id).await {
             Ok(response) => {
-                let _ = dbg!(response.body::<Document>());
                 async fn handle_response<T: Operation>(
                     client: &Client,
                     op: &T,

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -180,7 +180,7 @@ async fn connection_error_during_establishment() {
     client_options.repl_set_name = None;
 
     let client = TestClient::with_options(Some(client_options.clone())).await;
-    if !client.supports_fail_command().await {
+    if !client.supports_fail_command() {
         println!(
             "skipping {} due to failCommand not being supported",
             function_name!()
@@ -235,7 +235,7 @@ async fn connection_error_during_operation() {
     options.max_pool_size = Some(1);
 
     let client = TestClient::with_options(options.into()).await;
-    if !client.supports_fail_command().await {
+    if !client.supports_fail_command() {
         println!(
             "skipping {} due to failCommand not being supported",
             function_name!()

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -1354,7 +1354,7 @@ where
 }
 
 /// A struct modeling the canonical name for a collection in MongoDB.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Namespace {
     /// The name of the database associated with this namespace.
     pub db: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -470,6 +470,10 @@ pub enum ErrorKind {
     #[error("The server does not support a database operation: {message}")]
     #[non_exhaustive]
     IncompatibleServer { message: String },
+
+    /// No resume token was present in a change stream document.
+    #[error("Cannot provide resume functionality when the resume token is missing")]
+    MissingResumeToken,
 }
 
 impl ErrorKind {

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -615,7 +615,7 @@ async fn heartbeat_events() {
         .await
         .expect("should see server heartbeat succeeded event");
 
-    if !client.supports_fail_command().await {
+    if !client.supports_fail_command() {
         return;
     }
 

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -42,7 +42,7 @@ async fn min_heartbeat_frequency() {
 
     let setup_client = TestClient::with_options(Some(setup_client_options.clone())).await;
 
-    if !setup_client.supports_fail_command().await {
+    if !setup_client.supports_fail_command() {
         println!("skipping min_heartbeat_frequency test due to server not supporting fail points");
         return;
     }

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -80,7 +80,11 @@ async fn tracks_resume_token() -> Result<()> {
         .collect();
     let mut expected = vec![];
     // Token from `aggregate`
-    if let Some(initial) = events[0].reply.get_document("cursor")?.get("postBatchResumeToken") {
+    if let Some(initial) = events[0]
+        .reply
+        .get_document("cursor")?
+        .get("postBatchResumeToken")
+    {
         expected.push(initial.clone());
     }
     // Tokens from `getMore`s
@@ -97,13 +101,17 @@ fn expected_tokens(events: &[CommandSucceededEvent]) -> Result<Vec<Bson>> {
         if let Ok(next) = cursor.get_array("nextBatch") {
             // Tokens from results within the batch
             if next.len() > 1 {
-                for doc in &next[0..next.len()-1] {
+                for doc in &next[0..next.len() - 1] {
                     out.push(doc.as_document().unwrap().get("_id").unwrap().clone());
                 }
             }
             // Final token, if this wasn't an empty `getMore`
             if !next.is_empty() {
-                if let Some(last) = cursor.get("postBatchResumeToken").or_else(|| next.last().unwrap().as_document().unwrap().get("_id")).cloned() {
+                if let Some(last) = cursor
+                    .get("postBatchResumeToken")
+                    .or_else(|| next.last().unwrap().as_document().unwrap().get("_id"))
+                    .cloned()
+                {
                     out.push(last);
                 }
             }

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -458,8 +458,8 @@ async fn resume_uses_start_after() -> Result<()> {
         .build()
     ).await?;
 
+    // Create an event, and synthesize a resumable error when calling `getMore` for that event.
     coll.insert_one(doc! {}, None).await?;
-
     let _guard = FailPoint::fail_command(
         &["getMore"],
         FailPointMode::Times(1),
@@ -467,22 +467,76 @@ async fn resume_uses_start_after() -> Result<()> {
             .error_code(43)
             .build(),
     ).enable(&client, None).await?;
-
     stream.next().await.transpose()?;
 
     let commands = client.get_command_events(&["aggregate"]);
     assert_eq!(commands.len(), 4);
     fn has_start_after(command: &Document) -> Result<bool> {
-        Ok(command.get_array("pipeline")?[0]
+        let stage = command.get_array("pipeline")?[0]
             .as_document()
             .unwrap()
-            .get_document("$changeStream")?
-            .contains_key("startAfter"))
+            .get_document("$changeStream")?;
+        Ok(stage.contains_key("startAfter") && !stage.contains_key("resumeAfter"))
     }
     assert!(matches!(&commands[2], CommandEvent::Started(CommandStartedEvent {
         command,
         ..
     }) if has_start_after(command)?));
+
+    Ok(())
+}
+
+/// Prose test 18: Resuming a change stream after results uses `resumeAfter`.
+#[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]  // multi_thread required for FailPoint
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn resume_uses_resume_after() -> Result<()> {
+    let _guard = LOCK.run_exclusively().await;
+
+    let (client, coll, stream) = match init_stream("resume_uses_resume_after").await? {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    if !VersionReq::parse(">=4.1.1").unwrap().matches(&client.server_version) {
+        println!("skipping change stream test on unsupported version {:?}", client.server_version);
+        return Ok(());
+    }
+
+    coll.insert_one(doc! {}, None).await?;
+    let token = stream.resume_token().unwrap();
+
+    let mut stream = coll.watch(None, ChangeStreamOptions::builder()
+        .start_after(Some(token.clone()))
+        .build()
+    ).await?;
+
+    // Create an event and read it.
+    coll.insert_one(doc! {}, None).await?;
+    stream.next().await.transpose()?;
+
+    // Create an event, and synthesize a resumable error when calling `getMore` for that event.
+    coll.insert_one(doc! {}, None).await?;
+    let _guard = FailPoint::fail_command(
+        &["getMore"],
+        FailPointMode::Times(1),
+        FailCommandOptions::builder()
+            .error_code(43)
+            .build(),
+    ).enable(&client, None).await?;
+    stream.next().await.transpose()?;
+
+    let commands = client.get_command_events(&["aggregate"]);
+    assert_eq!(commands.len(), 6);
+    fn has_resume_after(command: &Document) -> Result<bool> {
+        let stage = command.get_array("pipeline")?[0]
+            .as_document()
+            .unwrap()
+            .get_document("$changeStream")?;
+        Ok(!stage.contains_key("startAfter") && stage.contains_key("resumeAfter"))
+    }
+    assert!(matches!(&commands[4], CommandEvent::Started(CommandStartedEvent {
+        command,
+        ..
+    }) if has_resume_after(command)?));
 
     Ok(())
 }

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -1,7 +1,9 @@
 use bson::{Document, doc};
 use tokio::sync::RwLockReadGuard;
 
-use crate::event::command::CommandSucceededEvent;
+//use crate::event::command::CommandSucceededEvent;
+
+use crate::change_stream::event::ResumeToken;
 
 use super::{LOCK, EventClient};
 
@@ -16,11 +18,13 @@ async fn track_resume_token() {
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("track_resume_token");
     let mut changes = client.watch(None, None).await.unwrap();
-    dbg!(changes.resume_token());
+    dbg!(client.get_command_events(&["aggregate", "getMore"]));
+    dbg!(changes.resume_token().cloned().map(ResumeToken::parsed));
     for _ in 0..3 {
         coll.insert_one(doc! {}, None).await.unwrap();
         dbg!(changes.next_if_any().await.unwrap());
-        dbg!(changes.resume_token());
+        dbg!(client.get_command_events(&["aggregate", "getMore"]));
+        dbg!(changes.resume_token().cloned().map(ResumeToken::parsed));
     }
 }
 

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -180,6 +180,10 @@ async fn resumes_on_error() -> Result<()> {
         }) if key == doc! { "_id": 2 }
     ));
 
+    // Assert that two `aggregate`s were issued, i.e. that a resume happened.
+    let events = client.get_command_started_events(&["aggregate"]);
+    assert_eq!(events.len(), 2);
+
     Ok(())
 }
 

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -198,7 +198,6 @@ async fn empty_batch_not_closed() -> Result<()> {
     stream.next().await.transpose()?;
 
     let events = client.get_command_events(&["aggregate", "getMore"]);
-    assert_eq!(events.len(), 4);
     let cursor_id = match &events[1] {
         CommandEvent::Succeeded(CommandSucceededEvent { reply, .. }) => {
             reply.get_document("cursor")?.get_i64("id")?

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -1,40 +1,66 @@
-use bson::{Document, doc};
+use bson::{Document, doc, Bson};
+use futures_util::StreamExt;
 use tokio::sync::RwLockReadGuard;
 
-//use crate::event::command::CommandSucceededEvent;
-
-use crate::change_stream::event::ResumeToken;
+use crate::{
+    test::CommandEvent, event::command::CommandSucceededEvent,
+};
 
 use super::{LOCK, EventClient};
 
 /// Prose test 1: ChangeStream must continuously track the last seen resumeToken
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn track_resume_token() {
+async fn track_resume_token() -> Result<(), Box<dyn std::error::Error>> {
     // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("track_resume_token");
-    let mut changes = client.watch(None, None).await.unwrap();
-    dbg!(client.get_command_events(&["aggregate", "getMore"]));
-    dbg!(changes.resume_token().cloned().map(ResumeToken::parsed));
+    let mut changes = client.watch(None, None).await?;
+    let mut tokens = vec![];
+    tokens.push(changes.resume_token().cloned().unwrap().parsed()?);
     for _ in 0..3 {
-        coll.insert_one(doc! {}, None).await.unwrap();
-        dbg!(changes.next_if_any().await.unwrap());
-        dbg!(client.get_command_events(&["aggregate", "getMore"]));
-        dbg!(changes.resume_token().cloned().map(ResumeToken::parsed));
+        coll.insert_one(doc! {}, None).await?;
+        changes.next().await.transpose()?;
+        tokens.push(changes.resume_token().cloned().unwrap().parsed()?);
     }
+    let events: Vec<_> = client.get_command_events(&["aggregate", "getMore"])
+        .into_iter()
+        .filter_map(|ev| {
+            match ev {
+                CommandEvent::Succeeded(s) => Some(s),
+                _ => None,
+            }
+        })
+        .collect();
+
+    assert_eq!(events.len(), 4);
+    assert_eq!(events[0].command_name, "aggregate");
+    for n in 1..4 {
+        assert_eq!(events[n].command_name, "getMore");
+    }
+    let expected_tokens: Vec<_> = events.iter()
+        .map(expected_token)
+        .collect();
+    assert_eq!(tokens, expected_tokens);
+
+    Ok(())
 }
 
-/*
-fn expected_resume_token(commands: &[CommandSucceededEvent], events_read: usize) -> Option<Document> {
-    let mut token = None;
-    let mut commands_checked: usize = 0;
-    for event in commands {
-
+fn expected_token(ev: &CommandSucceededEvent) -> Bson {
+    let cursor = ev.reply.get_document("cursor").unwrap();
+    if let Some(token) = cursor.get("postBatchResumeToken") {
+        token.clone()
+    } else {
+        cursor
+            .get_array("nextBatch")
+            .unwrap()[0]
+            .as_document()
+            .unwrap()
+            .get("_id")
+            .unwrap()
+            .clone()
     }
-    token
 }
-*/

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -1,5 +1,7 @@
-use bson::Document;
+use bson::{Document, doc};
 use tokio::sync::RwLockReadGuard;
+
+use crate::event::command::CommandSucceededEvent;
 
 use super::{LOCK, EventClient};
 
@@ -7,9 +9,28 @@ use super::{LOCK, EventClient};
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn track_resume_token() {
+    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("track_resume_token");
+    let mut changes = client.watch(None, None).await.unwrap();
+    dbg!(changes.resume_token());
+    for _ in 0..3 {
+        coll.insert_one(doc! {}, None).await.unwrap();
+        dbg!(changes.next_if_any().await.unwrap());
+        dbg!(changes.resume_token());
+    }
 }
+
+/*
+fn expected_resume_token(commands: &[CommandSucceededEvent], events_read: usize) -> Option<Document> {
+    let mut token = None;
+    let mut commands_checked: usize = 0;
+    for event in commands {
+
+    }
+    token
+}
+*/

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -13,7 +13,7 @@ use crate::{
     Collection,
 };
 
-use super::{EventClient, CLIENT_OPTIONS, LOCK, TestClient};
+use super::{EventClient, TestClient, CLIENT_OPTIONS, LOCK};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -1,0 +1,15 @@
+use bson::Document;
+use tokio::sync::RwLockReadGuard;
+
+use super::{LOCK, EventClient};
+
+/// Prose test 1: ChangeStream must continuously track the last seen resumeToken
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn track_resume_token() {
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+    let db = client.database("change_stream_tests");
+    let coll = db.collection::<Document>("track_resume_token");
+}

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -13,10 +13,12 @@ use super::{LOCK, EventClient};
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn tracks_resume_token() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
+    if !client.is_replica_set() && !client.is_sharded() {
+        println!("skipping change stream test on unsupported topology");
+    }
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("track_resume_token");
     let mut stream = coll.watch(None, None).await?;
@@ -63,10 +65,12 @@ fn expected_token(ev: CommandSucceededEvent) -> Bson {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn errors_on_missing_token() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
+    if !client.is_replica_set() && !client.is_sharded() {
+        println!("skipping change stream test on unsupported topology");
+    }
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("errors_on_missing_token");
     let mut stream = coll.watch(vec![
@@ -82,10 +86,12 @@ async fn errors_on_missing_token() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]  // multi_thread required for FailPoint
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn resumes_on_error() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard = LOCK.run_exclusively().await;
 
     let client = EventClient::new().await;
+    if !client.is_replica_set() && !client.is_sharded() {
+        println!("skipping change stream test on unsupported topology");
+    }
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("resumes_on_error");
     coll.drop(None).await?;
@@ -124,10 +130,12 @@ async fn resumes_on_error() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]  // multi_thread required for FailPoint
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn does_not_resume_aggregate() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard = LOCK.run_exclusively().await;
 
     let client = EventClient::new().await;
+    if !client.is_replica_set() && !client.is_sharded() {
+        println!("skipping change stream test on unsupported topology");
+    }
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("does_not_resume_aggregate");
     coll.drop(None).await?;
@@ -154,10 +162,12 @@ async fn does_not_resume_aggregate() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn empty_batch_not_closed() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
+    if !client.is_replica_set() && !client.is_sharded() {
+        println!("skipping change stream test on unsupported topology");
+    }
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("empty_batch_not_closed");
     let mut stream = coll.watch(None, None).await?;
@@ -190,10 +200,12 @@ async fn empty_batch_not_closed() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]  // multi_thread required for FailPoint
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn resume_kill_cursor_error_suppressed() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard = LOCK.run_exclusively().await;
 
     let client = EventClient::new().await;
+    if !client.is_replica_set() && !client.is_sharded() {
+        println!("skipping change stream test on unsupported topology");
+    }
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("resume_kill_cursor_error_suppressed");
     coll.drop(None).await?;

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -11,22 +11,23 @@ use super::{LOCK, EventClient};
 /// Prose test 1: ChangeStream must continuously track the last seen resumeToken
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn track_resume_token() -> Result<(), Box<dyn std::error::Error>> {
+async fn tracks_resume_token() -> Result<(), Box<dyn std::error::Error>> {
     // TODO aegnor: restrict to replica sets and sharded clusters
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let client = EventClient::new().await;
     let db = client.database("change_stream_tests");
     let coll = db.collection::<Document>("track_resume_token");
-    let mut changes = client.watch(None, None).await?;
+    let mut stream = coll.watch(None, None).await?;
     let mut tokens = vec![];
-    tokens.push(changes.resume_token().cloned().unwrap().parsed()?);
+    tokens.push(stream.resume_token().cloned().unwrap().parsed()?);
     for _ in 0..3 {
         coll.insert_one(doc! {}, None).await?;
-        changes.next().await.transpose()?;
-        tokens.push(changes.resume_token().cloned().unwrap().parsed()?);
+        stream.next().await.transpose()?;
+        tokens.push(stream.resume_token().cloned().unwrap().parsed()?);
     }
-    let events: Vec<_> = client.get_command_events(&["aggregate", "getMore"])
+
+    let expected_tokens: Vec<_> = client.get_command_events(&["aggregate", "getMore"])
         .into_iter()
         .filter_map(|ev| {
             match ev {
@@ -34,14 +35,6 @@ async fn track_resume_token() -> Result<(), Box<dyn std::error::Error>> {
                 _ => None,
             }
         })
-        .collect();
-
-    assert_eq!(events.len(), 4);
-    assert_eq!(events[0].command_name, "aggregate");
-    for n in 1..4 {
-        assert_eq!(events[n].command_name, "getMore");
-    }
-    let expected_tokens: Vec<_> = events.iter()
         .map(expected_token)
         .collect();
     assert_eq!(tokens, expected_tokens);
@@ -49,7 +42,7 @@ async fn track_resume_token() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn expected_token(ev: &CommandSucceededEvent) -> Bson {
+fn expected_token(ev: CommandSucceededEvent) -> Bson {
     let cursor = ev.reply.get_document("cursor").unwrap();
     if let Some(token) = cursor.get("postBatchResumeToken") {
         token.clone()
@@ -63,4 +56,23 @@ fn expected_token(ev: &CommandSucceededEvent) -> Bson {
             .unwrap()
             .clone()
     }
+}
+
+/// Prose test 2: ChangeStream will throw an exception if the server response is missing the resume token
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn errors_on_missing_token() -> Result<(), Box<dyn std::error::Error>> {
+    // TODO aegnor: restrict to replica sets and sharded clusters
+    let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
+
+    let client = EventClient::new().await;
+    let db = client.database("change_stream_tests");
+    let coll = db.collection::<Document>("errors_on_missing_token");
+    let mut stream = coll.watch(vec![
+        doc! { "$project": { "_id": 0 } },
+    ], None).await?;
+    coll.insert_one(doc! {}, None).await?;
+    assert!(stream.next().await.transpose().is_err());
+
+    Ok(())
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(not(feature = "sync"))]
 mod atlas_connectivity;
 mod auth_aws;
+mod change_stream;
 mod client;
 mod coll;
 mod cursor;

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -47,7 +47,7 @@ async fn retry_releases_connection() {
     client_options.max_pool_size = Some(1);
 
     let client = TestClient::with_options(Some(client_options)).await;
-    if !client.supports_fail_command().await {
+    if !client.supports_fail_command() {
         println!("skipping retry_releases_connection due to failCommand not being supported");
         return;
     }

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -235,7 +235,7 @@ impl TestClient {
         self.get_coll(db_name, coll_name)
     }
 
-    pub async fn supports_fail_command(&self) -> bool {
+    pub fn supports_fail_command(&self) -> bool {
         let version = if self.is_sharded() {
             VersionReq::parse(">= 4.1.5").unwrap()
         } else {


### PR DESCRIPTION
RUST-1149

This implements the prose tests for change streams, with the exception of test 6, which is (a) tricky to observe and (b) essentially guaranteed to be correct by the design of the Rust driver.  Some relatively minor updates were required to the change stream implementation as a result of bugs found by these tests.