### PR TITLE
RUST-910 Expose server connectionId in command monitoring events

### DIFF
--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -39,6 +39,7 @@ pub(crate) use wire::next_request_id;
 
 /// User-facing information about a connection to the database.
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ConnectionInfo {
     /// A driver-generated identifier that uniquely identifies the connection.

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -269,6 +269,8 @@ impl Handshaker {
             }
         }
 
+        conn.server_id = hello_reply.command_response.connection_id;
+
         Ok(HandshakeResult {
             hello_reply,
             first_round,

--- a/src/event/command.rs
+++ b/src/event/command.rs
@@ -8,9 +8,10 @@ use serde::Serialize;
 use crate::{
     bson::{oid::ObjectId, Document},
     bson_util::serialize_error_as_string,
-    cmap::ConnectionInfo,
     error::Error,
 };
+
+pub use crate::cmap::ConnectionInfo;
 
 /// An event that triggers when a database command is initiated.
 #[derive(Clone, Debug, Serialize)]

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -237,6 +237,10 @@ pub(crate) struct HelloCommandResponse {
 
     /// The maximum permitted size of a BSON wire protocol message.
     pub max_message_size_bytes: i32,
+
+    /// The server-generated ID for the connection the "hello" command was run on.
+    /// Present on server versions 4.2+.
+    pub connection_id: Option<i32>,
 }
 
 impl PartialEq for HelloCommandResponse {

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -126,6 +126,7 @@ impl From<TestHelloCommandResponse> for HelloCommandResponse {
             compressors: None,
             hello_ok: test.hello_ok,
             max_message_size_bytes: 48 * 1024 * 1024,
+            connection_id: None,
         }
     }
 }

--- a/src/test/spec/json/command-monitoring/unified/pre-42-server-connection-id.json
+++ b/src/test/spec/json/command-monitoring/unified/pre-42-server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "pre-42-server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events do not include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/command-monitoring/unified/pre-42-server-connection-id.yml
+++ b/src/test/spec/json/command-monitoring/unified/pre-42-server-connection-id.yml
@@ -1,0 +1,56 @@
+description: "pre-42-server-connection-id"
+
+schemaVersion: "1.6"
+
+runOnRequirements:
+  - maxServerVersion: "4.0.99"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName server-connection-id-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - databaseName: *databaseName
+    collectionName: *collectionName
+    documents: []
+
+tests:
+  - description: "command events do not include server connection id"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+            document: { x: 1 }
+      - name: find
+        object: *collection
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServerConnectionId: false
+          - commandSucceededEvent:
+              commandName: insert
+              hasServerConnectionId: false
+          - commandStartedEvent:
+              commandName: find
+              hasServerConnectionId: false
+          - commandFailedEvent:
+              commandName: find
+              hasServerConnectionId: false

--- a/src/test/spec/json/command-monitoring/unified/server-connection-id.json
+++ b/src/test/spec/json/command-monitoring/unified/server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/command-monitoring/unified/server-connection-id.yml
+++ b/src/test/spec/json/command-monitoring/unified/server-connection-id.yml
@@ -1,0 +1,56 @@
+description: "server-connection-id"
+
+schemaVersion: "1.6"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName server-connection-id-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - databaseName: *databaseName
+    collectionName: *collectionName
+    documents: []
+
+tests:
+  - description: "command events include server connection id"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+            document: { x: 1 }
+      - name: find
+        object: *collection
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServerConnectionId: true
+          - commandSucceededEvent:
+              commandName: insert
+              hasServerConnectionId: true
+          - commandStartedEvent:
+              commandName: find
+              hasServerConnectionId: true
+          - commandFailedEvent:
+              commandName: find
+              hasServerConnectionId: true

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -68,11 +68,16 @@ fn command_events_match(
                 database_name: expected_database_name,
                 command: expected_command,
                 has_service_id: expected_has_service_id,
+                has_server_connection_id: expected_has_server_connection_id,
             },
         ) => {
             match_opt(&actual.command_name, expected_command_name)?;
             match_opt(&actual.db, expected_database_name)?;
             match_opt(&actual.service_id.is_some(), expected_has_service_id)?;
+            match_opt(
+                &actual.connection.server_id.is_some(),
+                expected_has_server_connection_id,
+            )?;
             match_results_opt(&actual.command, expected_command, entities)?;
             Ok(())
         }
@@ -82,10 +87,15 @@ fn command_events_match(
                 command_name: expected_command_name,
                 reply: expected_reply,
                 has_service_id: expected_has_service_id,
+                has_server_connection_id: expected_has_server_connection_id,
             },
         ) => {
             match_opt(&actual.command_name, expected_command_name)?;
             match_opt(&actual.service_id.is_some(), expected_has_service_id)?;
+            match_opt(
+                &actual.connection.server_id.is_some(),
+                expected_has_server_connection_id,
+            )?;
             match_results_opt(&actual.reply, expected_reply, None)?;
             Ok(())
         }
@@ -94,9 +104,14 @@ fn command_events_match(
             ExpectedCommandEvent::Failed {
                 command_name: expected_command_name,
                 has_service_id: expected_has_service_id,
+                has_server_connection_id: expected_has_server_connection_id,
             },
         ) => {
             match_opt(&actual.service_id.is_some(), expected_has_service_id)?;
+            match_opt(
+                &actual.connection.server_id.is_some(),
+                expected_has_server_connection_id,
+            )?;
             match_opt(&actual.command_name, expected_command_name)?;
             Ok(())
         }

--- a/src/test/spec/unified_runner/mod.rs
+++ b/src/test/spec/unified_runner/mod.rs
@@ -31,13 +31,8 @@ pub use self::{
     test_runner::{EntityMap, TestRunner},
 };
 
-static SPEC_VERSIONS: &[Version] = &[
-    Version::new(1, 0, 0),
-    Version::new(1, 1, 0),
-    Version::new(1, 4, 0),
-    Version::new(1, 5, 0),
-    Version::new(1, 7, 0),
-];
+static MIN_SPEC_VERSION: Version = Version::new(1, 0, 0);
+static MAX_SPEC_VERSION: Version = Version::new(1, 7, 0);
 
 pub async fn run_unified_format_test(test_file: TestFile) {
     run_unified_format_test_filtered(test_file, |_| true).await
@@ -47,18 +42,9 @@ pub async fn run_unified_format_test_filtered(
     test_file: TestFile,
     pred: impl Fn(&TestCase) -> bool,
 ) {
-    let version_matches = SPEC_VERSIONS.iter().any(|req| {
-        if req.major != test_file.schema_version.major {
-            return false;
-        }
-        if req.minor < test_file.schema_version.minor {
-            return false;
-        }
-        // patch versions do not affect the test file format
-        true
-    });
     assert!(
-        version_matches,
+        test_file.schema_version >= MIN_SPEC_VERSION
+            && test_file.schema_version <= MAX_SPEC_VERSION,
         "Test runner not compatible with specification version {}",
         &test_file.schema_version
     );

--- a/src/test/spec/unified_runner/test_event.rs
+++ b/src/test/spec/unified_runner/test_event.rs
@@ -22,17 +22,20 @@ pub enum ExpectedCommandEvent {
         database_name: Option<String>,
         command: Option<Document>,
         has_service_id: Option<bool>,
+        has_server_connection_id: Option<bool>,
     },
     #[serde(rename = "commandSucceededEvent", rename_all = "camelCase")]
     Succeeded {
         command_name: Option<String>,
         reply: Option<Document>,
         has_service_id: Option<bool>,
+        has_server_connection_id: Option<bool>,
     },
     #[serde(rename = "commandFailedEvent", rename_all = "camelCase")]
     Failed {
         command_name: Option<String>,
         has_service_id: Option<bool>,
+        has_server_connection_id: Option<bool>,
     },
 }
 

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -98,15 +98,20 @@ impl TestRunner {
                 }
             }
             if !can_run_on {
-                log_uncaptured("Client topology not compatible with test");
+                log_uncaptured(format!(
+                    "Skipping file {}; client topology not compatible with test",
+                    test_file.description
+                ));
                 return;
             }
         }
 
+        log_uncaptured(format!("Running file {}", test_file.description));
+
         for test_case in test_file.tests {
             if let Some(skip_reason) = test_case.skip_reason {
                 log_uncaptured(format!(
-                    "Skipping {}: {}",
+                    "Skipping test case {}: {}",
                     &test_case.description, skip_reason
                 ));
                 continue;
@@ -119,7 +124,7 @@ impl TestRunner {
                 .map(|op| op.name.as_str())
             {
                 log_uncaptured(format!(
-                    "Skipping {}: unsupported operation {}",
+                    "Skipping test case {}: unsupported operation {}",
                     &test_case.description, op
                 ));
                 continue;
@@ -127,13 +132,11 @@ impl TestRunner {
 
             if !pred(&test_case) {
                 log_uncaptured(format!(
-                    "Skipping {}: predicate failed",
+                    "Skipping test case {}: predicate failed",
                     test_case.description
                 ));
                 continue;
             }
-
-            log_uncaptured(format!("Running {}", &test_case.description));
 
             if let Some(requirements) = test_case.run_on_requirements {
                 let mut can_run_on = false;
@@ -144,12 +147,14 @@ impl TestRunner {
                 }
                 if !can_run_on {
                     log_uncaptured(format!(
-                        "{}: client topology not compatible with test",
+                        "Skipping test case {}: client topology not compatible with test",
                         &test_case.description
                     ));
                     continue;
                 }
             }
+
+            log_uncaptured(format!("Running {}", &test_case.description));
 
             if let Some(ref initial_data) = test_file.initial_data {
                 for data in initial_data {


### PR DESCRIPTION
RUST-910

We'll want to expose this in command log messages, so I went ahead with adding this to the monitoring events. 