### PR TITLE
RUST-812 Reduce flakiness of `in_window::load_balancing_test`

### DIFF
--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -191,7 +191,6 @@ where
 
 /// The size in bytes of the provided document's entry in a BSON array at the given index.
 pub(crate) fn array_entry_size_bytes(index: usize, doc_len: usize) -> u64 {
-    // 
     //   * type (1 byte)
     //   * number of decimal digits in key
     //   * null terminator for the key (1 byte)

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -123,6 +123,11 @@ async fn load_balancing_test() {
         return;
     }
 
+    if setup_client_options.credential.is_some() {
+        println!("skipping load_balancing_test test due to auth being enabled");
+        return;
+    }
+
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
     let setup_client = TestClient::with_options(Some(setup_client_options)).await;

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -7,7 +7,6 @@ use serde::Deserialize;
 use tokio::sync::RwLockWriteGuard;
 
 use crate::{
-    client::options::ClientOptions,
     options::ServerAddress,
     runtime::AsyncJoinHandle,
     sdam::{description::topology::server_selection, Server},

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -192,11 +192,6 @@ async fn load_balancing_test() {
             *tallies.entry(event.connection.address.clone()).or_insert(0) += 1;
         }
 
-        if tallies.len() < 2 {
-            println!("{:#?}", tallies);
-            println!("{:#?}", client.topology_description().await);
-        }
-
         assert_eq!(tallies.len(), 2);
         let mut counts: Vec<_> = tallies.values().collect();
         counts.sort();

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -13,14 +13,17 @@ use crate::{
     selection_criteria::ReadPreference,
     test::{
         run_spec_test,
-        EventClient,
+        Event,
+        EventHandler,
         FailCommandOptions,
         FailPoint,
         FailPointMode,
+        SdamEvent,
         TestClient,
         CLIENT_OPTIONS,
         LOCK,
     },
+    ServerType,
     RUNTIME,
 };
 
@@ -158,8 +161,14 @@ async fn load_balancing_test() {
 
     /// min_share is the lower bound for the % of times the the less selected server
     /// was selected. max_share is the upper bound.
-    async fn do_test(client: &mut EventClient, min_share: f64, max_share: f64, iterations: usize) {
-        client.clear_cached_events();
+    async fn do_test(
+        client: &TestClient,
+        handler: &mut EventHandler,
+        min_share: f64,
+        max_share: f64,
+        iterations: usize,
+    ) {
+        handler.clear_cached_events();
 
         let mut handles: Vec<AsyncJoinHandle<()>> = Vec::new();
         for _ in 0..10 {
@@ -180,8 +189,13 @@ async fn load_balancing_test() {
         futures::future::join_all(handles).await;
 
         let mut tallies: HashMap<ServerAddress, u32> = HashMap::new();
-        for event in client.get_command_started_events(&["find"]) {
+        for event in handler.get_command_started_events(&["find"]) {
             *tallies.entry(event.connection.address.clone()).or_insert(0) += 1;
+        }
+
+        if tallies.len() < 2 {
+            println!("{:#?}", tallies);
+            println!("{:#?}", client.topology_description().await);
         }
 
         assert_eq!(tallies.len(), 2);
@@ -203,10 +217,30 @@ async fn load_balancing_test() {
         );
     }
 
-    let mut client = EventClient::new().await;
+    let mut handler = EventHandler::new();
+    let mut subscriber = handler.subscribe();
+    let client = TestClient::with_handler(Some(Arc::new(handler.clone())), None).await;
+
+    subscriber
+        .wait_for_event(Duration::from_secs(30), |event| {
+            if let Event::Sdam(SdamEvent::TopologyDescriptionChanged(event)) = event {
+                event
+                    .new_description
+                    .servers()
+                    .into_iter()
+                    .filter(|s| matches!(s.1.server_type(), ServerType::Mongos))
+                    .count()
+                    == 2
+            } else {
+                false
+            }
+        })
+        .await
+        .expect("timed out waiting for both mongoses to be discovered");
+    drop(subscriber);
 
     // saturate pools
-    do_test(&mut client, 0.0, 0.50, 100).await;
+    do_test(&client, &mut handler, 0.0, 0.50, 100).await;
 
     // enable a failpoint on one of the mongoses to slow it down
     let options = FailCommandOptions::builder()
@@ -220,9 +254,9 @@ async fn load_balancing_test() {
         .expect("enabling failpoint should succeed");
 
     // verify that the lesser picked server (slower one) was picked less than 25% of the time.
-    do_test(&mut client, 0.05, 0.25, 10).await;
+    do_test(&client, &mut handler, 0.05, 0.25, 10).await;
 
     // disable failpoint and rerun, should be back to even split
     drop(fp_guard);
-    do_test(&mut client, 0.40, 0.50, 100).await;
+    do_test(&client, &mut handler, 0.40, 0.50, 100).await;
 }

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -214,9 +214,8 @@ async fn load_balancing_test() {
 
     let mut handler = EventHandler::new();
     let mut subscriber = handler.subscribe();
-    let options = ClientOptions::builder()
-        .local_threshold(Duration::from_secs(30))
-        .build();
+    let mut options = CLIENT_OPTIONS.clone();
+    options.local_threshold = Duration::from_secs(30).into();
     let client = TestClient::with_handler(Some(Arc::new(handler.clone())), options).await;
 
     // wait for both servers to be discovered.

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -219,6 +219,12 @@ impl EventHandler {
     pub fn connections_checked_out(&self) -> u32 {
         *self.connections_checked_out.lock().unwrap()
     }
+
+    pub fn clear_cached_events(&self) {
+        self.command_events.write().unwrap().clear();
+        self.cmap_events.write().unwrap().clear();
+        self.sdam_events.write().unwrap().clear();
+    }
 }
 
 impl CmapEventHandler for EventHandler {
@@ -538,8 +544,7 @@ impl EventClient {
     }
 
     pub fn clear_cached_events(&self) {
-        self.handler.command_events.write().unwrap().clear();
-        self.handler.cmap_events.write().unwrap().clear();
+        self.handler.clear_cached_events()
     }
 }
 

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -61,7 +61,7 @@ impl TestClient {
         Self::with_handler(None, options).await
     }
 
-    async fn with_handler(
+    pub async fn with_handler(
         event_handler: Option<Arc<EventHandler>>,
         options: impl Into<Option<ClientOptions>>,
     ) -> Self {


### PR DESCRIPTION
RUST-812

This PR makes the following changes to hopefully eliminate the remaining flakiness in the `in_window::load_balancing_test`, which verifies that the operation-count tracking server selection algorithm successfully routes requests away from busy servers:
- Add a 30 second local threshold config to the client, ensuring both mongoses are always in the latency window
- Use SDAM monitoring events to ensure both mongoses are discovered before starting the test

From testing, it seems that this (in conjunction with skipping on auth + tls) eliminates the random failures, but we'll have to wait and see if they crop up again. Should these changes prove successful, I'll update the spec to require them so other drivers can avoid similar errors (DRIVERS-1926)