### PR TITLE
RUST-1327 Restrict change stream tests to replsets

### DIFF
--- a/src/test/spec/json/change-streams/unified/change-streams-errors.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-errors.json
@@ -1,6 +1,11 @@
 {
   "description": "change-streams-errors",
   "schemaVersion": "1.7",
+  "runOnRequirements": [
+    {
+      "serverless": "forbid"
+    }
+  ],
   "createEntities": [
     {
       "client": {

--- a/src/test/spec/json/change-streams/unified/change-streams-errors.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-errors.yml
@@ -1,5 +1,10 @@
 description: "change-streams-errors"
+
 schemaVersion: "1.7"
+
+runOnRequirements:
+  - serverless: forbid
+
 createEntities:
   - client:
       id: &client0 client0

--- a/src/test/spec/json/change-streams/unified/change-streams-pre_and_post_images.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-pre_and_post_images.json
@@ -1,6 +1,6 @@
 {
   "description": "change-streams-pre_and_post_images",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "6.0.0",
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded-replicaset",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/change-streams/unified/change-streams-pre_and_post_images.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-pre_and_post_images.yml
@@ -1,10 +1,11 @@
 description: "change-streams-pre_and_post_images"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0.0"
     topologies: [ replicaset, sharded-replicaset, load-balanced ]
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded-replicaset",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-allowlist.yml
@@ -1,9 +1,13 @@
 # Tests for resume behavior on server versions that do not support the ResumableChangeStreamError label
 description: "change-streams-resume-allowlist"
+
 schemaVersion: "1.7"
+
 runOnRequirements:
   - minServerVersion: "3.6"
     topologies: [ replicaset, sharded-replicaset, load-balanced ]
+    serverless: forbid
+
 createEntities:
   - client:
       id: &client0 client0

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.json
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded-replicaset",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams-resume-errorLabels.yml
@@ -1,9 +1,13 @@
 # Tests for resume behavior on server versions that support the ResumableChangeStreamError label
 description: "change-streams-resume-errorlabels"
+
 schemaVersion: "1.7"
+
 runOnRequirements:
   - minServerVersion: "4.3.1"
     topologies: [ replicaset, sharded-replicaset, load-balanced ]
+    serverless: forbid
+
 createEntities:
   - client:
       id: &client0 client0

--- a/src/test/spec/json/change-streams/unified/change-streams.json
+++ b/src/test/spec/json/change-streams/unified/change-streams.json
@@ -5,9 +5,9 @@
     {
       "minServerVersion": "3.6",
       "topologies": [
-        "replicaset",
-        "sharded-replicaset"
-      ]
+        "replicaset"
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [
@@ -273,6 +273,15 @@
     },
     {
       "description": "Test new structure in ns document MUST NOT err",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "maxServerVersion": "5.2.99"
+        },
+        {
+          "minServerVersion": "6.0"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",
@@ -449,10 +458,7 @@
       "description": "$changeStream must be the first stage in a change stream pipeline sent to the server",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -525,10 +531,7 @@
       "description": "The server returns change stream responses in the specified server response format",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -578,10 +581,7 @@
       "description": "Executing a watch helper on a Collection results in notifications for changes to the specified collection",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -666,10 +666,7 @@
       "description": "Change Stream should allow valid aggregate pipeline stages",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -756,10 +753,7 @@
       "description": "Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.8.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.8.0"
         }
       ],
       "operations": [
@@ -861,10 +855,7 @@
       "description": "Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.8.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.8.0"
         }
       ],
       "operations": [
@@ -985,10 +976,7 @@
       "description": "Test insert, update, replace, and delete event types",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "3.6.0"
         }
       ],
       "operations": [
@@ -1140,10 +1128,7 @@
       "description": "Test rename and invalidate event types",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0.1",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.0.1"
         }
       ],
       "operations": [
@@ -1220,10 +1205,7 @@
       "description": "Test drop and invalidate event types",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.0.1",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.0.1"
         }
       ],
       "operations": [
@@ -1289,10 +1271,7 @@
       "description": "Test consecutive resume",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "replicaset"
-          ]
+          "minServerVersion": "4.1.7"
         }
       ],
       "operations": [

--- a/src/test/spec/json/change-streams/unified/change-streams.yml
+++ b/src/test/spec/json/change-streams/unified/change-streams.yml
@@ -1,8 +1,14 @@
 description: "change-streams"
+
 schemaVersion: "1.7"
+
 runOnRequirements:
   - minServerVersion: "3.6"
-    topologies: [ replicaset, sharded-replicaset ]
+    # TODO(DRIVERS-2323): Run all possible tests against sharded clusters once we know the
+    # cause of unexpected command monitoring events.
+    topologies: [ replicaset ]
+    serverless: forbid
+
 createEntities:
   - client:
       id: &client0 client0
@@ -155,6 +161,10 @@ tests:
           newField: "newFieldValue"
 
   - description: "Test new structure in ns document MUST NOT err"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+        maxServerVersion: "5.2.99"
+      - minServerVersion: "6.0"
     operations:
       - name: createChangeStream
         object: *collection0
@@ -238,7 +248,6 @@ tests:
   - description: $changeStream must be the first stage in a change stream pipeline sent to the server
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -275,7 +284,6 @@ tests:
   - description: The server returns change stream responses in the specified server response format
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -301,7 +309,6 @@ tests:
   - description: Executing a watch helper on a Collection results in notifications for changes to the specified collection
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -344,7 +351,6 @@ tests:
   - description: Change Stream should allow valid aggregate pipeline stages
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -389,7 +395,6 @@ tests:
   - description: Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.
     runOnRequirements:
       - minServerVersion: "3.8.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *database0
@@ -442,7 +447,6 @@ tests:
   - description: Executing a watch helper on a MongoClient results in notifications for changes to all collections in all databases in the cluster.
     runOnRequirements:
       - minServerVersion: "3.8.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *client0
@@ -506,7 +510,6 @@ tests:
   - description: "Test insert, update, replace, and delete event types"
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -584,7 +587,6 @@ tests:
   - description: Test rename and invalidate event types
     runOnRequirements:
       - minServerVersion: "4.0.1"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -627,7 +629,6 @@ tests:
   - description: Test drop and invalidate event types
     runOnRequirements:
       - minServerVersion: "4.0.1"
-        topologies: [ replicaset ]
     operations:
       - name: createChangeStream
         object: *collection0
@@ -661,11 +662,10 @@ tests:
               databaseName: *database0
 
   # Test that resume logic works correctly even after consecutive retryable failures of a getMore command,
-  # with no intervening events.  This is ensured by setting the batch size of the change stream to 1,
+  # with no intervening events. This is ensured by setting the batch size of the change stream to 1,
   - description: Test consecutive resume
     runOnRequirements:
       - minServerVersion: "4.1.7"
-        topologies: [ replicaset ]
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
RUST-1327

Change stream tests on sharded clusters occasionally fail with unexpected `delete` / `invalidate` events ([example](https://evergreen.mongodb.com/lobster/evergreen/test/mongo_rust_driver_tests__async_runtime~tokio_auth_and_tls~auth_and_tls_compressor~zstd_compression_os~ubuntu_18.04_test_4.4_sharded_cluster_patch_0be1d677dc86a0981964f530d4b7d7e727e0b678_6287abc356234305617b1532_22_05_20_14_55_02/0/4e37ff7dfa11f725f536cdfeacd4bbe5/#bookmarks=0%2C123&l=1&shareLine=1)); these failures need investigation but in the meanwhile the tests are being restricted to replsets to reduce noise.

This sync also picked up the changes for RUST-1286.