### PR TITLE
RUST-1154 Fix junit-report-merger install failures

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -33,5 +33,16 @@ cargo install cargo2junit
 source ./.evergreen/env.sh
 
 # Install tool for merging different junit reports into a single one
-npm install -g junit-report-merger
+set +o errexit
+set -o pipefail
 
+npm install -g junit-report-merger --cache $(mktemp -d) 2>&1 | tee npm-install-output
+RESULT=$?
+MATCH=$(grep -o '/\S*-debug.log' npm-install-output)
+if [[ $MATCH != "" ]]; then
+    echo ===== BEGIN NPM LOG =====
+    cat $MATCH
+    echo ===== END NPM LOG =====
+fi
+
+exit $RESULT


### PR DESCRIPTION
RUST-1154

The problem is indeed some sort of cache corruption; the install logs of the fetches that fail are always from cache.  I'm not entirely sure how this happens because as far as I can tell the default cache dir is distinct for a given evergreen run, so there shouldn't be any concurrent access to corrupt it 🤷 .  The fix is to force each installation to use a fresh, unique directory as the cache directory.

I left the debugging code to dump the logfile present because otherwise it's pretty hard to figure out what's going wrong if the install fails, and the logfiles are not easily retrievable post facto.