### PR TITLE
RUST-1154 Fail evergreen tasks if precommands fail

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -660,6 +660,7 @@ functions:
       params:
         file: src/results.xml
 
+pre_error_fails_task: true
 pre:
   - func: "fetch source"
   - func: "prepare resources"


### PR DESCRIPTION
RUST-1154

This doesn't fix the actual issue, but it does mean that the failures are flagged as system failures rather than test failures.