### PR TITLE
RUST-805 Remove remaining oppressive language from the source code

### DIFF
--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -257,7 +257,7 @@ impl Handshaker {
                 .map(|server_first| client_first.into_first_round(server_first))
         });
 
-        // Check that master reply has a compressor list and unpack it
+        // Check that the hello reply has a compressor list and unpack it
         if let (Some(server_compressors), Some(client_compressors)) = (
             hello_reply.command_response.compressors.as_ref(),
             self.compressors.as_ref(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use crate::{bson::Document, options::ServerAddress};
 
 const RECOVERING_CODES: [i32; 5] = [11600, 11602, 13436, 189, 91];
-const NOTMASTER_CODES: [i32; 3] = [10107, 13435, 10058];
+const NOTWRITABLEPRIMARY_CODES: [i32; 3] = [10107, 13435, 10058];
 const SHUTTING_DOWN_CODES: [i32; 2] = [11600, 91];
 const RETRYABLE_READ_CODES: [i32; 11] =
     [11600, 11602, 10107, 13435, 13436, 189, 91, 7, 6, 89, 9001];
@@ -111,7 +111,7 @@ impl Error {
     }
 
     pub(crate) fn is_state_change_error(&self) -> bool {
-        self.is_recovering() || self.is_not_master()
+        self.is_recovering() || self.is_notwritableprimary()
     }
 
     pub(crate) fn is_auth_error(&self) -> bool {
@@ -297,10 +297,10 @@ impl Error {
         }
     }
 
-    /// If this error corresponds to a "not master" error as per the SDAM spec.
-    pub(crate) fn is_not_master(&self) -> bool {
+    /// If this error corresponds to a "not writable primary" error as per the SDAM spec.
+    pub(crate) fn is_notwritableprimary(&self) -> bool {
         self.code()
-            .map(|code| NOTMASTER_CODES.contains(&code))
+            .map(|code| NOTWRITABLEPRIMARY_CODES.contains(&code))
             .unwrap_or(false)
     }
 

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -701,7 +701,7 @@ async fn direct_connection() {
         .insert_one(doc! {}, None)
         .await
         .expect_err("write should fail with directConnection=true on secondary");
-    assert!(error.is_not_master());
+    assert!(error.is_notwritableprimary());
 
     let client =
         Client::with_options(secondary_options).expect("client construction should succeed");

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -219,7 +219,11 @@ async fn notwritableprimary_reset_pool() {
             .expect("insert should have succeeded");
     }
 
-    run_test("notwritableprimary_reset_pool", notwritableprimary_reset_pool_test).await;
+    run_test(
+        "notwritableprimary_reset_pool",
+        notwritableprimary_reset_pool_test,
+    )
+    .await;
 }
 
 #[function_name::named]

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -122,15 +122,15 @@ async fn get_more() {
 #[function_name::named]
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn not_master_keep_pool() {
-    async fn not_master_keep_pool_test(
+async fn notwritableprimary_keep_pool() {
+    async fn notwritableprimary_keep_pool_test(
         client: EventClient,
         _db: Database,
         coll: Collection<Document>,
     ) {
         // This test requires server version 4.2 or higher.
         if client.server_version_lt(4, 2) {
-            log_uncaptured("skipping not_master_keep_pool due to server version < 4.2");
+            log_uncaptured("skipping notwritableprimary_keep_pool due to server version < 4.2");
             return;
         }
 
@@ -167,21 +167,22 @@ async fn not_master_keep_pool() {
         assert_eq!(client.count_pool_cleared_events(), 0);
     }
 
-    run_test(function_name!(), not_master_keep_pool_test).await;
+    run_test(function_name!(), notwritableprimary_keep_pool_test).await;
 }
 
-#[function_name::named]
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn not_master_reset_pool() {
-    async fn not_master_reset_pool_test(
+async fn notwritableprimary_reset_pool() {
+    async fn notwritableprimary_reset_pool_test(
         client: EventClient,
         _db: Database,
         coll: Collection<Document>,
     ) {
         // This test must only run on 4.0 servers.
         if !client.server_version_eq(4, 0) {
-            log_uncaptured("skipping not_master_reset_pool due to unsupported server version");
+            log_uncaptured(
+                "skipping notwritableprimary_reset_pool due to unsupported server version",
+            );
             return;
         }
 
@@ -218,7 +219,7 @@ async fn not_master_reset_pool() {
             .expect("insert should have succeeded");
     }
 
-    run_test(function_name!(), not_master_reset_pool_test).await;
+    run_test("notwritableprimary_reset_pool", notwritableprimary_reset_pool_test).await;
 }
 
 #[function_name::named]


### PR DESCRIPTION
RUST-805

Most of the oppressive language was removed in #380, but a few were missed, which this PR fixes.