### PR TITLE
RUST-1384 Implement auto encryption

### DIFF
--- a/.evergreen/feature-combinations.sh
+++ b/.evergreen/feature-combinations.sh
@@ -6,5 +6,5 @@
 export FEATURE_COMBINATIONS=(
     '' # default features
     '--no-default-features --features async-std-runtime,sync' # features that conflict w/ default features
-    '--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth' # additive features
+    '--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth,csfle' # additive features
 )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,8 +83,7 @@ hex = "0.4.0"
 hmac = "0.12.1"
 lazy_static = "1.4.0"
 md-5 = "0.10.1"
-#mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
-mongocrypt = { path = "../libmongocrypt-rust/mongocrypt", optional = true }
+mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,14 @@ tokio-runtime = [
     "tokio/rt",
     "tokio/time",
     "serde_bytes",
+    "mongocrypt/tokio",
 ]
 async-std-runtime = [
     "async-std",
     "async-std/attributes",
     "async-std-resolver",
     "tokio-util/compat",
+    "mongocrypt/async-std",
 ]
 sync = ["async-std-runtime"]
 tokio-sync = ["tokio-runtime"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ hmac = "0.12.1"
 lazy_static = "1.4.0"
 md-5 = "0.10.1"
 # mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
-mongocrypt = { path = "../libmongocrypt-rust/mongocrypt", optional = true }
+mongocrypt = { git = "https://github.com/abr-egn/libmongocrypt-rust.git", branch = "RUST-1384/send-ctx", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,8 @@ hex = "0.4.0"
 hmac = "0.12.1"
 lazy_static = "1.4.0"
 md-5 = "0.10.1"
-mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
+#mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
+mongocrypt = { path = "../libmongocrypt-rust/mongocrypt", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,8 @@ hex = "0.4.0"
 hmac = "0.12.1"
 lazy_static = "1.4.0"
 md-5 = "0.10.1"
-mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
+# mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
+mongocrypt = { path = "../libmongocrypt-rust/mongocrypt", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,8 +83,7 @@ hex = "0.4.0"
 hmac = "0.12.1"
 lazy_static = "1.4.0"
 md-5 = "0.10.1"
-# mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
-mongocrypt = { git = "https://github.com/abr-egn/libmongocrypt-rust.git", branch = "RUST-1384/send-ctx", optional = true }
+mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,12 @@ tokio-runtime = [
     "tokio/rt",
     "tokio/time",
     "serde_bytes",
-    "mongocrypt/tokio",
 ]
 async-std-runtime = [
     "async-std",
     "async-std/attributes",
     "async-std-resolver",
     "tokio-util/compat",
-    "mongocrypt/async-std",
 ]
 sync = ["async-std-runtime"]
 tokio-sync = ["tokio-runtime"]
@@ -68,7 +66,7 @@ zlib-compression = ["flate2"]
 snappy-compression = ["snap"]
 
 # DO NOT USE; see https://jira.mongodb.org/browse/RUST-569 for the status of CSFLE support in the Rust driver.
-csfle = ["mongocrypt", "which"]
+csfle = ["mongocrypt", "which", "rayon"]
 
 [dependencies]
 async-trait = "0.1.42"
@@ -92,6 +90,7 @@ openssl-probe = { version = "0.1.5", optional = true }
 os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
+rayon = { version = "1.5.3", optional = true }
 rustc_version_runtime = "0.2.1"
 rustls-pemfile = "0.3.0"
 serde_with = "1.3.1"

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -3,7 +3,7 @@ mod state_machine;
 
 use std::{
     path::Path,
-    process::{Command, Stdio}, sync::Arc,
+    process::{Command, Stdio},
 };
 
 use derivative::Derivative;
@@ -32,7 +32,7 @@ use super::WeakClient;
 pub(super) struct ClientState {
     #[derivative(Debug = "ignore")]
     #[allow(dead_code)]
-    crypt: Arc<Crypt>,
+    pub(crate) crypt: Crypt,
     mongocryptd_client: Option<Client>,
     aux_clients: AuxClients,
     opts: AutoEncryptionOptions,
@@ -55,7 +55,7 @@ impl ClientState {
         let aux_clients = Self::make_aux_clients(client, &opts)?;
 
         Ok(Self {
-            crypt: Arc::new(crypt),
+            crypt,
             mongocryptd_client,
             aux_clients,
             opts,

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -32,7 +32,6 @@ use super::WeakClient;
 #[derivative(Debug)]
 pub(super) struct ClientState {
     #[derivative(Debug = "ignore")]
-    #[allow(dead_code)]
     pub(crate) crypt: Crypt,
     mongocryptd_client: Option<Client>,
     aux_clients: AuxClients,
@@ -42,12 +41,9 @@ pub(super) struct ClientState {
 
 #[derive(Debug)]
 struct AuxClients {
-    #[allow(dead_code)]
     key_vault_client: WeakClient,
-    #[allow(dead_code)]
     metadata_client: Option<WeakClient>,
-    #[allow(dead_code)]
-    internal_client: Option<Client>,
+    _internal_client: Option<Client>,
 }
 
 impl ClientState {
@@ -180,7 +176,7 @@ impl ClientState {
         Ok(AuxClients {
             key_vault_client,
             metadata_client,
-            internal_client,
+            _internal_client: internal_client,
         })
     }
 }

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -66,6 +66,10 @@ impl ClientState {
         &self.opts
     }
 
+    pub(crate) fn crypt(&self) -> &Crypt {
+        &self.crypt
+    }
+
     fn make_crypt(opts: &AutoEncryptionOptions) -> Result<Crypt> {
         let mut builder = Crypt::builder();
         if Some(true) != opts.bypass_auto_encryption {

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -3,7 +3,7 @@ mod state_machine;
 
 use std::{
     path::Path,
-    process::{Command, Stdio},
+    process::{Command, Stdio}, sync::Arc,
 };
 
 use derivative::Derivative;
@@ -32,7 +32,7 @@ use super::WeakClient;
 pub(super) struct ClientState {
     #[derivative(Debug = "ignore")]
     #[allow(dead_code)]
-    crypt: Crypt,
+    crypt: Arc<Crypt>,
     mongocryptd_client: Option<Client>,
     aux_clients: AuxClients,
     opts: AutoEncryptionOptions,
@@ -55,7 +55,7 @@ impl ClientState {
         let aux_clients = Self::make_aux_clients(client, &opts)?;
 
         Ok(Self {
-            crypt,
+            crypt: Arc::new(crypt),
             mongocryptd_client,
             aux_clients,
             opts,

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -66,10 +66,6 @@ impl ClientState {
         &self.opts
     }
 
-    pub(crate) fn crypt(&self) -> &Crypt {
-        &self.crypt
-    }
-
     fn make_crypt(opts: &AutoEncryptionOptions) -> Result<Crypt> {
         let mut builder = Crypt::builder();
         if Some(true) != opts.bypass_auto_encryption {

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -1,4 +1,5 @@
 pub mod options;
+mod state_machine;
 
 use std::{
     path::Path,

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,16 +1,28 @@
-use bson::RawDocumentBuf;
+use std::convert::TryInto;
+
+use bson::{RawDocumentBuf, Document, RawDocument};
 use mongocrypt::ctx::{Ctx, State};
 
-use crate::Client;
-use crate::error::Result;
+use crate::{Client, Database};
+use crate::error::{Error, Result};
+use crate::operation::{ListCollections, RawOutput};
+
+fn raw_to_doc(raw: &RawDocument) -> Result<Document> {
+    raw.try_into().map_err(|e| Error::internal("???"))
+}
 
 impl Client {
-    pub(crate) async fn run_mongocrypt_ctx(&self, ctx: &mut Ctx) -> Result<RawDocumentBuf> {
+    pub(crate) async fn run_mongocrypt_ctx(&self, ctx: &mut Ctx, db: Option<Database>) -> Result<RawDocumentBuf> {
         let mut result = RawDocumentBuf::new();
         loop {
             match ctx.state()? {
                 State::NeedMongoCollinfo => {
-                    let filter = ctx.mongo_op()?;
+                    let filter: Document = raw_to_doc(ctx.mongo_op()?)?;
+                    let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoCollinfo state"))?;
+                    let mut cursor = db.list_collections(filter, None).await?;
+                    if cursor.advance().await? {
+                        ctx.mongo_feed(cursor.current())?;
+                    }
                 }
                 _ => todo!(),
             }

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -84,8 +84,8 @@ impl Client {
                         .database(&kv_ns.db)
                         .collection::<RawDocumentBuf>(&kv_ns.coll);
                     let mut cursor = kv_coll.find(filter, None).await?;
-                    while let Some(result) = cursor.try_next().await? {
-                        ctx.mongo_feed(&result)?
+                    while cursor.advance().await? {
+                        ctx.mongo_feed(cursor.current())?;
                     }
                     ctx.mongo_done()?;
                 }

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,19 +1,25 @@
 use std::convert::TryInto;
 
-use bson::{RawDocumentBuf, Document, RawDocument};
-use futures_util::{TryStreamExt, stream};
+use bson::{Document, RawDocument, RawDocumentBuf};
+use futures_util::{stream, TryStreamExt};
 use mongocrypt::ctx::{Ctx, State};
-use tokio::io::{AsyncWriteExt, AsyncReadExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use crate::client::options::{ServerAddress, TlsOptions};
-use crate::cmap::options::StreamOptions;
-use crate::runtime::AsyncStream;
-use crate::{Client};
-use crate::error::{Error, Result};
-use crate::operation::{RawOutput, RunCommand};
+use crate::{
+    client::options::{ServerAddress, TlsOptions},
+    cmap::options::StreamOptions,
+    error::{Error, Result},
+    operation::{RawOutput, RunCommand},
+    runtime::AsyncStream,
+    Client,
+};
 
 impl Client {
-    pub(crate) async fn run_mongocrypt_ctx(&self, mut ctx: Ctx, db: Option<&str>) -> Result<RawDocumentBuf> {
+    pub(crate) async fn run_mongocrypt_ctx(
+        &self,
+        mut ctx: Ctx,
+        db: Option<&str>,
+    ) -> Result<RawDocumentBuf> {
         let guard = self.inner.csfle.read().await;
         let csfle = match guard.as_ref() {
             Some(csfle) => csfle,
@@ -25,7 +31,9 @@ impl Client {
             match state {
                 State::NeedMongoCollinfo => {
                     let filter = raw_to_doc(ctx.mongo_op()?)?;
-                    let db = self.database(db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoCollinfo state"))?);
+                    let db = self.database(db.as_ref().ok_or_else(|| {
+                        Error::internal("db required for NeedMongoCollinfo state")
+                    })?);
                     let mut cursor = db.list_collections(filter, None).await?;
                     if cursor.advance().await? {
                         ctx.mongo_feed(cursor.current())?;
@@ -34,14 +42,14 @@ impl Client {
                 }
                 State::NeedMongoMarkings => {
                     let command = ctx.mongo_op()?.to_raw_document_buf();
-                    let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoMarkings state"))?;
-                    let op = RawOutput(RunCommand::new_raw(
-                        db.to_string(),
-                        command,
-                        None,
-                        None,
-                    )?);
-                    let mongocryptd_client = csfle.mongocryptd_client.as_ref().ok_or_else(|| Error::internal("mongocryptd client not found"))?;
+                    let db = db.as_ref().ok_or_else(|| {
+                        Error::internal("db required for NeedMongoMarkings state")
+                    })?;
+                    let op = RawOutput(RunCommand::new_raw(db.to_string(), command, None, None)?);
+                    let mongocryptd_client = csfle
+                        .mongocryptd_client
+                        .as_ref()
+                        .ok_or_else(|| Error::internal("mongocryptd client not found"))?;
                     let response = mongocryptd_client.execute_operation(op, None).await?;
                     ctx.mongo_feed(response.raw_body())?;
                     ctx.mongo_done()?;
@@ -49,38 +57,50 @@ impl Client {
                 State::NeedMongoKeys => {
                     let filter = raw_to_doc(ctx.mongo_op()?)?;
                     let kv_ns = &csfle.opts.key_vault_namespace;
-                    let kv_client = csfle.aux_clients.key_vault_client.upgrade().ok_or_else(|| Error::internal("key vault client dropped"))?;
-                    let kv_coll = kv_client.database(&kv_ns.db).collection::<RawDocumentBuf>(&kv_ns.coll);
+                    let kv_client = csfle
+                        .aux_clients
+                        .key_vault_client
+                        .upgrade()
+                        .ok_or_else(|| Error::internal("key vault client dropped"))?;
+                    let kv_coll = kv_client
+                        .database(&kv_ns.db)
+                        .collection::<RawDocumentBuf>(&kv_ns.coll);
                     let mut cursor = kv_coll.find(filter, None).await?;
                     while let Some(result) = cursor.try_next().await? {
                         ctx.mongo_feed(&result)?
                     }
                     ctx.mongo_done()?;
-                }    
+                }
                 State::NeedKms => {
                     let scope = ctx.kms_scope();
                     let mut kms_ctxen: Vec<Result<_>> = vec![];
                     while let Some(kms_ctx) = scope.next_kms_ctx()? {
                         kms_ctxen.push(Ok(kms_ctx));
                     }
-                    stream::iter(kms_ctxen).try_for_each_concurrent(None, |mut kms_ctx| async move {
-                        let endpoint = kms_ctx.endpoint()?;
-                        let addr = ServerAddress::parse(endpoint)?;
-                        let mut stream = AsyncStream::connect(StreamOptions::builder()
-                            .address(addr)
-                            .tls_options(TlsOptions::default())
-                            .build()
-                        ).await?;
-                        stream.write_all(kms_ctx.message()?).await?;
-                        let mut buf = vec![];
-                        while kms_ctx.bytes_needed() > 0 {
-                            let buf_size = kms_ctx.bytes_needed().try_into().map_err(|e| Error::internal(format!("buffer size overflow: {}", e)))?;
-                            buf.resize(buf_size, 0);
-                            let count = stream.read(&mut buf).await?;
-                            kms_ctx.feed(&buf[0..count])?;
-                        }
-                        Ok(())
-                    }).await?;
+                    stream::iter(kms_ctxen)
+                        .try_for_each_concurrent(None, |mut kms_ctx| async move {
+                            let endpoint = kms_ctx.endpoint()?;
+                            let addr = ServerAddress::parse(endpoint)?;
+                            let mut stream = AsyncStream::connect(
+                                StreamOptions::builder()
+                                    .address(addr)
+                                    .tls_options(TlsOptions::default())
+                                    .build(),
+                            )
+                            .await?;
+                            stream.write_all(kms_ctx.message()?).await?;
+                            let mut buf = vec![];
+                            while kms_ctx.bytes_needed() > 0 {
+                                let buf_size = kms_ctx.bytes_needed().try_into().map_err(|e| {
+                                    Error::internal(format!("buffer size overflow: {}", e))
+                                })?;
+                                buf.resize(buf_size, 0);
+                                let count = stream.read(&mut buf).await?;
+                                kms_ctx.feed(&buf[0..count])?;
+                            }
+                            Ok(())
+                        })
+                        .await?;
                 }
                 State::NeedKmsCredentials => todo!("RUST-1314"),
                 State::Ready => result = Some(ctx.finalize()?.to_owned()),
@@ -96,5 +116,6 @@ impl Client {
 }
 
 fn raw_to_doc(raw: &RawDocument) -> Result<Document> {
-    raw.try_into().map_err(|e| Error::internal(format!("could not parse raw document: {}", e)))
+    raw.try_into()
+        .map_err(|e| Error::internal(format!("could not parse raw document: {}", e)))
 }

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -29,11 +29,6 @@ impl Client {
             None => return Err(Error::internal("no csfle state for mongocrypt ctx")),
         };
         let mut result = None;
-        let num_cpus = std::thread::available_parallelism()?.get();
-        let crypt_threads = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus)
-            .build()
-            .map_err(|e| Error::internal(format!("could not initialize thread pool: {}", e)))?;
         // This needs to be a `Result` so that the `Ctx` can be temporarily owned by the processing
         // thread for crypto finalization.  An `Option` would also work here, but `Result` means we
         // can return a helpful error if things get into a broken state rather than panicing.
@@ -125,7 +120,7 @@ impl Client {
                         &mut ctx,
                         Err(Error::internal("crypto context not present")),
                     )?;
-                    crypt_threads.spawn(move || {
+                    csfle.crypto_threads.spawn(move || {
                         let result = thread_ctx.finalize().map(|doc| doc.to_owned());
                         let _ = tx.send((thread_ctx, result));
                     });

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -39,7 +39,15 @@ impl Client {
                 State::NeedMongoCollinfo => {
                     let ctx = result_mut(&mut ctx)?;
                     let filter = raw_to_doc(ctx.mongo_op()?)?;
-                    let db = self.database(db.as_ref().ok_or_else(|| {
+                    let metadata_client = csfle
+                        .aux_clients
+                        .metadata_client
+                        .as_ref()
+                        .and_then(|w| w.upgrade())
+                        .ok_or_else(|| {
+                            Error::internal("metadata_client required for NeedMongoCollinfo state")
+                        })?;
+                    let db = metadata_client.database(db.as_ref().ok_or_else(|| {
                         Error::internal("db required for NeedMongoCollinfo state")
                     })?);
                     let mut cursor = db.list_collections(filter, None).await?;

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -28,15 +28,15 @@ impl Client {
             Some(csfle) => csfle,
             None => return Err(Error::internal("no csfle state for mongocrypt ctx")),
         };
-        // This needs to be a `Result` so that the `Ctx` can be temporarily owned by the processing
-        // thread for crypto finalization.  An `Option` would also work here, but `Result` means we
-        // can return a helpful error if things get into a broken state rather than panicing.
         let mut result = None;
         let num_cpus = std::thread::available_parallelism()?.get();
         let crypt_threads = rayon::ThreadPoolBuilder::new()
             .num_threads(num_cpus)
             .build()
             .map_err(|e| Error::internal(format!("could not initialize thread pool: {}", e)))?;
+        // This needs to be a `Result` so that the `Ctx` can be temporarily owned by the processing
+        // thread for crypto finalization.  An `Option` would also work here, but `Result` means we
+        // can return a helpful error if things get into a broken state rather than panicing.
         let mut ctx = Ok(ctx);
         loop {
             let state = result_ref(&ctx)?.state()?;

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 
 use bson::{RawDocumentBuf, Document, RawDocument};
+use futures_core::future::{BoxFuture, LocalBoxFuture};
 use mongocrypt::ctx::{Ctx, State};
 
 use crate::{Client, Database};
@@ -12,36 +13,42 @@ fn raw_to_doc(raw: &RawDocument) -> Result<Document> {
 }
 
 impl Client {
-    pub(crate) async fn run_mongocrypt_ctx(&self, ctx: &mut Ctx, db: Option<Database>) -> Result<RawDocumentBuf> {
-        let mut result = RawDocumentBuf::new();
-        loop {
-            match ctx.state()? {
-                State::NeedMongoCollinfo => {
-                    let filter = raw_to_doc(ctx.mongo_op()?)?;
-                    let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoCollinfo state"))?;
-                    let mut cursor = db.list_collections(filter, None).await?;
-                    if cursor.advance().await? {
-                        ctx.mongo_feed(cursor.current())?;
+    pub(crate) fn run_mongocrypt_ctx<'a>(&'a self, mut ctx: Ctx, db: Option<&'a str>) -> LocalBoxFuture<'a, Result<RawDocumentBuf>> {
+        Box::pin(async move {
+            let mut result = None;
+            loop {
+                let state = ctx.state()?;
+                match state {
+                    State::NeedMongoCollinfo => {
+                        let filter = raw_to_doc(ctx.mongo_op()?)?;
+                        let db = self.database(db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoCollinfo state"))?);
+                        let mut cursor = db.list_collections(filter, None).await?;
+                        if cursor.advance().await? {
+                            ctx.mongo_feed(cursor.current())?;
+                        }
+                        ctx.mongo_done()?;
                     }
-                    ctx.mongo_done()?;
+                    State::NeedMongoMarkings => {
+                        let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoMarkings state"))?;
+                        let op = RawOutput(RunCommand::new_raw(
+                            db.to_string(),
+                            ctx.mongo_op()?.to_raw_document_buf(),
+                            None,
+                            None,
+                        )?);
+                        let guard = self.inner.csfle.read().await;
+                        let csfle = guard.as_ref().ok_or_else(|| Error::internal("csfle state not found"))?;
+                        let mongocryptd_client = csfle.mongocryptd_client.as_ref().ok_or_else(|| Error::internal("mongocryptd client not found"))?;
+                        let result = mongocryptd_client.execute_operation(op, None).await?;
+                        ctx.mongo_feed(result.raw_body())?;
+                        ctx.mongo_done()?;
+                    }
+                    State::Ready => result = Some(ctx.finalize()?.to_owned()),
+                    State::Done => break,
+                    _ => todo!(),
                 }
-                State::NeedMongoMarkings => {
-                    let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoMarkings state"))?;
-                    let op = RawOutput(RunCommand::new_raw(
-                        db.name().to_string(),
-                        ctx.mongo_op()?.to_raw_document_buf(),
-                        None,
-                        None,
-                    )?);
-                    let result = self.execute_operation(op, None).await?;
-                    ctx.mongo_feed(result.raw_body())?;
-                    ctx.mongo_done()?;
-                }
-                State::Ready => result = ctx.finalize()?.to_owned(),
-                State::Done => break,    
-                _ => todo!(),
             }
-        }
-        Ok(result)
+            result.ok_or_else(|| Error::internal("libmongocrypt terminated without output"))
+        })
     }
 }

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,0 +1,11 @@
+use bson::RawDocumentBuf;
+use mongocrypt::ctx::Ctx;
+
+use crate::Client;
+use crate::error::Result;
+
+impl Client {
+    async fn run_mongocrypt_ctx(&self, ctx: &mut Ctx) -> Result<RawDocumentBuf> {
+        todo!()
+    }
+}

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,8 +1,7 @@
 use std::convert::TryInto;
-use std::sync::Arc;
 
 use bson::{RawDocumentBuf, Document, RawDocument};
-use futures_util::{StreamExt, TryStreamExt, stream};
+use futures_util::{TryStreamExt, stream};
 use mongocrypt::ctx::{Ctx, State};
 use tokio::io::{AsyncWriteExt, AsyncReadExt};
 
@@ -20,8 +19,8 @@ fn raw_to_doc(raw: &RawDocument) -> Result<Document> {
 impl Client {
     pub(crate) async fn run_mongocrypt_ctx(&self, mut ctx: Ctx, db: Option<&str>) -> Result<RawDocumentBuf> {
         let guard = self.inner.csfle.read().await;
-        let crypt = match guard.as_ref() {
-            Some(csfle) => &csfle.crypt,
+        let csfle = match guard.as_ref() {
+            Some(csfle) => csfle,
             None => return Err(Error::internal("no csfle state for mongocrypt ctx")),
         };
         let mut result = None;
@@ -37,6 +36,31 @@ impl Client {
                     }
                     ctx.mongo_done()?;
                 }
+                State::NeedMongoMarkings => {
+                    let command = ctx.mongo_op()?.to_raw_document_buf();
+                    let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoMarkings state"))?;
+                    let op = RawOutput(RunCommand::new_raw(
+                        db.to_string(),
+                        command,
+                        None,
+                        None,
+                    )?);
+                    let mongocryptd_client = csfle.mongocryptd_client.as_ref().ok_or_else(|| Error::internal("mongocryptd client not found"))?;
+                    let response = mongocryptd_client.execute_operation(op, None).await?;
+                    ctx.mongo_feed(response.raw_body())?;
+                    ctx.mongo_done()?;
+                }
+                State::NeedMongoKeys => {
+                    let filter = raw_to_doc(ctx.mongo_op()?)?;
+                    let kv_ns = &csfle.opts.key_vault_namespace;
+                    let kv_client = csfle.aux_clients.key_vault_client.upgrade().ok_or_else(|| Error::internal("key vault client dropped"))?;
+                    let kv_coll = kv_client.database(&kv_ns.db).collection::<RawDocumentBuf>(&kv_ns.coll);
+                    let mut cursor = kv_coll.find(filter, None).await?;
+                    while let Some(result) = cursor.try_next().await? {
+                        ctx.mongo_feed(&result)?
+                    }
+                    ctx.mongo_done()?;
+                }    
                 State::NeedKms => {
                     let scope = ctx.kms_scope();
                     let mut kms_ctxen: Vec<Result<_>> = vec![];
@@ -71,169 +95,5 @@ impl Client {
             Some(doc) => Ok(doc),
             None => Err(Error::internal("libmongocrypt terminated without output")),
         }
-        /*
-        let (send, mut recv) = tokio_mpsc::unbounded_channel();
-        thread::spawn(move || {
-            let builder = crypt.ctx_builder();
-            let ctx = match build_ctx(builder) {
-                Ok(c) => c,
-                Err(e) => {
-                    let _ = send.send(CtxRequest::Err(e));
-                    return;
-                }
-            };
-            let _ = match ctx_loop(ctx, send.clone()) {
-                Ok(Some(doc)) => send.send(CtxRequest::Done(doc)),
-                Ok(None) => send.send(CtxRequest::Err(Error::internal("libmongocrypt terminated without output"))),
-                Err(e) => send.send(CtxRequest::Err(e)),
-            };
-        });
-
-        loop {
-            let request = recv.recv().await.ok_or_else(thread_err)?;
-            match request {
-                CtxRequest::NeedMongoCollinfo { filter, reply } => {
-                    let db = self.database(db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoCollinfo state"))?);
-                    let mut cursor = db.list_collections(filter, None).await?;
-                    reply.send(if cursor.advance().await? {
-                        Some(cursor.current().to_raw_document_buf())
-                    } else {
-                        None
-                    })?;
-                }
-                CtxRequest::NeedMongoMarkings { command, reply } => {
-                    let db = db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoMarkings state"))?;
-                    let op = RawOutput(RunCommand::new_raw(
-                        db.to_string(),
-                        command,
-                        None,
-                        None,
-                    )?);
-                    let guard = self.inner.csfle.read().await;
-                    let csfle = guard.as_ref().ok_or_else(|| Error::internal("csfle state not found"))?;
-                    let mongocryptd_client = csfle.mongocryptd_client.as_ref().ok_or_else(|| Error::internal("mongocryptd client not found"))?;
-                    let result = mongocryptd_client.execute_operation(op, None).await?;
-                    reply.send(result.into_raw_document_buf())?;
-                }
-                CtxRequest::NeedMongoKeys { filter, reply } => {
-                    let guard = self.inner.csfle.read().await;
-                    let csfle = guard.as_ref().ok_or_else(|| Error::internal("csfle state not found"))?;
-                    let kv_ns = &csfle.opts.key_vault_namespace;
-                    let kv_client = csfle.aux_clients.key_vault_client.upgrade().ok_or_else(|| Error::internal("key vault client dropped"))?;
-                    let kv_coll = kv_client.database(&kv_ns.db).collection::<RawDocumentBuf>(&kv_ns.coll);
-                    let results: Vec<_> = kv_coll.find(filter, None).await?.try_collect().await?;
-                    reply.send(results)?;
-                }
-                CtxRequest::NeedKms { messages } => {
-
-                }
-                CtxRequest::Done(doc) => return Ok(doc),
-                CtxRequest::Err(e) => return Err(e),
-            }
-        }
-        */
     }
 }
-
-/*
-fn ctx_loop(mut ctx: Ctx, send: tokio_mpsc::UnboundedSender<CtxRequest>) -> Result<Option<RawDocumentBuf>> {
-    let mut result = None;
-    loop {
-        match ctx.state()? {
-            State::NeedMongoCollinfo => {
-                let filter = raw_to_doc(ctx.mongo_op()?)?;
-                let (reply, reply_recv) = reply_oneshot();
-                send.send(CtxRequest::NeedMongoCollinfo { filter, reply }).map_err(ctx_err)?;
-                if let Some(v) = reply_recv.recv()? {
-                    ctx.mongo_feed(&v)?;
-                }
-                ctx.mongo_done()?;
-            }
-            State::NeedMongoMarkings => {
-                let command = ctx.mongo_op()?.to_raw_document_buf();
-                let (reply, reply_recv) = reply_oneshot();
-                send.send(CtxRequest::NeedMongoMarkings { command, reply }).map_err(ctx_err)?;
-                ctx.mongo_feed(&reply_recv.recv()?)?;
-                ctx.mongo_done()?;
-            }
-            State::NeedMongoKeys => {
-                let filter = raw_to_doc(ctx.mongo_op()?)?;
-                let (reply, reply_recv) = reply_oneshot();
-                send.send(CtxRequest::NeedMongoKeys { filter, reply }).map_err(ctx_err)?;
-                for v in reply_recv.recv()? {
-                    ctx.mongo_feed(&v)?;
-                }
-                ctx.mongo_done()?;
-            }
-            State::NeedKms => {
-                let scope = ctx.kms_scope();
-                let mut messages = vec![];
-                while let Some(kms_ctx) = scope.next_kms_ctx() {
-                    let endpoint = kms_ctx.endpoint()?.to_string();
-                    let message = kms_ctx.message()?.to_vec();
-                    let (rsp_sender, responses_needed) = tokio_mpsc::unbounded_channel();
-                    messages.push(KmsMessage { endpoint, message, responses_needed });
-                }
-                send.send(CtxRequest::NeedKms { messages }).map_err(ctx_err)?;
-            }
-            State::Ready => result = Some(ctx.finalize()?.to_owned()),
-            State::Done => break,
-            _ => todo!(),
-        }
-    }
-    Ok(result)
-}
-
-enum CtxRequest {
-    NeedMongoCollinfo {
-        filter: Document,
-        reply: ReplySender<Option<RawDocumentBuf>>,
-    },
-    NeedMongoMarkings {
-        command: RawDocumentBuf,
-        reply: ReplySender<RawDocumentBuf>,
-    },
-    NeedMongoKeys {
-        filter: Document,
-        reply: ReplySender<Vec<RawDocumentBuf>>,
-    },
-    NeedKms {
-        messages: Vec<KmsMessage>,
-    },
-    Done(RawDocumentBuf),
-    Err(Error),
-}
-
-struct KmsMessage {
-    endpoint: String,
-    message: Vec<u8>,
-    responses_needed: tokio_mpsc::UnboundedReceiver<ResponseNeeded>,
-}
-
-struct ResponseNeeded {
-    bytes_needed: u8,
-    response: ReplySender<Vec<u8>>,
-}
-
-struct ReplySender<T>(sync_mpsc::SyncSender<T>);
-
-impl<T> ReplySender<T> {
-    fn send(self, value: T) -> Result<()> {
-        self.0.send(value).map_err(|_| thread_err())
-    }
-}
-
-struct ReplyReceiver<T>(sync_mpsc::Receiver<T>);
-
-impl<T> ReplyReceiver<T> {
-    fn recv(self) -> Result<T> {
-        self.0.recv().map_err(ctx_err)
-    }
-}
-
-/// This is a sync version of `tokio::sync::oneshot::channel`; sending will never block (and so can be used in async code), receiving will synchronously block until a value is sent.
-fn reply_oneshot<T>() -> (ReplySender<T>, ReplyReceiver<T>) {
-    let (sender, receiver) = sync_mpsc::sync_channel(1);
-    (ReplySender(sender), ReplyReceiver(receiver))
-}
-*/

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,11 +1,20 @@
 use bson::RawDocumentBuf;
-use mongocrypt::ctx::Ctx;
+use mongocrypt::ctx::{Ctx, State};
 
 use crate::Client;
 use crate::error::Result;
 
 impl Client {
-    async fn run_mongocrypt_ctx(&self, ctx: &mut Ctx) -> Result<RawDocumentBuf> {
-        todo!()
+    pub(crate) async fn run_mongocrypt_ctx(&self, ctx: &mut Ctx) -> Result<RawDocumentBuf> {
+        let mut result = RawDocumentBuf::new();
+        loop {
+            match ctx.state()? {
+                State::NeedMongoCollinfo => {
+                    let filter = ctx.mongo_op()?;
+                }
+                _ => todo!(),
+            }
+        }
+        Ok(result)
     }
 }

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,8 +1,12 @@
 use std::convert::TryInto;
+use std::sync::Arc;
+use std::sync::mpsc as sync_mpsc;
+use std::thread;
 
 use bson::{RawDocumentBuf, Document, RawDocument};
 use futures_core::future::{BoxFuture, LocalBoxFuture};
-use mongocrypt::ctx::{Ctx, State};
+use mongocrypt::ctx::{Ctx, State, CtxBuilder};
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{Client, Database};
 use crate::error::{Error, Result};
@@ -13,7 +17,42 @@ fn raw_to_doc(raw: &RawDocument) -> Result<Document> {
 }
 
 impl Client {
-    pub(crate) fn run_mongocrypt_ctx<'a>(&'a self, mut ctx: Ctx, db: Option<&'a str>) -> LocalBoxFuture<'a, Result<RawDocumentBuf>> {
+    pub(crate) async fn run_mongocrypt_ctx(&self, build_ctx: impl FnOnce(CtxBuilder) -> Ctx + Send + 'static, db: Option<&str>) -> Result<RawDocumentBuf> {
+        let guard = self.inner.csfle.read().await;
+        let crypt = match guard.as_ref() {
+            Some(csfle) => Arc::clone(&csfle.crypt),
+            None => return Err(Error::internal("no csfle state for mongocrypt ctx")),
+        };
+        let (send, mut recv) = tokio::sync::mpsc::unbounded_channel();
+        thread::spawn(move || {
+            let builder = crypt.ctx_builder();
+            let ctx = build_ctx(builder);
+            match ctx_loop(ctx, send.clone()) {
+                Ok(Some(doc)) => send.send(CtxRequest::Done(doc)),
+                Ok(None) => send.send(CtxRequest::Err(Error::internal("libmongocrypt terminated without output"))),
+                Err(e) => send.send(CtxRequest::Err(e)),
+            }
+        });
+        fn thread_err() -> Error {
+            Error::internal("ctx thread unexpectedly terminated")
+        }
+        loop {
+            let request = recv.recv().await.ok_or_else(thread_err)?;
+            match request {
+                CtxRequest::NeedMongoCollinfo { filter, reply } => {
+                    let db = self.database(db.as_ref().ok_or_else(|| Error::internal("db required for NeedMongoCollinfo state"))?);
+                    let mut cursor = db.list_collections(filter, None).await?;
+                    if cursor.advance().await? {
+                        reply.send(Some(cursor.current().to_raw_document_buf()));
+                    } else {
+                        reply.send(None);
+                    }
+                }
+                CtxRequest::Done(doc) => return Ok(doc),
+                CtxRequest::Err(e) => return Err(e),
+            }
+        }
+        /*
         Box::pin(async move {
             let mut result = None;
             loop {
@@ -50,5 +89,59 @@ impl Client {
             }
             result.ok_or_else(|| Error::internal("libmongocrypt terminated without output"))
         })
+        */
     }
+}
+
+fn ctx_loop(mut ctx: Ctx, send: UnboundedSender<CtxRequest>) -> Result<Option<RawDocumentBuf>> {
+    let mut result = None;
+    loop {
+        match ctx.state()? {
+            State::NeedMongoCollinfo => {
+                let filter = raw_to_doc(ctx.mongo_op()?)?;
+                let (reply, reply_recv) = sync_oneshot();
+                // TODO: terminate loop if send fails
+                send.send(CtxRequest::NeedMongoCollinfo { filter, reply });
+                match reply_recv.recv() {
+                    Ok(Some(v)) => ctx.mongo_feed(&v)?,
+                    Ok(None) => (),
+                    Err(_) => return Ok(None),  // waiting async task terminated, no need to keep running
+                }
+                ctx.mongo_done()?;
+            }
+            State::Done => break,
+            _ => todo!(),
+        }
+    }
+    Ok(result)
+}
+
+enum CtxRequest {
+    NeedMongoCollinfo {
+        filter: Document,
+        reply: SyncOneshotSender<Option<RawDocumentBuf>>,
+    },
+    Done(RawDocumentBuf),
+    Err(Error),
+}
+
+struct SyncOneshotSender<T>(sync_mpsc::SyncSender<T>);
+
+impl<T> SyncOneshotSender<T> {
+    fn send(self, value: T) -> std::result::Result<(), T> {
+        self.0.send(value).map_err(|sync_mpsc::SendError(value)| value)
+    }
+}
+
+struct SyncOneshotReceiver<T>(sync_mpsc::Receiver<T>);
+
+impl<T> SyncOneshotReceiver<T> {
+    fn recv(self) -> std::result::Result<T, sync_mpsc::RecvError> {
+        self.0.recv()
+    }
+}
+
+fn sync_oneshot<T>() -> (SyncOneshotSender<T>, SyncOneshotReceiver<T>) {
+    let (sender, receiver) = sync_mpsc::sync_channel(1);
+    (SyncOneshotSender(sender), SyncOneshotReceiver(receiver))
 }

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -1,13 +1,11 @@
 use bson::{doc, RawBsonRef, RawDocument, Timestamp, RawDocumentBuf};
 use futures_core::future::BoxFuture;
 use lazy_static::lazy_static;
-use mongocrypt::ctx::{CtxBuilder, Ctx};
 use serde::de::DeserializeOwned;
-use tokio::task::LocalSet;
 
 use std::{collections::HashSet, sync::Arc, time::Instant};
 
-use super::{session::TransactionState, Client, ClientSession, csfle::ClientState};
+use super::{session::TransactionState, Client, ClientSession};
 use crate::{
     bson::Document,
     change_stream::{

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -5,7 +5,7 @@ use serde::de::DeserializeOwned;
 
 use std::{collections::HashSet, sync::Arc, time::Instant};
 
-use super::{session::TransactionState, Client, ClientSession, csfle::ClientState};
+use super::{session::TransactionState, Client, ClientSession};
 use crate::{
     bson::Document,
     change_stream::{
@@ -773,9 +773,10 @@ impl Client {
         }
     }
 
+    #[cfg(feature = "csfle")]
     fn auto_encrypt<'a>(
         &'a self, 
-        csfle: &'a ClientState,
+        csfle: &'a super::csfle::ClientState,
         serialized: &'a [u8],
         target_db: &'a str,
     ) -> BoxFuture<'a, Result<RawDocumentBuf>> {

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -797,11 +797,12 @@ impl Client {
         target_db: &'a str,
     ) -> BoxFuture<'a, Result<RawDocumentBuf>> {
         Box::pin(async move {
-            let doc = RawDocument::from_bytes(serialized)?.to_raw_document_buf();
+            let doc = RawDocument::from_bytes(serialized)?;
             let db = target_db.to_string();
             let ctx = csfle
                 .crypt
-                .build_ctx(move |builder| builder.build_encrypt(&db, &doc))?;
+                .ctx_builder()
+                .build_encrypt(&db, doc)?;
             self.run_mongocrypt_ctx(ctx, Some(target_db)).await
         })
     }
@@ -813,10 +814,10 @@ impl Client {
         doc: &'a RawDocument,
     ) -> BoxFuture<'a, Result<RawDocumentBuf>> {
         Box::pin(async move {
-            let doc = doc.to_raw_document_buf();
             let ctx = csfle
                 .crypt
-                .build_ctx(move |builder| builder.build_decrypt(&doc))?;
+                .ctx_builder()
+                .build_decrypt(doc)?;
             self.run_mongocrypt_ctx(ctx, None).await
         })
     }

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -203,10 +203,11 @@ impl RawCommandResponse {
 
     pub(crate) fn new(source: ServerAddress, message: Message) -> Result<Self> {
         let raw = message.single_document_response()?;
-        Ok(Self {
-            source,
-            raw: RawDocumentBuf::from_bytes(raw)?,
-        })
+        Ok(Self::new_raw(source, RawDocumentBuf::from_bytes(raw)?))
+    }
+
+    pub(crate) fn new_raw(source: ServerAddress, raw: RawDocumentBuf) -> Self {
+        Self { source, raw }
     }
 
     pub(crate) fn body<'a, T: Deserialize<'a>>(&'a self) -> Result<T> {

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -1202,7 +1202,7 @@ where
 
         while n_attempted < ds.len() {
             let docs: Vec<&T> = ds.iter().skip(n_attempted).map(Borrow::borrow).collect();
-            let insert = Insert::new(self.namespace(), docs, options.clone(), encrypted);
+            let insert = Insert::new_encrypted(self.namespace(), docs, options.clone(), encrypted);
 
             match self
                 .client()
@@ -1329,7 +1329,6 @@ where
             self.namespace(),
             vec![doc],
             options.map(InsertManyOptions::from_insert_one_options),
-            false,
         );
         self.client()
             .execute_operation(insert, session)

--- a/src/operation/abort_transaction/mod.rs
+++ b/src/operation/abort_transaction/mod.rs
@@ -5,12 +5,12 @@ use crate::{
     client::session::TransactionPin,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{Operation, Retryability},
+    operation::{Retryability},
     options::WriteConcern,
     selection_criteria::SelectionCriteria,
 };
 
-use super::WriteConcernOnlyBody;
+use super::{WriteConcernOnlyBody, OperationWithDefaults};
 
 pub(crate) struct AbortTransaction {
     write_concern: Option<WriteConcern>,
@@ -26,7 +26,7 @@ impl AbortTransaction {
     }
 }
 
-impl Operation for AbortTransaction {
+impl OperationWithDefaults for AbortTransaction {
     type O = ();
     type Command = Document;
 

--- a/src/operation/abort_transaction/mod.rs
+++ b/src/operation/abort_transaction/mod.rs
@@ -5,12 +5,12 @@ use crate::{
     client::session::TransactionPin,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{Retryability},
+    operation::Retryability,
     options::WriteConcern,
     selection_criteria::SelectionCriteria,
 };
 
-use super::{WriteConcernOnlyBody, OperationWithDefaults};
+use super::{OperationWithDefaults, WriteConcernOnlyBody};
 
 pub(crate) struct AbortTransaction {
     write_concern: Option<WriteConcern>,

--- a/src/operation/aggregate/change_stream.rs
+++ b/src/operation/aggregate/change_stream.rs
@@ -4,7 +4,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    operation::{append_options, Operation, Retryability},
+    operation::{append_options, OperationWithDefaults, Retryability},
     options::{ChangeStreamOptions, SelectionCriteria, WriteConcern},
 };
 
@@ -39,7 +39,7 @@ impl ChangeStreamAggregate {
     }
 }
 
-impl Operation for ChangeStreamAggregate {
+impl OperationWithDefaults for ChangeStreamAggregate {
     type O = (CursorSpecification, ChangeStreamData);
     type Command = Document;
 

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     Namespace,
 };
 
-use super::{CursorBody, WriteConcernOnlyBody, SERVER_4_2_0_WIRE_VERSION, OperationWithDefaults};
+use super::{CursorBody, OperationWithDefaults, WriteConcernOnlyBody, SERVER_4_2_0_WIRE_VERSION};
 
 pub(crate) use change_stream::ChangeStreamAggregate;
 

--- a/src/operation/aggregate/mod.rs
+++ b/src/operation/aggregate/mod.rs
@@ -9,12 +9,12 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    operation::{append_options, remove_empty_write_concern, Operation, Retryability},
+    operation::{append_options, remove_empty_write_concern, Retryability},
     options::{AggregateOptions, SelectionCriteria, WriteConcern},
     Namespace,
 };
 
-use super::{CursorBody, WriteConcernOnlyBody, SERVER_4_2_0_WIRE_VERSION};
+use super::{CursorBody, WriteConcernOnlyBody, SERVER_4_2_0_WIRE_VERSION, OperationWithDefaults};
 
 pub(crate) use change_stream::ChangeStreamAggregate;
 
@@ -46,7 +46,7 @@ impl Aggregate {
 
 // IMPORTANT: If new method implementations are added here, make sure `ChangeStreamAggregate` has
 // the equivalent delegations.
-impl Operation for Aggregate {
+impl OperationWithDefaults for Aggregate {
     type O = CursorSpecification;
     type Command = Document;
 

--- a/src/operation/commit_transaction/mod.rs
+++ b/src/operation/commit_transaction/mod.rs
@@ -5,7 +5,7 @@ use bson::{doc, Document};
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, Operation, Retryability},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, Retryability},
     options::{Acknowledgment, TransactionOptions, WriteConcern},
 };
 
@@ -21,7 +21,7 @@ impl CommitTransaction {
     }
 }
 
-impl Operation for CommitTransaction {
+impl OperationWithDefaults for CommitTransaction {
     type O = ();
     type Command = Document;
 

--- a/src/operation/count/mod.rs
+++ b/src/operation/count/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::{options::EstimatedDocumentCountOptions, Namespace},
     error::{Error, Result},
-    operation::{append_options, Operation, Retryability},
+    operation::{append_options, OperationWithDefaults, Retryability},
     selection_criteria::SelectionCriteria,
 };
 
@@ -35,7 +35,7 @@ impl Count {
     }
 }
 
-impl Operation for Count {
+impl OperationWithDefaults for Count {
     type O = u64;
     type Command = Document;
 

--- a/src/operation/count_documents/mod.rs
+++ b/src/operation/count_documents/mod.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 
 use serde::Deserialize;
 
-use super::{Operation, Retryability, SingleCursorResult};
+use super::{OperationWithDefaults, Retryability, SingleCursorResult};
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, ErrorKind, Result},
@@ -75,7 +75,7 @@ impl CountDocuments {
     }
 }
 
-impl Operation for CountDocuments {
+impl OperationWithDefaults for CountDocuments {
     type O = u64;
     type Command = Document;
 

--- a/src/operation/create/mod.rs
+++ b/src/operation/create/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, Operation, WriteConcernOnlyBody},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, WriteConcernOnlyBody},
     options::{CreateCollectionOptions, WriteConcern},
     Namespace,
 };
@@ -35,7 +35,7 @@ impl Create {
     }
 }
 
-impl Operation for Create {
+impl OperationWithDefaults for Create {
     type O = ();
     type Command = Document;
 

--- a/src/operation/create/mod.rs
+++ b/src/operation/create/mod.rs
@@ -7,7 +7,12 @@ use crate::{
     bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, WriteConcernOnlyBody},
+    operation::{
+        append_options,
+        remove_empty_write_concern,
+        OperationWithDefaults,
+        WriteConcernOnlyBody,
+    },
     options::{CreateCollectionOptions, WriteConcern},
     Namespace,
 };

--- a/src/operation/create_indexes/mod.rs
+++ b/src/operation/create_indexes/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{ErrorKind, Result},
     index::IndexModel,
-    operation::{append_options, remove_empty_write_concern, Operation},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults},
     options::{CreateIndexOptions, WriteConcern},
     results::CreateIndexesResult,
     Namespace,
@@ -47,7 +47,7 @@ impl CreateIndexes {
     }
 }
 
-impl Operation for CreateIndexes {
+impl OperationWithDefaults for CreateIndexes {
     type O = CreateIndexesResult;
     type Command = Document;
     const NAME: &'static str = "createIndexes";

--- a/src/operation/delete/mod.rs
+++ b/src/operation/delete/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     operation::{
         append_options,
         remove_empty_write_concern,
-        Operation,
+        OperationWithDefaults,
         Retryability,
         WriteResponseBody,
     },
@@ -59,7 +59,7 @@ impl Delete {
     }
 }
 
-impl Operation for Delete {
+impl OperationWithDefaults for Delete {
     type O = DeleteResult;
     type Command = Document;
 

--- a/src/operation/distinct/mod.rs
+++ b/src/operation/distinct/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::{options::DistinctOptions, Namespace},
     error::Result,
-    operation::{append_options, Operation, Retryability},
+    operation::{append_options, OperationWithDefaults, Retryability},
     selection_criteria::SelectionCriteria,
 };
 
@@ -49,7 +49,7 @@ impl Distinct {
     }
 }
 
-impl Operation for Distinct {
+impl OperationWithDefaults for Distinct {
     type O = Vec<Bson>;
     type Command = Document;
 

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -7,7 +7,12 @@ use crate::{
     bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
-    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, WriteConcernOnlyBody},
+    operation::{
+        append_options,
+        remove_empty_write_concern,
+        OperationWithDefaults,
+        WriteConcernOnlyBody,
+    },
     options::{DropCollectionOptions, WriteConcern},
     Namespace,
 };

--- a/src/operation/drop_collection/mod.rs
+++ b/src/operation/drop_collection/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
-    operation::{append_options, remove_empty_write_concern, Operation, WriteConcernOnlyBody},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, WriteConcernOnlyBody},
     options::{DropCollectionOptions, WriteConcern},
     Namespace,
 };
@@ -35,7 +35,7 @@ impl DropCollection {
     }
 }
 
-impl Operation for DropCollection {
+impl OperationWithDefaults for DropCollection {
     type O = ();
     type Command = Document;
 

--- a/src/operation/drop_database/mod.rs
+++ b/src/operation/drop_database/mod.rs
@@ -7,7 +7,12 @@ use crate::{
     bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, WriteConcernOnlyBody},
+    operation::{
+        append_options,
+        remove_empty_write_concern,
+        OperationWithDefaults,
+        WriteConcernOnlyBody,
+    },
     options::{DropDatabaseOptions, WriteConcern},
 };
 

--- a/src/operation/drop_database/mod.rs
+++ b/src/operation/drop_database/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, Operation, WriteConcernOnlyBody},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, WriteConcernOnlyBody},
     options::{DropDatabaseOptions, WriteConcern},
 };
 
@@ -28,7 +28,7 @@ impl DropDatabase {
     }
 }
 
-impl Operation for DropDatabase {
+impl OperationWithDefaults for DropDatabase {
     type O = ();
     type Command = Document;
 

--- a/src/operation/drop_indexes/mod.rs
+++ b/src/operation/drop_indexes/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, Operation},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults},
     options::{DropIndexOptions, WriteConcern},
     Namespace,
 };
@@ -34,7 +34,7 @@ impl DropIndexes {
     }
 }
 
-impl Operation for DropIndexes {
+impl OperationWithDefaults for DropIndexes {
     type O = ();
     type Command = Document;
     const NAME: &'static str = "dropIndexes";

--- a/src/operation/find/mod.rs
+++ b/src/operation/find/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::{ErrorKind, Result},
-    operation::{append_options, CursorBody, Operation, Retryability},
+    operation::{append_options, CursorBody, OperationWithDefaults, Retryability},
     options::{CursorType, FindOptions, SelectionCriteria},
     Namespace,
 };
@@ -44,7 +44,7 @@ impl Find {
     }
 }
 
-impl Operation for Find {
+impl OperationWithDefaults for Find {
     type O = CursorSpecification;
     type Command = Document;
     const NAME: &'static str = "find";

--- a/src/operation/find_and_modify/mod.rs
+++ b/src/operation/find_and_modify/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         Namespace,
     },
     error::{ErrorKind, Result},
-    operation::{append_options, remove_empty_write_concern, Operation, Retryability},
+    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, Retryability},
     options::WriteConcern,
 };
 
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<T> Operation for FindAndModify<T>
+impl<T> OperationWithDefaults for FindAndModify<T>
 where
     T: DeserializeOwned,
 {

--- a/src/operation/get_more/mod.rs
+++ b/src/operation/get_more/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     cursor::CursorInformation,
     error::{ErrorKind, Result},
-    operation::Operation,
+    operation::OperationWithDefaults,
     options::SelectionCriteria,
     results::GetMoreResult,
     Namespace,
@@ -44,7 +44,7 @@ impl<'conn> GetMore<'conn> {
     }
 }
 
-impl<'conn> Operation for GetMore<'conn> {
+impl<'conn> OperationWithDefaults for GetMore<'conn> {
     type O = GetMoreResult;
     type Command = Document;
 

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -11,7 +11,12 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{BulkWriteFailure, Error, ErrorKind, Result},
-    operation::{remove_empty_write_concern, OperationWithDefaults, Retryability, WriteResponseBody},
+    operation::{
+        remove_empty_write_concern,
+        OperationWithDefaults,
+        Retryability,
+        WriteResponseBody,
+    },
     options::{InsertManyOptions, WriteConcern},
     results::InsertManyResult,
     Namespace,

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{BulkWriteFailure, Error, ErrorKind, Result},
-    operation::{remove_empty_write_concern, Operation, Retryability, WriteResponseBody},
+    operation::{remove_empty_write_concern, OperationWithDefaults, Retryability, WriteResponseBody},
     options::{InsertManyOptions, WriteConcern},
     results::InsertManyResult,
     Namespace,
@@ -49,7 +49,7 @@ impl<'a, T> Insert<'a, T> {
     }
 }
 
-impl<'a, T: Serialize> Operation for Insert<'a, T> {
+impl<'a, T: Serialize> OperationWithDefaults for Insert<'a, T> {
     type O = InsertManyResult;
     type Command = InsertCommand;
 

--- a/src/operation/insert/mod.rs
+++ b/src/operation/insert/mod.rs
@@ -38,6 +38,14 @@ impl<'a, T> Insert<'a, T> {
         ns: Namespace,
         documents: Vec<&'a T>,
         options: Option<InsertManyOptions>,
+    ) -> Self {
+        Self::new_encrypted(ns, documents, options, false)
+    }
+
+    pub(crate) fn new_encrypted(
+        ns: Namespace,
+        documents: Vec<&'a T>,
+        options: Option<InsertManyOptions>,
         encrypted: bool,
     ) -> Self {
         Self {

--- a/src/operation/list_collections/mod.rs
+++ b/src/operation/list_collections/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    operation::{append_options, CursorBody, Operation, Retryability},
+    operation::{append_options, CursorBody, OperationWithDefaults, Retryability},
     options::{ListCollectionsOptions, ReadPreference, SelectionCriteria},
 };
 
@@ -39,7 +39,7 @@ impl ListCollections {
     }
 }
 
-impl Operation for ListCollections {
+impl OperationWithDefaults for ListCollections {
     type O = CursorSpecification;
     type Command = Document;
 

--- a/src/operation/list_databases/mod.rs
+++ b/src/operation/list_databases/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, Operation, Retryability},
+    operation::{append_options, OperationWithDefaults, Retryability},
     options::ListDatabasesOptions,
     selection_criteria::{ReadPreference, SelectionCriteria},
 };
@@ -43,7 +43,7 @@ impl ListDatabases {
     }
 }
 
-impl Operation for ListDatabases {
+impl OperationWithDefaults for ListDatabases {
     type O = Vec<RawDocumentBuf>;
     type Command = Document;
 

--- a/src/operation/list_indexes/mod.rs
+++ b/src/operation/list_indexes/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    operation::{append_options, Operation},
+    operation::{append_options, OperationWithDefaults},
     options::ListIndexesOptions,
     selection_criteria::{ReadPreference, SelectionCriteria},
     Namespace,
@@ -36,7 +36,7 @@ impl ListIndexes {
     }
 }
 
-impl Operation for ListIndexes {
+impl OperationWithDefaults for ListIndexes {
     type O = CursorSpecification;
     type Command = Document;
 

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -17,6 +17,7 @@ mod insert;
 mod list_collections;
 mod list_databases;
 mod list_indexes;
+mod raw_output;
 mod run_command;
 mod update;
 

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -393,7 +393,7 @@ macro_rules! remove_empty_write_concern {
 pub(crate) use remove_empty_write_concern;
 
 // A mirror of the `Operation` trait, with default behavior where appropriate.  Should only be
-// implemented by leaf operation types.
+// implemented by operation types that do not delegate to other operations.
 pub(crate) trait OperationWithDefaults {
     /// The output type of this operation.
     type O;

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -153,6 +153,17 @@ impl CommandBody for Document {
     }
 }
 
+impl CommandBody for RawDocumentBuf {
+    fn should_redact(&self) -> bool {
+        if let Some(Ok((command_name, _))) = self.into_iter().next() {
+            HELLO_COMMAND_NAMES.contains(command_name.to_lowercase().as_str())
+                && self.get("speculativeAuthenticate").ok().flatten().is_some()
+        } else {
+            false
+        }
+    }
+}
+
 impl<T: CommandBody> Command<T> {
     pub(crate) fn should_redact(&self) -> bool {
         let name = self.name.to_lowercase();

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -75,8 +75,9 @@ pub(crate) use update::Update;
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
 
 /// A trait modeling the behavior of a server side operation.
-/// 
-/// No methods in this trait should have default behaviors to ensure that wrapper operations replicate all behavior.  Default behavior is provided by the `OperationDefault` trait.
+///
+/// No methods in this trait should have default behaviors to ensure that wrapper operations
+/// replicate all behavior.  Default behavior is provided by the `OperationDefault` trait.
 pub(crate) trait Operation {
     /// The output type of this operation.
     type O;
@@ -390,7 +391,8 @@ macro_rules! remove_empty_write_concern {
 
 pub(crate) use remove_empty_write_concern;
 
-// A mirror of the `Operation` trait, with default behavior where appropriate.  Should only be implemented by leaf operation types.
+// A mirror of the `Operation` trait, with default behavior where appropriate.  Should only be
+// implemented by leaf operation types.
 pub(crate) trait OperationWithDefaults {
     /// The output type of this operation.
     type O;
@@ -475,53 +477,53 @@ pub(crate) trait OperationWithDefaults {
 }
 
 impl<T: OperationWithDefaults> Operation for T {
-        type O = T::O;
-        type Command = T::Command;
-        const NAME: &'static str = T::NAME;    
-        fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
-            self.build(description)
-        }
-        fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
-            self.serialize_command(cmd)
-        }
-        fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
-            self.extract_at_cluster_time(response)
-        }
-        fn handle_response(
-            &self,
-            response: RawCommandResponse,
-            description: &StreamDescription,
-        ) -> Result<Self::O> {
-            self.handle_response(response, description)
-        }
-        fn handle_error(&self, error: Error) -> Result<Self::O> {
-            self.handle_error(error)
-        }
-        fn selection_criteria(&self) -> Option<&SelectionCriteria> {
-            self.selection_criteria()
-        }
-        fn is_acknowledged(&self) -> bool {
-            self.is_acknowledged()
-        }
-        fn write_concern(&self) -> Option<&WriteConcern> {
-            self.write_concern()
-        }
-        fn supports_read_concern(&self, description: &StreamDescription) -> bool {
-            self.supports_read_concern(description)
-        }
-        fn supports_sessions(&self) -> bool {
-            self.supports_sessions()
-        }
-        fn retryability(&self) -> Retryability {
-            self.retryability()
-        }
-        fn update_for_retry(&mut self) {
-            self.update_for_retry()
-        }
-        fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
-            self.pinned_connection()
-        }
-        fn name(&self) -> &str {
-            self.name()
-        }
+    type O = T::O;
+    type Command = T::Command;
+    const NAME: &'static str = T::NAME;
+    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+        self.build(description)
+    }
+    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
+        self.serialize_command(cmd)
+    }
+    fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
+        self.extract_at_cluster_time(response)
+    }
+    fn handle_response(
+        &self,
+        response: RawCommandResponse,
+        description: &StreamDescription,
+    ) -> Result<Self::O> {
+        self.handle_response(response, description)
+    }
+    fn handle_error(&self, error: Error) -> Result<Self::O> {
+        self.handle_error(error)
+    }
+    fn selection_criteria(&self) -> Option<&SelectionCriteria> {
+        self.selection_criteria()
+    }
+    fn is_acknowledged(&self) -> bool {
+        self.is_acknowledged()
+    }
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.write_concern()
+    }
+    fn supports_read_concern(&self, description: &StreamDescription) -> bool {
+        self.supports_read_concern(description)
+    }
+    fn supports_sessions(&self) -> bool {
+        self.supports_sessions()
+    }
+    fn retryability(&self) -> Retryability {
+        self.retryability()
+    }
+    fn update_for_retry(&mut self) {
+        self.update_for_retry()
+    }
+    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
+        self.pinned_connection()
+    }
+    fn name(&self) -> &str {
+        self.name()
+    }
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -74,6 +74,8 @@ pub(crate) use update::Update;
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
 
 /// A trait modeling the behavior of a server side operation.
+/// 
+/// No methods in this trait should have default behaviors to ensure that wrapper operations replicate all behavior.  Default behavior is provided by the `OperationDefault` trait.
 pub(crate) trait Operation {
     /// The output type of this operation.
     type O;
@@ -90,15 +92,11 @@ pub(crate) trait Operation {
 
     /// Perform custom serialization of the built command.
     /// By default, this will just call through to the `Serialize` implementation of the command.
-    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
-        Ok(bson::to_vec(&cmd)?)
-    }
+    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>>;
 
     /// Parse the response for the atClusterTime field.
     /// Depending on the operation, this may be found in different locations.
-    fn extract_at_cluster_time(&self, _response: &RawDocument) -> Result<Option<Timestamp>> {
-        Ok(None)
-    }
+    fn extract_at_cluster_time(&self, _response: &RawDocument) -> Result<Option<Timestamp>>;
 
     /// Interprets the server response to the command.
     fn handle_response(
@@ -109,52 +107,32 @@ pub(crate) trait Operation {
 
     /// Interpret an error encountered while sending the built command to the server, potentially
     /// recovering.
-    fn handle_error(&self, error: Error) -> Result<Self::O> {
-        Err(error)
-    }
+    fn handle_error(&self, error: Error) -> Result<Self::O>;
 
     /// Criteria to use for selecting the server that this operation will be executed on.
-    fn selection_criteria(&self) -> Option<&SelectionCriteria> {
-        None
-    }
+    fn selection_criteria(&self) -> Option<&SelectionCriteria>;
 
     /// Whether or not this operation will request acknowledgment from the server.
-    fn is_acknowledged(&self) -> bool {
-        self.write_concern()
-            .map(WriteConcern::is_acknowledged)
-            .unwrap_or(true)
-    }
+    fn is_acknowledged(&self) -> bool;
 
     /// The write concern to use for this operation, if any.
-    fn write_concern(&self) -> Option<&WriteConcern> {
-        None
-    }
+    fn write_concern(&self) -> Option<&WriteConcern>;
 
     /// Returns whether or not this command supports the `readConcern` field.
-    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
-        false
-    }
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool;
 
     /// Whether this operation supports sessions or not.
-    fn supports_sessions(&self) -> bool {
-        true
-    }
+    fn supports_sessions(&self) -> bool;
 
     /// The level of retryability the operation supports.
-    fn retryability(&self) -> Retryability {
-        Retryability::None
-    }
+    fn retryability(&self) -> Retryability;
 
     /// Updates this operation as needed for a retry.
-    fn update_for_retry(&mut self) {}
+    fn update_for_retry(&mut self);
 
-    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
-        None
-    }
+    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle>;
 
-    fn name(&self) -> &str {
-        Self::NAME
-    }
+    fn name(&self) -> &str;
 }
 
 pub(crate) trait CommandBody: Serialize {
@@ -399,3 +377,139 @@ macro_rules! remove_empty_write_concern {
 }
 
 pub(crate) use remove_empty_write_concern;
+
+// A mirror of the `Operation` trait, with default behavior where appropriate.  Should only be implemented by leaf operation types.
+pub(crate) trait OperationWithDefaults {
+    /// The output type of this operation.
+    type O;
+
+    /// The format of the command body constructed in `build`.
+    type Command: CommandBody;
+
+    /// The name of the server side command associated with this operation.
+    const NAME: &'static str;
+
+    /// Returns the command that should be sent to the server as part of this operation.
+    /// The operation may store some additional state that is required for handling the response.
+    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>>;
+
+    /// Perform custom serialization of the built command.
+    /// By default, this will just call through to the `Serialize` implementation of the command.
+    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
+        Ok(bson::to_vec(&cmd)?)
+    }
+
+    /// Parse the response for the atClusterTime field.
+    /// Depending on the operation, this may be found in different locations.
+    fn extract_at_cluster_time(&self, _response: &RawDocument) -> Result<Option<Timestamp>> {
+        Ok(None)
+    }
+
+    /// Interprets the server response to the command.
+    fn handle_response(
+        &self,
+        response: RawCommandResponse,
+        description: &StreamDescription,
+    ) -> Result<Self::O>;
+
+    /// Interpret an error encountered while sending the built command to the server, potentially
+    /// recovering.
+    fn handle_error(&self, error: Error) -> Result<Self::O> {
+        Err(error)
+    }
+
+    /// Criteria to use for selecting the server that this operation will be executed on.
+    fn selection_criteria(&self) -> Option<&SelectionCriteria> {
+        None
+    }
+
+    /// Whether or not this operation will request acknowledgment from the server.
+    fn is_acknowledged(&self) -> bool {
+        self.write_concern()
+            .map(WriteConcern::is_acknowledged)
+            .unwrap_or(true)
+    }
+
+    /// The write concern to use for this operation, if any.
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        None
+    }
+
+    /// Returns whether or not this command supports the `readConcern` field.
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
+        false
+    }
+
+    /// Whether this operation supports sessions or not.
+    fn supports_sessions(&self) -> bool {
+        true
+    }
+
+    /// The level of retryability the operation supports.
+    fn retryability(&self) -> Retryability {
+        Retryability::None
+    }
+
+    /// Updates this operation as needed for a retry.
+    fn update_for_retry(&mut self) {}
+
+    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
+        None
+    }
+
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+}
+
+impl<T: OperationWithDefaults> Operation for T {
+        type O = T::O;
+        type Command = T::Command;
+        const NAME: &'static str = T::NAME;    
+        fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+            self.build(description)
+        }
+        fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
+            self.serialize_command(cmd)
+        }
+        fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
+            self.extract_at_cluster_time(response)
+        }
+        fn handle_response(
+            &self,
+            response: RawCommandResponse,
+            description: &StreamDescription,
+        ) -> Result<Self::O> {
+            self.handle_response(response, description)
+        }
+        fn handle_error(&self, error: Error) -> Result<Self::O> {
+            self.handle_error(error)
+        }
+        fn selection_criteria(&self) -> Option<&SelectionCriteria> {
+            self.selection_criteria()
+        }
+        fn is_acknowledged(&self) -> bool {
+            self.is_acknowledged()
+        }
+        fn write_concern(&self) -> Option<&WriteConcern> {
+            self.write_concern()
+        }
+        fn supports_read_concern(&self, description: &StreamDescription) -> bool {
+            self.supports_read_concern(description)
+        }
+        fn supports_sessions(&self) -> bool {
+            self.supports_sessions()
+        }
+        fn retryability(&self) -> Retryability {
+            self.retryability()
+        }
+        fn update_for_retry(&mut self) {
+            self.update_for_retry()
+        }
+        fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
+            self.pinned_connection()
+        }
+        fn name(&self) -> &str {
+            self.name()
+        }
+}

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -68,6 +68,7 @@ pub(crate) use insert::Insert;
 pub(crate) use list_collections::ListCollections;
 pub(crate) use list_databases::ListDatabases;
 pub(crate) use list_indexes::ListIndexes;
+pub(crate) use raw_output::RawOutput;
 pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;
 

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -68,6 +68,7 @@ pub(crate) use insert::Insert;
 pub(crate) use list_collections::ListCollections;
 pub(crate) use list_databases::ListDatabases;
 pub(crate) use list_indexes::ListIndexes;
+#[cfg(feature = "csfle")]
 pub(crate) use raw_output::RawOutput;
 pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -3,7 +3,7 @@ use crate::error::Result;
 
 use super::Operation;
 
-pub(crate) struct RawOutput<Op>(Op);
+pub(crate) struct RawOutput<Op>(pub(crate) Op);
 
 impl<Op: Operation> Operation for RawOutput<Op> {
     type O = RawCommandResponse;
@@ -11,23 +11,23 @@ impl<Op: Operation> Operation for RawOutput<Op> {
     const NAME: &'static str = Op::NAME;
 
     fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
-        todo!()
+        self.0.build(description)
+    }
+
+    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
+        self.0.serialize_command(cmd)
+    }
+
+    fn extract_at_cluster_time(&self, response: &bson::RawDocument) -> Result<Option<bson::Timestamp>> {
+        self.0.extract_at_cluster_time(response)
     }
 
     fn handle_response(
         &self,
         response: RawCommandResponse,
-        description: &StreamDescription,
+        _description: &StreamDescription,
     ) -> Result<Self::O> {
-        todo!()
-    }
-
-    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
-        Ok(bson::to_vec(&cmd)?)
-    }
-
-    fn extract_at_cluster_time(&self, _response: &bson::RawDocument) -> Result<Option<bson::Timestamp>> {
-        Ok(None)
+        Ok(response)
     }
 
     fn handle_error(&self, error: crate::error::Error) -> Result<Self::O> {
@@ -35,38 +35,38 @@ impl<Op: Operation> Operation for RawOutput<Op> {
     }
 
     fn selection_criteria(&self) -> Option<&crate::selection_criteria::SelectionCriteria> {
-        None
+        self.0.selection_criteria()
     }
 
     fn is_acknowledged(&self) -> bool {
-        self.write_concern()
-            .map(crate::options::WriteConcern::is_acknowledged)
-            .unwrap_or(true)
+        self.0.is_acknowledged()
     }
 
     fn write_concern(&self) -> Option<&crate::options::WriteConcern> {
-        None
+        self.0.write_concern()
     }
 
-    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
-        false
+    fn supports_read_concern(&self, description: &StreamDescription) -> bool {
+        self.0.supports_read_concern(description)
     }
 
     fn supports_sessions(&self) -> bool {
-        true
+        self.0.supports_sessions()
     }
 
     fn retryability(&self) -> super::Retryability {
-        super::Retryability::None
+        self.0.retryability()
     }
 
-    fn update_for_retry(&mut self) {}
+    fn update_for_retry(&mut self) {
+        self.0.update_for_retry()
+    }
 
     fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
-        None
+        self.0.pinned_connection()
     }
 
     fn name(&self) -> &str {
-        Self::NAME
+        self.0.name()
     }
 }

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -1,5 +1,7 @@
-use crate::cmap::{StreamDescription, RawCommandResponse, Command};
-use crate::error::Result;
+use crate::{
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+};
 
 use super::Operation;
 
@@ -18,7 +20,10 @@ impl<Op: Operation> Operation for RawOutput<Op> {
         self.0.serialize_command(cmd)
     }
 
-    fn extract_at_cluster_time(&self, response: &bson::RawDocument) -> Result<Option<bson::Timestamp>> {
+    fn extract_at_cluster_time(
+        &self,
+        response: &bson::RawDocument,
+    ) -> Result<Option<bson::Timestamp>> {
         self.0.extract_at_cluster_time(response)
     }
 

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -5,6 +5,8 @@ use crate::{
 
 use super::Operation;
 
+/// Forwards all implementation to the wrapped `Operation`, but returns the response unparsed and
+/// unvalidated as a `RawCommandResponse`.
 pub(crate) struct RawOutput<Op>(pub(crate) Op);
 
 impl<Op: Operation> Operation for RawOutput<Op> {

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -1,0 +1,72 @@
+use crate::cmap::{StreamDescription, RawCommandResponse, Command};
+use crate::error::Result;
+
+use super::Operation;
+
+pub(crate) struct RawOutput<Op>(Op);
+
+impl<Op: Operation> Operation for RawOutput<Op> {
+    type O = RawCommandResponse;
+    type Command = Op::Command;
+    const NAME: &'static str = Op::NAME;
+
+    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+        todo!()
+    }
+
+    fn handle_response(
+        &self,
+        response: RawCommandResponse,
+        description: &StreamDescription,
+    ) -> Result<Self::O> {
+        todo!()
+    }
+
+    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
+        Ok(bson::to_vec(&cmd)?)
+    }
+
+    fn extract_at_cluster_time(&self, _response: &bson::RawDocument) -> Result<Option<bson::Timestamp>> {
+        Ok(None)
+    }
+
+    fn handle_error(&self, error: crate::error::Error) -> Result<Self::O> {
+        Err(error)
+    }
+
+    fn selection_criteria(&self) -> Option<&crate::selection_criteria::SelectionCriteria> {
+        None
+    }
+
+    fn is_acknowledged(&self) -> bool {
+        self.write_concern()
+            .map(crate::options::WriteConcern::is_acknowledged)
+            .unwrap_or(true)
+    }
+
+    fn write_concern(&self) -> Option<&crate::options::WriteConcern> {
+        None
+    }
+
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
+        false
+    }
+
+    fn supports_sessions(&self) -> bool {
+        true
+    }
+
+    fn retryability(&self) -> super::Retryability {
+        super::Retryability::None
+    }
+
+    fn update_for_retry(&mut self) {}
+
+    fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
+        None
+    }
+
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+}

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -3,7 +3,7 @@ mod test;
 
 use std::convert::TryInto;
 
-use bson::RawBsonRef;
+use bson::{RawBsonRef, RawDocumentBuf};
 
 use super::{CursorBody, OperationWithDefaults};
 use crate::{
@@ -18,7 +18,7 @@ use crate::{
 #[derive(Debug)]
 pub(crate) struct RunCommand<'conn> {
     db: String,
-    command: Document,
+    command: RawDocumentBuf,
     selection_criteria: Option<SelectionCriteria>,
     write_concern: Option<WriteConcern>,
     pinned_connection: Option<&'conn PinnedConnectionHandle>,
@@ -38,6 +38,27 @@ impl<'conn> RunCommand<'conn> {
 
         Ok(Self {
             db,
+            command: RawDocumentBuf::from_document(&command)?,
+            selection_criteria,
+            write_concern,
+            pinned_connection,
+        })
+    }
+
+    pub(crate) fn new_raw(
+        db: String,
+        command: RawDocumentBuf,
+        selection_criteria: Option<SelectionCriteria>,
+        pinned_connection: Option<&'conn PinnedConnectionHandle>,
+    ) -> Result<Self> {
+        let write_concern = command
+            .get("writeConcern")?
+            .and_then(|b| b.as_document())
+            .map(|doc| bson::from_slice::<WriteConcern>(doc.as_bytes()))
+            .transpose()?;
+
+        Ok(Self {
+            db,
             command,
             selection_criteria,
             write_concern,
@@ -46,19 +67,19 @@ impl<'conn> RunCommand<'conn> {
     }
 
     fn command_name(&self) -> Option<&str> {
-        self.command.keys().next().map(String::as_str)
+        self.command.into_iter().next().and_then(|r| r.ok()).map(|(k, _)| k)
     }
 }
 
 impl<'conn> OperationWithDefaults for RunCommand<'conn> {
     type O = Document;
-    type Command = Document;
+    type Command = RawDocumentBuf;
 
     // Since we can't actually specify a string statically here, we just put a descriptive string
     // that should fail loudly if accidentally passed to the server.
     const NAME: &'static str = "$genericRunCommand";
 
-    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command<Self::Command>> {
         let command_name = self
             .command_name()
             .ok_or_else(|| ErrorKind::InvalidArgument {

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 
 use bson::RawBsonRef;
 
-use super::{CursorBody, Operation};
+use super::{CursorBody, Operation, OperationWithDefaults};
 use crate::{
     bson::Document,
     client::SESSIONS_UNSUPPORTED_COMMANDS,
@@ -50,7 +50,7 @@ impl<'conn> RunCommand<'conn> {
     }
 }
 
-impl<'conn> Operation for RunCommand<'conn> {
+impl<'conn> OperationWithDefaults for RunCommand<'conn> {
     type O = Document;
     type Command = Document;
 

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -67,7 +67,11 @@ impl<'conn> RunCommand<'conn> {
     }
 
     fn command_name(&self) -> Option<&str> {
-        self.command.into_iter().next().and_then(|r| r.ok()).map(|(k, _)| k)
+        self.command
+            .into_iter()
+            .next()
+            .and_then(|r| r.ok())
+            .map(|(k, _)| k)
     }
 }
 

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 
 use bson::RawBsonRef;
 
-use super::{CursorBody, Operation, OperationWithDefaults};
+use super::{CursorBody, OperationWithDefaults};
 use crate::{
     bson::Document,
     client::SESSIONS_UNSUPPORTED_COMMANDS,

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -45,6 +45,7 @@ impl<'conn> RunCommand<'conn> {
         })
     }
 
+    #[cfg(feature = "csfle")]
     pub(crate) fn new_raw(
         db: String,
         command: RawDocumentBuf,

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -1,12 +1,9 @@
-use std::convert::TryInto;
-
 use bson::Timestamp;
 
 use super::RunCommand;
 use crate::{
     bson::doc,
-    cmap::StreamDescription,
-    operation::{test::handle_response_test, Operation},
+    operation::test::handle_response_test,
 };
 
 #[test]

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use bson::Timestamp;
 
 use super::RunCommand;
@@ -20,7 +22,8 @@ fn build() {
         command
             .body
             .get("hello")
-            .and_then(crate::bson_util::get_int),
+            .unwrap()
+            .and_then(|raw| crate::bson_util::get_int(&raw.try_into().unwrap())),
         Some(1)
     );
 }

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -10,25 +10,6 @@ use crate::{
 };
 
 #[test]
-fn build() {
-    let mut op = RunCommand::new("foo".into(), doc! { "hello": 1 }, None, None).unwrap();
-    assert!(op.selection_criteria().is_none());
-
-    let command = op.build(&StreamDescription::new_testing()).unwrap();
-
-    assert_eq!(command.name, "hello");
-    assert_eq!(command.target_db, "foo");
-    assert_eq!(
-        command
-            .body
-            .get("hello")
-            .unwrap()
-            .and_then(|raw| crate::bson_util::get_int(&raw.try_into().unwrap())),
-        Some(1)
-    );
-}
-
-#[test]
 fn handle_success() {
     let op = RunCommand::new("foo".into(), doc! { "hello": 1 }, None, None).unwrap();
 

--- a/src/operation/run_command/test.rs
+++ b/src/operation/run_command/test.rs
@@ -1,10 +1,7 @@
 use bson::Timestamp;
 
 use super::RunCommand;
-use crate::{
-    bson::doc,
-    operation::test::handle_response_test,
-};
+use crate::{bson::doc, operation::test::handle_response_test};
 
 #[test]
 fn handle_success() {

--- a/src/operation/update/mod.rs
+++ b/src/operation/update/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{convert_bulk_errors, Result},
-    operation::{Operation, Retryability, WriteResponseBody},
+    operation::{OperationWithDefaults, Retryability, WriteResponseBody},
     options::{UpdateModifications, UpdateOptions, WriteConcern},
     results::UpdateResult,
     Namespace,
@@ -55,7 +55,7 @@ impl Update {
     }
 }
 
-impl Operation for Update {
+impl OperationWithDefaults for Update {
     type O = UpdateResult;
     type Command = Document;
 


### PR DESCRIPTION
RUST-1384

This implements support for auto encryption and decryption; the large majority of the complexity is in `state_machine.rs`; the changes needed to the main executor were pretty minor.

This is the companion PR to https://github.com/mongodb/libmongocrypt-rust/pull/11 (and its ill-fated predecessor https://github.com/mongodb/libmongocrypt-rust/pull/9).