### PR TITLE
RUST-1191 Ensure change stream is in proper state in mid_batch_resume_token test

### DIFF
--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -3,12 +3,16 @@ pub mod event;
 pub(crate) mod options;
 pub mod session;
 
+#[cfg(test)]
+use std::collections::VecDeque;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
+#[cfg(test)]
+use bson::RawDocumentBuf;
 use bson::{Document, Timestamp};
 use derivative::Derivative;
 use futures_core::{future::BoxFuture, Stream};
@@ -166,6 +170,11 @@ where
     #[cfg(test)]
     pub(crate) fn set_kill_watcher(&mut self, tx: oneshot::Sender<()>) {
         self.cursor.set_kill_watcher(tx);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_batch(&self) -> &VecDeque<RawDocumentBuf> {
+        self.cursor.current_batch()
     }
 }
 

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -87,6 +87,11 @@ where
         self.state().buffer.current()
     }
 
+    #[cfg(test)]
+    pub(super) fn current_batch(&self) -> &VecDeque<RawDocumentBuf> {
+        self.state().buffer.as_ref()
+    }
+
     fn state_mut(&mut self) -> &mut CursorState {
         self.state.as_mut().unwrap()
     }
@@ -529,5 +534,11 @@ impl CursorBuffer {
 
     pub(crate) fn current(&self) -> Option<&RawDocument> {
         self.docs.front().map(|d| d.as_ref())
+    }
+}
+
+impl AsRef<VecDeque<RawDocumentBuf>> for CursorBuffer {
+    fn as_ref(&self) -> &VecDeque<RawDocumentBuf> {
+        &self.docs
     }
 }

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,12 +1,17 @@
 mod common;
 pub(crate) mod session;
 
+#[cfg(test)]
+use std::collections::VecDeque;
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
 
 use bson::RawDocument;
+
+#[cfg(test)]
+use bson::RawDocumentBuf;
 use futures_core::{future::BoxFuture, Stream};
 use serde::{de::DeserializeOwned, Deserialize};
 #[cfg(test)]
@@ -268,6 +273,11 @@ impl<T> Cursor<T> {
             "cursor already has a kill_watcher"
         );
         self.kill_watcher = Some(tx);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_batch(&self) -> &VecDeque<RawDocumentBuf> {
+        self.wrapped_cursor.as_ref().unwrap().current_batch()
     }
 }
 

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -455,7 +455,7 @@ async fn batch_mid_resume_token() -> Result<()> {
         None => return Ok(()),
     };
 
-    // This loop gets the stream to a point where it has been iterated up to but nt including
+    // This loop gets the stream to a point where it has been iterated up to but not including
     // the last event in its batch.
     let mut event_id = None;
     loop {


### PR DESCRIPTION
RUST-1191

This PR makes another attempt at reducing the flakiness of the `change_stream::mid_batch_resume_token` test.