### PR TITLE
Skip change streams test failing against server latest

### DIFF
--- a/src/test/spec/change_streams.rs
+++ b/src/test/spec/change_streams.rs
@@ -7,10 +7,11 @@ use super::{run_unified_format_test_filtered, unified_runner::TestCase};
 async fn run() {
     let _guard = LOCK.run_exclusively().await;
     let client = TestClient::new().await;
-    // TODO SERVER-65497: remove this skip.
-    let skip = client.is_sharded() && client.server_version_gte(6, 0);
-    let pred =
-        |tc: &TestCase| !skip || tc.description != "Test new structure in ns document MUST NOT err";
+    // TODO DRIVERS-2387: remove this skip.
+    let is_gte_6_1 = client.server_version_gte(6, 1);
+    let pred = |tc: &TestCase| {
+        !(is_gte_6_1 && tc.description == "change stream resumes after StaleShardVersion")
+    };
 
     run_spec_test(&["change-streams", "unified"], |f| {
         run_unified_format_test_filtered(f, pred)

--- a/src/test/spec/change_streams.rs
+++ b/src/test/spec/change_streams.rs
@@ -7,7 +7,7 @@ use super::{run_unified_format_test_filtered, unified_runner::TestCase};
 async fn run() {
     let _guard = LOCK.run_exclusively().await;
     let client = TestClient::new().await;
-    // TODO DRIVERS-2387: remove this skip.
+    // TODO RUST-1412: remove this skip.
     let is_gte_6_1 = client.server_version_gte(6, 1);
     let pred = |tc: &TestCase| {
         !(is_gte_6_1 && tc.description == "change stream resumes after StaleShardVersion")


### PR DESCRIPTION
This test is going to need to be changed or removed (see DRIVERS-2387); skipping it against server >= 6.1 in the meantime.