### PR TITLE
RUST-616 Error if message is too long

### DIFF
--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -275,7 +275,13 @@ impl Connection {
         self.error = write_result.is_err();
         write_result?;
 
-        let response_message_result = Message::read_from(&mut self.stream).await;
+        let response_message_result = Message::read_from(
+            &mut self.stream,
+            self.stream_description
+                .as_ref()
+                .and_then(|d| d.max_message_size_bytes),
+        )
+        .await;
         self.command_executing = false;
         self.error = response_message_result.is_err();
 

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -279,7 +279,7 @@ impl Connection {
             &mut self.stream,
             self.stream_description
                 .as_ref()
-                .and_then(|d| d.max_message_size_bytes),
+                .map(|d| d.max_message_size_bytes),
         )
         .await;
         self.command_executing = false;

--- a/src/cmap/conn/stream_description.rs
+++ b/src/cmap/conn/stream_description.rs
@@ -37,7 +37,7 @@ pub(crate) struct StreamDescription {
     pub(crate) hello_ok: bool,
 
     /// The maximum permitted size of a BSON wire protocol message.
-    pub max_message_size_bytes: Option<i32>,
+    pub(crate) max_message_size_bytes: i32,
 }
 
 impl StreamDescription {

--- a/src/cmap/conn/stream_description.rs
+++ b/src/cmap/conn/stream_description.rs
@@ -35,6 +35,9 @@ pub(crate) struct StreamDescription {
 
     /// Whether the server associated with this connection supports the `hello` command.
     pub(crate) hello_ok: bool,
+
+    /// The maximum permitted size of a BSON wire protocol message.
+    pub max_message_size_bytes: Option<i32>,
 }
 
 impl StreamDescription {
@@ -53,6 +56,7 @@ impl StreamDescription {
             max_bson_object_size: reply.command_response.max_bson_object_size,
             max_write_batch_size: reply.command_response.max_write_batch_size,
             hello_ok: reply.command_response.hello_ok.unwrap_or(false),
+            max_message_size_bytes: reply.command_response.max_message_size_bytes,
         }
     }
 
@@ -82,6 +86,7 @@ impl StreamDescription {
             max_bson_object_size: 16 * 1024 * 1024,
             max_write_batch_size: 100_000,
             hello_ok: false,
+            max_message_size_bytes: Default::default(),
         }
     }
 }

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -233,7 +233,7 @@ pub(crate) struct HelloCommandResponse {
     pub topology_version: Option<Document>,
 
     /// The maximum permitted size of a BSON wire protocol message.
-    pub max_message_size_bytes: Option<i32>,
+    pub max_message_size_bytes: i32,
 }
 
 impl PartialEq for HelloCommandResponse {

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -231,6 +231,9 @@ pub(crate) struct HelloCommandResponse {
 
     /// For internal use.
     pub topology_version: Option<Document>,
+
+    /// The maximum permitted size of a BSON wire protocol message.
+    pub max_message_size_bytes: Option<i32>,
 }
 
 impl PartialEq for HelloCommandResponse {
@@ -251,6 +254,7 @@ impl PartialEq for HelloCommandResponse {
             && self.max_bson_object_size == other.max_bson_object_size
             && self.max_write_batch_size == other.max_write_batch_size
             && self.service_id == other.service_id
+            && self.max_message_size_bytes == other.max_message_size_bytes
     }
 }
 

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -125,7 +125,7 @@ impl From<TestHelloCommandResponse> for HelloCommandResponse {
             topology_version: None,
             compressors: None,
             hello_ok: test.hello_ok,
-            max_message_size_bytes: None,
+            max_message_size_bytes: 48 * 1024 * 1024,
         }
     }
 }
@@ -746,6 +746,7 @@ async fn pool_cleared_error_does_not_mark_unknown() {
         "maxWireVersion": 6,
         "maxBsonObjectSize": 16_000,
         "maxWriteBatchSize": 10_000,
+        "maxMessageSizeBytes": 48_000_000,
     })
     .unwrap();
 

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -125,6 +125,7 @@ impl From<TestHelloCommandResponse> for HelloCommandResponse {
             topology_version: None,
             compressors: None,
             hello_ok: test.hello_ok,
+            max_message_size_bytes: None,
         }
     }
 }


### PR DESCRIPTION
RUST-616

This adds support for the `maxMessageSizeBytes` hello response field, and validates message header `length` against that maximum.