### PR TITLE
RUST-332 Return an error for replica set name mismatch

### DIFF
--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -478,7 +478,7 @@ async fn repl_set_name_mismatch() -> crate::error::Result<()> {
     options.hosts.drain(1..);
     options.direct_connection = Some(true);
     options.repl_set_name = Some("invalid".to_string());
-    let client = TestClient::with_options(Some(options)).await;
+    let client = Client::with_options(options)?;
     let result = client.list_database_names(None, None).await;
     assert!(match result {
         Err(Error { ref kind, .. }) => match **kind {

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -482,10 +482,7 @@ async fn repl_set_name_mismatch() -> crate::error::Result<()> {
     let result = client.list_database_names(None, None).await;
     assert!(
         match result {
-            Err(Error { ref kind, .. }) => match **kind {
-                ErrorKind::ServerSelection { .. } => true,
-                _ => false,
-            },
+            Err(Error { ref kind, .. }) => matches!(**kind, ErrorKind::ServerSelection { .. }),
             _ => false,
         },
         "Unexpected result {:?}",

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -480,13 +480,17 @@ async fn repl_set_name_mismatch() -> crate::error::Result<()> {
     options.repl_set_name = Some("invalid".to_string());
     let client = Client::with_options(options)?;
     let result = client.list_database_names(None, None).await;
-    assert!(match result {
-        Err(Error { ref kind, .. }) => match **kind {
-            ErrorKind::ServerSelection { .. } => true,
+    assert!(
+        match result {
+            Err(Error { ref kind, .. }) => match **kind {
+                ErrorKind::ServerSelection { .. } => true,
+                _ => false,
+            },
             _ => false,
-        }
-        _ => false,
-    }, "Unexpected result {:?}", result);
+        },
+        "Unexpected result {:?}",
+        result
+    );
 
     Ok(())
 }


### PR DESCRIPTION
RUST-332 / RUST-358

This causes servers that don't match the repl set name given in the connection string to be marked as unknown, so any operation will return an error.