### PR TITLE
Pin indexmap to 1.8.2 for MSRV compile tasks

### DIFF
--- a/.evergreen/MSRV-Cargo.lock
+++ b/.evergreen/MSRV-Cargo.lock
@@ -1,6 +1,6 @@
-# pin async-global-executor to 2.0.4 for 1.53 support.
 version = 3
 
+# pin async-global-executor to 2.0.4 for 1.53..<1.59 support.
 [[package]]
 name = "async-global-executor"
 version = "2.0.4"
@@ -15,4 +15,15 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
+]
+
+# pin indexmap to 1.8.2 for 1.53..<1.56 support.
+[[package]]
+name = "indexmap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]

--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -5,6 +5,11 @@ set -o errexit
 source ./.evergreen/configure-rust.sh
 rustup update $RUST_VERSION
 
+# pin dependencies who have bumped their MSRVs to > ours in recent releases.
+if [  "$MSRV" = "true" ]; then
+    cp .evergreen/MSRV-Cargo.lock Cargo.lock
+fi
+
 if [ "$ASYNC_RUNTIME" = "tokio" ]; then
     FEATURE_FLAGS=snappy-compression,zlib-compression
 
@@ -17,12 +22,6 @@ if [ "$ASYNC_RUNTIME" = "tokio" ]; then
     rustup run $RUST_VERSION cargo build --features tokio-sync,$FEATURE_FLAGS
 
 elif [ "$ASYNC_RUNTIME" = "async-std" ]; then
-    # v2.1 of async-global-executor bumped its MSRV to 1.59, so we need a Cargo.lock
-    # pinning to v2.0 to build with our MSRV.
-    if [  "$MSRV" = "true" ]; then
-        cp .evergreen/MSRV-Cargo.lock Cargo.lock
-    fi
-
     rustup run $RUST_VERSION cargo build --no-default-features --features async-std-runtime
     rustup run $RUST_VERSION cargo build --no-default-features --features sync
 else


### PR DESCRIPTION
indexmap bumped their MSRV to 1.56 in their latest release, so we need to pin it for our MSRV compilation tasks.