### PR TITLE
RUST-1106 Make the change streams API visible

### DIFF
--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -1,14 +1,12 @@
 //! Contains the types related to a `ChangeStream` event.
+#[cfg(test)]
 use std::convert::TryInto;
 
-use crate::{
-    coll::Namespace,
-    cursor::CursorSpecification,
-    error::Result,
-    options::ChangeStreamOptions,
-};
+use crate::{coll::Namespace, cursor::CursorSpecification, options::ChangeStreamOptions};
 
-use bson::{Bson, Document, RawBson, RawDocument, RawDocumentBuf, Timestamp};
+#[cfg(test)]
+use bson::Bson;
+use bson::{Document, RawBson, RawDocumentBuf, Timestamp};
 use serde::{Deserialize, Serialize};
 
 /// An opaque token used for resuming an interrupted

--- a/src/change_stream/session.rs
+++ b/src/change_stream/session.rs
@@ -1,21 +1,11 @@
 //! Types for change streams using sessions.
-use std::{
-    future::Future,
-    marker::PhantomData,
-    pin::Pin,
-    sync::{Arc, Mutex},
-    task::{Context, Poll},
-};
-
-use bson::Document;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    cursor::{BatchValue, CursorStream, NextInBatchFuture},
+    cursor::{BatchValue, NextInBatchFuture},
     error::Result,
     ClientSession,
     SessionCursor,
-    SessionCursorStream,
 };
 
 use super::{
@@ -25,10 +15,10 @@ use super::{
     WatchArgs,
 };
 
-/// A [`SessionChangeStream`] is a change stream that was created with a [`ClientSession`] that must
+/// A [`SessionChangeStream`] is a change stream that was created with a ClientSession that must
 /// be iterated using one. To iterate, use [`SessionChangeStream::next`]:
 ///
-/// ```ignore
+/// ```
 /// # use mongodb::{bson::Document, Client, error::Result};
 /// #
 /// # async fn do_stuff() -> Result<()> {
@@ -79,7 +69,7 @@ where
     /// Retrieve the next result from the change stream.
     /// The session provided must be the same session used to create the change stream.
     ///
-    /// ```ignore
+    /// ```
     /// # use bson::{doc, Document};
     /// # use mongodb::Client;
     /// # fn main() {
@@ -120,16 +110,16 @@ where
     /// empty.  This method should be used when storing the resume token in order to ensure the
     /// most up to date token is received, e.g.
     ///
-    /// ```ignore
-    /// # use mongodb::{Client, error::Result};
+    /// ```
+    /// # use mongodb::{Client, Collection, bson::Document, error::Result};
     /// # async fn func() -> Result<()> {
     /// # let client = Client::with_uri_str("mongodb://example.com").await?;
-    /// # let coll = client.database("foo").collection("bar");
+    /// # let coll: Collection<Document> = client.database("foo").collection("bar");
     /// # let mut session = client.start_session(None).await?;
     /// let mut change_stream = coll.watch_with_session(None, None, &mut session).await?;
     /// let mut resume_token = None;
     /// while change_stream.is_alive() {
-    ///     if let Some(event) = change_stream.next_if_any(&mut session) {
+    ///     if let Some(event) = change_stream.next_if_any(&mut session).await? {
     ///         // process event
     ///     }
     ///     resume_token = change_stream.resume_token();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -282,8 +282,7 @@ impl Client {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    #[allow(unused)]
-    pub(crate) async fn watch(
+    pub async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -299,8 +298,7 @@ impl Client {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in the cluster
     /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
-    #[allow(unused)]
-    pub(crate) async fn watch_with_session(
+    pub async fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -814,8 +814,7 @@ impl<T> Collection<T> {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    #[allow(unused)]
-    pub(crate) async fn watch(
+    pub async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -833,8 +832,7 @@ impl<T> Collection<T> {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this collection
     /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
-    #[allow(unused)]
-    pub(crate) async fn watch_with_session(
+    pub async fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -463,8 +463,7 @@ impl Database {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    #[allow(unused)]
-    pub(crate) async fn watch(
+    pub async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -479,8 +478,7 @@ impl Database {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this database
     /// using the provided [`ClientSession`].  See [`Database::watch`] for more information.
-    #[allow(unused)]
-    pub(crate) async fn watch_with_session(
+    pub async fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,8 +310,7 @@ pub mod options;
 pub use ::bson;
 
 mod bson_util;
-#[allow(unused)]
-pub(crate) mod change_stream;
+pub mod change_stream;
 mod client;
 mod cmap;
 mod coll;

--- a/src/options.rs
+++ b/src/options.rs
@@ -16,6 +16,7 @@
 //! ```
 
 pub use crate::{
+    change_stream::options::*,
     client::{auth::*, options::*},
     coll::options::*,
     collation::*,
@@ -25,9 +26,6 @@ pub use crate::{
     index::options::*,
     selection_criteria::*,
 };
-
-#[allow(unused)]
-pub(crate) use crate::change_stream::options::*;
 
 /// Updates an options struct with the read preference/read concern/write concern of a
 /// client/database/collection.

--- a/src/sync/change_stream.rs
+++ b/src/sync/change_stream.rs
@@ -95,17 +95,17 @@ where
     /// most up to date token is received, e.g.
     ///
     /// ```
-    /// # use mongodb::{sync::Client, error::Result};
+    /// # use mongodb::{bson::Document, sync::{Client, Collection}, error::Result};
     /// # fn func() -> Result<()> {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;
-    /// # let coll = client.database("foo").collection("bar");
+    /// # let coll: Collection<Document> = client.database("foo").collection("bar");
     /// let mut change_stream = coll.watch(None, None)?;
     /// let mut resume_token = None;
     /// while change_stream.is_alive() {
-    ///     if let Some(event) = change_stream.next_if_any() {
+    ///     if let Some(event) = change_stream.next_if_any()? {
     ///         // process event
     ///     }
-    ///     resume_token = change_stream.resume_token().cloned();
+    ///     resume_token = change_stream.resume_token();
     /// }
     /// #
     /// # Ok(())
@@ -216,15 +216,15 @@ where
     /// most up to date token is received, e.g.
     ///
     /// ```
-    /// # use mongodb::{sync::Client, error::Result};
+    /// # use mongodb::{bson::Document, sync::{Client, Collection}, error::Result};
     /// # async fn func() -> Result<()> {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;
-    /// # let coll = client.database("foo").collection("bar");
+    /// # let coll: Collection<Document> = client.database("foo").collection("bar");
     /// # let mut session = client.start_session(None)?;
     /// let mut change_stream = coll.watch_with_session(None, None, &mut session)?;
     /// let mut resume_token = None;
     /// while change_stream.is_alive() {
-    ///     if let Some(event) = change_stream.next_if_any(&mut session) {
+    ///     if let Some(event) = change_stream.next_if_any(&mut session)? {
     ///         // process event
     ///     }
     ///     resume_token = change_stream.resume_token();

--- a/src/sync/change_stream.rs
+++ b/src/sync/change_stream.rs
@@ -22,14 +22,14 @@ use super::ClientSession;
 /// ["resumable"](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error)
 /// errors, such as transient network failures. It can also be done manually by passing
 /// a [`ResumeToken`] retrieved from a past event into either the
-/// [`resume_after`](ChangeStreamOptions::resume_after) or
-/// [`start_after`](ChangeStreamOptions::start_after) (4.2+) options used to create the
-/// `ChangeStream`. Issuing a raw change stream aggregation is discouraged unless users wish to
+/// [`resume_after`](crate::options::ChangeStreamOptions::resume_after) or
+/// [`start_after`](crate::options::ChangeStreamOptions::start_after) (4.2+) options used to create
+/// the `ChangeStream`. Issuing a raw change stream aggregation is discouraged unless users wish to
 /// explicitly opt out of resumability.
 ///
 /// A `ChangeStream` can be iterated like any other [`Iterator`]:
 ///
-/// ```ignore
+/// ```
 /// # use mongodb::{sync::Client, error::Result, bson::doc,
 /// # change_stream::event::ChangeStreamEvent};
 /// #
@@ -94,7 +94,7 @@ where
     /// empty.  This method should be used when storing the resume token in order to ensure the
     /// most up to date token is received, e.g.
     ///
-    /// ```ignore
+    /// ```
     /// # use mongodb::{sync::Client, error::Result};
     /// # fn func() -> Result<()> {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;
@@ -130,7 +130,7 @@ where
 /// A [`SessionChangeStream`] is a change stream that was created with a [`ClientSession`] that must
 /// be iterated using one. To iterate, use [`SessionChangeStream::next`]:
 ///
-/// ```ignore
+/// ```
 /// # use mongodb::{bson::Document, sync::Client, error::Result};
 /// #
 /// # async fn do_stuff() -> Result<()> {
@@ -181,7 +181,7 @@ where
     /// Retrieve the next result from the change stream.
     /// The session provided must be the same session used to create the change stream.
     ///
-    /// ```ignore
+    /// ```
     /// # use bson::{doc, Document};
     /// # use mongodb::sync::Client;
     /// # fn main() {
@@ -215,7 +215,7 @@ where
     /// empty.  This method should be used when storing the resume token in order to ensure the
     /// most up to date token is received, e.g.
     ///
-    /// ```ignore
+    /// ```
     /// # use mongodb::{sync::Client, error::Result};
     /// # async fn func() -> Result<()> {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;

--- a/src/sync/client/mod.rs
+++ b/src/sync/client/mod.rs
@@ -177,8 +177,7 @@ impl Client {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    #[allow(unused)]
-    pub(crate) fn watch(
+    pub fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -190,8 +189,7 @@ impl Client {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in the cluster
     /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
-    #[allow(unused)]
-    pub(crate) fn watch_with_session(
+    pub fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/sync/coll.rs
+++ b/src/sync/coll.rs
@@ -557,7 +557,8 @@ impl<T> Collection<T> {
     }
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this collection
-    /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
+    /// using the provided [`ClientSession`].  See [`Client::watch`](crate::sync::Client::watch) for
+    /// more information.
     pub async fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,

--- a/src/sync/coll.rs
+++ b/src/sync/coll.rs
@@ -543,7 +543,7 @@ impl<T> Collection<T> {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    pub async fn watch(
+    pub fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -559,7 +559,7 @@ impl<T> Collection<T> {
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this collection
     /// using the provided [`ClientSession`].  See [`Client::watch`](crate::sync::Client::watch) for
     /// more information.
-    pub async fn watch_with_session(
+    pub fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/sync/coll.rs
+++ b/src/sync/coll.rs
@@ -543,8 +543,7 @@ impl<T> Collection<T> {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    #[allow(unused)]
-    pub(crate) async fn watch(
+    pub async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -559,8 +558,7 @@ impl<T> Collection<T> {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this collection
     /// using the provided [`ClientSession`].  See [`Client::watch`] for more information.
-    #[allow(unused)]
-    pub(crate) async fn watch_with_session(
+    pub async fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -298,7 +298,7 @@ impl Database {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    pub async fn watch(
+    pub fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -310,7 +310,7 @@ impl Database {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this database
     /// using the provided [`ClientSession`].  See [`Database::watch`] for more information.
-    pub async fn watch_with_session(
+    pub fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -298,8 +298,7 @@ impl Database {
     ///
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
-    #[allow(unused)]
-    pub(crate) async fn watch(
+    pub async fn watch(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,
@@ -311,8 +310,7 @@ impl Database {
 
     /// Starts a new [`SessionChangeStream`] that receives events for all changes in this database
     /// using the provided [`ClientSession`].  See [`Database::watch`] for more information.
-    #[allow(unused)]
-    pub(crate) async fn watch_with_session(
+    pub async fn watch_with_session(
         &self,
         pipeline: impl IntoIterator<Item = Document>,
         options: impl Into<Option<ChangeStreamOptions>>,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,6 +1,5 @@
 //! Contains the sync API. This is only available when the `sync` feature is enabled.
 
-#[allow(unused)]
 mod change_stream;
 mod client;
 mod coll;
@@ -10,7 +9,7 @@ mod db;
 #[cfg(test)]
 mod test;
 
-pub(crate) use change_stream::{ChangeStream, SessionChangeStream};
+pub use change_stream::{ChangeStream, SessionChangeStream};
 pub use client::{session::ClientSession, Client};
 pub use coll::Collection;
 pub use cursor::{Cursor, SessionCursor, SessionCursorIter};


### PR DESCRIPTION
RUST-1106

This PR marks the modules and `watch` functions `pub`, removes the `ignore` clause on the rustdoc examples (and fixes those examples), and cleans up a bunch of unused imports that apparently weren't being checked while it was `pub(crate)`.