### PR TITLE
RUST-1168 Future compatibility for change streams

### DIFF
--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -192,7 +192,7 @@ impl<'a> From<&'a OperationType> for OperationTypeWrapper<'a> {
             OperationType::Rename => Self::Known(OperationTypeHelper::Rename),
             OperationType::DropDatabase => Self::Known(OperationTypeHelper::DropDatabase),
             OperationType::Invalidate => Self::Known(OperationTypeHelper::Invalidate),
-            OperationType::Other(s) => Self::Unknown(&s),
+            OperationType::Other(s) => Self::Unknown(s),
         }
     }
 }

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -171,7 +171,7 @@ enum OperationTypeHelper {
     Drop,
     Rename,
     DropDatabase,
-    Invalidate,        
+    Invalidate,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -200,19 +200,17 @@ impl<'a> From<&'a OperationType> for OperationTypeWrapper<'a> {
 impl<'a> From<OperationTypeWrapper<'a>> for OperationType {
     fn from(src: OperationTypeWrapper) -> Self {
         match src {
-            OperationTypeWrapper::Known(h) => {
-                match h {
-                    OperationTypeHelper::Insert => Self::Insert,
-                    OperationTypeHelper::Update => Self::Update,
-                    OperationTypeHelper::Replace => Self::Replace,
-                    OperationTypeHelper::Delete => Self::Delete,
-                    OperationTypeHelper::Drop => Self::Drop,
-                    OperationTypeHelper::Rename => Self::Rename,
-                    OperationTypeHelper::DropDatabase => Self::DropDatabase,
-                    OperationTypeHelper::Invalidate => Self::Invalidate,
-                }
-            }
-            OperationTypeWrapper::Unknown(s) => Self::Other(s.to_string())
+            OperationTypeWrapper::Known(h) => match h {
+                OperationTypeHelper::Insert => Self::Insert,
+                OperationTypeHelper::Update => Self::Update,
+                OperationTypeHelper::Replace => Self::Replace,
+                OperationTypeHelper::Delete => Self::Delete,
+                OperationTypeHelper::Drop => Self::Drop,
+                OperationTypeHelper::Rename => Self::Rename,
+                OperationTypeHelper::DropDatabase => Self::DropDatabase,
+                OperationTypeHelper::Invalidate => Self::Invalidate,
+            },
+            OperationTypeWrapper::Unknown(s) => Self::Other(s.to_string()),
         }
     }
 }
@@ -220,7 +218,8 @@ impl<'a> From<OperationTypeWrapper<'a>> for OperationType {
 impl<'de> Deserialize<'de> for OperationType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de> {
+        D: serde::Deserializer<'de>,
+    {
         OperationTypeWrapper::deserialize(deserializer).map(OperationType::from)
     }
 }
@@ -228,7 +227,8 @@ impl<'de> Deserialize<'de> for OperationType {
 impl Serialize for OperationType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         OperationTypeWrapper::serialize(&self.into(), serializer)
     }
 }

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -130,8 +130,7 @@ pub struct TruncatedArray {
 }
 
 /// The operation type represented in a given change notification.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum OperationType {
     /// See [insert-event](https://docs.mongodb.com/manual/reference/change-events/#insert-event)
@@ -157,6 +156,81 @@ pub enum OperationType {
 
     /// See [invalidate-event](https://docs.mongodb.com/manual/reference/change-events/#invalidate-event)
     Invalidate,
+
+    /// A catch-all for future event types.
+    Other(String),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum OperationTypeHelper {
+    Insert,
+    Update,
+    Replace,
+    Delete,
+    Drop,
+    Rename,
+    DropDatabase,
+    Invalidate,        
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum OperationTypeWrapper<'a> {
+    Known(OperationTypeHelper),
+    Unknown(&'a str),
+}
+
+impl<'a> From<&'a OperationType> for OperationTypeWrapper<'a> {
+    fn from(src: &'a OperationType) -> Self {
+        match src {
+            OperationType::Insert => Self::Known(OperationTypeHelper::Insert),
+            OperationType::Update => Self::Known(OperationTypeHelper::Update),
+            OperationType::Replace => Self::Known(OperationTypeHelper::Replace),
+            OperationType::Delete => Self::Known(OperationTypeHelper::Delete),
+            OperationType::Drop => Self::Known(OperationTypeHelper::Drop),
+            OperationType::Rename => Self::Known(OperationTypeHelper::Rename),
+            OperationType::DropDatabase => Self::Known(OperationTypeHelper::DropDatabase),
+            OperationType::Invalidate => Self::Known(OperationTypeHelper::Invalidate),
+            OperationType::Other(s) => Self::Unknown(&s),
+        }
+    }
+}
+
+impl<'a> From<OperationTypeWrapper<'a>> for OperationType {
+    fn from(src: OperationTypeWrapper) -> Self {
+        match src {
+            OperationTypeWrapper::Known(h) => {
+                match h {
+                    OperationTypeHelper::Insert => Self::Insert,
+                    OperationTypeHelper::Update => Self::Update,
+                    OperationTypeHelper::Replace => Self::Replace,
+                    OperationTypeHelper::Delete => Self::Delete,
+                    OperationTypeHelper::Drop => Self::Drop,
+                    OperationTypeHelper::Rename => Self::Rename,
+                    OperationTypeHelper::DropDatabase => Self::DropDatabase,
+                    OperationTypeHelper::Invalidate => Self::Invalidate,
+                }
+            }
+            OperationTypeWrapper::Unknown(s) => Self::Other(s.to_string())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OperationType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de> {
+        OperationTypeWrapper::deserialize(deserializer).map(OperationType::from)
+    }
+}
+
+impl Serialize for OperationType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer {
+        OperationTypeWrapper::serialize(&self.into(), serializer)
+    }
 }
 
 /// Identifies the collection or database on which an event occurred.

--- a/src/test/spec/json/change-streams/unified/change-streams.json
+++ b/src/test/spec/json/change-streams/unified/change-streams.json
@@ -1,6 +1,15 @@
 {
   "description": "change-streams",
   "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset"
+      ]
+    }
+  ],
   "createEntities": [
     {
       "client": {
@@ -177,6 +186,264 @@
                 }
               ]
             }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test unknown operationType MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "addedInFutureMongoDBVersion",
+                  "ns": 1
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "addedInFutureMongoDBVersion",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test newField added in response MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": 1,
+                  "ns": 1,
+                  "newField": "newFieldValue"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "newField": "newFieldValue"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test new structure in ns document MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "insert",
+                  "ns.viewOn": "db.coll"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "viewOn": "db.coll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test modified structure in ns document MUST NOT err",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "operationType": "insert",
+                  "ns": {
+                    "db": "$ns.db",
+                    "coll": "$ns.coll",
+                    "viewOn": "db.coll"
+                  }
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0",
+              "viewOn": "db.coll"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test server error on projecting out _id",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 0
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "errorCode": 280,
+            "errorCodeName": "ChangeStreamFatalError",
+            "errorLabelsContain": [
+              "NonResumableChangeStreamError"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "description": "Test projection in change stream returns expected fields",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "optype": "$operationType",
+                  "ns": 1,
+                  "newField": "value"
+                }
+              }
+            ]
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "optype": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "newField": "value"
           }
         }
       ]

--- a/src/test/spec/json/change-streams/unified/change-streams.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams.yml
@@ -1,5 +1,8 @@
 description: "change-streams"
 schemaVersion: "1.0"
+runOnRequirements:
+  - minServerVersion: "3.6"
+    topologies: [ replicaset, sharded-replicaset ]
 createEntities:
   - client:
       id: &client0 client0
@@ -110,6 +113,129 @@ tests:
             ]
           }
         }
+
+  - description: "Test unknown operationType MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: "addedInFutureMongoDBVersion", ns: 1 } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "addedInFutureMongoDBVersion"
+          ns:
+            db: *database0
+            coll: *collection0
+
+  - description: "Test newField added in response MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: 1, ns: 1, newField: "newFieldValue" } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          newField: "newFieldValue"
+
+  - description: "Test new structure in ns document MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: "insert", "ns.viewOn": "db.coll" } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            viewOn: "db.coll"
+
+  - description: "Test modified structure in ns document MUST NOT err"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          # using $project to simulate future changes to ChangeStreamDocument structure
+          pipeline: [ { $project: { operationType: "insert", ns: { db: "$ns.db", coll: "$ns.coll", viewOn: "db.coll" } } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+            viewOn: "db.coll"
+
+  - description: "Test server error on projecting out _id"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        # Server returns an error if _id is modified on versions 4.2 and higher
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: [ { $project: { _id: 0 } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          errorCode: 280
+          errorCodeName: "ChangeStreamFatalError"
+          errorLabelsContain: [ "NonResumableChangeStreamError" ]
+
+  - description: "Test projection in change stream returns expected fields"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: [ { $project: { optype: "$operationType", ns: 1, newField: "value" } } ]
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          optype: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          newField: "value"
+
   - description: $changeStream must be the first stage in a change stream pipeline sent to the server
     runOnRequirements:
       - minServerVersion: 3.6.0

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -7,7 +7,7 @@ use tokio::sync::{oneshot, Mutex};
 
 use crate::{
     bson::{Bson, Document},
-    change_stream::{event::ChangeStreamEvent, ChangeStream},
+    change_stream::ChangeStream,
     client::{HELLO_COMMAND_NAMES, REDACTED_COMMANDS},
     event::command::CommandStartedEvent,
     test::{
@@ -63,7 +63,7 @@ pub enum TestCursor {
         session_id: String,
     },
     // `ChangeStream` has the same issue with 59245 as `Cursor`.
-    ChangeStream(Mutex<ChangeStream<ChangeStreamEvent<Document>>>),
+    ChangeStream(Mutex<ChangeStream<Document>>),
     Closed,
 }
 

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -223,7 +223,7 @@ fn expected_err<A: std::fmt::Debug, B: std::fmt::Debug>(
     actual: &A,
     expected: &B,
 ) -> Result<(), String> {
-    Err(format!("expected {:?}, got {:?}", actual, expected))
+    Err(format!("expected {:?}, got {:?}", expected, actual))
 }
 
 fn match_eq<V: PartialEq + std::fmt::Debug>(actual: &V, expected: &V) -> Result<(), String> {

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -164,15 +164,17 @@ pub async fn run_unified_format_test_filtered(
                             expected_value,
                             save_as_entity,
                         } => {
+                            let desc = &test_case.description;
                             let opt_entity = result.unwrap_or_else(|e| {
                                 panic!(
-                                    "{} should succeed, but failed with the following error: {}",
-                                    operation.name, e
+                                    "[{}] {} should succeed, but failed with the following error: \
+                                     {}",
+                                    desc, operation.name, e
                                 )
                             });
                             if expected_value.is_some() || save_as_entity.is_some() {
                                 let entity = opt_entity.unwrap_or_else(|| {
-                                    panic!("{} did not return an entity", operation.name)
+                                    panic!("[{}] {} did not return an entity", desc, operation.name)
                                 });
                                 if let Some(expected_bson) = expected_value {
                                     if let Entity::Bson(actual) = &entity {
@@ -183,15 +185,16 @@ pub async fn run_unified_format_test_filtered(
                                             Some(&test_runner.entities),
                                         ) {
                                             panic!(
-                                                "result mismatch, expected = {:#?}  actual = \
+                                                "[{}] result mismatch, expected = {:#?}  actual = \
                                                  {:#?}\nmismatch detail: {}",
-                                                expected_bson, actual, e
+                                                desc, expected_bson, actual, e
                                             );
                                         }
                                     } else {
                                         panic!(
-                                            "Incorrect entity type returned from {}, expected BSON",
-                                            operation.name
+                                            "[{}] Incorrect entity type returned from {}, \
+                                             expected BSON",
+                                            desc, operation.name
                                         );
                                     }
                                 }

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1876,7 +1876,7 @@ impl TestOperation for CreateChangeStream {
                 _ => panic!("Invalid entity for createChangeStream"),
             };
             Ok(Some(Entity::Cursor(TestCursor::ChangeStream(Mutex::new(
-                stream,
+                stream.with_type::<Document>(),
             )))))
         }
         .boxed()


### PR DESCRIPTION
RUST-1168

This PR syncs tests that check handling of new operation types and new fields in various places.  New operation types required setting up some serde helper types, and passing a test that needed a field preserved required switching from `ChangeStream<ChangeStreamEvent<Document>>` to `ChangeStream<Document>` in test contexts.