### PR TITLE
RUST-1385 Implement explicit encryption

### DIFF
--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -1,3 +1,4 @@
+pub mod client_encryption;
 pub mod options;
 mod state_machine;
 

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -52,9 +52,9 @@ impl ClientState {
         let mongocryptd_client = Self::spawn_mongocryptd_if_needed(&opts, &crypt).await?;
         let aux_clients = Self::make_aux_clients(client, &opts)?;
         let exec = CryptExecutor::new(
-            mongocryptd_client,
             aux_clients.key_vault_client,
             opts.key_vault_namespace.clone(),
+            mongocryptd_client,
             aux_clients.metadata_client,
         )?;
 

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -47,7 +47,7 @@ struct AuxClients {
 }
 
 impl ClientState {
-    pub(super) async fn new(client: &Client, opts: AutoEncryptionOptions) -> Result<Self> {
+    pub(super) async fn new(client: &Client, mut opts: AutoEncryptionOptions) -> Result<Self> {
         let crypt = Self::make_crypt(&opts)?;
         let mongocryptd_client = Self::spawn_mongocryptd_if_needed(&opts, &crypt).await?;
         let aux_clients = Self::make_aux_clients(client, &opts)?;
@@ -56,6 +56,7 @@ impl ClientState {
             opts.key_vault_namespace.clone(),
             mongocryptd_client,
             aux_clients.metadata_client,
+            opts.tls_options.take(),
         )?;
 
         Ok(Self {

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -9,7 +9,6 @@ use std::{
 
 use derivative::Derivative;
 use mongocrypt::Crypt;
-use rayon::ThreadPool;
 
 use crate::{
     error::{Error, Result},
@@ -27,24 +26,24 @@ use options::{
     EO_MONGOCRYPTD_URI,
 };
 
+use self::state_machine::CryptExecutor;
+
 use super::WeakClient;
 
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub(super) struct ClientState {
     #[derivative(Debug = "ignore")]
-    pub(crate) crypt: Crypt,
-    mongocryptd_client: Option<Client>,
-    aux_clients: AuxClients,
+    crypt: Crypt,
+    exec: CryptExecutor,
+    internal_client: Option<Client>,
     opts: AutoEncryptionOptions,
-    crypto_threads: ThreadPool,
 }
 
-#[derive(Debug)]
 struct AuxClients {
     key_vault_client: WeakClient,
     metadata_client: Option<WeakClient>,
-    _internal_client: Option<Client>,
+    internal_client: Option<Client>,
 }
 
 impl ClientState {
@@ -52,19 +51,27 @@ impl ClientState {
         let crypt = Self::make_crypt(&opts)?;
         let mongocryptd_client = Self::spawn_mongocryptd_if_needed(&opts, &crypt).await?;
         let aux_clients = Self::make_aux_clients(client, &opts)?;
-        let num_cpus = std::thread::available_parallelism()?.get();
-        let crypto_threads = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus)
-            .build()
-            .map_err(|e| Error::internal(format!("could not initialize thread pool: {}", e)))?;
+        let exec = CryptExecutor::new(
+            mongocryptd_client,
+            aux_clients.key_vault_client,
+            opts.key_vault_namespace.clone(),
+            aux_clients.metadata_client,
+        )?;
 
         Ok(Self {
             crypt,
-            mongocryptd_client,
-            aux_clients,
+            exec,
+            internal_client: aux_clients.internal_client,
             opts,
-            crypto_threads,
         })
+    }
+
+    pub(super) fn crypt(&self) -> &Crypt {
+        &self.crypt
+    }
+
+    pub(super) fn exec(&self) -> &CryptExecutor {
+        &self.exec
     }
 
     pub(super) fn opts(&self) -> &AutoEncryptionOptions {
@@ -177,7 +184,7 @@ impl ClientState {
         Ok(AuxClients {
             key_vault_client,
             metadata_client,
-            _internal_client: internal_client,
+            internal_client,
         })
     }
 }

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,11 +1,14 @@
 #![allow(dead_code)]
 
+use crate::coll::options::CollectionOptions;
+use crate::options::{WriteConcern, ReadConcern};
 use crate::results::DeleteResult;
-use crate::{Cursor, Client, Namespace};
+use crate::{Cursor, Client, Namespace, Collection};
 use crate::bson::{Binary, Document};
-use crate::error::Result;
+use crate::error::{Result, Error};
+use bson::{doc, RawDocumentBuf};
 use mongocrypt::Crypt;
-use mongocrypt::ctx::KmsProvider;
+use mongocrypt::ctx::{KmsProvider, Ctx};
 
 use super::options::{KmsProviders, KmsProvidersTlsOptions};
 use super::state_machine::CryptExecutor;
@@ -14,6 +17,7 @@ pub struct ClientEncryption {
     crypt: Crypt,
     exec: CryptExecutor,
     opts: ClientEncryptionOptions,
+    key_vault: Collection<RawDocumentBuf>,
 }
 
 impl ClientEncryption {
@@ -25,11 +29,55 @@ impl ClientEncryption {
             None,
             None,
         )?;
-        Ok(Self { crypt, exec, opts })
+        let key_vault = opts.key_vault_client
+            .database(&opts.key_vault_namespace.db)
+            .collection_with_options(
+                &opts.key_vault_namespace.coll, 
+                CollectionOptions::builder()
+                    .write_concern(WriteConcern::MAJORITY)
+                    .read_concern(ReadConcern::MAJORITY)
+                    .build(),
+            );
+        Ok(Self { crypt, exec, opts, key_vault })
     }
 
-    pub fn create_data_key(&self, _kms_provider: KmsProvider, _opts: DataKeyOptions) -> Result<Binary> {
-        todo!()
+    pub async fn create_data_key(&self, kms_provider: KmsProvider, opts: DataKeyOptions) -> Result<Binary> {
+        let ctx = self.create_data_key_ctx(kms_provider, opts)?;
+        let data_key = self.exec.run_ctx(ctx, None).await?;
+        self.key_vault.insert_one(&data_key, None).await?;
+        let bin_ref = data_key.get_binary("_id")
+            .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
+        // TODO: impl ToOwned
+        Ok(Binary {
+            subtype: bin_ref.subtype,
+            bytes: bin_ref.bytes.to_owned(),
+        })
+    }
+
+    fn create_data_key_ctx(&self, kms_provider: KmsProvider, opts: DataKeyOptions) -> Result<Ctx> {
+        let mut builder = self.crypt.ctx_builder();
+        // TODO: move this to KmsProvider
+        let kms_provider = match kms_provider {
+            KmsProvider::Aws => "aws",
+            KmsProvider::Azure => "azure",
+            KmsProvider::Gcp => "gcp",
+            KmsProvider::Kmip => "kmip",
+            KmsProvider::Other(s) => s,
+        };
+        let mut key_doc = doc! { "provider": kms_provider };
+        if let Some(master_key) = opts.master_key {
+            key_doc.extend(master_key);
+        }
+        builder = builder.key_encryption_key(&key_doc)?;
+        if let Some(alt_names) = opts.key_alt_names {
+            for name in alt_names {
+                builder = builder.key_alt_name(&name)?;
+            }
+        }
+        if let Some(material) = opts.key_material {
+            builder = builder.key_material(&material)?;
+        }
+        Ok(builder.build_datakey()?)
     }
 
     pub fn rewrap_many_data_key(&self, _filter: Document, _opts: RewrapManyDataKeyOptions) -> Result<RewrapManyDataKeyResult> {

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,20 +1,29 @@
 #![allow(dead_code)]
 
-use crate::coll::options::CollectionOptions;
-use crate::options::{WriteConcern, ReadConcern};
-use crate::results::DeleteResult;
-use crate::{Cursor, Client, Namespace, Collection};
-use crate::bson::{Binary, Document};
-use crate::error::{Result, Error};
-use bson::spec::BinarySubtype;
-use bson::{doc, RawDocumentBuf, RawBinaryRef};
-use mongocrypt::Crypt;
-use mongocrypt::ctx::{KmsProvider, Ctx, Algorithm};
+use crate::{
+    bson::{Binary, Document},
+    coll::options::CollectionOptions,
+    error::{Error, Result},
+    options::{ReadConcern, WriteConcern},
+    results::DeleteResult,
+    Client,
+    Collection,
+    Cursor,
+    Namespace,
+};
+use bson::{doc, spec::BinarySubtype, RawBinaryRef, RawDocumentBuf};
+use mongocrypt::{
+    ctx::{Algorithm, Ctx, KmsProvider},
+    Crypt,
+};
 
-use super::options::{KmsProviders, KmsProvidersTlsOptions};
-use super::state_machine::CryptExecutor;
+use super::{
+    options::{KmsProviders, KmsProvidersTlsOptions},
+    state_machine::CryptExecutor,
+};
 
-/// A handle to the key vault.  Used to create data encryption keys, and to explicitly encrypt and decrypt values when auto-encryption is not an option.
+/// A handle to the key vault.  Used to create data encryption keys, and to explicitly encrypt and
+/// decrypt values when auto-encryption is not an option.
 pub struct ClientEncryption {
     crypt: Crypt,
     exec: CryptExecutor,
@@ -32,40 +41,42 @@ impl ClientEncryption {
             None,
             opts.tls_options,
         )?;
-        let key_vault = opts.key_vault_client
+        let key_vault = opts
+            .key_vault_client
             .database(&opts.key_vault_namespace.db)
             .collection_with_options(
-                &opts.key_vault_namespace.coll, 
+                &opts.key_vault_namespace.coll,
                 CollectionOptions::builder()
                     .write_concern(WriteConcern::MAJORITY)
                     .read_concern(ReadConcern::MAJORITY)
                     .build(),
             );
-        Ok(Self { crypt, exec, key_vault })
+        Ok(Self {
+            crypt,
+            exec,
+            key_vault,
+        })
     }
 
     /// Creates a new key document and inserts into the key vault collection.
     /// Returns the _id of the created document as a UUID (BSON binary subtype 0x04).
-    pub async fn create_data_key(&self, kms_provider: KmsProvider, opts: DataKeyOptions) -> Result<Binary> {
+    pub async fn create_data_key(
+        &self,
+        kms_provider: KmsProvider,
+        opts: DataKeyOptions,
+    ) -> Result<Binary> {
         let ctx = self.create_data_key_ctx(kms_provider, opts)?;
         let data_key = self.exec.run_ctx(ctx, None).await?;
         self.key_vault.insert_one(&data_key, None).await?;
-        let bin_ref = data_key.get_binary("_id")
+        let bin_ref = data_key
+            .get_binary("_id")
             .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
         Ok(bin_owned(bin_ref))
     }
 
     fn create_data_key_ctx(&self, kms_provider: KmsProvider, opts: DataKeyOptions) -> Result<Ctx> {
         let mut builder = self.crypt.ctx_builder();
-        // TODO(aegnor): move this to KmsProvider
-        let kms_provider = match kms_provider {
-            KmsProvider::Aws => "aws",
-            KmsProvider::Azure => "azure",
-            KmsProvider::Gcp => "gcp",
-            KmsProvider::Kmip => "kmip",
-            KmsProvider::Other(s) => s,
-        };
-        let mut key_doc = doc! { "provider": kms_provider };
+        let mut key_doc = doc! { "provider": kms_provider.name() };
         if let Some(master_key) = opts.master_key {
             key_doc.extend(master_key);
         }
@@ -81,14 +92,13 @@ impl ClientEncryption {
         Ok(builder.build_datakey()?)
     }
 
-    /*
-    pub async fn rewrap_many_data_key(&self, _filter: Document, _opts: RewrapManyDataKeyOptions) -> Result<RewrapManyDataKeyResult> {
-        todo!("RUST-1441")
-    }
-    */
+    // pub async fn rewrap_many_data_key(&self, _filter: Document, _opts: RewrapManyDataKeyOptions)
+    // -> Result<RewrapManyDataKeyResult> { todo!("RUST-1441")
+    // }
 
-    /// Removes the key document with the given UUID (BSON binary subtype 0x04) from the key vault collection.
-    /// Returns the result of the internal deleteOne() operation on the key vault collection.
+    /// Removes the key document with the given UUID (BSON binary subtype 0x04) from the key vault
+    /// collection. Returns the result of the internal deleteOne() operation on the key vault
+    /// collection.
     pub async fn delete_key(&self, id: &Binary) -> Result<DeleteResult> {
         self.key_vault.delete_one(doc! { "_id": id }, None).await
     }
@@ -102,18 +112,34 @@ impl ClientEncryption {
     /// Finds all documents in the key vault collection.
     /// Returns the result of the internal find() operation on the key vault collection.
     pub async fn get_keys(&self) -> Result<Cursor<RawDocumentBuf>> {
-        self.key_vault.find(doc! { }, None).await
+        self.key_vault.find(doc! {}, None).await
     }
 
-    /// Adds a keyAltName to the keyAltNames array of the key document in the key vault collection with the given UUID (BSON binary subtype 0x04).
-    /// Returns the previous version of the key document.
-    pub async fn add_key_alt_name(&self, id: &Binary, key_alt_name: &str) -> Result<Option<RawDocumentBuf>> {
-        self.key_vault.find_one_and_update(doc! { "_id": id }, doc! { "$addToSet": { "keyAltNames": key_alt_name } }, None).await
+    /// Adds a keyAltName to the keyAltNames array of the key document in the key vault collection
+    /// with the given UUID (BSON binary subtype 0x04). Returns the previous version of the key
+    /// document.
+    pub async fn add_key_alt_name(
+        &self,
+        id: &Binary,
+        key_alt_name: &str,
+    ) -> Result<Option<RawDocumentBuf>> {
+        self.key_vault
+            .find_one_and_update(
+                doc! { "_id": id },
+                doc! { "$addToSet": { "keyAltNames": key_alt_name } },
+                None,
+            )
+            .await
     }
 
-    /// Removes a keyAltName from the keyAltNames array of the key document in the key vault collection with the given UUID (BSON binary subtype 0x04).
-    /// Returns the previous version of the key document.
-    pub async fn remove_key_alt_name(&self, id: &Binary, key_alt_name: &str) -> Result<Option<RawDocumentBuf>> {
+    /// Removes a keyAltName from the keyAltNames array of the key document in the key vault
+    /// collection with the given UUID (BSON binary subtype 0x04). Returns the previous version
+    /// of the key document.
+    pub async fn remove_key_alt_name(
+        &self,
+        id: &Binary,
+        key_alt_name: &str,
+    ) -> Result<Option<RawDocumentBuf>> {
         let update = doc! {
             "$set": {
                 "keyAltNames": {
@@ -130,20 +156,25 @@ impl ClientEncryption {
                 }
             }
         };
-        self.key_vault.find_one_and_update(doc! { "_id": id }, vec![update], None).await
+        self.key_vault
+            .find_one_and_update(doc! { "_id": id }, vec![update], None)
+            .await
     }
 
-   /// Returns a key document in the key vault collection with the given keyAltName.
-   pub async fn get_key_by_alt_name(&self, key_alt_name: &str) -> Result<Option<RawDocumentBuf>> {
-        self.key_vault.find_one(doc! { "keyAltNames": key_alt_name }, None).await
+    /// Returns a key document in the key vault collection with the given keyAltName.
+    pub async fn get_key_by_alt_name(&self, key_alt_name: &str) -> Result<Option<RawDocumentBuf>> {
+        self.key_vault
+            .find_one(doc! { "keyAltNames": key_alt_name }, None)
+            .await
     }
 
-   /// Encrypts a BsonValue with a given key and algorithm.
-   /// Returns an encrypted value (BSON binary of subtype 6).
-   pub async fn encrypt(&self, value: bson::RawBson, opts: EncryptOptions) -> Result<Binary> {
+    /// Encrypts a BsonValue with a given key and algorithm.
+    /// Returns an encrypted value (BSON binary of subtype 6).
+    pub async fn encrypt(&self, value: bson::RawBson, opts: EncryptOptions) -> Result<Binary> {
         let ctx = self.encrypt_ctx(value, opts)?;
         let result = self.exec.run_ctx(ctx, None).await?;
-        let bin_ref = result.get_binary("v")
+        let bin_ref = result
+            .get_binary("v")
             .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
         Ok(bin_owned(bin_ref))
     }
@@ -172,11 +203,21 @@ impl ClientEncryption {
     /// Returns the original BSON value.
     pub async fn decrypt<'a>(&self, value: RawBinaryRef<'a>) -> Result<bson::RawBson> {
         if value.subtype != BinarySubtype::Encrypted {
-            return Err(Error::invalid_argument(format!("Invalid binary subtype for decrypt: expected {:?}, got {:?}", BinarySubtype::Encrypted, value.subtype)));
+            return Err(Error::invalid_argument(format!(
+                "Invalid binary subtype for decrypt: expected {:?}, got {:?}",
+                BinarySubtype::Encrypted,
+                value.subtype
+            )));
         }
-        let ctx = self.crypt.ctx_builder().build_explicit_decrypt(value.bytes)?;
+        let ctx = self
+            .crypt
+            .ctx_builder()
+            .build_explicit_decrypt(value.bytes)?;
         let result = self.exec.run_ctx(ctx, None).await?;
-        Ok(result.get("v")?.ok_or_else(|| Error::internal("invalid decryption result"))?.to_raw_bson())
+        Ok(result
+            .get("v")?
+            .ok_or_else(|| Error::internal("invalid decryption result"))?
+            .to_raw_bson())
     }
 }
 
@@ -192,43 +233,59 @@ fn bin_ref(bin: &Binary) -> RawBinaryRef {
 #[non_exhaustive]
 pub struct ClientEncryptionOptions {
     /// The key vault `Client`.
-    /// 
-    /// Typically this is the same as the main client; it can be different in order to route data key queries to a separate MongoDB cluster, or the same cluster but with a different credential.
+    ///
+    /// Typically this is the same as the main client; it can be different in order to route data
+    /// key queries to a separate MongoDB cluster, or the same cluster but with a different
+    /// credential.
     pub key_vault_client: Client,
-    /// The key vault `Namespace`, referring to a collection that contains all data keys used for encryption and decryption.
+    /// The key vault `Namespace`, referring to a collection that contains all data keys used for
+    /// encryption and decryption.
     pub key_vault_namespace: Namespace,
     /// Map of KMS provider properties; multiple KMS providers may be specified.
     pub kms_providers: KmsProviders,
-    /// 
+    /// TLS options for connecting to KMS providers.  If not given, default options will be used.
     pub tls_options: Option<KmsProvidersTlsOptions>,
 }
 
+/// Options for creating a data key.
 #[non_exhaustive]
 pub struct DataKeyOptions {
+    /// The master key document, a KMS-specific key used to encrypt the new data key.
     pub master_key: Option<Document>,
+    /// An optional list of alternate names used to reference a key.
     pub key_alt_names: Option<Vec<String>>,
+    /// An optional buffer of 96 bytes to use as custom key material for the data key being
+    /// created.  If unset, key material for the new data key is generated from a cryptographically
+    /// secure random device.
     pub key_material: Option<Vec<u8>>,
 }
 
-#[non_exhaustive]
-pub struct RewrapManyDataKeyOptions {
-    pub provider: KmsProvider,
-    pub master_key: Option<Document>,
-}
+// #[non_exhaustive]
+// pub struct RewrapManyDataKeyOptions {
+// pub provider: KmsProvider,
+// pub master_key: Option<Document>,
+// }
+//
+//
+// #[non_exhaustive]
+// pub struct RewrapManyDataKeyResult {
+// pub bulk_write_result: Option<BulkWriteResult>,
+// }
 
-#[non_exhaustive]
-pub struct RewrapManyDataKeyResult {
-    //pub bulk_write_result: Option<BulkWriteResult>  // No bulk write support!
-}
-
+/// The options for explicit encryption.
 #[non_exhaustive]
 pub struct EncryptOptions {
+    /// The key to use.
     pub key: EncryptKey,
+    /// The encryption algorithm.
     pub algorithm: Algorithm,
+    /// The contention factor.
     pub contention_factor: Option<i64>,
+    /// The query type.
     pub query_type: Option<String>,
 }
 
+/// An encryption key reference, either an _id value or alternate name.
 pub enum EncryptKey {
     Id(Binary),
     AltName(String),
@@ -236,5 +293,8 @@ pub enum EncryptKey {
 
 // TODO(aegnor): impl ToOwned
 fn bin_owned(bin_ref: RawBinaryRef) -> Binary {
-    Binary { subtype: bin_ref.subtype, bytes: bin_ref.bytes.to_owned() }
+    Binary {
+        subtype: bin_ref.subtype,
+        bytes: bin_ref.bytes.to_owned(),
+    }
 }

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use crate::results::DeleteResult;
 use crate::{Cursor, Client, Namespace};
 use crate::bson::{Binary, Document};
 use crate::error::Result;
@@ -68,6 +69,7 @@ impl ClientEncryption {
     }
 }
 
+#[non_exhaustive]
 pub struct ClientEncryptionOptions {
     pub key_vault_client: Client,
     pub key_vault_namespace: Namespace,
@@ -75,22 +77,33 @@ pub struct ClientEncryptionOptions {
     pub tls_options: Option<KmsProvidersTlsOptions>,
 }
 
+#[non_exhaustive]
 pub struct DataKeyOptions {
-    _todo: (),
+    pub master_key: Option<Document>,
+    pub key_alt_names: Option<Vec<String>>,
+    pub key_material: Option<Vec<u8>>,  // TODO: BinData?
 }
 
+#[non_exhaustive]
 pub struct RewrapManyDataKeyOptions {
-    _todo: (),
+    pub provider: KmsProvider,  // TODO: String?
+    pub master_key: Option<Document>,
 }
 
+#[non_exhaustive]
 pub struct RewrapManyDataKeyResult {
-    _todo: (),
+    //pub bulk_write_result: Option<BulkWriteResult>  // No bulk write support!
 }
 
-pub struct DeleteResult {
-    _todo: (),
-}
-
+#[non_exhaustive]
 pub struct EncryptOptions {
-    _todo: (),
+    pub key: EncryptKey,
+    pub algorithm: String,
+    pub contention_factor: Option<i64>,
+    pub query_type: Option<String>,
+}
+
+pub enum EncryptKey {
+    Id(Binary),
+    AltName(String),
 }

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -148,8 +148,10 @@ impl ClientEncryption {
         Ok(builder.build_explicit_encrypt(value)?)
     }
 
-    pub fn decrypt(&self, value: Binary) -> Result<bson::Bson> {
-        todo!()
+    pub async fn decrypt(&self, value: &[u8]) -> Result<bson::RawBson> {
+        let ctx = self.crypt.ctx_builder().build_explicit_decrypt(value)?;
+        let result = self.exec.run_ctx(ctx, None).await?;
+        Ok(result.get("v")?.ok_or_else(|| Error::internal("invalid decryption result"))?.to_raw_bson())
     }
 }
 

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,0 +1,78 @@
+use crate::Cursor;
+use crate::bson::{Binary, Document};
+use crate::error::Result;
+use mongocrypt::ctx::KmsProvider;
+
+pub struct ClientEncryption {
+    _todo: (),
+}
+
+impl ClientEncryption {
+    pub fn new(_opts: ClientEncryptionOptions) -> Self {
+        Self { _todo: () }
+    }
+
+    pub fn create_data_key(&self, _kms_provider: KmsProvider, _opts: DataKeyOptions) -> Result<Binary> {
+        todo!()
+    }
+
+    pub fn rewrap_many_data_key(&self, _filter: Document, _opts: RewrapManyDataKeyOptions) -> Result<RewrapManyDataKeyResult> {
+        todo!()
+    }
+
+    pub fn delete_key(&self, _id: &Binary) -> Result<DeleteResult> {
+        todo!()
+    }
+
+    pub fn get_key(&self, _id: &Binary) -> Result<Option<Document>> {
+        todo!()
+    }
+
+    pub fn get_keys(&self) -> Result<Cursor<Document>> {
+        todo!()
+    }
+
+    pub fn add_key_alt_name(&self, _id: &Binary, key_alt_name: &str) -> Result<Option<Document>> {
+        todo!()
+    }
+
+    pub fn remove_key_alt_name(&self, _id: &Binary, key_alt_name: &str) -> Result<Option<Document>> {
+        todo!()
+    }
+
+    pub fn get_key_by_alt_name(&self, key_alt_name: &str) -> Result<Option<Document>> {
+        todo!()
+    }
+
+    pub fn encrypt(&self, value: bson::Bson, opts: EncryptOptions) -> Result<Binary> {
+        todo!()
+    }
+
+    pub fn decrypt(&self, value: Binary) -> Result<bson::Bson> {
+        todo!()
+    }
+}
+
+pub struct ClientEncryptionOptions {
+    _todo: (),
+}
+
+pub struct DataKeyOptions {
+    _todo: (),
+}
+
+pub struct RewrapManyDataKeyOptions {
+    _todo: (),
+}
+
+pub struct RewrapManyDataKeyResult {
+    _todo: (),
+}
+
+pub struct DeleteResult {
+    _todo: (),
+}
+
+pub struct EncryptOptions {
+    _todo: (),
+}

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -221,14 +221,6 @@ impl ClientEncryption {
     }
 }
 
-// TODO(aegnor): Binary::as_raw()
-fn bin_ref(bin: &Binary) -> RawBinaryRef {
-    RawBinaryRef {
-        subtype: bin.subtype,
-        bytes: &bin.bytes,
-    }
-}
-
 /// Options for initializing a new `ClientEncryption`.
 #[non_exhaustive]
 pub struct ClientEncryptionOptions {
@@ -293,7 +285,6 @@ pub enum EncryptKey {
     AltName(String),
 }
 
-// TODO(aegnor): impl ToOwned
 fn bin_owned(bin_ref: RawBinaryRef) -> Binary {
     Binary {
         subtype: bin_ref.subtype,

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+//! Support for explicit encryption.
 
 use crate::{
     bson::{Binary, Document},
@@ -285,9 +285,11 @@ pub struct EncryptOptions {
     pub query_type: Option<String>,
 }
 
-/// An encryption key reference, either an _id value or alternate name.
+/// An encryption key reference.
 pub enum EncryptKey {
+    /// Find the key by _id value.
     Id(Binary),
+    /// Find the key by alternate name.
     AltName(String),
 }
 

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -30,6 +30,7 @@ impl ClientEncryption {
             opts.key_vault_namespace.clone(),
             None,
             None,
+            opts.tls_options,
         )?;
         let key_vault = opts.key_vault_client
             .database(&opts.key_vault_namespace.db)

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -226,6 +226,7 @@ impl ClientEncryption {
 
 /// Options for initializing a new `ClientEncryption`.
 #[derive(TypedBuilder)]
+#[builder(field_defaults(setter(into)))]
 #[non_exhaustive]
 pub struct ClientEncryptionOptions {
     /// The key vault `Client`.
@@ -246,6 +247,7 @@ pub struct ClientEncryptionOptions {
 
 /// Options for creating a data key.
 #[derive(TypedBuilder)]
+#[builder(field_defaults(setter(into)))]
 #[non_exhaustive]
 pub struct DataKeyOptions {
     /// The master key document, a KMS-specific key used to encrypt the new data key.
@@ -316,6 +318,7 @@ pub enum MasterKey {
 
 /// The options for explicit encryption.
 #[derive(TypedBuilder)]
+#[builder(field_defaults(setter(into)))]
 #[non_exhaustive]
 pub struct EncryptOptions {
     /// The key to use.

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,18 +1,30 @@
+#![allow(dead_code)]
+
 use crate::{Cursor, Client, Namespace};
 use crate::bson::{Binary, Document};
 use crate::error::Result;
+use mongocrypt::Crypt;
 use mongocrypt::ctx::KmsProvider;
 
-use super::ClientState;
 use super::options::{KmsProviders, KmsProvidersTlsOptions};
+use super::state_machine::CryptExecutor;
 
 pub struct ClientEncryption {
-    csfle: ClientState,
+    crypt: Crypt,
+    exec: CryptExecutor,
+    opts: ClientEncryptionOptions,
 }
 
 impl ClientEncryption {
-    pub fn new(_opts: ClientEncryptionOptions) -> Self {
-        todo!()
+    pub fn new(opts: ClientEncryptionOptions) -> Result<Self> {
+        let crypt = Crypt::builder().build()?;
+        let exec = CryptExecutor::new(
+            opts.key_vault_client.weak(),
+            opts.key_vault_namespace.clone(),
+            None,
+            None,
+        )?;
+        Ok(Self { crypt, exec, opts })
     }
 
     pub fn create_data_key(&self, _kms_provider: KmsProvider, _opts: DataKeyOptions) -> Result<Binary> {

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,7 +1,7 @@
 //! Support for explicit encryption.
 
 use crate::{
-    bson::{Binary, Document},
+    bson::Binary,
     coll::options::CollectionOptions,
     error::{Error, Result},
     options::{ReadConcern, WriteConcern},
@@ -260,16 +260,46 @@ pub struct DataKeyOptions {
     pub key_material: Option<Vec<u8>>,
 }
 
+/// A KMS-specific key used to encrypt data keys.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase", untagged)]
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub enum MasterKey {
     Aws {
         region: String,
+        /// The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
         key: String,
+        /// An alternate host identifier to send KMS requests to. May include port number. Defaults
+        /// to "kms.<region>.amazonaws.com"
         endpoint: Option<String>,
     },
+    Azure {
+        /// Host with optional port. Example: "example.vault.azure.net".
+        key_vault_endpoint: String,
+        key_name: String,
+        /// A specific version of the named key, defaults to using the key's primary version.
+        key_version: Option<String>,
+    },
+    Gcp {
+        project_id: String,
+        location: String,
+        key_ring: String,
+        key_name: String,
+        /// A specific version of the named key, defaults to using the key's primary version.
+        key_version: Option<String>,
+        /// Host with optional port. Defaults to "cloudkms.googleapis.com".
+        endpoint: Option<String>,
+    },
+    /// Master keys are not applicable to `KmsProvider::Local`.
     Local,
+    Kmip {
+        /// keyId is the KMIP Unique Identifier to a 96 byte KMIP Secret Data managed object.  If
+        /// keyId is omitted, the driver creates a random 96 byte KMIP Secret Data managed object.
+        key_id: Option<String>,
+        /// Host with optional port.
+        endpoint: Option<String>,
+    },
 }
 
 // #[non_exhaustive]
@@ -291,6 +321,10 @@ pub struct EncryptOptions {
     /// The key to use.
     pub key: EncryptKey,
     /// The encryption algorithm.
+    ///
+    /// To insert or query with an "Indexed" encrypted payload, use a `Client` configured with
+    /// `AutoEncryptionOptions`. `AutoEncryptionOptions.bypass_query_analysis may be true.
+    /// `AutoEncryptionOptions.bypass_auto_encryption` must be false.
     pub algorithm: Algorithm,
     /// The contention factor.
     #[builder(default)]

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,15 +1,18 @@
-use crate::Cursor;
+use crate::{Cursor, Client, Namespace};
 use crate::bson::{Binary, Document};
 use crate::error::Result;
 use mongocrypt::ctx::KmsProvider;
 
+use super::ClientState;
+use super::options::{KmsProviders, KmsProvidersTlsOptions};
+
 pub struct ClientEncryption {
-    _todo: (),
+    csfle: ClientState,
 }
 
 impl ClientEncryption {
     pub fn new(_opts: ClientEncryptionOptions) -> Self {
-        Self { _todo: () }
+        todo!()
     }
 
     pub fn create_data_key(&self, _kms_provider: KmsProvider, _opts: DataKeyOptions) -> Result<Binary> {
@@ -54,7 +57,10 @@ impl ClientEncryption {
 }
 
 pub struct ClientEncryptionOptions {
-    _todo: (),
+    pub key_vault_client: Client,
+    pub key_vault_namespace: Namespace,
+    pub kms_providers: KmsProviders,
+    pub tls_options: Option<KmsProvidersTlsOptions>,
 }
 
 pub struct DataKeyOptions {

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -77,7 +77,7 @@ impl ClientEncryption {
     }
 
     pub async fn rewrap_many_data_key(&self, _filter: Document, _opts: RewrapManyDataKeyOptions) -> Result<RewrapManyDataKeyResult> {
-        todo!()
+        todo!("RUST-1441")
     }
 
     pub async fn delete_key(&self, id: &Binary) -> Result<DeleteResult> {
@@ -167,12 +167,12 @@ pub struct ClientEncryptionOptions {
 pub struct DataKeyOptions {
     pub master_key: Option<Document>,
     pub key_alt_names: Option<Vec<String>>,
-    pub key_material: Option<Vec<u8>>,  // TODO(aegnor): BinData?
+    pub key_material: Option<Vec<u8>>,
 }
 
 #[non_exhaustive]
 pub struct RewrapManyDataKeyOptions {
-    pub provider: KmsProvider,  // TODO(aegnor): String?
+    pub provider: KmsProvider,
     pub master_key: Option<Document>,
 }
 

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -285,6 +285,7 @@ pub enum EncryptKey {
     AltName(String),
 }
 
+// TODO: this can be `bin_ref.to_binary()` once PR#370 is merged.
 fn bin_owned(bin_ref: RawBinaryRef) -> Binary {
     Binary {
         subtype: bin_ref.subtype,

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -20,18 +20,18 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) struct CryptExecutor {
-    mongocryptd_client: Option<Client>,
     key_vault_client: WeakClient,
     key_vault_namespace: Namespace,
+    mongocryptd_client: Option<Client>,
     metadata_client: Option<WeakClient>,
     crypto_threads: ThreadPool,
 }
 
 impl CryptExecutor {
     pub(crate) fn new(
-        mongocryptd_client: Option<Client>,
         key_vault_client: WeakClient,
         key_vault_namespace: Namespace,
+        mongocryptd_client: Option<Client>,
         metadata_client: Option<WeakClient>,
     ) -> Result<Self> {
         let num_cpus = std::thread::available_parallelism()?.get();
@@ -40,9 +40,9 @@ impl CryptExecutor {
             .build()
             .map_err(|e| Error::internal(format!("could not initialize thread pool: {}", e)))?;
         Ok(Self {
-            mongocryptd_client,
             key_vault_client,
             key_vault_namespace,
+            mongocryptd_client,
             metadata_client,
             crypto_threads,
         })

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -15,7 +15,8 @@ use crate::{
     error::{Error, Result},
     operation::{RawOutput, RunCommand},
     runtime::AsyncStream,
-    Client, Namespace,
+    Client,
+    Namespace,
 };
 
 use super::options::KmsProvidersTlsOptions;
@@ -53,11 +54,7 @@ impl CryptExecutor {
         })
     }
 
-    pub(crate) async fn run_ctx(
-        &self,
-        ctx: Ctx,
-        db: Option<&str>,
-    ) -> Result<RawDocumentBuf> {
+    pub(crate) async fn run_ctx(&self, ctx: Ctx, db: Option<&str>) -> Result<RawDocumentBuf> {
         let mut result = None;
         // This needs to be a `Result` so that the `Ctx` can be temporarily owned by the processing
         // thread for crypto finalization.  An `Option` would also work here, but `Result` means we
@@ -74,8 +71,8 @@ impl CryptExecutor {
                         .as_ref()
                         .and_then(|w| w.upgrade())
                         .ok_or_else(|| {
-                            Error::internal("metadata_client required for NeedMongoCollinfo state")
-                        })?;
+                        Error::internal("metadata_client required for NeedMongoCollinfo state")
+                    })?;
                     let db = metadata_client.database(db.as_ref().ok_or_else(|| {
                         Error::internal("db required for NeedMongoCollinfo state")
                     })?);

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -811,7 +811,7 @@ impl Client {
                 .crypt
                 .ctx_builder()
                 .build_encrypt(target_db, command)?;
-            self.run_mongocrypt_ctx(ctx, Some(target_db)).await
+            csfle.run_mongocrypt_ctx(ctx, Some(self.database(target_db))).await
         })
     }
 
@@ -823,7 +823,7 @@ impl Client {
     ) -> BoxFuture<'a, Result<RawDocumentBuf>> {
         Box::pin(async move {
             let ctx = csfle.crypt.ctx_builder().build_decrypt(response)?;
-            self.run_mongocrypt_ctx(ctx, None).await
+            csfle.run_mongocrypt_ctx(ctx, None).await
         })
     }
 

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -808,10 +808,10 @@ impl Client {
     ) -> BoxFuture<'a, Result<RawDocumentBuf>> {
         Box::pin(async move {
             let ctx = csfle
-                .crypt
+                .crypt()
                 .ctx_builder()
                 .build_encrypt(target_db, command)?;
-            csfle.run_mongocrypt_ctx(ctx, Some(self.database(target_db))).await
+            csfle.exec().run_ctx(ctx, Some(target_db)).await
         })
     }
 
@@ -822,8 +822,8 @@ impl Client {
         response: &'a RawDocument,
     ) -> BoxFuture<'a, Result<RawDocumentBuf>> {
         Box::pin(async move {
-            let ctx = csfle.crypt.ctx_builder().build_decrypt(response)?;
-            csfle.run_mongocrypt_ctx(ctx, None).await
+            let ctx = csfle.crypt().ctx_builder().build_decrypt(response)?;
+            csfle.exec().run_ctx(ctx, None).await
         })
     }
 

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -30,6 +30,7 @@ pub struct ReadConcern {
 }
 
 impl ReadConcern {
+    // TODO(aegnor): consts for other levels
     pub const MAJORITY: ReadConcern = ReadConcern { level: ReadConcernLevel::Majority };
 }
 
@@ -226,6 +227,7 @@ pub struct WriteConcern {
 impl WriteConcern {
     // Can't use `Default::default()` in const contexts yet :(
     const DEFAULT: WriteConcern = WriteConcern { w: None, w_timeout: None, journal: None };
+    // TODO(aegnor): consts for other acknowledgements
     pub const MAJORITY: WriteConcern = WriteConcern { w: Some(Acknowledgment::Majority), ..WriteConcern::DEFAULT };
 }
 

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -30,9 +30,25 @@ pub struct ReadConcern {
 }
 
 impl ReadConcern {
-    // TODO(aegnor): consts for other levels
+    /// A `ReadConcern` with level `ReadConcernLevel::Local`.
+    pub const LOCAL: ReadConcern = ReadConcern {
+        level: ReadConcernLevel::Local,
+    };
+    /// A `ReadConcern` with level `ReadConcernLevel::Majority`.
     pub const MAJORITY: ReadConcern = ReadConcern {
         level: ReadConcernLevel::Majority,
+    };
+    /// A `ReadConcern` with level `ReadConcernLevel::Linearizable`.
+    pub const LINEARIZABLE: ReadConcern = ReadConcern {
+        level: ReadConcernLevel::Linearizable,
+    };
+    /// A `ReadConcern` with level `ReadConcernLevel::Available`.
+    pub const AVAILBLE: ReadConcern = ReadConcern {
+        level: ReadConcernLevel::Available,
+    };
+    /// A `ReadConcern` with level `ReadConcernLevel::Snapshot`.
+    pub const SNAPSHOT: ReadConcern = ReadConcern {
+        level: ReadConcernLevel::Snapshot,
     };
 }
 
@@ -233,7 +249,7 @@ impl WriteConcern {
         w_timeout: None,
         journal: None,
     };
-    // TODO(aegnor): consts for other acknowledgements
+    /// A `WriteConcern` requesting `Acknowledgment::Majority`.
     pub const MAJORITY: WriteConcern = WriteConcern {
         w: Some(Acknowledgment::Majority),
         ..WriteConcern::DEFAULT

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -29,6 +29,10 @@ pub struct ReadConcern {
     pub level: ReadConcernLevel,
 }
 
+impl ReadConcern {
+    pub const MAJORITY: ReadConcern = ReadConcern { level: ReadConcernLevel::Majority };
+}
+
 /// An internal-only read concern type that allows the omission of a "level" as well as
 /// specification of "atClusterTime" and "afterClusterTime".
 #[skip_serializing_none]
@@ -217,6 +221,12 @@ pub struct WriteConcern {
     /// Requests acknowledgement that the operation has propagated to the on-disk journal.
     #[serde(rename = "j", alias = "journal")]
     pub journal: Option<bool>,
+}
+
+impl WriteConcern {
+    // Can't use `Default::default()` in const contexts yet :(
+    const DEFAULT: WriteConcern = WriteConcern { w: None, w_timeout: None, journal: None };
+    pub const MAJORITY: WriteConcern = WriteConcern { w: Some(Acknowledgment::Majority), ..WriteConcern::DEFAULT };
 }
 
 /// The type of the `w` field in a [`WriteConcern`](struct.WriteConcern.html).

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -43,7 +43,7 @@ impl ReadConcern {
         level: ReadConcernLevel::Linearizable,
     };
     /// A `ReadConcern` with level `ReadConcernLevel::Available`.
-    pub const AVAILBLE: ReadConcern = ReadConcern {
+    pub const AVAILABLE: ReadConcern = ReadConcern {
         level: ReadConcernLevel::Available,
     };
     /// A `ReadConcern` with level `ReadConcernLevel::Snapshot`.

--- a/src/concern/mod.rs
+++ b/src/concern/mod.rs
@@ -31,7 +31,9 @@ pub struct ReadConcern {
 
 impl ReadConcern {
     // TODO(aegnor): consts for other levels
-    pub const MAJORITY: ReadConcern = ReadConcern { level: ReadConcernLevel::Majority };
+    pub const MAJORITY: ReadConcern = ReadConcern {
+        level: ReadConcernLevel::Majority,
+    };
 }
 
 /// An internal-only read concern type that allows the omission of a "level" as well as
@@ -226,9 +228,16 @@ pub struct WriteConcern {
 
 impl WriteConcern {
     // Can't use `Default::default()` in const contexts yet :(
-    const DEFAULT: WriteConcern = WriteConcern { w: None, w_timeout: None, journal: None };
+    const DEFAULT: WriteConcern = WriteConcern {
+        w: None,
+        w_timeout: None,
+        journal: None,
+    };
     // TODO(aegnor): consts for other acknowledgements
-    pub const MAJORITY: WriteConcern = WriteConcern { w: Some(Acknowledgment::Majority), ..WriteConcern::DEFAULT };
+    pub const MAJORITY: WriteConcern = WriteConcern {
+        w: Some(Acknowledgment::Majority),
+        ..WriteConcern::DEFAULT
+    };
 }
 
 /// The type of the `w` field in a [`WriteConcern`](struct.WriteConcern.html).

--- a/src/gridfs.rs
+++ b/src/gridfs.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 pub mod options;
 
 use core::task::{Context, Poll};

--- a/src/gridfs.rs
+++ b/src/gridfs.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, unused_variables)]
+// TODO(RUST-1395) Remove these allows.
 
 pub mod options;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ mod test;
 extern crate derive_more;
 
 pub use crate::{
-    client::{session::ClientSession, Client, csfle::client_encryption},
+    client::{session::ClientSession, Client},
     coll::Collection,
     cursor::{
         session::{SessionCursor, SessionCursorStream},
@@ -352,6 +352,8 @@ pub use crate::{
     },
     db::Database,
 };
+#[cfg(feature = "csfle")]
+pub use crate::client::csfle::client_encryption;
 
 pub use {client::session::ClusterTime, coll::Namespace, index::IndexModel, sdam::public::*};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,7 +344,7 @@ mod test;
 extern crate derive_more;
 
 pub use crate::{
-    client::{session::ClientSession, Client},
+    client::{session::ClientSession, Client, csfle::client_encryption},
     coll::Collection,
     cursor::{
         session::{SessionCursor, SessionCursorStream},


### PR DESCRIPTION
RUST-1385

This implements the `ClientEncryption` struct which provides the explicit encryption API.  This required a bit of refactoring to allow a `Ctx` to be executed independently of a `Client`, but is otherwise mostly just data plumbing; the API is just a wrapper around CRUD operations plus `Ctx` operations.