### PR TITLE
RUST-1328 Only emit SDAM changed events when servers change

### DIFF
--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -122,6 +122,7 @@ impl PartialEq for ServerDescription {
 
                 self_response == other_response
             }
+            (Err(self_err), Err(other_err)) => self_err == other_err,
             _ => false,
         }
     }

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -646,7 +646,7 @@ async fn heartbeat_events() {
         .await
         .expect("should see server heartbeat succeeded event");
 
-    if !client.supports_fail_command_appname() {
+    if !client.supports_fail_command_appname_initial_handshake() {
         return;
     }
 

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -394,7 +394,7 @@ pub struct EventSubscriber<'a> {
     receiver: tokio::sync::broadcast::Receiver<Event>,
 }
 
-impl<'a> EventSubscriber<'a> {
+impl EventSubscriber<'_> {
     pub async fn wait_for_event<F>(&mut self, timeout: Duration, mut filter: F) -> Option<Event>
     where
         F: FnMut(&Event) -> bool,

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -244,9 +244,19 @@ impl TestClient {
         version.matches(&self.server_version)
     }
 
-    pub fn supports_fail_command_appname(&self) -> bool {
-        let version = VersionReq::parse(">= 4.2.9").unwrap();
-        version.matches(&self.server_version)
+    /// Whether the deployment supports failing the initial handshake
+    /// only when it uses a specified appName.
+    ///
+    /// See SERVER-49336 for more info.
+    pub fn supports_fail_command_appname_initial_handshake(&self) -> bool {
+        let requirements = [
+            VersionReq::parse(">= 4.2.15, < 4.3.0").unwrap(),
+            VersionReq::parse(">= 4.4.7, < 4.5.0").unwrap(),
+            VersionReq::parse(">= 4.9.0").unwrap(),
+        ];
+        requirements
+            .iter()
+            .any(|req| req.matches(&self.server_version))
     }
 
     pub fn supports_transactions(&self) -> bool {


### PR DESCRIPTION
This fixes a bug where ServerDescriptionChanged and
TopologyDescriptionChanged events were emitted despite no changes to
the topology. This would happen in cases where a ServerDescription was
Unknown due to an error.

This also adds a test for the fix for RUST-1274.