### PR TITLE
minor: fix change stream tests

### DIFF
--- a/src/test/spec/json/change-streams/unified/change-streams-errors.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-errors.json
@@ -10,7 +10,8 @@
         ],
         "ignoreCommandMonitoringEvents": [
           "killCursors"
-        ]
+        ],
+        "useMultipleMongoses": false
       }
     },
     {

--- a/src/test/spec/json/change-streams/unified/change-streams-errors.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-errors.yml
@@ -5,6 +5,7 @@ createEntities:
       id: &client0 client0
       observeEvents: [ commandStartedEvent ]
       ignoreCommandMonitoringEvents: [ killCursors ]
+      useMultipleMongoses: false
   - client:
       id: &globalClient globalClient
       useMultipleMongoses: false

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.json
@@ -10,7 +10,8 @@
         ],
         "ignoreCommandMonitoringEvents": [
           "killCursors"
-        ]
+        ],
+        "useMultipleMongoses": false
       }
     },
     {

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.yml
@@ -5,6 +5,7 @@ createEntities:
       id: &client0 client0
       observeEvents: [ commandStartedEvent ]
       ignoreCommandMonitoringEvents: [ killCursors ]
+      useMultipleMongoses: false
   - client:
       id: &globalClient globalClient
       useMultipleMongoses: false

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.json
@@ -10,7 +10,8 @@
         ],
         "ignoreCommandMonitoringEvents": [
           "killCursors"
-        ]
+        ],
+        "useMultipleMongoses": false
       }
     },
     {

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.yml
@@ -5,6 +5,7 @@ createEntities:
       id: &client0 client0
       observeEvents: [ commandStartedEvent ]
       ignoreCommandMonitoringEvents: [ killCursors ]
+      useMultipleMongoses: false
   - client:
       id: &globalClient globalClient
       useMultipleMongoses: false

--- a/src/test/spec/json/change-streams/unified/change-streams.json
+++ b/src/test/spec/json/change-streams/unified/change-streams.json
@@ -10,7 +10,8 @@
         ],
         "ignoreCommandMonitoringEvents": [
           "killCursors"
-        ]
+        ],
+        "useMultipleMongoses": false
       }
     },
     {

--- a/src/test/spec/json/change-streams/unified/change-streams.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams.yml
@@ -5,6 +5,7 @@ createEntities:
       id: &client0 client0
       observeEvents: [ commandStartedEvent ]
       ignoreCommandMonitoringEvents: [ killCursors ]
+      useMultipleMongoses: false
   - client:
       id: &globalClient globalClient
       useMultipleMongoses: false

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -201,8 +201,10 @@ pub async fn run_unified_format_test_filtered(
                             }
                         }
                         Expectation::Error(expect_error) => {
-                            let error = result
-                                .expect_err(&format!("{} should return an error", operation.name));
+                            let error = result.expect_err(&format!(
+                                "{}: {} should return an error",
+                                test_case.description, operation.name
+                            ));
                             expect_error.verify_result(error);
                         }
                         Expectation::Ignore => (),


### PR DESCRIPTION
The tests need to set `useMultipleMongoses: false` for both clients to avoid being vulnerable to race conditions and topological flakiness.

Also updated the test runner to output the description of the test when an expected error isn't found.