### PR TITLE
RUST-1216 Use correct runOnRequirements in estimatedDocumentCount tests

### DIFF
--- a/src/test/spec/json/crud/unified/estimatedDocumentCount-comment.json
+++ b/src/test/spec/json/crud/unified/estimatedDocumentCount-comment.json
@@ -125,7 +125,11 @@
       "runOnRequirements": [
         {
           "minServerVersion": "3.6.0",
-          "maxServerVersion": "4.4.13"
+          "maxServerVersion": "4.4.13",
+          "topologies": [
+            "single",
+            "replicaset"
+          ]
         }
       ],
       "operations": [

--- a/src/test/spec/json/crud/unified/estimatedDocumentCount-comment.yml
+++ b/src/test/spec/json/crud/unified/estimatedDocumentCount-comment.yml
@@ -68,6 +68,9 @@ tests:
     runOnRequirements:
       - minServerVersion: "3.6.0"
         maxServerVersion: "4.4.13"
+        # Server does not raise an error if topology is sharded.
+        # https://jira.mongodb.org/browse/SERVER-65954
+        topologies: [ single, replicaset ]
     operations:
       - name: estimatedDocumentCount
         object: *collection0

--- a/src/test/spec/json/crud/unified/estimatedDocumentCount.json
+++ b/src/test/spec/json/crud/unified/estimatedDocumentCount.json
@@ -34,6 +34,13 @@
         "database": "database0",
         "collectionName": "coll1"
       }
+    },
+    {
+      "collection": {
+        "id": "collection0View",
+        "database": "database0",
+        "collectionName": "coll0view"
+      }
     }
   ],
   "initialData": [
@@ -254,6 +261,89 @@
               "commandStartedEvent": {
                 "command": {
                   "count": "coll0"
+                },
+                "commandName": "count",
+                "databaseName": "edc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "estimatedDocumentCount works correctly on views",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "coll0view"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "coll0view",
+            "viewOn": "coll0",
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection0View",
+          "expectResult": 2
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "coll0view"
+                },
+                "commandName": "drop",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "coll0view",
+                  "viewOn": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "create",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0view"
                 },
                 "commandName": "count",
                 "databaseName": "edc-tests"

--- a/src/test/spec/json/crud/unified/estimatedDocumentCount.yml
+++ b/src/test/spec/json/crud/unified/estimatedDocumentCount.yml
@@ -21,6 +21,10 @@ createEntities:
       id: &collection1 collection1
       database: *database0
       collectionName: &collection1Name coll1
+  - collection:
+      id: &collection0View collection0View
+      database: *database0
+      collectionName: &collection0ViewName coll0view
 
 initialData:
   - collectionName: *collection0Name
@@ -133,5 +137,45 @@ tests:
           - commandStartedEvent:
               command:
                 count: *collection0Name
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount works correctly on views"
+    # viewOn option was added to the create command in 3.4
+    runOnRequirements:
+      - minServerVersion: "3.4.0"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0ViewName
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0ViewName
+          viewOn: *collection0Name
+          pipeline: &pipeline
+            - { $match: { _id: { $gt: 1 } } }
+      - name: estimatedDocumentCount
+        object: *collection0View
+        expectResult: 2
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0ViewName
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0ViewName
+                viewOn: *collection0Name
+                pipeline: *pipeline
+              commandName: create
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                count: *collection0ViewName
               commandName: count
               databaseName: *database0Name

--- a/src/test/spec/json/versioned-api/README.rst
+++ b/src/test/spec/json/versioned-api/README.rst
@@ -1,6 +1,6 @@
-===================
-Versioned API Tests
-===================
+================
+Stable API Tests
+================
 
 .. contents::
 
@@ -9,7 +9,7 @@ Versioned API Tests
 Notes
 =====
 
-This directory contains tests for the Versioned API specification. They are
+This directory contains tests for the Stable API specification. They are
 implemented in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__,
 and require schema version 1.1. Note that to run these tests, the server must be
 started with both ``enableTestCommands`` and ``acceptApiVersion2`` parameters

--- a/src/test/spec/json/versioned-api/crud-api-version-1-strict.json
+++ b/src/test/spec/json/versioned-api/crud-api-version-1-strict.json
@@ -615,7 +615,7 @@
       "description": "estimatedDocumentCount appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0.8",
+          "minServerVersion": "5.0.9",
           "maxServerVersion": "5.0.99"
         },
         {

--- a/src/test/spec/json/versioned-api/crud-api-version-1-strict.yml
+++ b/src/test/spec/json/versioned-api/crud-api-version-1-strict.yml
@@ -231,7 +231,7 @@ tests:
   - description: "estimatedDocumentCount appends declared API version"
     # See: https://jira.mongodb.org/browse/SERVER-63850
     runOnRequirements:
-      - minServerVersion: "5.0.8"
+      - minServerVersion: "5.0.9"
         maxServerVersion: "5.0.99"
       - minServerVersion: "5.3.2"
     operations:

--- a/src/test/spec/json/versioned-api/crud-api-version-1.json
+++ b/src/test/spec/json/versioned-api/crud-api-version-1.json
@@ -607,7 +607,7 @@
       "description": "estimatedDocumentCount appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0.8",
+          "minServerVersion": "5.0.9",
           "maxServerVersion": "5.0.99"
         },
         {

--- a/src/test/spec/json/versioned-api/crud-api-version-1.yml
+++ b/src/test/spec/json/versioned-api/crud-api-version-1.yml
@@ -225,7 +225,7 @@ tests:
   - description: "estimatedDocumentCount appends declared API version"
     # See: https://jira.mongodb.org/browse/SERVER-63850
     runOnRequirements:
-      - minServerVersion: "5.0.8"
+      - minServerVersion: "5.0.9"
         maxServerVersion: "5.0.99"
       - minServerVersion: "5.3.2"
     operations:


### PR DESCRIPTION
RUST-1216

This PR syncs the `estimated_document_count` tests to use the correct runOnRequirements (the backport of adding `count` to the stable API missed the cut for 5.0.8).

This PR also syncs in a new test that was added to ensure `estimated_document_count` works against views.