### PR TITLE
RUST-1193 Provide a public `ConnectionString` type

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -794,7 +794,7 @@ pub struct ConnectionString {
     pub load_balanced: Option<bool>,
 
     /// Amount of time spent attempting to send or receive on a socket before timing out; note that
-    /// this only applies to application operations, not SDAM.
+    /// this only applies to application operations, not server discovery and monitoring.
     pub socket_timeout: Option<Duration>,
 
     /// Default read preference for the client.

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2145,6 +2145,13 @@ impl ConnectionString {
     }
 }
 
+impl FromStr for ConnectionString {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self> {
+        ConnectionString::parse(s)
+    }
+}
+
 impl<'de> Deserialize<'de> for ConnectionString {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1172,6 +1172,18 @@ impl ClientOptions {
         Ok(options)
     }
 
+    /// Creates a `ClientOptions` from the given `ConnectionString`.
+    ///
+    /// In the case that "mongodb+srv" is used, SRV and TXT record lookups will be done using the
+    /// provided `ResolverConfig` as part of this method.
+    #[cfg(any(feature = "sync", feature = "tokio-sync"))]
+    pub fn parse_connection_string_sync(
+        conn_str: ConnectionString,
+        resolver_config: impl Into<Option<ResolverConfig>>,
+    ) -> Result<Self> {
+        crate::runtime::block_on(Self::parse_connection_string(conn_str, resolver_config))
+    }
+
     #[cfg(test)]
     pub(crate) fn parse_without_srv_resolution(s: &str) -> Result<Self> {
         let mut conn_str = ConnectionString::parse(s)?;

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -835,7 +835,7 @@ pub enum HostInfo {
     /// A set of addresses.
     HostIdentifiers(Vec<ServerAddress>),
     /// A DNS record for SRV lookup.
-    DnsRecord(String)
+    DnsRecord(String),
 }
 
 impl Default for HostInfo {
@@ -848,7 +848,7 @@ impl Into<Vec<ServerAddress>> for HostInfo {
     fn into(self) -> Vec<ServerAddress> {
         match self {
             Self::HostIdentifiers(hosts) => hosts,
-            Self::DnsRecord(host) => vec![ServerAddress::Tcp { host, port: None }]
+            Self::DnsRecord(host) => vec![ServerAddress::Tcp { host, port: None }],
         }
     }
 }
@@ -1479,7 +1479,8 @@ impl ConnectionString {
             None => (None, None),
         };
 
-        let host_list: Result<Vec<_>> = hosts_section.split(',').map(ServerAddress::parse).collect();
+        let host_list: Result<Vec<_>> =
+            hosts_section.split(',').map(ServerAddress::parse).collect();
 
         let host_list = host_list?;
 
@@ -1713,7 +1714,12 @@ impl ConnectionString {
         Ok(parts)
     }
 
-    fn parse_option_pair(&mut self, parts: &mut ConnectionStringParts, key: &str, value: &str) -> Result<()> {
+    fn parse_option_pair(
+        &mut self,
+        parts: &mut ConnectionStringParts,
+        key: &str,
+        value: &str,
+    ) -> Result<()> {
         macro_rules! get_bool {
             ($value:expr, $option:expr) => {
                 match $value {
@@ -1937,7 +1943,8 @@ impl ConnectionString {
                         .collect()
                 };
 
-                parts.read_preference_tags
+                parts
+                    .read_preference_tags
                     .get_or_insert_with(Vec::new)
                     .push(tags?);
             }
@@ -2127,7 +2134,8 @@ impl ConnectionString {
 impl<'de> Deserialize<'de> for ConnectionString {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
-        D: Deserializer<'de> {
+        D: Deserializer<'de>,
+    {
         deserializer.deserialize_str(ConnectionStringVisitor)
     }
 }
@@ -2143,7 +2151,8 @@ impl<'de> serde::de::Visitor<'de> for ConnectionStringVisitor {
 
     fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
     where
-            E: serde::de::Error, {
+        E: serde::de::Error,
+    {
         ConnectionString::parse(v).map_err(serde::de::Error::custom)
     }
 }

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -828,16 +828,24 @@ pub struct ConnectionString {
     /// specified in the URI.
     pub read_preference_tags: Option<Vec<TagSet>>,
 
+    pub(crate) srv: bool,
+    wait_queue_timeout: Option<Duration>,
+    tls_insecure: Option<bool>,
+    original_uri: String,
+}
+
+impl ConnectionString {
     /// Amount of time spent attempting to check out a connection from a server's connection pool
     /// before timing out.  Not supported by the Rust driver.
-    pub wait_queue_timeout: Option<Duration>,
+    pub fn wait_queue_timeout(&self) -> Option<Duration> {
+        self.wait_queue_timeout
+    }
 
     /// Relax TLS constraints as much as possible (e.g. allowing invalid certificates or hostname
     /// mismatches).  Not supported by the Rust driver.
-    pub tls_insecure: Option<bool>,
-
-    pub(crate) srv: bool,
-    original_uri: String,
+    pub fn tls_insecure(&self) -> Option<bool> {
+        self.tls_insecure
+    }
 }
 
 /// Specifies whether TLS configuration should be used with the operations that the

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1226,7 +1226,7 @@ impl ClientOptions {
             direct_connection: conn_str.direct_connection,
             default_database: conn_str.default_database,
             driver_info: None,
-            credential: credential,
+            credential,
             cmap_event_handler: None,
             command_event_handler: None,
             original_srv_info: None,

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -844,8 +844,8 @@ impl Default for HostInfo {
     }
 }
 
-impl Into<Vec<ServerAddress>> for HostInfo {
-    fn into(self) -> Vec<ServerAddress> {
+impl HostInfo {
+    fn into_addresses(self) -> Vec<ServerAddress> {
         match self {
             Self::HostIdentifiers(hosts) => hosts,
             Self::DnsRecord(host) => vec![ServerAddress::Tcp { host, port: None }],
@@ -980,7 +980,7 @@ pub struct DriverInfo {
 impl From<ConnectionString> for ClientOptions {
     fn from(conn_str: ConnectionString) -> Self {
         Self {
-            hosts: conn_str.hosts.into(),
+            hosts: conn_str.hosts.into_addresses(),
             app_name: conn_str.app_name,
             tls: conn_str.tls,
             heartbeat_freq: conn_str.heartbeat_frequency,
@@ -1512,12 +1512,11 @@ impl ConnectionString {
             ..Default::default()
         };
 
-        let mut parts;
-        if let Some(opts) = options_section {
-            parts = conn_str.parse_options(opts)?;
+        let mut parts = if let Some(opts) = options_section {
+            conn_str.parse_options(opts)?
         } else {
-            parts = ConnectionStringParts::default();
-        }
+            ConnectionStringParts::default()
+        };
 
         // Set username and password.
         if let Some(u) = username {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2124,6 +2124,30 @@ impl ConnectionString {
     }
 }
 
+impl<'de> Deserialize<'de> for ConnectionString {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de> {
+        deserializer.deserialize_str(ConnectionStringVisitor)
+    }
+}
+
+struct ConnectionStringVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ConnectionStringVisitor {
+    type Value = ConnectionString;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a MongoDB connection string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>
+    where
+            E: serde::de::Error, {
+        ConnectionString::parse(v).map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(all(test, not(feature = "sync"), not(feature = "tokio-sync")))]
 mod tests {
     use std::time::Duration;

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1193,9 +1193,7 @@ impl ClientOptions {
         if let Some(credential) = credential.as_mut() {
             if credential.source.is_none() {
                 credential.source = match &credential.mechanism {
-                    Some(mechanism) => {
-                        Some(mechanism.default_source(db.as_deref()).into())
-                    }
+                    Some(mechanism) => Some(mechanism.default_source(db.as_deref()).into()),
                     None => {
                         // If credentials exist (i.e. username is specified) but no mechanism, the
                         // default source is chosen from the following list in

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -795,13 +795,17 @@ pub struct ConnectionString {
     /// Whether or not the client is connecting to a MongoDB cluster through a load balancer.
     pub load_balanced: Option<bool>,
 
-    /// Amount of time spent attempting to send or receive on a socket before timing out; note that this only applies to application operations, not SDAM.
+    /// Amount of time spent attempting to send or receive on a socket before timing out; note that
+    /// this only applies to application operations, not SDAM.
     pub socket_timeout: Option<Duration>,
 
-    /// Specifies the level of compression when using zlib to compress wire protocol messages; -1 signifies the default level, 0 signifies no compression, 1 signifies the fastest speed, and 9 signifies the best compression.
+    /// Specifies the level of compression when using zlib to compress wire protocol messages; -1
+    /// signifies the default level, 0 signifies no compression, 1 signifies the fastest speed, and
+    /// 9 signifies the best compression.
     pub zlib_compression: Option<i32>,
 
-    /// The maximum replication lag, in wall clock time, that a secondary can suffer and still be eligible for server selection.
+    /// The maximum replication lag, in wall clock time, that a secondary can suffer and still be
+    /// eligible for server selection.
     pub max_staleness: Option<Duration>,
 
     /// The authentication mechanism method to use for connection to the server.
@@ -810,21 +814,26 @@ pub struct ConnectionString {
     /// The database that connections should authenticate against.
     pub auth_source: Option<String>,
 
-    /// Additional options provided for authentication (e.g. to enable hostname canonicalization for GSSAPI).
+    /// Additional options provided for authentication (e.g. to enable hostname canonicalization
+    /// for GSSAPI).
     pub auth_mechanism_properties: Option<Document>,
 
     /// Default read preference for the client (excluding tags).
     pub read_preference: Option<ReadPreference>,
 
-    /// Default read preference tags for the client; only valid if the read preference mode is not primary.
+    /// Default read preference tags for the client; only valid if the read preference mode is not
+    /// primary.
     ///
-    /// The order of the tag sets in the read preference is the same as the order they are specified in the URI.
+    /// The order of the tag sets in the read preference is the same as the order they are
+    /// specified in the URI.
     pub read_preference_tags: Option<Vec<TagSet>>,
 
-    /// Amount of time spent attempting to check out a connection from a server's connection pool before timing out.  Not supported by the Rust driver.
+    /// Amount of time spent attempting to check out a connection from a server's connection pool
+    /// before timing out.  Not supported by the Rust driver.
     pub wait_queue_timeout: Option<Duration>,
 
-    /// Relax TLS constraints as much as possible (e.g. allowing invalid certificates or hostname mismatches).  Not supported by the Rust driver.
+    /// Relax TLS constraints as much as possible (e.g. allowing invalid certificates or hostname
+    /// mismatches).  Not supported by the Rust driver.
     pub tls_insecure: Option<bool>,
 
     pub(crate) srv: bool,

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -833,20 +833,6 @@ struct ConnectionStringParts {
     read_preference_tags: Option<Vec<TagSet>>,
 }
 
-impl ConnectionString {
-    /// Amount of time spent attempting to check out a connection from a server's connection pool
-    /// before timing out.  Not supported by the Rust driver.
-    pub fn wait_queue_timeout(&self) -> Option<Duration> {
-        self.wait_queue_timeout
-    }
-
-    /// Relax TLS constraints as much as possible (e.g. allowing invalid certificates or hostname
-    /// mismatches).  Not supported by the Rust driver.
-    pub fn tls_insecure(&self) -> Option<bool> {
-        self.tls_insecure
-    }
-}
-
 /// Specifies whether TLS configuration should be used with the operations that the
 /// [`Client`](../struct.Client.html) performs.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -1588,6 +1574,18 @@ impl ConnectionString {
         }
 
         Ok(options)
+    }
+
+    /// Amount of time spent attempting to check out a connection from a server's connection pool
+    /// before timing out.  Not supported by the Rust driver.
+    pub fn wait_queue_timeout(&self) -> Option<Duration> {
+        self.wait_queue_timeout
+    }
+
+    /// Relax TLS constraints as much as possible (e.g. allowing invalid certificates or hostname
+    /// mismatches).  Not supported by the Rust driver.
+    pub fn tls_insecure(&self) -> Option<bool> {
+        self.tls_insecure
     }
 
     fn parse_options(&mut self, options: &str) -> Result<()> {

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1179,7 +1179,7 @@ impl ClientOptions {
         let mut options = Self::from_connection_string(conn_str);
         options.hosts = match host_info {
             HostInfo::HostIdentifiers(hosts) => hosts,
-            HostInfo::DnsRecord(host) => vec![ServerAddress::Tcp { host, port: None }],
+            HostInfo::DnsRecord(_) => panic!("Expected non-SRV URI, got {:?}", s),
         };
         options.validate()?;
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -544,6 +544,7 @@ pub struct ClientOptions {
     #[derivative(Debug = "ignore")]
     pub(crate) original_srv_info: Option<OriginalSrvInfo>,
 
+    #[cfg(test)]
     #[builder(default, setter(skip))]
     #[derivative(Debug = "ignore")]
     pub(crate) original_uri: Option<String>,
@@ -705,7 +706,7 @@ pub struct ConnectionString {
     /// The amount of time each monitoring thread should wait between performing server checks.
     ///
     /// The default value is 10 seconds.
-    pub heartbeat_freq: Option<Duration>,
+    pub heartbeat_frequency: Option<Duration>,
 
     /// When running a read operation with a ReadPreference that allows selecting secondaries,
     /// `local_threshold` is used to determine how much longer the average round trip time between
@@ -814,6 +815,7 @@ pub struct ConnectionString {
 
     wait_queue_timeout: Option<Duration>,
     tls_insecure: Option<bool>,
+    #[cfg(test)]
     original_uri: String,
 }
 
@@ -981,7 +983,7 @@ impl From<ConnectionString> for ClientOptions {
             hosts: conn_str.hosts.into(),
             app_name: conn_str.app_name,
             tls: conn_str.tls,
-            heartbeat_freq: conn_str.heartbeat_freq,
+            heartbeat_freq: conn_str.heartbeat_frequency,
             local_threshold: conn_str.local_threshold,
             read_concern: conn_str.read_concern,
             selection_criteria: conn_str.read_preference.map(Into::into),
@@ -1003,6 +1005,7 @@ impl From<ConnectionString> for ClientOptions {
             cmap_event_handler: None,
             command_event_handler: None,
             original_srv_info: None,
+            #[cfg(test)]
             original_uri: Some(conn_str.original_uri),
             resolver_config: None,
             server_api: None,
@@ -1503,6 +1506,7 @@ impl ConnectionString {
 
         let mut conn_str = ConnectionString {
             hosts,
+            #[cfg(test)]
             original_uri: s.into(),
             ..Default::default()
         };
@@ -1839,7 +1843,7 @@ impl ConnectionString {
                     .into());
                 }
 
-                self.heartbeat_freq = Some(Duration::from_millis(duration));
+                self.heartbeat_frequency = Some(Duration::from_millis(duration));
             }
             k @ "journal" => {
                 let mut write_concern = self.write_concern.get_or_insert_with(Default::default);

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -760,7 +760,7 @@ pub struct ConnectionString {
     /// The order of compressors indicates preference of compressors.
     pub compressors: Option<Vec<Compressor>>,
 
-    /// The connect timeout passed to each underlying TcpStream when attemtping to connect to the
+    /// The connect timeout passed to each underlying TcpStream when attempting to connect to the
     /// server.
     ///
     /// The default value is 10 seconds.

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 use crate::{
     bson::{Bson, Document},
-    client::options::{ClientOptions, ClientOptionsParser, ServerAddress},
+    client::options::{ClientOptions, ConnectionString, ServerAddress},
     error::ErrorKind,
     options::Compressor,
     test::run_spec_test,
@@ -201,7 +201,7 @@ async fn run_connection_string_spec_tests() {
 }
 
 async fn parse_uri(option: &str, suggestion: Option<&str>) {
-    match ClientOptionsParser::parse(&format!("mongodb://host:27017/?{}=test", option))
+    match ConnectionString::parse(&format!("mongodb://host:27017/?{}=test", option))
         .map_err(|e| *e.kind)
     {
         Ok(_) => panic!("expected error for option {}", option),


### PR DESCRIPTION
RUST-1193

This renames and makes public the existing `ClientOptionsParser` struct as `ConnectionString` to allow for parsing and modeling connection strings without requiring IO for DNS lookup.  I was deliberately conservative in this addition - there's no builder type, so the only way to construct one is from a string, and only those fields that were already directly exposed in `ClientOptions` are also exposed here.