### PR TITLE
[2.3.x] Release automation fix

### DIFF
--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -49,6 +49,7 @@ functions:
 
           TAG=${GIT_TAG}           \
           TOKEN=${CRATES_IO_TOKEN} \
+          PROJECT_DIRECTORY="$(pwd)" \
             bash .evergreen/release-danger-do-not-run-manually.sh
 
 tasks:


### PR DESCRIPTION
Latest release task failed due to PROJECT_DIRECTORY being unset, which causes the configure-rust.sh script to think `/.cargo` is CARGO_HOME rather than `$PROJECT_DIRECTORY/.cargo`. 
Can't guarantee this fixes the automation, but one step closer to fixed anyway...