### PR TITLE
RUST-1124 Pin version of clippy used in CI

### DIFF
--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -3,6 +3,8 @@
 set -o errexit
 
 . ~/.cargo/env
+# Pin clippy to the lastest version. This should be updated when new versions of Rust are released.
+rustup default 1.59.0
 cargo clippy --all-targets -p mongodb -- -D warnings
 # check clippy with compressors separately
 cargo clippy --all-targets -p mongodb --features zstd-compression,snappy-compression,zlib-compression -- -D warnings

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -24,6 +24,9 @@ source ~/.cargo/env
 # Install nightly rustfmt
 rustup toolchain install nightly -c rustfmt
 
+# Pin clippy version to the latest Rust version. This should be updated with each new Rust release.
+rustup toolchain install 1.59.0 -c clippy
+
 # Install tool for converting cargo test output to junit
 cargo install cargo2junit
 

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -24,9 +24,6 @@ source ~/.cargo/env
 # Install nightly rustfmt
 rustup toolchain install nightly -c rustfmt
 
-# Pin clippy version to the latest Rust version. This should be updated with each new Rust release.
-rustup toolchain install 1.59.0 -c clippy
-
 # Install tool for converting cargo test output to junit
 cargo install cargo2junit
 

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -33,7 +33,7 @@ impl ResumeToken {
             Some(token) if spec.initial_buffer.is_empty() => Some(token.clone()),
             // Token from options passed to `watch`
             _ => options
-                .and_then(|o| o.start_after.as_ref().or_else(|| o.resume_after.as_ref()))
+                .and_then(|o| o.start_after.as_ref().or(o.resume_after.as_ref()))
                 .cloned(),
         }
     }

--- a/src/operation/aggregate/change_stream.rs
+++ b/src/operation/aggregate/change_stream.rs
@@ -61,7 +61,7 @@ impl Operation for ChangeStreamAggregate {
                 let saved_time = new_opts
                     .start_at_operation_time
                     .as_ref()
-                    .or_else(|| data.initial_operation_time.as_ref());
+                    .or(data.initial_operation_time.as_ref());
                 if saved_time.is_some() && description.max_wire_version.map_or(false, |v| v >= 7) {
                     new_opts.start_at_operation_time = saved_time.cloned();
                 }

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -343,13 +343,13 @@ async fn basic_matching() {
 
     let actual = doc! { "x": 1 };
     let expected = doc! { "x": 1, "y": 1 };
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Document(actual)),
         &Bson::Document(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -363,13 +363,13 @@ async fn array_matching() {
     for i in 1..3 {
         expected.push(Bson::Int32(i));
     }
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Array(actual)),
         &Bson::Array(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 
     let actual = vec![
         Bson::Document(doc! { "x": 1, "y": 1 }),
@@ -379,13 +379,13 @@ async fn array_matching() {
         Bson::Document(doc! { "x": 1 }),
         Bson::Document(doc! { "x": 2 }),
     ];
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Array(actual)),
         &Bson::Array(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -403,13 +403,13 @@ async fn special_operators() {
 
     let actual = doc! { "x": 1 };
     let expected = doc! { "x": { "$$exists": false } };
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Document(actual)),
         &Bson::Document(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 
     let actual = doc! { "x": 1 };
     let expected = doc! { "y": { "$$exists": false } };
@@ -423,13 +423,13 @@ async fn special_operators() {
 
     let actual = doc! { "x": 1 };
     let expected = doc! { "y": { "$$exists": true } };
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Document(actual)),
         &Bson::Document(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 
     let actual = doc! { "x": 1 };
     let expected = doc! { "x": { "$$type": [ "int", "long" ] } };
@@ -463,13 +463,13 @@ async fn special_operators() {
 
     let actual = doc! { "x": 2 };
     let expected = doc! { "x": { "$$unsetOrMatches": 1 } };
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Document(actual)),
         &Bson::Document(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 
     let expected = doc! { "x": { "y": { "$$exists": false } } };
     let actual = doc! { "x": {} };
@@ -497,13 +497,13 @@ async fn extra_fields() {
 
     let actual = doc! { "doc": { "x": 1, "y": 2 } };
     let expected = doc! { "doc": { "x": 1 } };
-    assert!(!results_match(
+    assert!(results_match(
         Some(&Bson::Document(actual)),
         &Bson::Document(expected),
         false,
         None,
     )
-    .is_ok());
+    .is_err());
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -515,7 +515,7 @@ async fn numbers() {
 
     let actual = Bson::Double(2.5);
     let expected = Bson::Int32(2);
-    assert!(!results_match(Some(&actual), &expected, false, None).is_ok());
+    assert!(results_match(Some(&actual), &expected, false, None).is_err());
 
     let actual = Bson::Double(2.0);
     let expected = Bson::Int64(2);


### PR DESCRIPTION
This PR fixes our existing clippy errors and pins clippy to the latest version (1.59.0).