### PR TITLE
RUST-1413 Add Unicode-DFS-2016 to the list of allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,8 +49,6 @@ notice = "deny"
 # output a note when they are encountered.
 ignore = [
     # TODO RUST-1293
-    "RUSTSEC-2020-0159",
-    # TODO RUST-1293
     "RUSTSEC-2020-0071",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
@@ -80,6 +78,7 @@ allow = [
     "OpenSSL",
     "BSD-3-Clause",
     "MPL-2.0",
+    "Unicode-DFS-2016",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
RUST-1413

This also removes a now-obsolete advisory from the ignore list.  [Successful evergreen run](https://evergreen.mongodb.com/lobster/evergreen/task/mongo_rust_driver_lint_check_cargo_deny_patch_1d52ed798ebb11c6a4e5ab5b67fe5b974dd89f97_62ec10235623434ce224d36a_22_08_04_18_30_01/0/task#bookmarks=0%2C984&l=1&shareLine=885).