### PR TITLE
minor: revert changes to documentation example comments

### DIFF
--- a/src/test/documentation_examples/mod.rs
+++ b/src/test/documentation_examples/mod.rs
@@ -1392,14 +1392,14 @@ async fn stable_api_examples() -> GenericResult<()> {
     }
 
     let uri = DEFAULT_URI.clone();
-    // Start Stable API Example 1
+    // Start Versioned API Example 1
     let mut options = ClientOptions::parse(&uri).await?;
     let server_api = ServerApi::builder().version(ServerApiVersion::V1).build();
     options.server_api = Some(server_api);
     let client = Client::with_options(options)?;
-    // End Stable API Example 1
+    // End Versioned API Example 1
 
-    // Start Stable API Example 2
+    // Start Versioned API Example 2
     let mut options = ClientOptions::parse(&uri).await?;
     let server_api = ServerApi::builder()
         .version(ServerApiVersion::V1)
@@ -1407,9 +1407,9 @@ async fn stable_api_examples() -> GenericResult<()> {
         .build();
     options.server_api = Some(server_api);
     let client = Client::with_options(options)?;
-    // End Stable API Example 2
+    // End Versioned API Example 2
 
-    // Start Stable API Example 3
+    // Start Versioned API Example 3
     let mut options = ClientOptions::parse(&uri).await?;
     let server_api = ServerApi::builder()
         .version(ServerApiVersion::V1)
@@ -1417,9 +1417,9 @@ async fn stable_api_examples() -> GenericResult<()> {
         .build();
     options.server_api = Some(server_api);
     let client = Client::with_options(options)?;
-    // End Stable API Example 3
+    // End Versioned API Example 3
 
-    // Start Stable API Example 4
+    // Start Versioned API Example 4
     let mut options = ClientOptions::parse(&uri).await?;
     let server_api = ServerApi::builder()
         .version(ServerApiVersion::V1)
@@ -1427,7 +1427,7 @@ async fn stable_api_examples() -> GenericResult<()> {
         .build();
     options.server_api = Some(server_api);
     let client = Client::with_options(options)?;
-    // End Stable API Example 4
+    // End Versioned API Example 4
 
     let mut options = ClientOptions::parse(&uri).await?;
     let server_api = ServerApi::builder()
@@ -1441,7 +1441,7 @@ async fn stable_api_examples() -> GenericResult<()> {
 
     use std::{error::Error, result::Result};
 
-    // Start Stable API Example 5
+    // Start Versioned API Example 5
     // With the `bson-chrono-0_4` feature enabled, this function can be dropped in favor of using
     // `chrono::DateTime` values directly.
     fn iso_date(text: &str) -> Result<bson::DateTime, Box<dyn Error>> {
@@ -1458,9 +1458,9 @@ async fn stable_api_examples() -> GenericResult<()> {
         doc! { "_id" : 7, "item" : "xyz", "price" : 5, "quantity" : 10, "date" : iso_date("2021-02-15T14:12:12Z")? },
         doc! { "_id" : 8, "item" : "abc", "price" : 10, "quantity" : 5, "date" : iso_date("2021-03-16T20:20:13Z")? }
     ], None).await?;
-    // End Stable API Example 5
+    // End Versioned API Example 5
 
-    // Start Stable API Example 6
+    // Start Versioned API Example 6
     let result = db
         .run_command(
             doc! {
@@ -1480,7 +1480,7 @@ async fn stable_api_examples() -> GenericResult<()> {
         //     },
         // )
     }
-    // End Stable API Example 6
+    // End Versioned API Example 6
     if let ErrorKind::Command(ref err) = *result.as_ref().unwrap_err().kind {
         assert_eq!(err.code, 323);
         assert_eq!(err.code_name, "APIStrictError".to_string());
@@ -1488,16 +1488,16 @@ async fn stable_api_examples() -> GenericResult<()> {
         panic!("invalid result {:?}", result);
     };
 
-    // Start Stable API Example 7
+    // Start Versioned API Example 7
     let count = db
         .collection::<Document>("sales")
         .count_documents(None, None)
         .await?;
-    // End Stable API Example 7
+    // End Versioned API Example 7
 
-    // Start Stable API Example 8
+    // Start Versioned API Example 8
     assert_eq!(count, 8);
-    // End Stable API Example 8
+    // End Versioned API Example 8
 
     Ok(())
 }


### PR DESCRIPTION
Someone on the docs team reached out to let me know that they're still relying upon the stable API examples to be delineated with "Start Versioned API Example...", so this PR reverts the changes made to those comments in #585.