### PR TITLE
RUST-1268 Correctly report rustc version used for compilation in handshake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
+rustc_version_runtime = "0.1.4"
 rustls-pemfile = "0.3.0"
 serde_with = "1.3.1"
 sha-1 = "0.10.0"
@@ -84,7 +85,6 @@ tokio-openssl = { version = "0.6.3", optional = true }
 trust-dns-proto = "0.21.1"
 trust-dns-resolver = "0.21.1"
 typed-builder = "0.10.0"
-version_check = "0.9.1"
 webpki-roots = "0.22.2"
 zstd = { version = "0.11.0", optional = true }
 

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -35,7 +35,7 @@ struct ClientMetadata {
     application: Option<AppMetadata>,
     driver: DriverMetadata,
     os: OsMetadata,
-    platform: Option<String>,
+    platform: String,
 }
 
 #[derive(Clone, Debug)]
@@ -74,10 +74,7 @@ impl From<ClientMetadata> for Bson {
         );
 
         metadata_doc.insert("os", metadata.os);
-
-        if let Some(platform) = metadata.platform {
-            metadata_doc.insert("platform", platform);
-        }
+        metadata_doc.insert("platform", metadata.platform);
 
         Bson::Document(metadata_doc)
     }
@@ -118,7 +115,7 @@ lazy_static! {
                 name: None,
                 version: None,
             },
-            platform: None,
+            platform: format!("{} with {}", rustc_version_runtime::version_meta().short_version_string, RUNTIME_NAME),
         };
 
         let info = os_info::get();
@@ -129,11 +126,6 @@ lazy_static! {
             if *version != Version::Unknown {
                 metadata.os.version = Some(info.version().to_string());
             }
-        }
-
-        if let Some((version, channel, date)) = version_check::triple() {
-            metadata.platform =
-                Some(format!("rustc {} {} ({}) with {}", version, channel, date, RUNTIME_NAME));
         }
 
         metadata
@@ -182,11 +174,9 @@ impl Handshaker {
                     metadata.driver.version.push_str(version);
                 }
 
-                if let Some(ref mut platform) = metadata.platform {
-                    if let Some(ref driver_info_platform) = driver_info.platform {
-                        platform.push('|');
-                        platform.push_str(driver_info_platform);
-                    }
+                if let Some(ref driver_info_platform) = driver_info.platform {
+                    metadata.platform.push('|');
+                    metadata.platform.push_str(driver_info_platform);
                 }
             }
 


### PR DESCRIPTION
RUST-1268

Switches the driver to use `rustc_version_runtime` to retrieve the rustc version used for compilation for inclusion in the driver handshake metadata.

Previously, on a machine where rustc was available the platforms field looked like this:
```
"rustc 1.60.0 stable (2022-04-04) with tokio" // stable release
"rustc 1.62.0 nightly (2022-04-11) with tokio" // nightly release
```

When rustc is not available, this field was null.

Now, it looks like this (slightly different due to the formatting of `VersionMeta.short_version_string`, but the relevant info is still there and in a similar format):
```
"rustc 1.60.0 (7737e0b5c 2022-04-04) with tokio" // stable release
"rustc 1.62.0-nightly (90ca44752 2022-04-11) with tokio" // nightly release
```

It doesn't seem like we test this at all right now, but I did test manually to get the results I pasted above. I don't think a test would have caught the bug this fixes anyway though, since we always have rustc available when we are running tests. 

Feel free to check yourselves as well.  Note one quirk is that if you switch Rust versions and recompile, it seems `rustc_version_runtime` doesn't get rebuilt, so you have to `cargo clean --package rustc_version_runtime` and rebuild to get that updated. 