### PR TITLE
RUST-1217 Skip tailable cursor test on serverless

### DIFF
--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -8,13 +8,20 @@ use crate::{
     bson::doc,
     options::{CreateCollectionOptions, CursorType, FindOptions},
     runtime,
-    test::{util::EventClient, TestClient, LOCK},
+    test::{log_uncaptured, util::EventClient, TestClient, LOCK, SERVERLESS},
 };
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[function_name::named]
 async fn tailable_cursor() {
+    if *SERVERLESS {
+        log_uncaptured(
+            "skipping cursor::tailable_cursor; serverless does not support capped collections",
+        );
+        return;
+    }
+
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
     let client = TestClient::new().await;


### PR DESCRIPTION
This always fails on serverless now, so skipping it there.