### PR TITLE
RUST-1283 Build docs in read-only directory and install cargo in project directory on Evergreen

### DIFF
--- a/.evergreen/check-all.sh
+++ b/.evergreen/check-all.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 

--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 # Pin clippy to the lastest version. This should be updated when new versions of Rust are released.
 rustup default 1.59.0
 cargo clippy --all-targets -p mongodb -- -D warnings

--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -5,9 +5,9 @@ set -o errexit
 source ./.evergreen/configure-rust.sh
 # Pin clippy to the lastest version. This should be updated when new versions of Rust are released.
 rustup default 1.59.0
-cargo clippy --all-targets -p mongodb -- -D warnings
-# check clippy with compressors separately
-cargo clippy --all-targets -p mongodb --features zstd-compression,snappy-compression,zlib-compression -- -D warnings
-cargo clippy --all-targets --no-default-features --features async-std-runtime -p mongodb -- -D warnings
-cargo clippy --all-targets --no-default-features --features sync -p mongodb -- -D warnings
-cargo clippy --all-targets --features tokio-sync -p mongodb -- -D warnings
+
+source ./.evergreen/feature-combinations.sh
+
+for ((i = 0; i < ${#FEATURE_COMBINATIONS[@]}; i++)); do
+    cargo clippy --all-targets ${FEATURE_COMBINATIONS[$i]}  -p mongodb -- -D warnings
+done

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -1,8 +1,23 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
+
+# docs.rs builds the driver on a read-only file system. to create a more realistic environment, we first
+# build the driver to ensure we have all the deps already in src, and then limit the permissions on that directory
+# and rebuild the docs.
+# this is to help us avoid introducing problems like those described here 
+# https://docs.rs/about/builds#read-only-directories where we or a dependency modify source code during the
+# build process.
+cargo +nightly build
+cargo +nightly build --no-default-features --features async-std-runtime
+cargo +nightly build --no-default-features --features sync
+cargo +nightly build --features tokio-sync
+cargo clean
+
+chmod -R 555 ${CARGO_HOME}/registry/src
+
 cargo +nightly rustdoc -- -D warnings --cfg docsrs
 cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings --cfg docsrs
 cargo +nightly rustdoc --no-default-features --features sync -- -D warnings --cfg docsrs

--- a/.evergreen/check-rustdoc.sh
+++ b/.evergreen/check-rustdoc.sh
@@ -10,15 +10,18 @@ source ./.evergreen/configure-rust.sh
 # this is to help us avoid introducing problems like those described here 
 # https://docs.rs/about/builds#read-only-directories where we or a dependency modify source code during the
 # build process.
-cargo +nightly build
-cargo +nightly build --no-default-features --features async-std-runtime
-cargo +nightly build --no-default-features --features sync
-cargo +nightly build --features tokio-sync
+
+source ./.evergreen/feature-combinations.sh
+
+# build with all available features to ensure all optional dependencies are brought in too.
+for ((i = 0; i < ${#FEATURE_COMBINATIONS[@]}; i++)); do
+    cargo +nightly build ${FEATURE_COMBINATIONS[$i]}
+done
 cargo clean
 
 chmod -R 555 ${CARGO_HOME}/registry/src
 
-cargo +nightly rustdoc -- -D warnings --cfg docsrs
-cargo +nightly rustdoc --no-default-features --features async-std-runtime -- -D warnings --cfg docsrs
-cargo +nightly rustdoc --no-default-features --features sync -- -D warnings --cfg docsrs
-cargo +nightly rustdoc --features tokio-sync -- -D warnings --cfg docsrs
+for ((i = 0; i < ${#FEATURE_COMBINATIONS[@]}; i++)); do
+    cargo +nightly rustdoc ${FEATURE_COMBINATIONS[$i]} -- -D warnings --cfg docsrs
+done
+

--- a/.evergreen/check-rustfmt.sh
+++ b/.evergreen/check-rustfmt.sh
@@ -2,6 +2,6 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 rustfmt +nightly --unstable-features --check src/**/*.rs
 rustfmt +nightly --unstable-features --check src/*.rs

--- a/.evergreen/compile-only-async-std.sh
+++ b/.evergreen/compile-only-async-std.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 rustup run $RUST_VERSION cargo build --no-default-features --features async-std-runtime
 rustup run $RUST_VERSION cargo build --no-default-features --features sync

--- a/.evergreen/compile-only-tokio.sh
+++ b/.evergreen/compile-only-tokio.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 # Enable snappy, zlib unconditionally
 FEATURE_FLAGS=snappy-compression,zlib-compression

--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 rustup update $RUST_VERSION
 
 if [ "$ASYNC_RUNTIME" = "tokio" ]; then

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -252,6 +252,7 @@ functions:
     - command: shell.exec
       type: test
       params:
+        shell: bash
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
@@ -265,7 +266,7 @@ functions:
 
           # compile mini test project
           cd $PROJECT_DIRECTORY/.evergreen/aws-ecs-test
-          . ~/.cargo/env
+          . ${PROJECT_DIRECTORY}/.evergreen/configure-rust.sh
           cargo build
           cd -
 
@@ -431,6 +432,7 @@ functions:
           export MONGO_ATLAS_TLS11_URI_SRV='${MONGO_ATLAS_TLS11_URI_SRV}'
           export MONGO_ATLAS_TLS12_URI='${MONGO_ATLAS_TLS12_URI}'
           export MONGO_ATLAS_TLS12_URI_SRV='${MONGO_ATLAS_TLS12_URI_SRV}'
+          export PROJECT_DIRECTORY='${PROJECT_DIRECTORY}'
           ASYNC_RUNTIME=${ASYNC_RUNTIME} .evergreen/run-atlas-tests.sh
 
   "run ocsp test":
@@ -617,7 +619,6 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          rm -rf ~/.rustup
           rm -rf $DRIVERS_TOOLS || true
 
   "fix absolute paths":

--- a/.evergreen/configure-rust.sh
+++ b/.evergreen/configure-rust.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export RUSTUP_HOME="${PROJECT_DIRECTORY}/.rustup"
+export PATH="${RUSTUP_HOME}/bin:$PATH"
+export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
+export PATH="${CARGO_HOME}/bin:$PATH"
+
+if [[ "Windows_NT" == "$OS" ]]; then
+    # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
+    export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
+    export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
+fi
+
+. ${CARGO_HOME}/env

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-export PATH="/opt/mongodbtoolchain/v2/bin:$PATH"
-
-source ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"

--- a/.evergreen/feature-combinations.sh
+++ b/.evergreen/feature-combinations.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Array of feature combinations that, in total, provides complete coverage of the driver.
+# This is useful for linting tasks where we want to get coverage of all features.
+# Since some of our features are mutually exclusive we cannot just use --all-features.
+export FEATURE_COMBINATIONS=(
+    '' # default features
+    '--no-default-features --features async-std-runtime,sync' # features that conflict w/ default features
+    '--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth' # additive features
+)

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -1,25 +1,26 @@
 #!/bin/bash
 
+set -o xtrace
+set -o errexit
+
+export RUSTUP_HOME="${PROJECT_DIRECTORY}/.rustup"
+export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
+
 # Make sure to use msvc toolchain rather than gnu, which is the default for cygwin
 if [ "Windows_NT" == "$OS" ]; then
     export DEFAULT_HOST_OPTIONS='--default-host x86_64-pc-windows-msvc'
+    # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
+    export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
+    export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
 fi
 
-rm -rf ~/.rustup
 curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path $DEFAULT_HOST_OPTIONS
 
-# rustup installs into C:\Users\$USER instead of C:\home\$USER, so we symlink both .rustup and .cargo
-if [ "Windows_NT" == "$OS" ]; then
-    ln -s /cygdrive/c/Users/$USER/.rustup/ ~/.rustup
-    ln -s /cygdrive/c/Users/$USER/.cargo/ ~/.cargo
-fi
-
 # This file is not created by default on Windows
-echo 'export PATH=$PATH:~/.cargo/bin' >> ~/.cargo/env
+echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >> ${CARGO_HOME}/env
+echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ${CARGO_HOME}/env
 
-echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >> ~/.cargo/env
-
-source ~/.cargo/env
+source ${CARGO_HOME}/env
 
 # Install nightly rustfmt
 rustup toolchain install nightly -c rustfmt

--- a/.evergreen/release-danger-do-not-run-manually.sh
+++ b/.evergreen/release-danger-do-not-run-manually.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢ ☠ ☢
 # # Danger!
 #
@@ -24,6 +26,6 @@ fi
 git fetch origin tag $TAG --no-tags
 git checkout $TAG
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 cargo publish --token $TOKEN

--- a/.evergreen/run-async-std-atlas-tests.sh
+++ b/.evergreen/run-async-std-atlas-tests.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 RUST_BACKTRACE=1 cargo test atlas_connectivity --no-default-features --features async-std-runtime
 

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -42,6 +42,6 @@ set -x
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 cargo test --features aws-auth auth_aws::auth_aws

--- a/.evergreen/run-bson-benchmarks.sh
+++ b/.evergreen/run-bson-benchmarks.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 cd benchmarks
 cargo run \

--- a/.evergreen/run-compile-benchmarks.sh
+++ b/.evergreen/run-compile-benchmarks.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 FEATURES=""
 

--- a/.evergreen/run-connection-string-tests.sh
+++ b/.evergreen/run-connection-string-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o xtrace
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 cargo test --features aws-auth spec::auth
 RUST_BACKTRACE=1 cargo test --features aws-auth uri_options

--- a/.evergreen/run-driver-benchmarks.sh
+++ b/.evergreen/run-driver-benchmarks.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 FEATURES=""
 

--- a/.evergreen/run-ocsp-test.sh
+++ b/.evergreen/run-ocsp-test.sh
@@ -33,6 +33,6 @@ CA_FILE=`echo "${DRIVERS_TOOLS}/.evergreen/ocsp/${OCSP_ALGORITHM}/ca.pem" | sed 
 
 export MONGODB_URI="${MONGODB_URI}tls=true&tlsCAFile=${CA_FILE}"
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 cargo test spec::ocsp

--- a/.evergreen/run-plain-tests.sh
+++ b/.evergreen/run-plain-tests.sh
@@ -3,6 +3,6 @@
 set -o errexit
 set -o xtrace 
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 RUST_BACKTRACE=1 MONGO_PLAIN_AUTH_TEST=1 cargo test plain

--- a/.evergreen/run-tokio-atlas-tests.sh
+++ b/.evergreen/run-tokio-atlas-tests.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 RUST_BACKTRACE=1 cargo test atlas_connectivity
 

--- a/manual/test.sh
+++ b/manual/test.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 
-. ~/.cargo/env
+source ./.evergreen/configure-rust.sh
 
 cd $(dirname $0)/deps
 cargo build


### PR DESCRIPTION
Attempts to better simulate the docs.rs build environment in our check-rustdoc test by making the cargo registry directory read-only.
Since the `chmod` makes the cargo registry unusable for future tasks that need to e.g. download different dependencies than the docs one, this also required changing how we install rustup cargo so that it happens in the project directory and is cleaned up at the end of each task, which is the "right" thing to do on Evergreen anyway rather than writing to the shared home directory.

Here's a[ patch](https://spruce.mongodb.com/task/mongo_rust_driver_lint_check_rustdoc_patch_279322cae0fe4f2302ed14fd541de640eebd75c4_627af92132f4173983980fd9_22_05_10_23_45_53/logs?execution=0) showing that check-rustdoc now fails if using the old version of `rustc_version_runtime` that we ran into issues with. 

I was concerned this change might lead to our tasks taking a lot longer since we are starting from scratch with rustup and cargo each time now, but the difference between my patch on this PR and the latest commit on main in terms of total runtime across all tasks is 293 hours (mine) vs 283 hours (main) so it doesn't seem to make a huge difference.