### PR TITLE
RUST-1299, RUST-1316: Update server versions tested on Evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -863,6 +863,17 @@ tasks:
           TOPOLOGY: "sharded_cluster"
       - func: "run tests"
 
+  - name: "test-5.0-load_balancer"
+    tags: ["5.0", "load_balancer"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "5.0"
+          TOPOLOGY: "sharded_cluster"
+          LOAD_BALANCER: "true"
+      - func: "start load balancer"
+      - func: "run tests"
+
   - name: "test-5.0-aws-auth"
     # "5.0" explicitly left off to keep this out of the generic matrix
     tags: ["aws-auth"]
@@ -871,6 +882,118 @@ tasks:
         vars:
           ORCHESTRATION_FILE: "auth-aws.json"
           MONGODB_VERSION: "5.0"
+          AUTH: "auth"
+          TOPOLOGY: "server"
+      - func: "add aws auth variables to file"
+      - func: "run aws auth test with regular aws credentials"
+      - func: "run aws auth test with assume role credentials"
+      - func: "run aws auth test with aws credentials as environment variables"
+      - func: "run aws auth test with aws credentials and session token as environment variables"
+      - func: "run aws auth test with aws EC2 credentials"
+      - func: "run aws ECS auth test"
+
+  - name: "test-6.0-standalone"
+    tags: ["6.0", "standalone"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "server"
+      - func: "run tests"
+
+  - name: "test-6.0-replica_set"
+    tags: ["6.0", "replica_set"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "replica_set"
+      - func: "run tests"
+
+  - name: "test-6.0-sharded_cluster"
+    tags: ["6.0", "sharded_cluster"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "sharded_cluster"
+      - func: "run tests"
+
+  - name: "test-6.0-load_balancer"
+    tags: ["6.0", "load_balancer"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "6.0"
+          TOPOLOGY: "sharded_cluster"
+          LOAD_BALANCER: "true"
+      - func: "start load balancer"
+      - func: "run tests"
+
+  - name: "test-6.0-aws-auth"
+    # "6.0" explicitly left off to keep this out of the generic matrix
+    tags: ["aws-auth"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          ORCHESTRATION_FILE: "auth-aws.json"
+          MONGODB_VERSION: "6.0"
+          AUTH: "auth"
+          TOPOLOGY: "server"
+      - func: "add aws auth variables to file"
+      - func: "run aws auth test with regular aws credentials"
+      - func: "run aws auth test with assume role credentials"
+      - func: "run aws auth test with aws credentials as environment variables"
+      - func: "run aws auth test with aws credentials and session token as environment variables"
+      - func: "run aws auth test with aws EC2 credentials"
+      - func: "run aws ECS auth test"
+
+  - name: "test-rapid-standalone"
+    tags: ["rapid", "standalone"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "rapid"
+          TOPOLOGY: "server"
+      - func: "run tests"
+
+  - name: "test-rapid-replica_set"
+    tags: ["rapid", "replica_set"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "rapid"
+          TOPOLOGY: "replica_set"
+      - func: "run tests"
+
+  - name: "test-rapid-sharded_cluster"
+    tags: ["rapid", "sharded_cluster"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "rapid"
+          TOPOLOGY: "sharded_cluster"
+      - func: "run tests"
+
+  - name: "test-rapid-load_balancer"
+    tags: ["rapid", "load_balancer"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          MONGODB_VERSION: "rapid"
+          TOPOLOGY: "sharded_cluster"
+          LOAD_BALANCER: "true"
+      - func: "start load balancer"
+      - func: "run tests"
+
+  - name: "test-rapid-aws-auth"
+    # "rapid" explicitly left off to keep this out of the generic matrix
+    tags: ["aws-auth"]
+    commands:
+      - func: "bootstrap mongo-orchestration"
+        vars:
+          ORCHESTRATION_FILE: "auth-aws.json"
+          MONGODB_VERSION: "rapid"
           AUTH: "auth"
           TOPOLOGY: "server"
       - func: "add aws auth variables to file"
@@ -1332,6 +1455,14 @@ axes:
         display_name: "latest"
         variables:
            MONGODB_VERSION: "latest"
+      - id: "rapid"
+        display_name: "rapid"
+        variables:
+           MONGODB_VERSION: "rapid"
+      - id: "6.0"
+        display_name: "6.0"
+        variables:
+          MONGODB_VERSION: "6.0"
       - id: "5.0"
         display_name: "5.0"
         variables:
@@ -1540,6 +1671,8 @@ buildvariants:
   display_name: "! ${os} ${auth-and-tls} with ${async-runtime} and ${compressor}"
   tasks:
      - ".latest"
+     - ".rapid"
+     - ".6.0"
      - ".5.0"
      - ".4.4"
      - ".4.2"
@@ -1697,6 +1830,8 @@ buildvariants:
   display_name: "Versioned API ${versioned-api}"
   tasks:
     - ".latest .standalone"
+    - ".rapid .standalone"
+    - ".6.0 .standalone"
     - ".5.0 .standalone"
 
 -


### PR DESCRIPTION
* Add 6.0 tasks
* Add "rapid" tasks (these test against the latest "rapid" release, so currently 5.3)
* Add load balancer testing for all server versions 5.0+ now that LB support was backported (this was a quick win we had a ticket for already, RUST-1316)