### PR TITLE
RUST-1080 Improve maxStalenessSeconds parsing

### DIFF
--- a/src/cmap/test/file.rs
+++ b/src/cmap/test/file.rs
@@ -10,9 +10,9 @@ use bson::Document;
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TestFile {
     #[serde(rename = "version")]
-    _version: u8,
+    _version: u8, // can ignore this field as there's only one version
     #[serde(rename = "style")]
-    _style: TestStyle,
+    _style: TestStyle, // we use the presence of fail_point / run_on to determine this
     pub description: String,
     pub(crate) pool_options: Option<ConnectionPoolOptions>,
     pub operations: Vec<ThreadedOperation>,

--- a/src/cmap/test/file.rs
+++ b/src/cmap/test/file.rs
@@ -7,13 +7,12 @@ use crate::{bson_util, cmap::options::ConnectionPoolOptions, error::Result, test
 use bson::Document;
 
 #[derive(Debug, Deserialize)]
-// TODO RUST-1079: remove the #[allow(dead_code)] tag and add #[serde(deny_unknown_fields)] to
-// ensure these tests are being fully run
-#[allow(dead_code)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TestFile {
-    version: u8,
-    style: TestStyle,
+    #[serde(rename = "version")]
+    _version: u8,
+    #[serde(rename = "style")]
+    _style: TestStyle,
     pub description: String,
     pub(crate) pool_options: Option<ConnectionPoolOptions>,
     pub operations: Vec<ThreadedOperation>,

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -14,11 +14,12 @@ use crate::{
     client::ClusterTime,
     cmap::Command,
     options::{ClientOptions, ServerAddress},
-    sdam::description::server::{ServerDescription, ServerType},
+    sdam::{
+        description::server::{ServerDescription, ServerType},
+        DEFAULT_HEARTBEAT_FREQUENCY,
+    },
     selection_criteria::{ReadPreference, SelectionCriteria},
 };
-
-const DEFAULT_HEARTBEAT_FREQUENCY: Duration = Duration::from_secs(10);
 
 /// The possible types for a topology.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize)]

--- a/src/sdam/description/topology/server_selection/mod.rs
+++ b/src/sdam/description/topology/server_selection/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 const DEFAULT_LOCAL_THRESHOLD: Duration = Duration::from_millis(15);
+pub(crate) const IDLE_WRITE_PERIOD: Duration = Duration::from_secs(10);
 
 /// Struct encapsulating a selected server that handles the opcount accounting.
 #[derive(Debug)]
@@ -133,9 +134,9 @@ impl TopologyDescription {
     }
 
     fn suitable_servers<'a>(
-        &'a self,
+        &self,
         read_preference: &'a ReadPreference,
-    ) -> Result<Vec<&'a ServerDescription>> {
+    ) -> Result<Vec<&ServerDescription>> {
         let servers = match self.topology_type {
             TopologyType::Unknown => Vec::new(),
             TopologyType::Single | TopologyType::LoadBalanced => self.servers.values().collect(),
@@ -185,9 +186,9 @@ impl TopologyDescription {
     }
 
     fn suitable_servers_in_replica_set<'a>(
-        &'a self,
+        &self,
         read_preference: &'a ReadPreference,
-    ) -> Result<Vec<&'a ServerDescription>> {
+    ) -> Result<Vec<&ServerDescription>> {
         let servers = match read_preference {
             ReadPreference::Primary => self.servers_with_type(&[ServerType::RsPrimary]).collect(),
             ReadPreference::Secondary { ref options } => self
@@ -230,11 +231,11 @@ impl TopologyDescription {
     }
 
     fn suitable_servers_for_read_preference<'a>(
-        &'a self,
-        types: &'a [ServerType],
+        &self,
+        types: &'static [ServerType],
         tag_sets: Option<&'a Vec<TagSet>>,
         max_staleness: Option<Duration>,
-    ) -> Result<Vec<&'a ServerDescription>> {
+    ) -> Result<Vec<&ServerDescription>> {
         super::verify_max_staleness(max_staleness)?;
 
         let mut servers = self.servers_with_type(types).collect();

--- a/src/sdam/description/topology/server_selection/test/logic.rs
+++ b/src/sdam/description/topology/server_selection/test/logic.rs
@@ -10,9 +10,7 @@ use crate::{
 use super::{TestServerDescription, TestTopologyDescription};
 
 #[derive(Debug, Deserialize)]
-// TODO RUST-1080: remove the #[allow(dead_code)] tag and add #[serde(deny_unknown_fields)] to
-// ensure these tests are being fully run
-#[allow(dead_code)]
+#[serde(deny_unknown_fields)]
 struct TestFile {
     #[serde(rename = "heartbeatFrequencyMS")]
     heartbeat_frequency_ms: Option<u64>,
@@ -21,6 +19,9 @@ struct TestFile {
     suitable_servers: Option<Vec<TestServerDescription>>,
     in_latency_window: Option<Vec<TestServerDescription>>,
     error: Option<bool>,
+    #[serde(rename = "operation")]
+    // don't need this since we don't have separate server selection functions for reads/writes
+    _operation: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/sdam/description/topology/server_selection/test/logic.rs
+++ b/src/sdam/description/topology/server_selection/test/logic.rs
@@ -7,9 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{Error, Result},
-    selection_criteria::{ReadPreference, ReadPreferenceOptions, SelectionCriteria, TagSet},
+    selection_criteria::{ReadPreference, ReadPreferenceOptions, TagSet},
     test::run_spec_test,
-    Client,
 };
 
 use super::{TestServerDescription, TestTopologyDescription};
@@ -108,7 +107,11 @@ async fn run_test(test_file: TestFile) {
         // ClientOptions::parse.
         #[cfg(not(any(feature = "sync", feature = "tokio-sync")))]
         {
-            use crate::client::options::ClientOptions;
+            use crate::{
+                client::options::ClientOptions,
+                selection_criteria::SelectionCriteria,
+                Client,
+            };
 
             let mut options = Vec::new();
             if let Some(ref mode) = test_file.read_preference.mode {

--- a/src/sdam/description/topology/server_selection/test/logic.rs
+++ b/src/sdam/description/topology/server_selection/test/logic.rs
@@ -84,7 +84,9 @@ async fn run_test(test_file: TestFile) {
             );
         }
     } else if test_file.error == Some(true) {
-        #[cfg(not(feature = "sync"))]
+        // skip on sync to avoid compilation conflicts with the sync version of
+        // ClientOptions::parse.
+        #[cfg(not(any(feature = "sync", feature = "tokio-sync")))]
         {
             let mut options = Vec::new();
             if let Some(ref mode) = test_file.read_preference.mode {

--- a/src/sdam/mod.rs
+++ b/src/sdam/mod.rs
@@ -14,14 +14,14 @@ pub(crate) use self::{
     description::{
         server::ServerDescription,
         topology::{
-            server_selection::SelectedServer,
+            server_selection::{SelectedServer, IDLE_WRITE_PERIOD},
             SessionSupportStatus,
             TopologyDescription,
             TransactionSupportStatus,
         },
     },
     message_manager::TopologyMessageManager,
-    monitor::MIN_HEARTBEAT_FREQUENCY,
+    monitor::{DEFAULT_HEARTBEAT_FREQUENCY, MIN_HEARTBEAT_FREQUENCY},
     state::{
         server::{Server, ServerUpdate, ServerUpdateReceiver, ServerUpdateSender},
         HandshakePhase,

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -17,8 +17,7 @@ use crate::{
     runtime,
 };
 
-pub(super) const DEFAULT_HEARTBEAT_FREQUENCY: Duration = Duration::from_secs(10);
-
+pub(crate) const DEFAULT_HEARTBEAT_FREQUENCY: Duration = Duration::from_secs(10);
 pub(crate) const MIN_HEARTBEAT_FREQUENCY: Duration = Duration::from_millis(500);
 
 pub(crate) struct Monitor {


### PR DESCRIPTION
RUST-1080

This PR updates the client options validator to error on invalid maxStalenessSeconds values, accept -1 to mean "no max staleness", and updates the maxStaleness spec test runner to cover error cases. This PR also completes RUST-1079 by ensuring all CMAP spec test fields are deserialized.