### PR TITLE
RUST-1274 Fix commitTransaction on check out retries

### DIFF
--- a/src/event/sdam/mod.rs
+++ b/src/event/sdam/mod.rs
@@ -36,6 +36,17 @@ pub struct ServerDescriptionChangedEvent {
     pub new_description: ServerDescription,
 }
 
+impl ServerDescriptionChangedEvent {
+    #[cfg(test)]
+    pub(crate) fn is_marked_unknown_event(&self) -> bool {
+        self.previous_description
+            .description
+            .server_type
+            .is_available()
+            && self.new_description.description.server_type == crate::ServerType::Unknown
+    }
+}
+
 /// Published when a server is initialized.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[non_exhaustive]

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -379,7 +379,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum Retryability {
     Write,
     Read,

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -122,6 +122,7 @@ impl PartialEq for ServerDescription {
 
                 self_response == other_response
             }
+            (Err(self_err), Err(other_err)) => self_err == other_err,
             _ => false,
         }
     }

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -127,9 +127,8 @@ impl HeartbeatMonitor {
             let mut topology_check_requests_subscriber =
                 topology.subscribe_to_topology_check_requests();
 
-            if self.check_server(&topology, &server).await {
-                topology.notify_topology_changed();
-            }
+            self.check_server(&topology, &server).await;
+            topology.notify_topology_changed();
 
             // drop strong reference to topology before going back to sleep in case it drops off
             // in between checks.

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -731,7 +731,7 @@ async fn retry_commit_txn_check_out() {
         .unwrap();
 
     // enable a fail point that clears the connection pools so that
-    // commitTransaction will check out a connection
+    // commitTransaction will create a new connection during check out.
     let fp = FailPoint::fail_command(
         &["ping"],
         FailPointMode::Times(1),

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -779,7 +779,7 @@ async fn retry_commit_txn_check_out() {
     // enable a failpoint on the handshake to cause check_out
     // to fail with a retryable error
     let fp = FailPoint::fail_command(
-        &[LEGACY_HELLO_COMMAND_NAME],
+        &[LEGACY_HELLO_COMMAND_NAME, "hello"],
         FailPointMode::Times(1),
         FailCommandOptions::builder()
             .error_code(11600)

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -389,9 +389,9 @@ pub struct EventSubscriber<'a> {
 }
 
 impl EventSubscriber<'_> {
-    pub async fn wait_for_event<F>(&mut self, timeout: Duration, filter: F) -> Option<Event>
+    pub async fn wait_for_event<F>(&mut self, timeout: Duration, mut filter: F) -> Option<Event>
     where
-        F: Fn(&Event) -> bool,
+        F: FnMut(&Event) -> bool,
     {
         runtime::timeout(timeout, async {
             loop {

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -240,6 +240,21 @@ impl TestClient {
         version.matches(&self.server_version)
     }
 
+    /// Whether the deployment supports failing the initial handshake
+    /// only when it uses a specified appName.
+    ///
+    /// See SERVER-49336 for more info.
+    pub fn supports_fail_command_appname_initial_handshake(&self) -> bool {
+        let requirements = [
+            VersionReq::parse(">= 4.2.15, < 4.3.0").unwrap(),
+            VersionReq::parse(">= 4.4.7, < 4.5.0").unwrap(),
+            VersionReq::parse(">= 4.9.0").unwrap(),
+        ];
+        requirements
+            .iter()
+            .any(|req| req.matches(&self.server_version))
+    }
+
     pub fn supports_transactions(&self) -> bool {
         self.is_replica_set() && self.server_version_gte(4, 0)
             || self.is_sharded() && self.server_version_gte(4, 2)


### PR DESCRIPTION
RUST-1274

This backports the fix for `InvalidOptions` errors that are seen when `commitTransaction` commands are retried due to connection check out failures. The fix for this was included on `main` in #628.