### PR TITLE
RUST-1383 Create or drop auxiliary collections when doing so for a collection with encrypted fields.

### DIFF
--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -10,7 +10,8 @@ use mongocrypt::Crypt;
 
 use crate::{
     error::{Error, Result},
-    Client, Namespace,
+    Client,
+    Namespace,
 };
 
 use options::{
@@ -175,14 +176,20 @@ impl ClientState {
     }
 }
 
-pub(crate) fn aux_collections(base_name: &str, enc_fields: &bson::Document) -> Result<Vec<Namespace>> {
+pub(crate) fn aux_collections(
+    base_name: &str,
+    enc_fields: &bson::Document,
+) -> Result<Vec<Namespace>> {
     let mut out = vec![];
     for &key in &["esc", "ecc", "ecoc"] {
         let name = match enc_fields.get_str(format!("{}Collection", key)) {
             Ok(s) => s.to_string(),
             Err(_) => format!("enxcol_.{}.{}", base_name, key),
         };
-        out.push(Namespace::from_str(&name).ok_or_else(|| Error::invalid_argument(format!("invalid namespace {:?}", name)))?);
+        out.push(
+            Namespace::from_str(&name)
+                .ok_or_else(|| Error::invalid_argument(format!("invalid namespace {:?}", name)))?,
+        );
     }
     Ok(out)
 }

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -10,7 +10,7 @@ use mongocrypt::Crypt;
 
 use crate::{
     error::{Error, Result},
-    Client,
+    Client, Namespace,
 };
 
 use options::{
@@ -175,14 +175,14 @@ impl ClientState {
     }
 }
 
-pub(crate) fn aux_collection_names(base_name: &str, enc_fields: &bson::Document) -> Vec<String> {
+pub(crate) fn aux_collections(base_name: &str, enc_fields: &bson::Document) -> Result<Vec<Namespace>> {
     let mut out = vec![];
     for &key in &["esc", "ecc", "ecoc"] {
         let name = match enc_fields.get_str(format!("{}Collection", key)) {
             Ok(s) => s.to_string(),
             Err(_) => format!("enxcol_.{}.{}", base_name, key),
         };
-        out.push(name);
+        out.push(Namespace::from_str(&name).ok_or_else(|| Error::invalid_argument(format!("invalid namespace {:?}", name)))?);
     }
-    out
+    Ok(out)
 }

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -174,3 +174,15 @@ impl ClientState {
         })
     }
 }
+
+pub(crate) fn aux_collection_names(base_name: &str, enc_fields: &bson::Document) -> Vec<String> {
+    let mut out = vec![];
+    for &key in &["esc", "ecc", "ecoc"] {
+        let name = match enc_fields.get_str(format!("{}Collection", key)) {
+            Ok(s) => s.to_string(),
+            Err(_) => format!("enxcol_.{}.{}", base_name, key),
+        };
+        out.push(name);
+    }
+    out
+}

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -177,19 +177,19 @@ impl ClientState {
 }
 
 pub(crate) fn aux_collections(
-    base_name: &str,
+    base_ns: &Namespace,
     enc_fields: &bson::Document,
 ) -> Result<Vec<Namespace>> {
     let mut out = vec![];
     for &key in &["esc", "ecc", "ecoc"] {
-        let name = match enc_fields.get_str(format!("{}Collection", key)) {
+        let coll = match enc_fields.get_str(format!("{}Collection", key)) {
             Ok(s) => s.to_string(),
-            Err(_) => format!("enxcol_.{}.{}", base_name, key),
+            Err(_) => format!("enxcol_.{}.{}", base_ns.coll, key),
         };
-        out.push(
-            Namespace::from_str(&name)
-                .ok_or_else(|| Error::invalid_argument(format!("invalid namespace {:?}", name)))?,
-        );
+        out.push(Namespace {
+            coll,
+            ..base_ns.clone()
+        });
     }
     Ok(out)
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,6 @@
 pub mod auth;
 #[cfg(feature = "csfle")]
-mod csfle;
+pub(crate) mod csfle;
 mod executor;
 pub mod options;
 pub mod session;

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -276,7 +276,7 @@ impl<T> Collection<T> {
         let found;
         if enc_fields.is_none() && client_enc_fields.is_some() {
             let filter = doc! { "name": self.name() };
-            let specs: Vec<_> = match session.as_deref_mut() {
+            let mut specs: Vec<_> = match session.as_deref_mut() {
                 Some(s) => {
                     let mut cursor = self
                         .inner
@@ -294,11 +294,10 @@ impl<T> Collection<T> {
                         .await?
                 }
             };
-            for spec in specs {
+            if let Some(spec) = specs.pop() {
                 if let Some(enc) = spec.options.encrypted_fields {
                     found = enc;
                     enc_fields = Some(&found);
-                    break;
                 }
             }
         }

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -305,7 +305,7 @@ impl<T> Collection<T> {
 
         // Drop the collections.
         if let Some(enc_fields) = enc_fields {
-            for ns in crate::client::csfle::aux_collections(self.name(), enc_fields)? {
+            for ns in crate::client::csfle::aux_collections(&self.namespace(), enc_fields)? {
                 let drop = DropCollection::new(ns, options.cloned());
                 self.client()
                     .execute_operation(drop, session.as_deref_mut())

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -222,10 +222,13 @@ impl<T> Collection<T> {
         options: impl Into<Option<DropCollectionOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<()> {
-        let session = session.into();
+        let mut session = session.into();
 
-        let mut options = options.into();
+        let mut options: Option<DropCollectionOptions> = options.into();
         resolve_options!(self, options, [write_concern]);
+
+        #[cfg(feature = "csfle")]
+        self.drop_aux_collections(options.as_ref(), session.as_deref_mut()).await?;
 
         let drop = DropCollection::new(self.namespace(), options);
         self.client().execute_operation(drop, session).await
@@ -244,6 +247,50 @@ impl<T> Collection<T> {
         session: &mut ClientSession,
     ) -> Result<()> {
         self.drop_common(options, session).await
+    }
+
+    #[cfg(feature = "csfle")]
+    async fn drop_aux_collections(
+        &self,
+        options: Option<&DropCollectionOptions>,
+        mut session: Option<&mut ClientSession>,
+    ) -> Result<()> {
+        // Find associated `encrypted_fields`:
+        // * from options to this call
+        let mut enc_fields = options
+            .and_then(|o| o.encrypted_fields.as_ref());
+        let enc_opts = self
+            .client()
+            .auto_encryption_opts()
+            .await;
+        // * from client-wide `encrypted_fields_map`:
+        let client_enc_fields = enc_opts
+            .as_ref()
+            .and_then(|eo| eo.encrypted_fields_map.as_ref());
+        if enc_fields.is_none() {
+            enc_fields = client_enc_fields
+                .and_then(|efm| efm.get(&format!("{}", self.namespace())));
+        }
+        // * from a `list_collections` call:
+        let found;
+        if enc_fields.is_none() && client_enc_fields.is_some() {
+            let filter = doc! { "name": self.name() };
+            let specs: Vec<_> = match session.as_deref_mut() {
+                Some(s) => {
+                    let mut cursor = self.inner.db.list_collections_with_session(filter, None, s).await?;
+                    cursor.stream(s).try_collect().await?
+                },
+                None => self.inner.db.list_collections(filter, None).await?.try_collect().await?,
+            };
+            for spec in specs {
+                if let Some(enc) = spec.options.encrypted_fields {
+                    found = enc;
+                    enc_fields = Some(&found);
+                    break;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Runs an aggregation operation.

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -387,7 +387,7 @@ impl<T> Collection<T> {
             .await
     }
 
-    async fn create_index_common(
+    pub(crate) async fn create_index_common(
         &self,
         index: IndexModel,
         options: impl Into<Option<CreateIndexOptions>>,

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -948,6 +948,11 @@ pub struct CreateIndexOptions {
 pub struct DropCollectionOptions {
     /// The write concern for the operation.
     pub write_concern: Option<WriteConcern>,
+
+    /// Map of encrypted fields for the collection.
+    #[cfg(feature = "csfle")]
+    #[serde(skip)]
+    pub encrypted_fields: Option<Document>,
 }
 
 /// Specifies the options to a

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -114,6 +114,11 @@ pub struct CreateCollectionOptions {
     /// Map of encrypted fields for the created collection.
     #[cfg(feature = "csfle")]
     pub encrypted_fields: Option<Document>,
+
+    /// Allow lookup of the collection in `AutoEncryptionOpts.encrypted_fields_map`.
+    #[cfg(feature = "csfle")]
+    #[serde(skip)]
+    pub(crate) use_encrypted_fields_map: Option<bool>,
 }
 
 /// Specifies how strictly the database should apply validation rules to existing documents during

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -110,6 +110,10 @@ pub struct CreateCollectionOptions {
 
     /// Options for clustered collections.
     pub clustered_index: Option<ClusteredIndex>,
+
+    /// Map of encrypted fields for the created collection.
+    #[cfg(feature = "csfle")]
+    pub encrypted_fields: Option<Document>,
 }
 
 /// Specifies how strictly the database should apply validation rules to existing documents during

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -114,11 +114,6 @@ pub struct CreateCollectionOptions {
     /// Map of encrypted fields for the created collection.
     #[cfg(feature = "csfle")]
     pub encrypted_fields: Option<Document>,
-
-    /// Allow lookup of the collection in `AutoEncryptionOpts.encrypted_fields_map`.
-    #[cfg(feature = "csfle")]
-    #[serde(skip)]
-    pub(crate) use_encrypted_fields_map: Option<bool>,
 }
 
 /// Specifies how strictly the database should apply validation rules to existing documents during

--- a/src/operation/drop_collection/test.rs
+++ b/src/operation/drop_collection/test.rs
@@ -15,6 +15,7 @@ fn build() {
             w: Some(Acknowledgment::Custom("abc".to_string())),
             ..Default::default()
         }),
+        ..Default::default()
     };
 
     let ns = Namespace {

--- a/src/operation/drop_collection/test.rs
+++ b/src/operation/drop_collection/test.rs
@@ -1,54 +1,8 @@
 use crate::{
     bson::doc,
-    cmap::StreamDescription,
-    concern::{Acknowledgment, WriteConcern},
     error::{ErrorKind, WriteFailure},
-    operation::{test::handle_response_test, DropCollection, Operation},
-    options::DropCollectionOptions,
-    Namespace,
+    operation::{test::handle_response_test, DropCollection},
 };
-
-#[test]
-fn build() {
-    let options = DropCollectionOptions {
-        write_concern: Some(WriteConcern {
-            w: Some(Acknowledgment::Custom("abc".to_string())),
-            ..Default::default()
-        }),
-        ..Default::default()
-    };
-
-    let ns = Namespace {
-        db: "test_db".to_string(),
-        coll: "test_coll".to_string(),
-    };
-
-    let mut op = DropCollection::new(ns.clone(), Some(options));
-
-    let description = StreamDescription::new_testing();
-    let cmd = op.build(&description).expect("build should succeed");
-
-    assert_eq!(cmd.name.as_str(), "drop");
-    assert_eq!(cmd.target_db.as_str(), "test_db");
-    assert_eq!(
-        cmd.body,
-        doc! {
-            "drop": "test_coll",
-            "writeConcern": { "w": "abc" }
-        }
-    );
-
-    let mut op = DropCollection::new(ns, None);
-    let cmd = op.build(&description).expect("build should succeed");
-    assert_eq!(cmd.name.as_str(), "drop");
-    assert_eq!(cmd.target_db.as_str(), "test_db");
-    assert_eq!(
-        cmd.body,
-        doc! {
-            "drop": "test_coll",
-        }
-    );
-}
 
 #[test]
 fn handle_success() {


### PR DESCRIPTION
RUST-1383

Per the [spec](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#queryable-encryption-create-and-drop-collection-helpers), `create` and `drop` need additional operations when acting on collections with encrypted fields.  The actual operations here are pretty straightforward; following the right defaulting logic for the associated `encrypted_fields` map is the majority of the complexity here.