### PR TITLE
RUST-1283 Simulate docs.rs build environment on Evergreen

### DIFF
--- a/.evergreen/check-all.sh
+++ b/.evergreen/check-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 

--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 # Pin clippy to the lastest version. This should be updated when new versions of Rust are released.
 rustup default 1.59.0
 cargo clippy --all-targets -p mongodb -- -D warnings

--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 # Pin clippy to the lastest version. This should be updated when new versions of Rust are released.
 rustup default 1.59.0
 cargo clippy --all-targets -p mongodb -- -D warnings

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 # docs.rs builds the driver on a read-only file system. to create a more realistic environment, we first
 # build the driver to ensure we have all the deps already in src, and then limit the permissions on that directory.
@@ -11,7 +11,8 @@ set -o errexit
 # build process.
 cargo +nightly build
 cargo clean
-chmod -R 555 ~/.cargo/registry/src
+
+chmod -R 555 ${CARGO_HOME}/registry/src
 
 cargo +nightly rustdoc -- -D warnings --cfg docsrs
 cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings --cfg docsrs

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -10,6 +10,9 @@ source ./.evergreen/configure-rust.sh
 # https://docs.rs/about/builds#read-only-directories where we or a dependency modify source code during the
 # build process.
 cargo +nightly build
+cargo +nightly --no-default-features --features async-std-runtime
+cargo +nightly --no-default-features --features sync
+cargo +nightly --features tokio-sync
 cargo clean
 
 chmod -R 555 ${CARGO_HOME}/registry/src

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -3,6 +3,16 @@
 set -o errexit
 
 . ~/.cargo/env
+
+# docs.rs builds the driver on a read-only file system. to create a more realistic environment, we first
+# build the driver to ensure we have all the deps already in src, and then limit the permissions on that directory.
+# this is to help us avoid introducing problems like those described here 
+# https://docs.rs/about/builds#read-only-directories where we or a dependency modify source code during the
+# build process.
+cargo +nightly build
+cargo clean
+chmod -R 555 ~/.cargo/registry/src
+
 cargo +nightly rustdoc -- -D warnings --cfg docsrs
 cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings --cfg docsrs
 cargo +nightly rustdoc --no-default-features --features sync -- -D warnings --cfg docsrs

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 # docs.rs builds the driver on a read-only file system. to create a more realistic environment, we first
 # build the driver to ensure we have all the deps already in src, and then limit the permissions on that directory.

--- a/.evergreen/check-rustfmt.sh
+++ b/.evergreen/check-rustfmt.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 rustfmt +nightly --unstable-features --check src/**/*.rs
 rustfmt +nightly --unstable-features --check src/*.rs

--- a/.evergreen/check-rustfmt.sh
+++ b/.evergreen/check-rustfmt.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 rustfmt +nightly --unstable-features --check src/**/*.rs
 rustfmt +nightly --unstable-features --check src/*.rs

--- a/.evergreen/compile-only-async-std.sh
+++ b/.evergreen/compile-only-async-std.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 rustup run $RUST_VERSION cargo build --no-default-features --features async-std-runtime
 rustup run $RUST_VERSION cargo build --no-default-features --features sync

--- a/.evergreen/compile-only-async-std.sh
+++ b/.evergreen/compile-only-async-std.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 rustup run $RUST_VERSION cargo build --no-default-features --features async-std-runtime
 rustup run $RUST_VERSION cargo build --no-default-features --features sync

--- a/.evergreen/compile-only-tokio.sh
+++ b/.evergreen/compile-only-tokio.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 # Enable snappy, zlib unconditionally
 FEATURE_FLAGS=snappy-compression,zlib-compression

--- a/.evergreen/compile-only-tokio.sh
+++ b/.evergreen/compile-only-tokio.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 # Enable snappy, zlib unconditionally
 FEATURE_FLAGS=snappy-compression,zlib-compression

--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 rustup update $RUST_VERSION
 
 if [ "$ASYNC_RUNTIME" = "tokio" ]; then

--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 rustup update $RUST_VERSION
 
 if [ "$ASYNC_RUNTIME" = "tokio" ]; then

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -265,7 +265,7 @@ functions:
 
           # compile mini test project
           cd $PROJECT_DIRECTORY/.evergreen/aws-ecs-test
-          . ~/.cargo/env
+          source $PROJECT_DIRECTORY/.evergreen/env.sh
           cargo build
           cd -
 
@@ -607,7 +607,6 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          rm -rf ~/.rustup
           rm -rf $DRIVERS_TOOLS || true
 
   "fix absolute paths":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -265,7 +265,7 @@ functions:
 
           # compile mini test project
           cd $PROJECT_DIRECTORY/.evergreen/aws-ecs-test
-          source $PROJECT_DIRECTORY/.evergreen/env.sh
+          . ${PROJECT_DIRECTORY}/.evergreen/configure-rust.sh
           cargo build
           cd -
 

--- a/.evergreen/configure-rust.sh
+++ b/.evergreen/configure-rust.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+export RUSTUP_HOME="${PROJECT_DIRECTORY}/.rustup"
+export PATH="${RUSTUP_HOME}/bin:$PATH"
+export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
+export PATH="${CARGO_HOME}/bin:$PATH"
+
+if [ "Windows_NT" == "$OS" ]; then
+    # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
+    export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
+    export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
+fi
+
+source ${CARGO_HOME}/env

--- a/.evergreen/configure-rust.sh
+++ b/.evergreen/configure-rust.sh
@@ -6,10 +6,10 @@ export PATH="${RUSTUP_HOME}/bin:$PATH"
 export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
 export PATH="${CARGO_HOME}/bin:$PATH"
 
-if [ "Windows_NT" == "$OS" ]; then
+if [[ "Windows_NT" == "$OS" ]]; then
     # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
     export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
     export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
 fi
 
-source ${CARGO_HOME}/env
+. ${CARGO_HOME}/env

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
 export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
+export RUSTUP_HOME="${PROJECT_DIRECTORY}/.rustup"
+export PATH="${RUSTUP_HOME}/bin:$PATH"
+export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
+export PATH="${CARGO_HOME}/bin:$PATH"
 
-source ~/.cargo/env
+if [ "Windows_NT" == "$OS" ]; then
+    # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
+    export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
+    export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
+fi
+
+source ${CARGO_HOME}/env
 
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 
-export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-export RUSTUP_HOME="${PROJECT_DIRECTORY}/.rustup"
-export PATH="${RUSTUP_HOME}/bin:$PATH"
-export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
-export PATH="${CARGO_HOME}/bin:$PATH"
-
-if [ "Windows_NT" == "$OS" ]; then
-    # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
-    export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
-    export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
-fi
-
-source ${CARGO_HOME}/env
+source ./.evergreen/configure-rust.sh
 
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 
+set -o xtrace
+set -o errexit
+
+export RUSTUP_HOME="${PROJECT_DIRECTORY}/.rustup"
+export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
+
 # Make sure to use msvc toolchain rather than gnu, which is the default for cygwin
 if [ "Windows_NT" == "$OS" ]; then
     export DEFAULT_HOST_OPTIONS='--default-host x86_64-pc-windows-msvc'
+    # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
+    export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
+    export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
 fi
 
-rm -rf ~/.rustup
 curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path $DEFAULT_HOST_OPTIONS
 
-# rustup installs into C:\Users\$USER instead of C:\home\$USER, so we symlink both .rustup and .cargo
-if [ "Windows_NT" == "$OS" ]; then
-    ln -s /cygdrive/c/Users/$USER/.rustup/ ~/.rustup
-    ln -s /cygdrive/c/Users/$USER/.cargo/ ~/.cargo
-fi
-
 # This file is not created by default on Windows
-echo 'export PATH=$PATH:~/.cargo/bin' >> ~/.cargo/env
+echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >> ${CARGO_HOME}/env
+echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ${CARGO_HOME}/env
 
-echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ~/.cargo/env
-
-source ~/.cargo/env
+source ${CARGO_HOME}/env
 
 # Install nightly rustfmt
 rustup toolchain install nightly -c rustfmt

--- a/.evergreen/release-danger-do-not-run-manually.sh
+++ b/.evergreen/release-danger-do-not-run-manually.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢
 # # Danger!
 #
@@ -24,6 +26,6 @@ fi
 git fetch origin tag $TAG --no-tags
 git checkout $TAG
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 cargo publish --token $TOKEN

--- a/.evergreen/release-danger-do-not-run-manually.sh
+++ b/.evergreen/release-danger-do-not-run-manually.sh
@@ -24,6 +24,6 @@ fi
 git fetch origin tag $TAG --no-tags
 git checkout $TAG
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 cargo publish --token $TOKEN

--- a/.evergreen/run-async-std-atlas-tests.sh
+++ b/.evergreen/run-async-std-atlas-tests.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 RUST_BACKTRACE=1 cargo test atlas_connectivity --no-default-features --features async-std-runtime
 

--- a/.evergreen/run-async-std-atlas-tests.sh
+++ b/.evergreen/run-async-std-atlas-tests.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 RUST_BACKTRACE=1 cargo test atlas_connectivity --no-default-features --features async-std-runtime
 

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -42,6 +42,6 @@ set -x
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 cargo test --features aws-auth auth_aws::auth_aws

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -42,6 +42,6 @@ set -x
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 RUST_BACKTRACE=1 cargo test --features aws-auth auth_aws::auth_aws

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 cd benchmarks
 cargo run \

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 cd benchmarks
 cargo run \

--- a/.evergreen/run-compile-benchmarks.sh
+++ b/.evergreen/run-compile-benchmarks.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 FEATURES=""
 

--- a/.evergreen/run-compile-benchmarks.sh
+++ b/.evergreen/run-compile-benchmarks.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 FEATURES=""
 

--- a/.evergreen/run-connection-string-tests.sh
+++ b/.evergreen/run-connection-string-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o xtrace
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 RUST_BACKTRACE=1 cargo test --features aws-auth spec::auth
 RUST_BACKTRACE=1 cargo test --features aws-auth uri_options

--- a/.evergreen/run-connection-string-tests.sh
+++ b/.evergreen/run-connection-string-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o xtrace
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 cargo test --features aws-auth spec::auth
 RUST_BACKTRACE=1 cargo test --features aws-auth uri_options

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 FEATURES=""
 

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 FEATURES=""
 

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -33,6 +33,6 @@ CA_FILE=`echo "${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem" | sed 
 
 export MONGODB_URI="${MONGODB_URI}tls=true&tlsCAFile=${CA_FILE}"
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 RUST_BACKTRACE=1 cargo test spec::ocsp

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -33,6 +33,6 @@ CA_FILE=`echo "${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem" | sed 
 
 export MONGODB_URI="${MONGODB_URI}tls=true&tlsCAFile=${CA_FILE}"
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 cargo test spec::ocsp

--- a/.evergreen/run-plain-tests.sh
+++ b/.evergreen/run-plain-tests.sh
@@ -3,6 +3,6 @@
 set -o errexit
 set -o xtrace 
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 
 RUST_BACKTRACE=1 MONGO_PLAIN_AUTH_TEST=1 cargo test plain

--- a/.evergreen/run-plain-tests.sh
+++ b/.evergreen/run-plain-tests.sh
@@ -3,6 +3,6 @@
 set -o errexit
 set -o xtrace 
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 MONGO_PLAIN_AUTH_TEST=1 cargo test plain

--- a/.evergreen/run-tokio-atlas-tests.sh
+++ b/.evergreen/run-tokio-atlas-tests.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/env.sh
 RUST_BACKTRACE=1 cargo test atlas_connectivity
 

--- a/.evergreen/run-tokio-atlas-tests.sh
+++ b/.evergreen/run-tokio-atlas-tests.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 RUST_BACKTRACE=1 cargo test atlas_connectivity
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
-rustc_version_runtime = "0.1.4"
+rustc_version_runtime = "0.2.1"
 rustls-pemfile = "0.3.0"
 serde_with = "1.3.1"
 sha-1 = "0.10.0"


### PR DESCRIPTION
Fixes our broken docs.rs build by bumping to the latest version of `rustc_version_runtime`, and updates our check-rustdoc.sh script to try to more closely simulate docs.rs builds.

Here's an example of check-rustdoc.sh failing with these changes when using the old version of `rustc_version_runtime`: https://spruce.mongodb.com/task/mongo_rust_driver_lint_check_rustdoc_patch_43723f9cf53fa91243dd066c7b28fa5fda8b504d_625f057e0305b9378a239ee0_22_04_19_18_54_58/logs?execution=0

The error is slightly different because the error is due to a being in a read-only directory rather than in an entirely read-only file system, but I think it probably gives close enough coverage.