### PR TITLE
RUST-1102 Run sync tests with `#[test]` attribute

### DIFF
--- a/src/bson_util/mod.rs
+++ b/src/bson_util/mod.rs
@@ -217,9 +217,8 @@ pub(crate) fn read_document_bytes<R: Read>(mut reader: R) -> Result<Vec<u8>> {
 mod test {
     use crate::bson_util::num_decimal_digits;
 
-    #[cfg_attr(feature = "tokio-runtime", tokio::test)]
-    #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-    async fn num_digits() {
+    #[test]
+    fn num_digits() {
         assert_eq!(num_decimal_digits(0), 1);
         assert_eq!(num_decimal_digits(1), 1);
         assert_eq!(num_decimal_digits(10), 2);

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -721,9 +721,8 @@ mod tests {
 
     use super::ServerFirst;
 
-    #[cfg_attr(feature = "tokio-runtime", tokio::test)]
-    #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-    async fn test_iteration_count() {
+    #[test]
+    fn test_iteration_count() {
         let nonce = "mocked";
 
         let invalid_iteration_count = ServerFirst {

--- a/src/client/auth/test.rs
+++ b/src/client/auth/test.rs
@@ -11,9 +11,8 @@ lazy_static! {
     ];
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn negotiate_both_scram() {
+#[test]
+fn negotiate_both_scram() {
     let description_both = StreamDescription {
         sasl_supported_mechs: Some(MECHS.to_vec()),
         ..Default::default()
@@ -24,9 +23,8 @@ async fn negotiate_both_scram() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn negotiate_sha1_only() {
+#[test]
+fn negotiate_sha1_only() {
     let description_sha1 = StreamDescription {
         sasl_supported_mechs: Some(MECHS[0..=0].to_vec()),
         ..Default::default()
@@ -37,9 +35,8 @@ async fn negotiate_sha1_only() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn negotiate_sha256_only() {
+#[test]
+fn negotiate_sha256_only() {
     let description_sha256 = StreamDescription {
         sasl_supported_mechs: Some(MECHS[1..=1].to_vec()),
         ..Default::default()
@@ -50,9 +47,8 @@ async fn negotiate_sha256_only() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn negotiate_none() {
+#[test]
+fn negotiate_none() {
     let description_none: StreamDescription = Default::default();
     assert_eq!(
         AuthMechanism::from_stream_description(&description_none),
@@ -60,9 +56,8 @@ async fn negotiate_none() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn negotiate_mangled() {
+#[test]
+fn negotiate_mangled() {
     let description_mangled = StreamDescription {
         sasl_supported_mechs: Some(["NOT A MECHANISM".to_string(), "OTHER".to_string()].to_vec()),
         ..Default::default()
@@ -89,16 +84,14 @@ fn scram_sasl_first_options(mechanism: AuthMechanism) {
     }
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn sasl_first_options_specified() {
+#[test]
+fn sasl_first_options_specified() {
     scram_sasl_first_options(AuthMechanism::ScramSha1);
     scram_sasl_first_options(AuthMechanism::ScramSha256);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn sasl_first_options_not_specified() {
+#[test]
+fn sasl_first_options_not_specified() {
     let sasl_first = SaslStart::new(String::new(), AuthMechanism::MongoDbX509, Vec::new(), None);
     let command = sasl_first.into_command();
     assert!(

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2336,10 +2336,6 @@ mod tests {
 
     #[cfg_attr(feature = "tokio-runtime", tokio::test)]
     #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-    async fn with_invalid_read_preference_mode() {}
-
-    #[cfg_attr(feature = "tokio-runtime", tokio::test)]
-    #[cfg_attr(feature = "async-std-runtime", async_std::test)]
     async fn with_mixed_options() {
         let uri = "mongodb://localhost,localhost:27018/?w=majority&readConcernLevel=majority&\
                    journal=false&wtimeoutMS=27&replicaSet=foo&heartbeatFrequencyMS=1000&\

--- a/src/operation/aggregate/test.rs
+++ b/src/operation/aggregate/test.rs
@@ -40,9 +40,8 @@ fn build_test(
     assert_eq!(cmd_doc, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -74,9 +73,8 @@ async fn build() {
     build_test(ns, pipeline, Some(options), expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_batch_size() {
+#[test]
+fn build_batch_size() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -128,9 +126,8 @@ async fn build_batch_size() {
     build_test(ns, merge_pipeline, Some(batch_size_options), expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_target() {
+#[test]
+fn build_target() {
     let pipeline = Vec::new();
 
     let ns = Namespace {
@@ -155,9 +152,8 @@ async fn build_target() {
     build_test(ns.db, pipeline, None, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_max_await_time() {
+#[test]
+fn build_max_await_time() {
     let options = AggregateOptions::builder()
         .max_await_time(Duration::from_millis(5))
         .max_time(Duration::from_millis(10))
@@ -174,9 +170,8 @@ async fn build_max_await_time() {
     build_test("test_db".to_string(), Vec::new(), Some(options), body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     test::op_selection_criteria(|selection_criteria| {
         let options = AggregateOptions {
             selection_criteria,
@@ -186,9 +181,8 @@ async fn op_selection_criteria() {
     });
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_max_await_time() {
+#[test]
+fn handle_max_await_time() {
     let response = doc! {
         "ok": 1,
         "cursor": {
@@ -211,9 +205,8 @@ async fn handle_max_await_time() {
     assert_eq!(spec.max_time(), Some(max_await));
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_concern_error() {
+#[test]
+fn handle_write_concern_error() {
     let response = doc! {
         "ok": 1.0,
         "cursor": {
@@ -244,9 +237,8 @@ async fn handle_write_concern_error() {
     }
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_invalid_response() {
+#[test]
+fn handle_invalid_response() {
     let aggregate = Aggregate::empty();
 
     let garbled = doc! { "asdfasf": "ASdfasdf" };

--- a/src/operation/count/test.rs
+++ b/src/operation/count/test.rs
@@ -15,9 +15,8 @@ use crate::{
     options::ReadConcernLevel,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -35,9 +34,8 @@ async fn build() {
     assert_eq!(count_command.target_db, "test_db");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_options() {
+#[test]
+fn build_with_options() {
     let read_concern: ReadConcern = ReadConcernLevel::Local.into();
     let max_time = Duration::from_millis(2_u64);
     let options: EstimatedDocumentCountOptions = EstimatedDocumentCountOptions::builder()
@@ -71,9 +69,8 @@ async fn build_with_options() {
     assert_eq!(cmd_doc, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     test::op_selection_criteria(|selection_criteria| {
         let options = EstimatedDocumentCountOptions {
             selection_criteria,
@@ -83,9 +80,8 @@ async fn op_selection_criteria() {
     });
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let count_op = Count::empty();
 
     let n = 26;
@@ -95,9 +91,8 @@ async fn handle_success() {
     assert_eq!(actual_values, n);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success_agg() {
+#[test]
+fn handle_success_agg() {
     let count_op = Count::empty();
 
     let n = 26;
@@ -116,9 +111,8 @@ async fn handle_success_agg() {
     assert_eq!(actual_values, n);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_response_no_n() {
+#[test]
+fn handle_response_no_n() {
     let count_op = Count::empty();
     handle_response_test(&count_op, doc! { "ok": 1.0 }).unwrap_err();
 }

--- a/src/operation/count_documents/test.rs
+++ b/src/operation/count_documents/test.rs
@@ -13,9 +13,8 @@ use crate::{
 
 use super::CountDocuments;
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -41,9 +40,8 @@ async fn build() {
     assert_eq!(count_command.target_db, "test_db");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_options() {
+#[test]
+fn build_with_options() {
     let skip = 2;
     let limit = 5;
     let options = CountOptions::builder()
@@ -84,9 +82,8 @@ async fn build_with_options() {
     assert_eq!(cmd_doc, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     test::op_selection_criteria(|selection_criteria| {
         let options = CountOptions {
             selection_criteria,
@@ -96,9 +93,8 @@ async fn op_selection_criteria() {
     });
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),

--- a/src/operation/create/test.rs
+++ b/src/operation/create/test.rs
@@ -8,9 +8,8 @@ use crate::{
     Namespace,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let mut op = Create::new(
         Namespace {
             db: "test_db".to_string(),
@@ -43,9 +42,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_validator() {
+#[test]
+fn build_validator() {
     let query = doc! { "x": { "$gt": 1 } };
     let mut op = Create::new(
         Namespace {
@@ -72,16 +70,14 @@ async fn build_validator() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = Create::empty();
     handle_response_test(&op, doc! { "ok": 1.0 }).unwrap();
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_concern_error() {
+#[test]
+fn handle_write_concern_error() {
     let op = Create::empty();
 
     let response = doc! {

--- a/src/operation/create_indexes/test.rs
+++ b/src/operation/create_indexes/test.rs
@@ -13,9 +13,8 @@ use crate::{
     results::CreateIndexesResult,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -54,9 +53,8 @@ async fn build() {
     )
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let a = IndexModel::builder()
         .keys(doc! { "a": 1 })
         .options(Some(

--- a/src/operation/delete/test.rs
+++ b/src/operation/delete/test.rs
@@ -11,9 +11,8 @@ use crate::{
     Namespace,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_many() {
+#[test]
+fn build_many() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -54,9 +53,8 @@ async fn build_many() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_one() {
+#[test]
+fn build_one() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -97,9 +95,8 @@ async fn build_one() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = Delete::empty();
 
     let delete_result = handle_response_test(
@@ -113,9 +110,8 @@ async fn handle_success() {
     assert_eq!(delete_result.deleted_count, 3);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_invalid_response() {
+#[test]
+fn handle_invalid_response() {
     let op = Delete::empty();
     handle_response_test(
         &op,
@@ -127,9 +123,8 @@ async fn handle_invalid_response() {
     .expect_err("should fail");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_failure() {
+#[test]
+fn handle_write_failure() {
     let op = Delete::empty();
 
     let write_error_response = doc! {
@@ -158,9 +153,8 @@ async fn handle_write_failure() {
     };
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_concern_failure() {
+#[test]
+fn handle_write_concern_failure() {
     let op = Delete::empty();
 
     let wc_error_response = doc! {

--- a/src/operation/distinct/test.rs
+++ b/src/operation/distinct/test.rs
@@ -12,9 +12,8 @@ use crate::{
     },
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let field_name = "field_name".to_string();
     let ns = Namespace {
         db: "test_db".to_string(),
@@ -34,9 +33,8 @@ async fn build() {
     assert_eq!(distinct_command.target_db, "test_db");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_query() {
+#[test]
+fn build_with_query() {
     let field_name = "field_name".to_string();
     let query = doc! {"something" : "something else"};
     let ns = Namespace {
@@ -58,9 +56,8 @@ async fn build_with_query() {
     assert_eq!(distinct_command.target_db, "test_db");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_options() {
+#[test]
+fn build_with_options() {
     let field_name = "field_name".to_string();
     let max_time = Duration::new(2_u64, 0);
     let options: DistinctOptions = DistinctOptions::builder().max_time(max_time).build();
@@ -84,9 +81,8 @@ async fn build_with_options() {
     assert_eq!(distinct_command.target_db, "test_db");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     test::op_selection_criteria(|selection_criteria| {
         let options = DistinctOptions {
             selection_criteria,
@@ -96,9 +92,8 @@ async fn op_selection_criteria() {
     });
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let distinct_op = Distinct::empty();
 
     let expected_values: Vec<Bson> =
@@ -113,9 +108,8 @@ async fn handle_success() {
     assert_eq!(actual_values, expected_values);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_response_with_empty_values() {
+#[test]
+fn handle_response_with_empty_values() {
     let distinct_op = Distinct::empty();
 
     let response = doc! {
@@ -128,9 +122,8 @@ async fn handle_response_with_empty_values() {
     assert_eq!(actual_values, expected_values);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_response_no_values() {
+#[test]
+fn handle_response_no_values() {
     let distinct_op = Distinct::empty();
 
     let response = doc! {

--- a/src/operation/drop_collection/test.rs
+++ b/src/operation/drop_collection/test.rs
@@ -8,9 +8,8 @@ use crate::{
     Namespace,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let options = DropCollectionOptions {
         write_concern: Some(WriteConcern {
             w: Some(Acknowledgment::Custom("abc".to_string())),
@@ -50,9 +49,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = DropCollection::empty();
 
     let ok_response = doc! { "ok": 1.0 };
@@ -61,9 +59,8 @@ async fn handle_success() {
     handle_response_test(&op, ok_extra).unwrap();
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_concern_error() {
+#[test]
+fn handle_write_concern_error() {
     let op = DropCollection::empty();
 
     let response = doc! {

--- a/src/operation/drop_database/test.rs
+++ b/src/operation/drop_database/test.rs
@@ -7,9 +7,8 @@ use crate::{
     options::DropDatabaseOptions,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let mut op = DropDatabase {
         target_db: "test_db".to_string(),
         options: Some(DropDatabaseOptions {
@@ -48,9 +47,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = DropDatabase::empty();
 
     let ok_response = doc! { "ok": 1.0 };
@@ -59,9 +57,8 @@ async fn handle_success() {
     handle_response_test(&op, ok_extra).unwrap();
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_concern_error() {
+#[test]
+fn handle_write_concern_error() {
     let op = DropDatabase::empty();
 
     let response = doc! {

--- a/src/operation/drop_indexes/test.rs
+++ b/src/operation/drop_indexes/test.rs
@@ -8,9 +8,8 @@ use crate::{
     operation::{test::handle_response_test, DropIndexes, Operation},
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -36,9 +35,8 @@ async fn build() {
     )
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = DropIndexes::empty();
     let response = doc! { "ok": 1 };
     handle_response_test(&op, response).unwrap();

--- a/src/operation/find/test.rs
+++ b/src/operation/find/test.rs
@@ -35,9 +35,8 @@ fn build_test(
     assert_eq!(cmd_doc, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -75,9 +74,8 @@ async fn build() {
     build_test(ns, Some(filter), Some(options), expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_cursor_type() {
+#[test]
+fn build_cursor_type() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -125,9 +123,8 @@ async fn build_cursor_type() {
     build_test(ns, None, Some(tailable_await_options), tailable_await_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_max_await_time() {
+#[test]
+fn build_max_await_time() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -147,9 +144,8 @@ async fn build_max_await_time() {
     build_test(ns, None, Some(options), body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_limit() {
+#[test]
+fn build_limit() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -177,9 +173,8 @@ async fn build_limit() {
     build_test(ns, None, Some(negative_options), negative_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_batch_size() {
+#[test]
+fn build_batch_size() {
     let options = FindOptions::builder().batch_size(1).build();
     let body = doc! {
         "find": "",
@@ -195,9 +190,8 @@ async fn build_batch_size() {
     assert!(op.build(&StreamDescription::new_testing()).is_err())
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     test::op_selection_criteria(|selection_criteria| {
         let options = FindOptions {
             selection_criteria,
@@ -234,9 +228,8 @@ fn verify_max_await_time(max_await_time: Option<Duration>, cursor_type: Option<C
     assert_eq!(spec.max_time(), max_await_time);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_max_await_time() {
+#[test]
+fn handle_max_await_time() {
     verify_max_await_time(None, None);
     verify_max_await_time(Some(Duration::from_millis(5)), None);
     verify_max_await_time(
@@ -250,9 +243,8 @@ async fn handle_max_await_time() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_invalid_response() {
+#[test]
+fn handle_invalid_response() {
     let find = Find::empty();
 
     let garbled = doc! { "asdfasf": "ASdfasdf" };

--- a/src/operation/find_and_modify/test.rs
+++ b/src/operation/find_and_modify/test.rs
@@ -27,9 +27,8 @@ fn empty_delete() -> FindAndModify {
     FindAndModify::with_delete(ns, filter, None)
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_delete_hint() {
+#[test]
+fn build_with_delete_hint() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -68,9 +67,8 @@ async fn build_with_delete_hint() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_delete_no_options() {
+#[test]
+fn build_with_delete_no_options() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -97,9 +95,8 @@ async fn build_with_delete_no_options() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_delete() {
+#[test]
+fn build_with_delete() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -132,9 +129,8 @@ async fn build_with_delete() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success_delete() {
+#[test]
+fn handle_success_delete() {
     let op = empty_delete();
     let value = doc! {
         "_id" : Bson::ObjectId(ObjectId::new()),
@@ -161,18 +157,16 @@ async fn handle_success_delete() {
     assert_eq!(result.unwrap(), value);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_null_value_delete() {
+#[test]
+fn handle_null_value_delete() {
     let op = empty_delete();
 
     let result = handle_response_test(&op, doc! { "ok": 1.0, "value": Bson::Null }).unwrap();
     assert_eq!(result, None);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_no_value_delete() {
+#[test]
+fn handle_no_value_delete() {
     let op = empty_delete();
 
     handle_response_test(&op, doc! { "ok": 1.0 }).unwrap_err();
@@ -190,9 +184,8 @@ fn empty_replace() -> FindAndModify {
     FindAndModify::with_replace(ns, filter, replacement, None).unwrap()
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_replace_hint() {
+#[test]
+fn build_with_replace_hint() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -240,9 +233,8 @@ async fn build_with_replace_hint() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_replace_no_options() {
+#[test]
+fn build_with_replace_no_options() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -272,9 +264,8 @@ async fn build_with_replace_no_options() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_replace() {
+#[test]
+fn build_with_replace() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -317,9 +308,8 @@ async fn build_with_replace() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success_replace() {
+#[test]
+fn handle_success_replace() {
     let op = empty_replace();
     let value = doc! {
         "_id" : Bson::ObjectId(ObjectId::new()),
@@ -346,17 +336,15 @@ async fn handle_success_replace() {
     assert_eq!(result.unwrap(), value);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_null_value_replace() {
+#[test]
+fn handle_null_value_replace() {
     let op = empty_replace();
     let result = handle_response_test(&op, doc! { "ok": 1.0, "value": Bson::Null }).unwrap();
     assert_eq!(result, None);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_no_value_replace() {
+#[test]
+fn handle_no_value_replace() {
     let op = empty_replace();
     handle_response_test(&op, doc! { "ok": 1.0 }).unwrap_err();
 }
@@ -373,9 +361,8 @@ fn empty_update() -> FindAndModify {
     FindAndModify::with_update(ns, filter, update, None).unwrap()
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_update_hint() {
+#[test]
+fn build_with_update_hint() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -417,9 +404,8 @@ async fn build_with_update_hint() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_update_no_options() {
+#[test]
+fn build_with_update_no_options() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -447,9 +433,8 @@ async fn build_with_update_no_options() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_update() {
+#[test]
+fn build_with_update() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -486,9 +471,8 @@ async fn build_with_update() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success_update() {
+#[test]
+fn handle_success_update() {
     let op = empty_update();
     let value = doc! {
         "_id" : Bson::ObjectId(ObjectId::new()),
@@ -515,17 +499,15 @@ async fn handle_success_update() {
     assert_eq!(result.unwrap(), value);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_null_value_update() {
+#[test]
+fn handle_null_value_update() {
     let op = empty_update();
     let result = handle_response_test(&op, doc! { "ok": 1.0, "value": Bson::Null }).unwrap();
     assert_eq!(result, None);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_no_value_update() {
+#[test]
+fn handle_no_value_update() {
     let op = empty_update();
     handle_response_test(&op, doc! { "ok": 1.0 }).unwrap_err();
 }

--- a/src/operation/get_more/test.rs
+++ b/src/operation/get_more/test.rs
@@ -40,9 +40,8 @@ fn build_test(
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -72,9 +71,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_batch_size() {
+#[test]
+fn build_batch_size() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -121,9 +119,8 @@ async fn build_batch_size() {
     assert!(op.build(&StreamDescription::new_testing()).is_err())
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     let address = ServerAddress::Tcp {
         host: "myhost.com".to_string(),
         port: Some(1234),

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -58,9 +58,8 @@ fn fixtures(opts: Option<InsertManyOptions>) -> TestFixtures {
     }
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let mut fixtures = fixtures(None);
 
     let description = StreamDescription::new_testing();
@@ -114,9 +113,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_ordered() {
+#[test]
+fn build_ordered() {
     let docs = vec![Document::new()];
     let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None);
     let cmd = insert
@@ -168,9 +166,8 @@ struct Documents<D> {
     documents: Vec<D>,
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn generate_ids() {
+#[test]
+fn generate_ids() {
     let docs = vec![doc! { "x": 1 }, doc! { "_id": 1_i32, "x": 2 }];
 
     let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None);
@@ -201,9 +198,8 @@ async fn generate_ids() {
     assert_eq!(docs.documents[0].iter().next().unwrap().0, "_id")
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn serialize_all_types() {
+#[test]
+fn serialize_all_types() {
     let binary = Binary {
         bytes: vec![36, 36, 36],
         subtype: BinarySubtype::Generic,
@@ -265,9 +261,8 @@ async fn serialize_all_types() {
     assert_eq!(cmd.documents, docs);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let mut fixtures = fixtures(None);
 
     // populate _id for documents that don't provide it
@@ -284,16 +279,14 @@ async fn handle_success() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_invalid_response() {
+#[test]
+fn handle_invalid_response() {
     let fixtures = fixtures(None);
     handle_response_test(&fixtures.op, doc! { "ok": 1.0, "asdfadsf": 123123 }).unwrap_err();
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_failure() {
+#[test]
+fn handle_write_failure() {
     let mut fixtures = fixtures(None);
 
     // generate _id for operations missing it.

--- a/src/operation/list_collections/test.rs
+++ b/src/operation/list_collections/test.rs
@@ -19,9 +19,8 @@ fn build_test(db_name: &str, mut list_collections: ListCollections, mut expected
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let list_collections = ListCollections::new("test_db".to_string(), None, false, None);
     let expected_body = doc! {
         "listCollections": 1,
@@ -40,9 +39,8 @@ async fn build() {
     build_test("test_db", list_collections, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_name_only() {
+#[test]
+fn build_name_only() {
     let list_collections = ListCollections::new("test_db".to_string(), None, true, None);
     build_test(
         "test_db",
@@ -92,9 +90,8 @@ async fn build_name_only() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_batch_size() {
+#[test]
+fn build_batch_size() {
     let list_collections = ListCollections::new("test_db".to_string(), None, true, None);
     build_test(
         "test_db",
@@ -120,18 +117,16 @@ async fn build_batch_size() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     assert!(ListCollections::empty()
         .selection_criteria()
         .expect("should have criteria")
         .is_read_pref_primary());
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_invalid_response() {
+#[test]
+fn handle_invalid_response() {
     let list_collections = ListCollections::empty();
 
     let garbled = doc! { "asdfasf": "ASdfasdf" };

--- a/src/operation/list_databases/test.rs
+++ b/src/operation/list_databases/test.rs
@@ -9,9 +9,8 @@ use crate::{
     selection_criteria::ReadPreference,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let mut list_databases_op = ListDatabases::empty();
     let list_databases_command = list_databases_op
         .build(&StreamDescription::new_testing())
@@ -26,9 +25,8 @@ async fn build() {
     assert_eq!(list_databases_command.target_db, "admin");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_name_only() {
+#[test]
+fn build_with_name_only() {
     let name_only = true;
 
     let mut list_databases_op = ListDatabases::new(None, name_only, None);
@@ -46,9 +44,8 @@ async fn build_with_name_only() {
     assert_eq!(list_databases_command.target_db, "admin");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_filter() {
+#[test]
+fn build_with_filter() {
     let filter = doc! {"something" : "something else"};
 
     let mut list_databases_op = ListDatabases::new(Some(filter.clone()), false, None);
@@ -66,9 +63,8 @@ async fn build_with_filter() {
     assert_eq!(list_databases_command.target_db, "admin");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_with_options() {
+#[test]
+fn build_with_options() {
     let options = ListDatabasesOptions::builder()
         .authorized_databases(true)
         .build();
@@ -88,9 +84,8 @@ async fn build_with_options() {
     assert_eq!(list_databases_command.target_db, "admin");
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let total_size = 251658240;
 
     let databases = vec![
@@ -129,9 +124,8 @@ async fn handle_success() {
     assert_eq!(actual_values, raw_databases);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_response_no_databases() {
+#[test]
+fn handle_response_no_databases() {
     let result = handle_response_test(&ListDatabases::empty(), doc! { "ok": 1 });
     match result.map_err(|e| *e.kind) {
         Err(ErrorKind::InvalidResponse { .. }) => {}
@@ -139,9 +133,8 @@ async fn handle_response_no_databases() {
     }
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn op_selection_criteria() {
+#[test]
+fn op_selection_criteria() {
     let list_databases_op = ListDatabases::empty();
     assert_eq!(
         *list_databases_op

--- a/src/operation/list_indexes/test.rs
+++ b/src/operation/list_indexes/test.rs
@@ -10,9 +10,8 @@ use crate::{
     Namespace,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -40,9 +39,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = ListIndexes::empty();
 
     let first_batch = vec![

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -7,9 +7,8 @@ use crate::{
     operation::{test::handle_response_test, Operation},
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let mut op = RunCommand::new("foo".into(), doc! { "isMaster": 1 }, None, None).unwrap();
     assert!(op.selection_criteria().is_none());
 
@@ -26,9 +25,8 @@ async fn build() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = RunCommand::new("foo".into(), doc! { "hello": 1 }, None, None).unwrap();
 
     let doc = doc! {

--- a/src/operation/test.rs
+++ b/src/operation/test.rs
@@ -40,9 +40,8 @@ where
     assert_eq!(op.selection_criteria(), Some(&read_pref));
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn response_success() {
+#[test]
+fn response_success() {
     let cluster_timestamp = Timestamp {
         time: 123,
         increment: 345,
@@ -99,9 +98,8 @@ async fn response_success() {
     );
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn response_failure() {
+#[test]
+fn response_failure() {
     let cluster_timestamp = Timestamp {
         time: 123,
         increment: 345,

--- a/src/operation/update/test.rs
+++ b/src/operation/update/test.rs
@@ -12,9 +12,8 @@ use crate::{
     Namespace,
 };
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build() {
+#[test]
+fn build() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -62,9 +61,8 @@ async fn build() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_hint() {
+#[test]
+fn build_hint() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -117,9 +115,8 @@ async fn build_hint() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn build_many() {
+#[test]
+fn build_many() {
     let ns = Namespace {
         db: "test_db".to_string(),
         coll: "test_coll".to_string(),
@@ -153,9 +150,8 @@ async fn build_many() {
     assert_eq!(cmd.body, expected_body);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success() {
+#[test]
+fn handle_success() {
     let op = Update::empty();
 
     let ok_response = doc! {
@@ -173,9 +169,8 @@ async fn handle_success() {
     assert_eq!(update_result.upserted_id, Some(Bson::Int32(1)));
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_success_no_upsert() {
+#[test]
+fn handle_success_no_upsert() {
     let op = Update::empty();
 
     let ok_response = doc! {
@@ -190,9 +185,8 @@ async fn handle_success_no_upsert() {
     assert_eq!(update_result.upserted_id, None);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_failure() {
+#[test]
+fn handle_write_failure() {
     let op = Update::empty();
 
     let write_error_response = doc! {
@@ -223,9 +217,8 @@ async fn handle_write_failure() {
     };
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn handle_write_concern_failure() {
+#[test]
+fn handle_write_concern_failure() {
     let op = Update::empty();
 
     let wc_error_response = doc! {

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -328,9 +328,8 @@ fn type_matches(types: &Bson, actual: &Bson) -> Result<(), String> {
     }
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn basic_matching() {
+#[test]
+fn basic_matching() {
     let actual = doc! { "x": 1, "y": 1 };
     let expected = doc! { "x": 1 };
     assert!(results_match(
@@ -352,9 +351,8 @@ async fn basic_matching() {
     .is_err());
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn array_matching() {
+#[test]
+fn array_matching() {
     let mut actual: Vec<Bson> = Vec::new();
     for i in 1..4 {
         actual.push(Bson::Int32(i));
@@ -388,9 +386,8 @@ async fn array_matching() {
     .is_err());
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn special_operators() {
+#[test]
+fn special_operators() {
     let actual = doc! { "x": 1 };
     let expected = doc! { "x": { "$$exists": true } };
     assert!(results_match(
@@ -482,9 +479,8 @@ async fn special_operators() {
     .is_ok());
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn extra_fields() {
+#[test]
+fn extra_fields() {
     let actual = doc! { "x": 1, "y": 2 };
     let expected = doc! { "x": 1 };
     assert!(results_match(
@@ -506,9 +502,8 @@ async fn extra_fields() {
     .is_err());
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn numbers() {
+#[test]
+fn numbers() {
     let actual = Bson::Int32(2);
     let expected = Bson::Int64(2);
     assert!(results_match(Some(&actual), &expected, false, None).is_ok());

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -397,9 +397,8 @@ async fn merged_uri_options() {
     assert_eq!(options.read_concern.unwrap(), read_concern);
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn deserialize_selection_criteria() {
+#[test]
+fn deserialize_selection_criteria() {
     let read_preference = doc! {
         "mode": "SecondaryPreferred",
         "maxStalenessSeconds": 100,
@@ -420,9 +419,8 @@ async fn deserialize_selection_criteria() {
     }
 }
 
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn deserialize_read_concern() {
+#[test]
+fn deserialize_read_concern() {
     let read_concern = doc! {
         "level": "local",
     };


### PR DESCRIPTION
Updates any tests without async code to use `#[test]`.