### PR TITLE
RUST-1090 Fix serverless tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -395,10 +395,8 @@ functions:
           export SERVERLESS_ATLAS_USER="${SERVERLESS_ATLAS_USER}"
           export SERVERLESS_ATLAS_PASSWORD="${SERVERLESS_ATLAS_PASSWORD}"
 
-          export MONGODB_URI="${MONGODB_URI}"
           export SSL="${SSL}"
-          export SINGLE_MONGOS_LB_URI="${SINGLE_ATLASPROXY_SERVERLESS_URI}"
-          export MULTI_MONGOS_LB_URI="${MULTI_ATLASPROXY_SERVERLESS_URI}"
+          export SINGLE_MONGOS_LB_URI="${SERVERLESS_URI}"
           . .evergreen/generate-uri.sh
 
           SNAPPY_COMPRESSION_ENABLED="true" \

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -45,7 +45,8 @@ cargo_test test::spec::sessions > sessions.xml
 cargo_test test::spec::transactions > transactions.xml
 cargo_test test::spec::load_balancers > load_balancers.xml
 cargo_test test::cursor > cursor.xml
+cargo_test test::spec::collection_management > coll.xml
 
-junit-report-merger results.xml crud.xml retryable_reads.xml retryable_writes.xml versioned_api.xml sessions.xml transactions.xml load_balancers.xml cursor.xml
+junit-report-merger results.xml crud.xml retryable_reads.xml retryable_writes.xml versioned_api.xml sessions.xml transactions.xml load_balancers.xml cursor.xml coll.xml
 
 exit $CARGO_RESULT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ features = ["v4"]
 
 [dev-dependencies]
 approx = "0.5.1"
+async_once = "0.2.6"
 derive_more = "0.99.13"
 function_name = "0.2.1"
 futures = "0.3"

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -1184,20 +1184,6 @@ impl ClientOptions {
         crate::runtime::block_on(Self::parse_connection_string(conn_str, resolver_config))
     }
 
-    #[cfg(test)]
-    pub(crate) fn parse_without_srv_resolution(s: &str) -> Result<Self> {
-        let mut conn_str = ConnectionString::parse(s)?;
-        let host_info = std::mem::take(&mut conn_str.host_info);
-        let mut options = Self::from_connection_string(conn_str);
-        options.hosts = match host_info {
-            HostInfo::HostIdentifiers(hosts) => hosts,
-            HostInfo::DnsRecord(_) => panic!("Expected non-SRV URI, got {:?}", s),
-        };
-        options.validate()?;
-
-        Ok(options)
-    }
-
     fn from_connection_string(conn_str: ConnectionString) -> Self {
         let mut credential = conn_str.credential;
         // Populate default auth source, if needed.

--- a/src/client/session/test/mod.rs
+++ b/src/client/session/test/mod.rs
@@ -248,7 +248,7 @@ async fn cluster_time_in_commands() {
         F: Fn(EventClient) -> G,
         G: Future<Output = Result<R>>,
     {
-        let mut options = CLIENT_OPTIONS.clone();
+        let mut options = CLIENT_OPTIONS.get().await.clone();
         options.heartbeat_freq = Some(Duration::from_secs(1000));
         let client = EventClient::with_options(options).await;
 

--- a/src/cmap/establish/test.rs
+++ b/src/cmap/establish/test.rs
@@ -41,7 +41,7 @@ async fn speculative_auth_test(
             .credential(credential.clone())
             .build(),
     );
-    pool_options.tls_options = CLIENT_OPTIONS.tls_options();
+    pool_options.tls_options = CLIENT_OPTIONS.get().await.tls_options();
 
     let description = client.topology_description();
 

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -42,7 +42,7 @@ struct DatabaseEntry {
 async fn acquire_connection_and_send_command() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
-    let client_options = CLIENT_OPTIONS.clone();
+    let client_options = CLIENT_OPTIONS.get().await.clone();
     let mut pool_options = ConnectionPoolOptions::from_client_options(&client_options);
     pool_options.ready = Some(true);
 
@@ -86,7 +86,7 @@ async fn acquire_connection_and_send_command() {
 async fn concurrent_connections() {
     let _guard = LOCK.run_exclusively().await;
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     if options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping concurrent_connections test due to load-balanced topology");
         return;
@@ -117,13 +117,13 @@ async fn concurrent_connections() {
         .expect("failpoint should succeed");
 
     let handler = Arc::new(EventHandler::new());
-    let client_options = CLIENT_OPTIONS.clone();
+    let client_options = CLIENT_OPTIONS.get().await.clone();
     let mut options = ConnectionPoolOptions::from_client_options(&client_options);
     options.cmap_event_handler = Some(handler.clone() as Arc<dyn crate::cmap::CmapEventHandler>);
     options.ready = Some(true);
 
     let pool = ConnectionPool::new(
-        CLIENT_OPTIONS.hosts[0].clone(),
+        CLIENT_OPTIONS.get().await.hosts[0].clone(),
         Default::default(),
         TopologyUpdater::channel().0,
         Some(options),
@@ -174,7 +174,7 @@ async fn concurrent_connections() {
 async fn connection_error_during_establishment() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     if client_options.load_balanced.unwrap_or(false) {
         log_uncaptured(
             "skipping connection_error_during_establishment test due to load-balanced topology",
@@ -235,7 +235,7 @@ async fn connection_error_during_establishment() {
 async fn connection_error_during_operation() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     let handler = Arc::new(EventHandler::new());
     options.cmap_event_handler = Some(handler.clone() as Arc<dyn CmapEventHandler>);
     options.hosts.drain(1..);

--- a/src/compression/test.rs
+++ b/src/compression/test.rs
@@ -69,7 +69,7 @@ fn test_snappy_compressor() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[cfg(feature = "zlib-compression")]
 async fn ping_server_with_zlib_compression() {
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.compressors = Some(vec![Compressor::Zlib { level: Some(4) }]);
     send_ping_with_compression(client_options).await;
 }
@@ -78,7 +78,7 @@ async fn ping_server_with_zlib_compression() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[cfg(feature = "zstd-compression")]
 async fn ping_server_with_zstd_compression() {
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.compressors = Some(vec![Compressor::Zstd { level: None }]);
     send_ping_with_compression(client_options).await;
 }
@@ -87,7 +87,7 @@ async fn ping_server_with_zstd_compression() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[cfg(feature = "snappy-compression")]
 async fn ping_server_with_snappy_compression() {
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.compressors = Some(vec![Compressor::Snappy]);
     send_ping_with_compression(client_options).await;
 }
@@ -100,7 +100,7 @@ async fn ping_server_with_snappy_compression() {
     feature = "snappy-compression"
 ))]
 async fn ping_server_with_all_compressors() {
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.compressors = Some(vec![
         Compressor::Zlib { level: None },
         Compressor::Snappy,

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -118,7 +118,7 @@ async fn select_in_window() {
 async fn load_balancing_test() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut setup_client_options = CLIENT_OPTIONS.clone();
+    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
 
     if setup_client_options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping load_balancing_test test due to load-balanced topology");
@@ -148,7 +148,7 @@ async fn load_balancing_test() {
         return;
     }
 
-    if CLIENT_OPTIONS.hosts.len() != 2 {
+    if CLIENT_OPTIONS.get().await.hosts.len() != 2 {
         log_uncaptured("skipping load_balancing_test test due to topology not having 2 mongoses");
         return;
     }
@@ -215,7 +215,7 @@ async fn load_balancing_test() {
 
     let mut handler = EventHandler::new();
     let mut subscriber = handler.subscribe();
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     let max_pool_size = 10;
     let hosts = options.hosts.clone();
     options.local_threshold = Duration::from_secs(30).into();
@@ -260,7 +260,7 @@ async fn load_balancing_test() {
         .build();
     let failpoint = FailPoint::fail_command(&["find"], FailPointMode::AlwaysOn, options);
 
-    let slow_host = CLIENT_OPTIONS.hosts[0].clone();
+    let slow_host = CLIENT_OPTIONS.get().await.hosts[0].clone();
     let criteria = SelectionCriteria::Predicate(Arc::new(move |si| si.address() == &slow_host));
     let fp_guard = setup_client
         .enable_failpoint(failpoint, criteria)

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -611,7 +611,7 @@ async fn topology_closed_event_last() {
 async fn heartbeat_events() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     options.hosts.drain(1..);
     options.heartbeat_freq = Some(Duration::from_millis(50));
     options.app_name = "heartbeat_events".to_string().into();
@@ -692,7 +692,7 @@ async fn direct_connection() {
         .await
         .expect("failed to select secondary");
 
-    let mut secondary_options = CLIENT_OPTIONS.clone();
+    let mut secondary_options = CLIENT_OPTIONS.get().await.clone();
     secondary_options.hosts = vec![secondary_address];
 
     let mut direct_false_options = secondary_options.clone();

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -118,7 +118,7 @@ async fn no_results() {
 async fn load_balanced_no_srv_polling() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
-    if CLIENT_OPTIONS.load_balanced != Some(true) {
+    if CLIENT_OPTIONS.get().await.load_balanced != Some(true) {
         log_uncaptured("skipping load_balanced_no_srv_polling due to not load balanced topology");
         return;
     }

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -33,7 +33,7 @@ use crate::{
 async fn min_heartbeat_frequency() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut setup_client_options = CLIENT_OPTIONS.clone();
+    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
     if setup_client_options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping min_heartbeat_frequency test due to load-balanced topology");
         return;
@@ -102,7 +102,7 @@ async fn min_heartbeat_frequency() {
 async fn sdam_pool_management() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     if options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping sdam_pool_management test due to load-balanced topology");
         return;
@@ -198,7 +198,7 @@ async fn sdam_pool_management() {
 async fn sdam_min_pool_size_error() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut setup_client_options = CLIENT_OPTIONS.clone();
+    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
     if setup_client_options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping sdam_min_pool_size_error test due to load-balanced topology");
         return;
@@ -291,7 +291,7 @@ async fn sdam_min_pool_size_error() {
 async fn auth_error() {
     let _guard: RwLockWriteGuard<_> = LOCK.run_exclusively().await;
 
-    let mut setup_client_options = CLIENT_OPTIONS.clone();
+    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
     setup_client_options.hosts.drain(1..);
     let setup_client = TestClient::with_options(Some(setup_client_options.clone())).await;
     if !VersionReq::parse(">= 4.4.0")
@@ -402,7 +402,7 @@ async fn auth_error() {
 async fn hello_ok_true() {
     let _guard: RwLockReadGuard<_> = LOCK.run_concurrently().await;
 
-    let mut setup_client_options = CLIENT_OPTIONS.clone();
+    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
     setup_client_options.hosts.drain(1..);
 
     if setup_client_options.server_api.is_some() {
@@ -474,7 +474,7 @@ async fn repl_set_name_mismatch() -> crate::error::Result<()> {
         return Ok(());
     }
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     options.hosts.drain(1..);
     options.direct_connection = Some(true);
     options.repl_set_name = Some("invalid".to_string());

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use lazy_static::lazy_static;
 use pretty_assertions::assert_eq;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLockReadGuard;
@@ -18,7 +19,7 @@ use crate::{
     },
     runtime,
     sync::{Client, Collection},
-    test::{TestClient as AsyncTestClient, CLIENT_OPTIONS, LOCK},
+    test::{TestClient as AsyncTestClient, LOCK},
 };
 
 fn init_db_and_coll(client: &Client, db_name: &str, coll_name: &str) -> Collection<Document> {
@@ -31,6 +32,11 @@ fn init_db_and_typed_coll<T>(client: &Client, db_name: &str, coll_name: &str) ->
     let coll = client.database(db_name).collection(coll_name);
     coll.drop(None).unwrap();
     coll
+}
+
+lazy_static! {
+    static ref CLIENT_OPTIONS: ClientOptions =
+        runtime::block_on(async { crate::test::CLIENT_OPTIONS.get().await.clone() });
 }
 
 #[test]

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -40,7 +40,7 @@ async fn init_stream(
         return Ok(None);
     }
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     // Direct connection is needed for reliable behavior with fail points.
     if direct_connection && init_client.is_sharded() {
         options.direct_connection = Some(true);

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -956,7 +956,7 @@ async fn typed_returns() {
 async fn count_documents_with_wc() {
     let _guard: RwLockReadGuard<()> = LOCK.run_concurrently().await;
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     options.write_concern = WriteConcern::builder()
         .w(Acknowledgment::Majority)
         .journal(true)

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,6 +33,7 @@ pub(crate) use self::{
     },
 };
 
+use async_once::AsyncOnce;
 use home::home_dir;
 use lazy_static::lazy_static;
 
@@ -49,11 +50,11 @@ use std::{fs::read_to_string, str::FromStr};
 const MAX_POOL_SIZE: u32 = 100;
 
 lazy_static! {
-    pub(crate) static ref CLIENT_OPTIONS: ClientOptions = {
-        let mut options = ClientOptions::parse_without_srv_resolution(&DEFAULT_URI).unwrap();
+    pub(crate) static ref CLIENT_OPTIONS: AsyncOnce<ClientOptions> = AsyncOnce::new(async {
+        let mut options = ClientOptions::parse_uri(&*DEFAULT_URI, None).await.unwrap();
         update_options_for_testing(&mut options);
         options
-    };
+    });
     pub(crate) static ref LOCK: TestLock = TestLock::new();
     pub(crate) static ref DEFAULT_URI: String = get_default_uri();
     pub(crate) static ref SERVER_API: Option<ServerApi> = match std::env::var("MONGODB_API_VERSION")

--- a/src/test/spec/command_monitoring/mod.rs
+++ b/src/test/spec/command_monitoring/mod.rs
@@ -86,7 +86,7 @@ async fn run_command_monitoring_test(test_file: TestFile) {
 
         let options = ClientOptions::builder()
             .retry_writes(false)
-            .hosts(CLIENT_OPTIONS.hosts.clone())
+            .hosts(CLIENT_OPTIONS.get().await.hosts.clone())
             .build();
         let client =
             EventClient::with_additional_options(Some(options), None, Some(false), None).await;

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -28,7 +28,7 @@ async fn run_test<F: Future>(
     let _guard: RwLockWriteGuard<()> = LOCK.run_exclusively().await;
 
     let options = ClientOptions::builder()
-        .hosts(CLIENT_OPTIONS.hosts.clone())
+        .hosts(CLIENT_OPTIONS.get().await.hosts.clone())
         .retry_writes(false)
         .build();
     let client = EventClient::with_additional_options(Some(options), None, None, None).await;

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -158,7 +158,7 @@ async fn run_test(mut test_file: TestFile) {
 
         let mut options_with_tls = options.clone();
         if requires_tls {
-            options_with_tls.tls = CLIENT_OPTIONS.tls.clone();
+            options_with_tls.tls = CLIENT_OPTIONS.get().await.tls.clone();
         }
 
         let client = Client::with_options(options_with_tls).unwrap();

--- a/src/test/spec/ocsp.rs
+++ b/src/test/spec/ocsp.rs
@@ -22,7 +22,7 @@ async fn run() {
         .unwrap()
         .to_lowercase();
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     let mut tls_options = options.tls_options().unwrap();
     options.server_selection_timeout = Duration::from_millis(200).into();
 

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -49,7 +49,7 @@ async fn run_unified() {
 async fn retry_releases_connection() {
     let _guard: RwLockWriteGuard<()> = LOCK.run_exclusively().await;
 
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.hosts.drain(1..);
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
@@ -83,7 +83,7 @@ async fn retry_read_pool_cleared() {
 
     let handler = Arc::new(EventHandler::new());
 
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
     client_options.cmap_event_handler = Some(handler.clone() as Arc<dyn CmapEventHandler>);

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -53,9 +53,9 @@ async fn run_legacy() {
             if test_case.operation.name == "bulkWrite" {
                 continue;
             }
-
+            let hosts = &CLIENT_OPTIONS.get().await.hosts;
             let options = test_case.client_options.map(|mut opts| {
-                opts.hosts = CLIENT_OPTIONS.hosts.clone();
+                opts.hosts = hosts.clone();
                 opts
             });
             let client = EventClient::with_additional_options(
@@ -414,7 +414,7 @@ async fn retry_write_pool_cleared() {
 
     let handler = Arc::new(EventHandler::new());
 
-    let mut client_options = CLIENT_OPTIONS.clone();
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
     client_options.retry_writes = Some(true);
     client_options.max_pool_size = Some(1);
     client_options.cmap_event_handler = Some(handler.clone() as Arc<dyn CmapEventHandler>);

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -15,6 +15,7 @@ use crate::{
         DEFAULT_URI,
         LOAD_BALANCED_MULTIPLE_URI,
         LOAD_BALANCED_SINGLE_URI,
+        SERVERLESS,
         SERVER_API,
     },
     Client,
@@ -95,8 +96,9 @@ impl TestRunner {
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());
                     let observer = Arc::new(EventHandler::new());
 
-                    let given_uri = if CLIENT_OPTIONS.load_balanced.unwrap_or(false) {
-                        if client.use_multiple_mongoses.unwrap_or(true) {
+                    let given_uri = if CLIENT_OPTIONS.get().await.load_balanced.unwrap_or(false) {
+                        // for serverless testing, ignore use_multiple_mongoses.
+                        if client.use_multiple_mongoses.unwrap_or(true) && !*SERVERLESS {
                             LOAD_BALANCED_MULTIPLE_URI.as_ref().expect(
                                 "Test requires URI for load balancer fronting multiple servers",
                             )

--- a/src/test/spec/versioned_api.rs
+++ b/src/test/spec/versioned_api.rs
@@ -61,7 +61,7 @@ async fn transaction_handling() {
 
     let version = ServerApi::builder().version(ServerApiVersion::V1).build();
 
-    let mut options = CLIENT_OPTIONS.clone();
+    let mut options = CLIENT_OPTIONS.get().await.clone();
     options.server_api = Some(version);
     let client = EventClient::with_options(options).await;
     if !client.is_replica_set() || client.server_version_lt(5, 0) {


### PR DESCRIPTION
RUST-1090

The original task here was to fix the serverless testing tasks, which had started failing recently after some changes were made to the drivers-evergreen-tools scripts for setting up serverless testing. See DRIVERS-1967 for details, but essentially the required changes for that were:
* update the `SERVERLESS_DRIVERS_GROUP` variable on our Evergreen project
* drivers-evergreen-tools only generates a single URI now, `SERVERLESS_URI`; always use this for serverless tests
* When testing against serverless, ignore `useMultipleMongoses` and always use the `SERVERLESS_URI` / `SINGLE_MONGOS_LB_URI`
* run _all_ unified spec tests against serverless

This was quite straightforward in Swift (see https://github.com/mongodb/mongo-swift-driver/pull/754), but presented some extra challenges in Rust, because as part of DRIVERS-1967 the SERVERLESS_URI was switched to use the `mongodb+srv` scheme. For some historical reasons discussed [here](https://github.com/mongodb/mongo-rust-driver/pull/187#issuecomment-635526507), we were not performing SRV resolution when parsing `CLIENT_OPTIONS`, which prevented any client created using `CLIENT_OPTIONS` from connecting to serverless. Our explicit SRV-related tests don't use `CLIENT_OPTIONS` so this wasn't a problem previously, but basically all of our test runners with tests we run against serverless do use it. To work around this, I've switched to using [async_once](https://docs.rs/async_once/latest/async_once/) to allow us to have an async lazy static, and updated tests to use that instead. 