### PR TITLE
RUST-1202 Sync latest initial DNS seedlist discovery tests

### DIFF
--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -211,9 +211,10 @@ async fn replica_set() {
              requirement ({})",
             skip
         ));
-    } else {
-        run_spec_test(&["initial-dns-seedlist-discovery", "replica-set"], run_test).await;
+        return;
     }
+
+    run_spec_test(&["initial-dns-seedlist-discovery", "replica-set"], run_test).await;
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
@@ -228,7 +229,6 @@ async fn load_balanced() {
         );
         return;
     }
-
     run_spec_test(
         &["initial-dns-seedlist-discovery", "load-balanced"],
         run_test,

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -108,7 +108,7 @@ async fn run_test(mut test_file: TestFile) {
 
     let options = result.unwrap();
 
-    if let Some(mut expected_seeds) = test_file.seeds {
+    if let Some(ref mut expected_seeds) = test_file.seeds {
         let mut actual_seeds = options
             .hosts
             .iter()
@@ -118,7 +118,7 @@ async fn run_test(mut test_file: TestFile) {
         expected_seeds.sort();
         actual_seeds.sort();
 
-        assert_eq!(expected_seeds, actual_seeds,);
+        assert_eq!(*expected_seeds, actual_seeds,);
         if let Some(expected_seed_count) = test_file.num_seeds {
             assert_eq!(actual_seeds.len(), expected_seed_count,)
         }

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -32,6 +32,7 @@ struct ResolvedOptions {
     load_balanced: Option<bool>,
     direct_connection: Option<bool>,
     srv_max_hosts: Option<u32>,
+    srv_service_name: Option<String>,
 }
 
 impl ResolvedOptions {
@@ -57,12 +58,22 @@ struct ParsedOptions {
 }
 
 async fn run_test(mut test_file: TestFile) {
-    // TODO RUST-933: Remove this skip once we support the option.
     if let Some(ref options) = test_file.options {
-        if options.srv_max_hosts.is_some() {
-            log_uncaptured(
-                "skipping test case due to unsupported connection string option srvMaxHosts",
-            );
+        // TODO RUST-933: Remove this skip.
+        let skip = if options.srv_max_hosts.is_some() {
+            Some("srvMaxHosts")
+        // TODO-RUST-911: Remove this skip.
+        } else if options.srv_service_name.is_some() {
+            Some("srvServiceName")
+        } else {
+            None
+        };
+
+        if let Some(skip) = skip {
+            log_uncaptured(format!(
+                "skipping test case due to unsupported connection string option {}",
+                skip,
+            ));
             return;
         }
     }

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -57,7 +57,7 @@ struct ParsedOptions {
 }
 
 async fn run_test(mut test_file: TestFile) {
-    // TODO RUST-933: Remove this skip once we support the optgion.
+    // TODO RUST-933: Remove this skip once we support the option.
     if let Some(ref options) = test_file.options {
         if options.srv_max_hosts.is_some() {
             log_uncaptured(

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -75,7 +75,8 @@ async fn run_test(mut test_file: TestFile) {
 
         if let Some(skip) = skip {
             log_uncaptured(format!(
-                "skipping initial_dns_seedlist_discovery test case due to unsupported connection string option: {}",
+                "skipping initial_dns_seedlist_discovery test case due to unsupported connection \
+                 string option: {}",
                 skip,
             ));
             return;
@@ -131,7 +132,9 @@ async fn run_test(mut test_file: TestFile) {
     };
     let client = TestClient::new().await;
     if requires_tls != client.options.tls_options().is_some() {
-        log_uncaptured("skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch")
+        log_uncaptured(
+            "skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch",
+        )
     } else {
         // If the connection URI provides authentication information, manually create the user
         // before connecting.

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -75,7 +75,7 @@ async fn run_test(mut test_file: TestFile) {
 
         if let Some(skip) = skip {
             log_uncaptured(format!(
-                "skipping test case due to unsupported connection string option {}",
+                "skipping initial_dns_seedlist_discovery test case due to unsupported connection string option: {}",
                 skip,
             ));
             return;
@@ -131,7 +131,7 @@ async fn run_test(mut test_file: TestFile) {
     };
     let client = TestClient::new().await;
     if requires_tls != client.options.tls_options().is_some() {
-        log_uncaptured("skipping test case due to TLS requirement mismatch")
+        log_uncaptured("skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch")
     } else {
         // If the connection URI provides authentication information, manually create the user
         // before connecting.

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -112,7 +112,7 @@ async fn run_test(mut test_file: TestFile) {
     };
     let client = TestClient::new().await;
     if requires_tls != client.options.tls_options().is_some() {
-        log_uncaptured("skipping initial_dns_seedlist_discovery due to TLS requirement mismatch")
+        log_uncaptured("skipping test case due to TLS requirement mismatch")
     } else {
         // If the connection URI provides authentication information, manually create the user
         // before connecting.

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -61,7 +61,7 @@ async fn run_test(mut test_file: TestFile) {
     if let Some(ref options) = test_file.options {
         if options.srv_max_hosts.is_some() {
             log_uncaptured(
-                "skipping test case due to unsupported connection string option srvMaxHosts"
+                "skipping test case due to unsupported connection string option srvMaxHosts",
             );
             return;
         }
@@ -112,9 +112,7 @@ async fn run_test(mut test_file: TestFile) {
     };
     let client = TestClient::new().await;
     if requires_tls != client.options.tls_options().is_some() {
-        log_uncaptured(
-            "skipping initial_dns_seedlist_discovery due to TLS requirement mismatch"
-        )
+        log_uncaptured("skipping initial_dns_seedlist_discovery due to TLS requirement mismatch")
     } else {
         // If the connection URI provides authentication information, manually create the user
         // before connecting.
@@ -199,16 +197,18 @@ async fn run_test(mut test_file: TestFile) {
 async fn replica_set() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
     let client = TestClient::new().await;
-    let skip = if client.is_replica_set() && client.options.repl_set_name.as_deref() != Some("repl0") {
-        Some("repl_set_name != repl0")
-    } else if !client.is_replica_set() {
-        Some("not a replica set")
-    } else {
-        None
-    };
+    let skip =
+        if client.is_replica_set() && client.options.repl_set_name.as_deref() != Some("repl0") {
+            Some("repl_set_name != repl0")
+        } else if !client.is_replica_set() {
+            Some("not a replica set")
+        } else {
+            None
+        };
     if let Some(skip) = skip {
         log_uncaptured(format!(
-            "skipping initial_dns_seedlist_discovery::replica_set due to unmet topology requirement ({})",
+            "skipping initial_dns_seedlist_discovery::replica_set due to unmet topology \
+             requirement ({})",
             skip
         ));
     } else {
@@ -223,7 +223,8 @@ async fn load_balanced() {
     let client = TestClient::new().await;
     if !client.is_load_balanced() {
         log_uncaptured(
-            "skipping initial_dns_seedlist_discovery::load_balanced due to unmet topology requirement (not a load balanced cluster)"
+            "skipping initial_dns_seedlist_discovery::load_balanced due to unmet topology \
+             requirement (not a load balanced cluster)",
         );
         return;
     }

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -118,9 +118,9 @@ async fn run_test(mut test_file: TestFile) {
         expected_seeds.sort();
         actual_seeds.sort();
 
-        assert_eq!(*expected_seeds, actual_seeds,);
+        assert_eq!(*expected_seeds, actual_seeds);
         if let Some(expected_seed_count) = test_file.num_seeds {
-            assert_eq!(actual_seeds.len(), expected_seed_count,)
+            assert_eq!(actual_seeds.len(), expected_seed_count)
         }
     }
 

--- a/src/test/spec/json/initial-dns-seedlist-discovery/README.rst
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/README.rst
@@ -10,11 +10,21 @@ Test Setup
 
 The tests in the ``replica-set`` directory MUST be executed against a
 three-node replica set on localhost ports 27017, 27018, and 27019 with
-replica set name ``repl0``. The tests in ``load-balanced`` MUST be executed
-against a load-balanced sharded cluster with the mongos servers running on
-localhost ports 27017 and 27018 and load balancers, shard servers, and config
-servers running on any open ports. In both cases, the clusters MUST be
-started with SSL enabled.
+replica set name ``repl0``.
+
+The tests in the ``load-balanced`` directory MUST be executed against a
+load-balanced sharded cluster with the mongos servers running on localhost ports
+27017 and 27018 and ``--loadBalancerPort`` 27050 and 27051, respectively
+(corresponding to the script in `drivers-evergreen-tools`_). The load balancers,
+shard servers, and config servers may run on any open ports.
+
+.. _`drivers-evergreen-tools`: https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/run-load-balancer.sh
+
+The tests in the ``sharded`` directory MUST be executed against a sharded
+cluster with the mongos servers running on localhost ports 27017 and 27018.
+Shard servers and config servers may run on any open ports.
+
+In all cases, the clusters MUST be started with SSL enabled.
 
 To run the tests that accompany this spec, you need to configure the SRV and
 TXT records with a real name server. The following records are required for
@@ -24,29 +34,32 @@ these tests::
   localhost.test.build.10gen.cc.            86400  IN A    127.0.0.1
   localhost.sub.test.build.10gen.cc.        86400  IN A    127.0.0.1
 
-  Record                                    TTL    Class   Port   Target
-  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test3.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test5.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test6.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test7.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test8.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test10.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test11.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test12.test.build.10gen.cc. 86400  IN SRV  27017  localhost.build.10gen.cc.
-  _mongodb._tcp.test13.test.build.10gen.cc. 86400  IN SRV  27017  test.build.10gen.cc.
-  _mongodb._tcp.test14.test.build.10gen.cc. 86400  IN SRV  27017  localhost.not-test.build.10gen.cc.
-  _mongodb._tcp.test15.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.not-build.10gen.cc.
-  _mongodb._tcp.test16.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.not-10gen.cc.
-  _mongodb._tcp.test17.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.not-cc.
-  _mongodb._tcp.test18.test.build.10gen.cc. 86400  IN SRV  27017  localhost.sub.test.build.10gen.cc.
-  _mongodb._tcp.test19.test.build.10gen.cc. 86400  IN SRV  27017  localhost.evil.build.10gen.cc.
-  _mongodb._tcp.test19.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test20.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test21.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  Record                                      TTL    Class   Port   Target
+  _mongodb._tcp.test1.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test1.test.build.10gen.cc.    86400  IN SRV  27018  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test2.test.build.10gen.cc.    86400  IN SRV  27018  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test2.test.build.10gen.cc.    86400  IN SRV  27019  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test3.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test5.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test6.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test7.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test8.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test10.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test11.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test12.test.build.10gen.cc.   86400  IN SRV  27017  localhost.build.10gen.cc.
+  _mongodb._tcp.test13.test.build.10gen.cc.   86400  IN SRV  27017  test.build.10gen.cc.
+  _mongodb._tcp.test14.test.build.10gen.cc.   86400  IN SRV  27017  localhost.not-test.build.10gen.cc.
+  _mongodb._tcp.test15.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.not-build.10gen.cc.
+  _mongodb._tcp.test16.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.not-10gen.cc.
+  _mongodb._tcp.test17.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.not-cc.
+  _mongodb._tcp.test18.test.build.10gen.cc.   86400  IN SRV  27017  localhost.sub.test.build.10gen.cc.
+  _mongodb._tcp.test19.test.build.10gen.cc.   86400  IN SRV  27017  localhost.evil.build.10gen.cc.
+  _mongodb._tcp.test19.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test20.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test21.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _customname._tcp.test22.test.build.10gen.cc 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test23.test.build.10gen.cc.   86400  IN SRV  8000   localhost.test.build.10gen.cc.
+  _mongodb._tcp.test24.test.build.10gen.cc.   86400  IN SRV  8000   localhost.test.build.10gen.cc.
 
   Record                                    TTL    Class   Text
   test5.test.build.10gen.cc.                86400  IN TXT  "replicaSet=repl0&authSource=thisDB"
@@ -58,11 +71,18 @@ these tests::
   test11.test.build.10gen.cc.               86400  IN TXT  "replicaS" "et=rep" "l0"
   test20.test.build.10gen.cc.               86400  IN TXT  "loadBalanced=true"
   test21.test.build.10gen.cc.               86400  IN TXT  "loadBalanced=false"
+  test24.test.build.10gen.cc.               86400  IN TXT  "loadBalanced=true"
 
-Note that ``test4`` is omitted deliberately to test what happens with no SRV
-record. ``test9`` is missing because it was deleted during the development of
-the tests. The missing ``test.`` sub-domain in the SRV record target for
-``test12`` is deliberate.
+Notes:
+
+- ``test4`` is omitted deliberately to test what happens with no SRV record.
+- ``test9`` is missing because it was deleted during the development of the
+  tests.
+- The missing ``test.`` sub-domain in the SRV record target for ``test12`` is
+  deliberate.
+- ``test22`` is used to test a custom service name (``customname``).
+- ``test23`` and ``test24`` point to port 8000 (HAProxy) and are used for
+  load-balanced tests.
 
 In our tests we have used ``localhost.test.build.10gen.cc`` as the domain, and
 then configured ``localhost.test.build.10gen.cc`` to resolve to 127.0.0.1.
@@ -76,28 +96,49 @@ Test Format and Use
 
 These YAML and JSON files contain the following fields:
 
-- ``uri``: a mongodb+srv connection string
+- ``uri``: a ``mongodb+srv`` connection string
 - ``seeds``: the expected set of initial seeds discovered from the SRV record
+- ``numSeeds``: the expected number of initial seeds discovered from the SRV
+  record. This is mainly used to test ``srvMaxHosts``, since randomly selected
+  hosts cannot be deterministically asserted.
 - ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
-- ``options``: the parsed connection string options as discovered from URI and
-  TXT records
-- ``parsed_options``: additional options present in the `Connection String`_
-  URI such as ``Userinfo`` (as ``user`` and ``password``), and ``Auth
-  database`` (as ``auth_database``).
+- ``numHosts``: the expected number of hosts discovered once SDAM completes a
+  scan. This is mainly used to test ``srvMaxHosts``, since randomly selected
+  hosts cannot be deterministically asserted.
+- ``options``: the parsed `URI options`_ as discovered from the
+  `Connection String`_'s "Connection Options" component and SRV resolution
+  (e.g. TXT records, implicit ``tls`` default).
+- ``parsed_options``: additional, parsed options from other `Connection String`_
+  components. This is mainly used for asserting ``UserInfo`` (as ``user`` and
+  ``password``) and ``Auth database`` (as ``auth_database``).
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
 
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
+.. _`URI options`: ../../uri-options/uri-options.rst
 
-For each file, create MongoClient initialized with the mongodb+srv connection
-string. You SHOULD verify that the client's initial seed list matches the list of
-seeds. You MUST verify that the set of ServerDescriptions in the client's
-TopologyDescription eventually matches the list of hosts. You MUST verify that
-each of the values of the Connection String Options under ``options`` match the
-Client's parsed value for that option. There may be other options parsed by
-the Client as well, which a test does not verify. In ``uri-with-auth`` the URI
-contains a user/password set and additional options are provided in
-``parsed_options`` so that tests can verify authentication is maintained when
-evaluating URIs. You MUST verify that an error has been thrown if ``error`` is
-present.
+For each file, create a MongoClient initialized with the ``mongodb+srv``
+connection string.
+
+If ``seeds`` is specified, drivers SHOULD verify that the set of hosts in the
+client's initial seedlist matches the list in ``seeds``. If ``numSeeds`` is
+specified, drivers SHOULD verify that the size of that set matches ``numSeeds``.
+
+If ``hosts`` is specified, drivers MUST verify that the set of
+ServerDescriptions in the client's TopologyDescription eventually matches the
+list in ``hosts``. If ``numHosts`` is specified, drivers MUST verify that the
+size of that set matches ``numHosts``.
+
+If ``options`` is specified, drivers MUST verify each of the values under
+``options`` match the MongoClient's parsed value for that option. There may be
+other options parsed by the MongoClient as well, which a test does not verify.
+
+If ``parsed_options`` is specified, drivers MUST verify that each of the values
+under ``parsed_options`` match the MongoClient's parsed value for that option.
+Supported values include, but are not limited to, ``user`` and ``password``
+(parsed from ``UserInfo``) and ``auth_database`` (parsed from
+``Auth database``).
+
+If ``error`` is specified and ``true``, drivers MUST verify that an error has
+been thrown.

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
@@ -1,12 +1,12 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
 # DRIVERS-1721 introduced this test as passing.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-replicaSet-errors.yml
@@ -1,5 +1,5 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset"
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
+uri: "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset"
 seeds: []
 hosts: []
 error: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
@@ -1,10 +1,10 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/"
+uri: "mongodb+srv://test24.test.build.10gen.cc/"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true (TXT)"
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true (TXT)

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true"
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with loadBalanced=true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
     "localhost.test.build.10gen.cc:8000"
   ],
@@ -8,7 +8,7 @@
   ],
   "options": {
     "loadBalanced": true,
-    "ssl": true,
-    "directConnection": false
+    "srvMaxHosts": 0,
+    "ssl": true
   }
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
@@ -1,0 +1,10 @@
+# loadBalanced=true (TXT) is permitted because srvMaxHosts is non-positive
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:8000
+hosts:
+    - localhost.test.build.10gen.cc:8000
+options:
+    loadBalanced: true
+    srvMaxHosts: 0
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
   "seeds": [
     "localhost.test.build.10gen.cc:8000"
   ],
@@ -8,7 +8,7 @@
   ],
   "options": {
     "loadBalanced": true,
-    "ssl": true,
-    "directConnection": false
+    "srvMaxHosts": 0,
+    "ssl": true
   }
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
@@ -1,0 +1,10 @@
+# loadBalanced=true is permitted because srvMaxHosts is non-positive
+uri: "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:8000
+hosts:
+    - localhost.test.build.10gen.cc:8000
+options:
+    loadBalanced: true
+    srvMaxHosts: 0
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true,
+    "srvServiceName": "customname"
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true
+    srvServiceName: "customname"

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option (TXT)"
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet-txt.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with replicaSet option (TXT)

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.json
@@ -1,0 +1,7 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1",
+  "seeds": [],
+  "hosts": [],
+  "error": true,
+  "comment": "Should fail because positive integer for srvMaxHosts conflicts with replicaSet option"
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-conflicts_with_replicaSet.yml
@@ -1,0 +1,5 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=1"
+seeds: []
+hosts: []
+error: true
+comment: Should fail because positive integer for srvMaxHosts conflicts with replicaSet option

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+  "numSeeds": 2,
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 2,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
@@ -1,0 +1,16 @@
+# When srvMaxHosts equals the number of SRV records, all hosts are added to the
+# seed list.
+#
+# The replicaSet URI option is omitted to avoid a URI validation error.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2"
+numSeeds: 2
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    srvMaxHosts: 2
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 3,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
@@ -1,0 +1,15 @@
+# When srvMaxHosts is greater than the number of SRV records, all hosts are
+# added to the seed list.
+#
+# The replicaSet URI option is omitted to avoid a URI validation error.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    srvMaxHosts: 3
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -1,0 +1,13 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
+  "numSeeds": 1,
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "srvMaxHosts": 1,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
@@ -1,0 +1,15 @@
+# When srvMaxHosts is less than the number of SRV records, a random subset of
+# hosts are added to the seed list. We cannot anticipate which hosts will be
+# selected, so this test uses numSeeds instead of seeds. Since this is a replica
+# set, all hosts should ultimately be discovered by SDAM.
+#
+# The replicaSet URI option is omitted to avoid a URI validation error.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1"
+numSeeds: 1
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    srvMaxHosts: 1
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "authSource": "thisDB",
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
@@ -1,0 +1,15 @@
+# When srvMaxHosts is zero, all hosts are added to the seed list.
+#
+# replicaSet (TXT) is permitted because srvMaxHosts is non-positive.
+uri: "mongodb+srv://test5.test.build.10gen.cc/?srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    authSource: thisDB
+    replicaSet: repl0
+    srvMaxHosts: 0
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.json
@@ -1,0 +1,17 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.yml
@@ -1,0 +1,15 @@
+# When srvMaxHosts is zero, all hosts are added to the seed list.
+#
+# replicaSet is permitted because srvMaxHosts is non-positive.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    replicaSet: repl0
+    srvMaxHosts: 0
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+  "numSeeds": 2,
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 2,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.yml
@@ -1,0 +1,13 @@
+# When srvMaxHosts equals the number of SRV records, all hosts are added to the
+# seed list.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2"
+numSeeds: 2
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+options:
+    srvMaxHosts: 2
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 3,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.yml
@@ -1,0 +1,12 @@
+# When srvMaxHosts is greater than the number of SRV records, all hosts are
+# added to the seed list.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=3"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+options:
+    srvMaxHosts: 3
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.json
@@ -1,0 +1,9 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1",
+  "numSeeds": 1,
+  "numHosts": 1,
+  "options": {
+    "srvMaxHosts": 1,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.yml
@@ -1,0 +1,10 @@
+# When srvMaxHosts is less than the number of SRV records, a random subset of
+# hosts are added to the seed list. We cannot anticipate which hosts will be
+# selected, so this test uses numSeeds and numHosts instead of seeds and hosts,
+# respectively.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=1"
+numSeeds: 1
+numHosts: 1
+options:
+    srvMaxHosts: 1
+    ssl: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "options": {
+    "srvMaxHosts": 0,
+    "ssl": true
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.yml
@@ -1,0 +1,11 @@
+# When srvMaxHosts is zero, all hosts are added to the seed list.
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+options:
+    srvMaxHosts: 0
+    ssl: true


### PR DESCRIPTION
* Sync latest copy of initial DNS seedlist discovery spec tests
* Updates the test runner to support some file format adjustments, unskip new tests we can now run, and skip some new ones we can't run yet

there are some failures on Evergreen but they all seem unrelated to these changes.