### PR TITLE
RUST-1163 Fix load balancer auth tests

### DIFF
--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -316,17 +316,15 @@ async fn auth_test_options(
     mechanism: Option<AuthMechanism>,
     success: bool,
 ) {
-    let mut options = ClientOptions::builder()
-        .hosts(CLIENT_OPTIONS.hosts.clone())
-        .max_pool_size(1)
-        .credential(Credential {
-            username: Some(user.to_string()),
-            password: Some(password.to_string()),
-            mechanism,
-            ..Default::default()
-        })
-        .build();
-    options.tls = CLIENT_OPTIONS.tls.clone();
+    let mut options = CLIENT_OPTIONS.clone();
+    options.max_pool_size = Some(1);
+    options.credential = Credential {
+        username: Some(user.to_string()),
+        password: Some(password.to_string()),
+        mechanism,
+        ..Default::default()
+    }
+    .into();
 
     auth_test(Client::with_options(options).unwrap(), success).await;
 }
@@ -385,6 +383,10 @@ async fn auth_test_uri(
                 .to_string(),
             );
         }
+    }
+
+    if let Some(true) = CLIENT_OPTIONS.load_balanced {
+        uri.push_str(("&loadBalanced=true"));
     }
 
     auth_test(

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -386,7 +386,7 @@ async fn auth_test_uri(
     }
 
     if let Some(true) = CLIENT_OPTIONS.load_balanced {
-        uri.push_str(("&loadBalanced=true"));
+        uri.push_str("&loadBalanced=true");
     }
 
     auth_test(


### PR DESCRIPTION
RUST-1163 (kinda)

In DRIVERS-1983, the auth configs in drivers-evergreen-tools were fixed to actually enable auth, exposing a few LB failures in our runner. This PR fixes those tests by ensuring the `loadBalanced=true` option is always respected.