### PR TITLE
RUST-886 Use lossy UTF-8 decoding for responses to insert and update commands

### DIFF
--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -217,6 +217,16 @@ impl RawCommandResponse {
         })
     }
 
+    /// Used to handle decoding responses where the server may return invalid UTF-8 in error
+    /// messages.
+    pub(crate) fn body_utf8_lossy<'a, T: Deserialize<'a>>(&'a self) -> Result<T> {
+        bson::from_slice_utf8_lossy(self.raw.as_bytes()).map_err(|e| {
+            Error::from(ErrorKind::InvalidResponse {
+                message: format!("{}", e),
+            })
+        })
+    }
+
     pub(crate) fn raw_body(&self) -> &RawDocument {
         &self.raw
     }

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -135,7 +135,7 @@ impl<'a, T: Serialize> Operation for Insert<'a, T> {
         raw_response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody = raw_response.body()?;
+        let response: WriteResponseBody = raw_response.body_utf8_lossy()?;
 
         let mut map = HashMap::new();
         if self.is_ordered() {

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -118,7 +118,7 @@ impl Operation for Update {
         raw_response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody<UpdateBody> = raw_response.body()?;
+        let response: WriteResponseBody<UpdateBody> = raw_response.body_utf8_lossy()?;
         response.validate().map_err(convert_bulk_errors)?;
 
         let modified_count = response.n_modified;


### PR DESCRIPTION
These changes work around a somewhat commonly encountered issue in the server where long error messages containing multi-byte characters are truncated incorrectly such that they are no longer valid UTF-8.

From digging through all of the related tickets for the server and drivers, this only ever seems to be observed in duplicate key errors, which I believe can only result from `insert` and `update` commands, so I've limited this PR to those two operations. It seems possible it could come up elsewhere, but I figured we could start with this and expand our usage of the lossy decoding later if the need arises.

Before my changes, all of the errors below, which are now duplicate key errors, would instead be something like
```
Error { kind: InvalidResponse { message: "invalid utf-8 sequence of 1 bytes from index 264" }, labels: {}, wire_version: Some(15) }
```

