### PR TITLE
RUST-1191 Reduce flakiness of `change_stream::batch_mid_resume_token` test

### DIFF
--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -226,8 +226,10 @@ fn get_resume_token(
                 None => return Err(ErrorKind::MissingResumeToken.into()),
             };
             if *is_last && batch_token.is_some() {
+                println!("using post batch token");
                 batch_token.cloned()
             } else {
+                println!("using doc token");
                 Some(doc_token)
             }
         }

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -226,10 +226,8 @@ fn get_resume_token(
                 None => return Err(ErrorKind::MissingResumeToken.into()),
             };
             if *is_last && batch_token.is_some() {
-                println!("using post batch token");
                 batch_token.cloned()
             } else {
-                println!("using doc token");
                 Some(doc_token)
             }
         }

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -449,8 +449,9 @@ async fn batch_mid_resume_token() -> Result<()> {
     };
 
     coll.insert_one(doc! {}, None).await?;
-    coll.insert_one(doc! {}, None).await?;
+    // coll.insert_one(doc! {}, None).await?;
 
+    let event = stream.next().await.transpose()?.unwrap();
     let mid_id = stream.next().await.transpose()?.unwrap().id;
     assert_eq!(stream.resume_token(), Some(mid_id));
 

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -8,8 +8,10 @@ use crate::{
         options::ChangeStreamOptions,
         ChangeStream,
     },
+    coll::options::CollectionOptions,
     db::options::{ChangeStreamPreAndPostImages, CreateCollectionOptions},
     event::command::{CommandStartedEvent, CommandSucceededEvent},
+    options::{Acknowledgment, WriteConcern},
     test::{CommandEvent, FailCommandOptions, FailPoint, FailPointMode},
     Collection,
 };
@@ -46,7 +48,12 @@ async fn init_stream(
     }
     let client = EventClient::with_options(options).await;
     let db = client.database("change_stream_tests");
-    let coll = db.collection::<Document>(coll_name);
+    let coll = db.collection_with_options::<Document>(
+        coll_name,
+        CollectionOptions::builder()
+            .write_concern(WriteConcern::builder().w(Acknowledgment::Majority).build())
+            .build(),
+    );
     coll.drop(None).await?;
     let stream = coll.watch(None, None).await?;
     Ok(Some((client, coll, stream)))
@@ -448,10 +455,9 @@ async fn batch_mid_resume_token() -> Result<()> {
         None => return Ok(()),
     };
 
-    coll.insert_one(doc! {}, None).await?;
-    // coll.insert_one(doc! {}, None).await?;
+    coll.insert_many((0..2).map(|i| doc! { "_id": i as i32 }), None)
+        .await?;
 
-    let event = stream.next().await.transpose()?.unwrap();
     let mid_id = stream.next().await.transpose()?.unwrap().id;
     assert_eq!(stream.resume_token(), Some(mid_id));
 


### PR DESCRIPTION
RUST-1191

This PR updates the driver's implementation of prose test 13 from the change stream spec, which is the following:

>For a ChangeStream under these conditions:
>
>    The batch is not empty.
>    The batch has been iterated up to but not including the last element.
>
>Expected result:
>
>    getResumeToken must return the _id of the previous document returned.

Our implementation of the test used two separate `insert_one` operations to generate the events. I think this caused sporadic failures on sharded clusters due to the events not arriving in the same batch sometimes. Change Streams are much faster on replica sets, so this problem wasn't as common there.

The test has been updated to use a single `insert_many` operation instead, along with a majority write concern, which seems to fix the failures. This matches the Python implementation of the test.