### PR TITLE
minor: skip failing documentation test

### DIFF
--- a/src/test/documentation_examples/mod.rs
+++ b/src/test/documentation_examples/mod.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLockReadGuard;
 
 use crate::{
     bson::{doc, Bson},
-    error::{ErrorKind, Result},
+    error::Result,
     options::{ClientOptions, FindOptions, ServerApi, ServerApiVersion},
     test::{log_uncaptured, TestClient, DEFAULT_URI, LOCK},
     Client,

--- a/src/test/documentation_examples/mod.rs
+++ b/src/test/documentation_examples/mod.rs
@@ -1481,12 +1481,14 @@ async fn stable_api_examples() -> GenericResult<()> {
         // )
     }
     // End Versioned API Example 6
-    if let ErrorKind::Command(ref err) = *result.as_ref().unwrap_err().kind {
-        assert_eq!(err.code, 323);
-        assert_eq!(err.code_name, "APIStrictError".to_string());
-    } else {
-        panic!("invalid result {:?}", result);
-    };
+
+    // TODO: Uncomment or remove this test once the prior example is updated
+    // if let ErrorKind::Command(ref err) = *result.as_ref().unwrap_err().kind {
+    //     assert_eq!(err.code, 323);
+    //     assert_eq!(err.code_name, "APIStrictError".to_string());
+    // } else {
+    //     panic!("invalid result {:?}", result);
+    // };
 
     // Start Versioned API Example 7
     let count = db


### PR DESCRIPTION
Skips a documentation test that now fails on latest due to count being added to the stable API.