### PR TITLE
RUST-1290 Add the `wall_time` field to change stream events.

### DIFF
--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -6,7 +6,7 @@ use crate::{cursor::CursorSpecification, options::ChangeStreamOptions};
 
 #[cfg(test)]
 use bson::Bson;
-use bson::{Document, RawBson, RawDocumentBuf, Timestamp};
+use bson::{Document, RawBson, RawDocumentBuf, Timestamp, DateTime};
 use serde::{Deserialize, Serialize};
 
 /// An opaque token used for resuming an interrupted
@@ -86,6 +86,9 @@ pub struct ChangeStreamEvent<T> {
 
     /// The cluster time at which the change occurred.
     pub cluster_time: Option<Timestamp>,
+
+    /// The wall time from the mongod that the change event originated from.
+    pub wall_time: Option<DateTime>,
 
     /// The `Document` created or modified by the `insert`, `replace`, `delete`, `update`
     /// operations (i.e. CRUD operations).

--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -6,7 +6,7 @@ use crate::{cursor::CursorSpecification, options::ChangeStreamOptions};
 
 #[cfg(test)]
 use bson::Bson;
-use bson::{Document, RawBson, RawDocumentBuf, Timestamp, DateTime};
+use bson::{DateTime, Document, RawBson, RawDocumentBuf, Timestamp};
 use serde::{Deserialize, Serialize};
 
 /// An opaque token used for resuming an interrupted

--- a/src/test/spec/json/change-streams/unified/change-streams.json
+++ b/src/test/spec/json/change-streams/unified/change-streams.json
@@ -1428,6 +1428,48 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Test wallTime field is set in a change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.0.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "wallTime": {
+              "$$exists": true
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/test/spec/json/change-streams/unified/change-streams.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams.yml
@@ -737,3 +737,24 @@ tests:
                 pipeline: [ { $changeStream: {} } ]
               commandName: aggregate
               databaseName: *database0
+
+  - description: "Test wallTime field is set in a change event"
+    runOnRequirements:
+      - minServerVersion: "6.0.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          wallTime: { $$exists: true }


### PR DESCRIPTION
RUST-1290

This is a PoC implementation for the spec change for [DRIVERS-2285](https://jira.mongodb.org/browse/DRIVERS-2285).