### PR TITLE
RUST-1272 Bump rustc_version_runtime to fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
-rustc_version_runtime = "0.1.4"
+rustc_version_runtime = "0.2.1"
 rustls-pemfile = "0.3.0"
 serde_with = "1.3.1"
 sha-1 = "0.10.0"


### PR DESCRIPTION
Bump to a newer version of rustc_version_runtime which does not need to write to the `src` directory of the crate. docs.rs builds the docs on a read-only file system which does not permit that.