### PR TITLE
RUST-1017 Reduce flakiness of SDAM `heartbeat_events` test

### DIFF
--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -603,6 +603,7 @@ async fn heartbeat_events() {
     let mut options = CLIENT_OPTIONS.clone();
     options.hosts.drain(1..);
     options.heartbeat_freq = Some(Duration::from_millis(50));
+    options.app_name = "heartbeat_events".to_string().into();
 
     let event_handler = EventHandler::new();
     let mut subscriber = event_handler.subscribe();
@@ -634,11 +635,14 @@ async fn heartbeat_events() {
         .await
         .expect("should see server heartbeat succeeded event");
 
-    if !client.supports_fail_command() {
+    if !client.supports_fail_command_appname() {
         return;
     }
 
-    let options = FailCommandOptions::builder().error_code(1234).build();
+    let options = FailCommandOptions::builder()
+        .error_code(1234)
+        .app_name("heartbeat_events".to_string())
+        .build();
     let failpoint = FailPoint::fail_command(
         &[LEGACY_HELLO_COMMAND_NAME, "hello"],
         FailPointMode::Times(1),

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -240,6 +240,11 @@ impl TestClient {
         version.matches(&self.server_version)
     }
 
+    pub fn supports_fail_command_appname(&self) -> bool {
+        let version = VersionReq::parse(">= 4.2.9").unwrap();
+        version.matches(&self.server_version)
+    }
+
     pub fn supports_transactions(&self) -> bool {
         self.is_replica_set() && self.server_version_gte(4, 0)
             || self.is_sharded() && self.server_version_gte(4, 2)


### PR DESCRIPTION
RUST-1017

This PR attempts to reduce the flakiness of the `heartbeat_events` test by scoping the failpoint only to commands issued with a given appname to prevent collisions with other tests. I *think* this is the cause of the occasional failures, but we'll have to see.