### PR TITLE
RUST-1210 Expose test failures and compile failures

### DIFF
--- a/.evergreen/run-tokio-tests.sh
+++ b/.evergreen/run-tokio-tests.sh
@@ -14,11 +14,19 @@ FEATURE_FLAGS="zstd-compression,snappy-compression,zlib-compression"
 
 echo "cargo test options: --features $FEATURE_FLAGS ${OPTIONS}"
 
+set +o errexit
+CARGO_RESULT=0
+
 RUST_BACKTRACE=1 cargo test --features $FEATURE_FLAGS $OPTIONS | tee results.json
+(( CARGO_RESULT = CARGO_RESULT || $? ))
 cat results.json | cargo2junit > async-tests.xml
 RUST_BACKTRACE=1 cargo test sync --features tokio-sync,$FEATURE_FLAGS $OPTIONS | tee sync-tests.json
+(( CARGO_RESULT = CARGO_RESULT || $? ))
 cat sync-tests.json | cargo2junit > sync-tests.xml
 RUST_BACKTRACE=1 cargo test --doc sync --features tokio-sync,$FEATURE_FLAGS $OPTIONS | tee sync-doc-tests.json
+(( CARGO_RESULT = CARGO_RESULT || $? ))
 cat sync-doc-tests.json | cargo2junit > sync-doc-tests.xml
 
 junit-report-merger results.xml async-tests.xml sync-tests.xml sync-doc-tests.xml
+
+exit $CARGO_RESULT


### PR DESCRIPTION
RUST-1210

Because bash treats ``false || true`` to be a success by default, test scripts with ``cargo test ... | tee ...`` would mask any test or compile failures.  Setting `pipefail` fixes that, but in turn meant that test failures would immediately exit the script because of ``errexit``, preventing the generated reports from being converted and merged.  This PR fixes *that* by unsetting ``errexit`` for that portion of the script and keeping a "running or" of the ``cargo test`` exit statuses.