### PR TITLE
RUST-1295 Sync tests for pre and post image options in collection helpers

### DIFF
--- a/src/test/spec/collection_management.rs
+++ b/src/test/spec/collection_management.rs
@@ -1,4 +1,4 @@
-use crate::test::LOCK;
+use crate::test::{log_uncaptured, LOCK};
 
 use super::{run_spec_test_with_path, run_unified_format_test};
 
@@ -6,5 +6,13 @@ use super::{run_spec_test_with_path, run_unified_format_test};
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
     let _guard = LOCK.run_exclusively().await;
-    run_spec_test_with_path(&["collection-management"], run_unified_format_test).await;
+    run_spec_test_with_path(&["collection-management"], |path, test| async {
+        if path.ends_with("modifyCollection-pre_and_post_images.json") {
+            // modifyCollection is unsupported.
+            log_uncaptured("skipping modifyCollection-pre_and_post_images");
+            return;
+        }
+        run_unified_format_test(path, test).await;
+    })
+    .await;
 }

--- a/src/test/spec/json/collection-management/createCollection-pre_and_post_images.json
+++ b/src/test/spec/json/collection-management/createCollection-pre_and_post_images.json
@@ -1,0 +1,92 @@
+{
+  "description": "createCollection-pre_and_post_images",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "papi-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "createCollection with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "papi-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "papi-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": true
+                  }
+                },
+                "databaseName": "papi-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/collection-management/createCollection-pre_and_post_images.yml
+++ b/src/test/spec/json/collection-management/createCollection-pre_and_post_images.yml
@@ -1,0 +1,50 @@
+description: "createCollection-pre_and_post_images"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "6.0"
+    serverless: forbid
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name papi-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "createCollection with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: true }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                changeStreamPreAndPostImages: { enabled: true }
+              databaseName: *database0Name

--- a/src/test/spec/json/collection-management/modifyCollection-pre_and_post_images.json
+++ b/src/test/spec/json/collection-management/modifyCollection-pre_and_post_images.json
@@ -1,0 +1,111 @@
+{
+  "description": "modifyCollection-pre_and_post_images",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "papi-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "modifyCollection to changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "papi-tests",
+            "collectionName": "test"
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "changeStreamPreAndPostImages": {
+              "enabled": true
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "papi-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "collMod": "test",
+                  "changeStreamPreAndPostImages": {
+                    "enabled": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/collection-management/modifyCollection-pre_and_post_images.yml
+++ b/src/test/spec/json/collection-management/modifyCollection-pre_and_post_images.yml
@@ -1,0 +1,58 @@
+description: "modifyCollection-pre_and_post_images"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "6.0"
+    serverless: forbid
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name papi-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "modifyCollection to changeStreamPreAndPostImages enabled"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: false }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: modifyCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                changeStreamPreAndPostImages: { enabled: false }
+          - commandStartedEvent:
+              command:
+                collMod: *collection0Name
+                changeStreamPreAndPostImages: { enabled: true }


### PR DESCRIPTION
RUST-1295

This is mostly just a test sync; however, one of the test files is exercising the `modifyCollection` helper, which the Rust driver doesn't have, so it needed a code change to skip that.  I couldn't find a bug to implement that, so I left it with a non-TODO comment.