### PR TITLE
Deps: bump various dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ os_info = { version = "3.0.1", default-features = false }
 percent-encoding = "2.0.0"
 rand = { version = "0.8.3", features = ["small_rng"] }
 rustc_version_runtime = "0.2.1"
-rustls-pemfile = "0.3.0"
+rustls-pemfile = "1.0.1"
 serde_with = "1.3.1"
 sha-1 = "0.10.0"
 sha2 = "0.10.2"
@@ -101,12 +101,12 @@ strsim = "0.10.0"
 take_mut = "0.2.2"
 thiserror = "1.0.24"
 tokio-openssl = { version = "0.6.3", optional = true }
-trust-dns-proto = "0.21.1"
-trust-dns-resolver = "0.21.1"
+trust-dns-proto = "0.21.2"
+trust-dns-resolver = "0.21.2"
 typed-builder = "0.10.0"
-webpki-roots = "0.22.2"
+webpki-roots = "0.22.4"
 which = { version = "4.2.5", optional = true }
-zstd = { version = "0.11.0", optional = true }
+zstd = { version = "0.11.2", optional = true }
 
 [dependencies.async-std]
 version = "1.9.0"
@@ -117,7 +117,7 @@ version = "0.21.1"
 optional = true
 
 [dependencies.pbkdf2]
-version = "0.10.1"
+version = "0.11.0"
 default-features = false
 
 [dependencies.reqwest]


### PR DESCRIPTION
Hello there! I noticed that one of my projects had multiple duplicate dependencies due to `mongodb`. This PR bumps up the crate versions. Most of the bumps were patch-level. The notable bumps are noted below:

Crate | Old | New | Notes
----- | --- | --- | -----
`rustls-pemfile` | `0.3` | `1.0` | The [changelog](https://github.com/rustls/pemfile#release-history) declares no API changes. This is a safe major version bump.
`pbkdf2` | `0.10` | `0.11` | [Now uses the `2021` edition with MSRV `1.57`.](https://github.com/RustCrypto/password-hashes/blob/master/pbkdf2/CHANGELOG.md#0110-2022-03-28)

Sadly, the `time` crate appears to be an unremovable duplicate crate (for now) since `chrono` requires the `time` crate at version `0.1` while `bson` requires it at version `0.3`. The current maintainers did mention that the `time` dependency will be dropped ["in the next semver-compatible release"](https://github.com/chronotope/chrono/issues/602#issuecomment-1075915577). Let's make sure to upgrade to it so we can finally put the [CVE-2020-26235](https://nvd.nist.gov/vuln/detail/CVE-2020-26235) warnings to rest. 😅

There is one issue with the `pbkdf2` upgrade, though. I realized in hindsight that `mongodb` officially supports an MSRV of `1.56`, not `1.57`—just one minor release behind! With that said, I would like to propose bumping up the MSRV (by one version) in the next release.

If this is not possible _yet_, I wouldn't mind removing the `pbkdf2` upgrade for now. It would be great to resolve this as early as possible, though, so that there would be less dependency duplication.

Thanks! 🎉