### PR TITLE
RUST-1396 Respawn mongocryptd on server selection failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ default = ["tokio-runtime"]
 tokio-runtime = [
     "tokio/macros",
     "tokio/net",
+    "tokio/process",
     "tokio/rt",
     "tokio/time",
     "serde_bytes",
@@ -38,6 +39,7 @@ tokio-runtime = [
 async-std-runtime = [
     "async-std",
     "async-std/attributes",
+    "async-std/unstable",
     "async-std-resolver",
     "tokio-util/compat",
 ]
@@ -66,7 +68,7 @@ zlib-compression = ["flate2"]
 snappy-compression = ["snap"]
 
 # DO NOT USE; see https://jira.mongodb.org/browse/RUST-569 for the status of CSFLE support in the Rust driver.
-csfle = ["mongocrypt", "which", "rayon"]
+csfle = ["mongocrypt", "rayon"]
 
 [dependencies]
 async-trait = "0.1.42"
@@ -106,7 +108,6 @@ trust-dns-proto = "0.21.2"
 trust-dns-resolver = "0.21.2"
 typed-builder = "0.10.0"
 webpki-roots = "0.22.4"
-which = { version = "4.2.5", optional = true }
 zstd = { version = "0.11.2", optional = true }
 
 [dependencies.async-std]

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -2,9 +2,7 @@ pub mod client_encryption;
 pub mod options;
 mod state_machine;
 
-use std::{
-    path::Path,
-};
+use std::path::Path;
 
 use derivative::Derivative;
 use mongocrypt::Crypt;
@@ -56,7 +54,8 @@ impl ClientState {
             opts.tls_options.take(),
             mongocryptd_opts,
             aux_clients.metadata_client,
-        ).await?;
+        )
+        .await?;
 
         Ok(Self {
             crypt,
@@ -97,7 +96,10 @@ impl ClientState {
         Ok(crypt)
     }
 
-    fn make_mongocryptd_opts(opts: &AutoEncryptionOptions, crypt: &Crypt) -> Result<Option<MongocryptdOptions>> {
+    fn make_mongocryptd_opts(
+        opts: &AutoEncryptionOptions,
+        crypt: &Crypt,
+    ) -> Result<Option<MongocryptdOptions>> {
         if opts.bypass_auto_encryption == Some(true)
             || opts.extra_option(&EO_MONGOCRYPTD_BYPASS_SPAWN)? == Some(true)
             || crypt.shared_lib_version().is_some()
@@ -105,7 +107,9 @@ impl ClientState {
         {
             return Ok(None);
         }
-        let spawn_path = opts.extra_option(&EO_MONGOCRYPTD_SPAWN_PATH)?.map(std::path::PathBuf::from);
+        let spawn_path = opts
+            .extra_option(&EO_MONGOCRYPTD_SPAWN_PATH)?
+            .map(std::path::PathBuf::from);
         let mut spawn_args = vec![];
         if let Some(args) = opts.extra_option(&EO_MONGOCRYPTD_SPAWN_ARGS)? {
             for arg in args {
@@ -115,7 +119,9 @@ impl ClientState {
                 spawn_args.push(str_arg.to_string());
             }
         }
-        let uri = opts.extra_option(&EO_MONGOCRYPTD_URI)?.map(|s| s.to_string());
+        let uri = opts
+            .extra_option(&EO_MONGOCRYPTD_URI)?
+            .map(|s| s.to_string());
         Ok(Some(MongocryptdOptions {
             spawn_path,
             spawn_args,

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -4,7 +4,6 @@ mod state_machine;
 
 use std::{
     path::Path,
-    process::{Command, Stdio},
 };
 
 use derivative::Derivative;
@@ -26,7 +25,7 @@ use options::{
     EO_MONGOCRYPTD_URI,
 };
 
-use self::state_machine::CryptExecutor;
+use self::state_machine::{CryptExecutor, MongocryptdOptions};
 
 use super::WeakClient;
 
@@ -49,15 +48,15 @@ struct AuxClients {
 impl ClientState {
     pub(super) async fn new(client: &Client, mut opts: AutoEncryptionOptions) -> Result<Self> {
         let crypt = Self::make_crypt(&opts)?;
-        let mongocryptd_client = Self::spawn_mongocryptd_if_needed(&opts, &crypt).await?;
+        let mongocryptd_opts = Self::make_mongocryptd_opts(&opts, &crypt)?;
         let aux_clients = Self::make_aux_clients(client, &opts)?;
-        let exec = CryptExecutor::new(
+        let exec = CryptExecutor::new_implicit(
             aux_clients.key_vault_client,
             opts.key_vault_namespace.clone(),
-            mongocryptd_client,
-            aux_clients.metadata_client,
             opts.tls_options.take(),
-        )?;
+            mongocryptd_opts,
+            aux_clients.metadata_client,
+        ).await?;
 
         Ok(Self {
             crypt,
@@ -98,12 +97,7 @@ impl ClientState {
         Ok(crypt)
     }
 
-    /// If crypt_shared is unavailable and options have not disabled it, spawn mongocryptd.  Returns
-    /// a `Client` connected to the mongocryptd if one was spawned.
-    async fn spawn_mongocryptd_if_needed(
-        opts: &AutoEncryptionOptions,
-        crypt: &Crypt,
-    ) -> Result<Option<Client>> {
+    fn make_mongocryptd_opts(opts: &AutoEncryptionOptions, crypt: &Crypt) -> Result<Option<MongocryptdOptions>> {
         if opts.bypass_auto_encryption == Some(true)
             || opts.extra_option(&EO_MONGOCRYPTD_BYPASS_SPAWN)? == Some(true)
             || crypt.shared_lib_version().is_some()
@@ -111,44 +105,22 @@ impl ClientState {
         {
             return Ok(None);
         }
-        let which_path;
-        let bin_path = match opts.extra_option(&EO_MONGOCRYPTD_SPAWN_PATH)? {
-            Some(s) => Path::new(s),
-            None => {
-                which_path = which::which("mongocryptd")
-                    .map_err(|e| Error::invalid_argument(format!("{}", e)))?;
-                &which_path
-            }
-        };
-        let mut args: Vec<&str> = vec![];
-        let has_idle = if let Some(spawn_args) = opts.extra_option(&EO_MONGOCRYPTD_SPAWN_ARGS)? {
-            let mut has_idle = false;
-            for arg in spawn_args {
+        let spawn_path = opts.extra_option(&EO_MONGOCRYPTD_SPAWN_PATH)?.map(std::path::PathBuf::from);
+        let mut spawn_args = vec![];
+        if let Some(args) = opts.extra_option(&EO_MONGOCRYPTD_SPAWN_ARGS)? {
+            for arg in args {
                 let str_arg = arg.as_str().ok_or_else(|| {
                     Error::invalid_argument("non-string entry in mongocryptdSpawnArgs")
                 })?;
-                has_idle |= str_arg.starts_with("--idleShutdownTimeoutSecs");
-                args.push(str_arg);
+                spawn_args.push(str_arg.to_string());
             }
-            has_idle
-        } else {
-            false
-        };
-        if !has_idle {
-            args.push("--idleShutdownTimeoutSecs=60");
         }
-        Command::new(bin_path)
-            .args(&args)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?;
-
-        let uri = opts
-            .extra_option(&EO_MONGOCRYPTD_URI)?
-            .unwrap_or("mongodb://localhost:27020");
-        let mut options = super::options::ClientOptions::parse_uri(uri, None).await?;
-        options.server_selection_timeout = Some(std::time::Duration::from_millis(10_000));
-        Ok(Some(Client::with_options(options)?))
+        let uri = opts.extra_option(&EO_MONGOCRYPTD_URI)?.map(|s| s.to_string());
+        Ok(Some(MongocryptdOptions {
+            spawn_path,
+            spawn_args,
+            uri,
+        }))
     }
 
     fn make_aux_clients(

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -36,11 +36,9 @@ impl ClientEncryption {
     /// Create a new key vault handle with the given options.
     pub fn new(options: ClientEncryptionOptions) -> Result<Self> {
         let crypt = Crypt::builder().build()?;
-        let exec = CryptExecutor::new(
+        let exec = CryptExecutor::new_explicit(
             options.key_vault_client.weak(),
             options.key_vault_namespace.clone(),
-            None,
-            None,
             options.tls_options,
         )?;
         let key_vault = options

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -238,7 +238,13 @@ impl Mongocryptd {
                 return unit_err(&*self.child.lock().await);
             }
         };
-        *child = Self::spawn(&self.opts);
+        let new_child = Self::spawn(&self.opts);
+        if new_child.is_ok() {
+            if let Ok(old_child) = child.as_mut() {
+                let _ = old_child.wait().await;
+            }
+        }
+        *child = new_child;
         unit_err(&*child)
     }
 

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,4 +1,7 @@
-use std::{convert::TryInto, path::{PathBuf, Path}};
+use std::{
+    convert::TryInto,
+    path::{Path, PathBuf},
+};
 
 use bson::{Document, RawDocument, RawDocumentBuf};
 use futures_util::{stream, TryStreamExt};
@@ -220,7 +223,11 @@ impl Mongocryptd {
         let mut options = crate::options::ClientOptions::parse_uri(uri, None).await?;
         options.server_selection_timeout = Some(std::time::Duration::from_millis(10_000));
         let client = Client::with_options(options)?;
-        Ok(Self { opts, client, child })
+        Ok(Self {
+            opts,
+            client,
+            child,
+        })
     }
 
     async fn respawn(&self) -> Result<()> {

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,6 +1,7 @@
 use std::{
     convert::TryInto,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use bson::{Document, RawDocument, RawDocumentBuf};
@@ -221,11 +222,14 @@ struct Mongocryptd {
 }
 
 impl Mongocryptd {
+    const DEFAULT_URI: &'static str = "mongodb://localhost:27020";
+    const SERVER_SELECTION_TIMEOUT: Duration = Duration::from_millis(10_000);
+
     async fn new(opts: MongocryptdOptions) -> Result<Self> {
         let child = Mutex::new(Ok(Self::spawn(&opts)?));
-        let uri = opts.uri.as_deref().unwrap_or("mongodb://localhost:27020");
+        let uri = opts.uri.as_deref().unwrap_or(Self::DEFAULT_URI);
         let mut options = crate::options::ClientOptions::parse_uri(uri, None).await?;
-        options.server_selection_timeout = Some(std::time::Duration::from_millis(10_000));
+        options.server_selection_timeout = Some(Self::SERVER_SELECTION_TIMEOUT);
         let client = Client::with_options(options)?;
         Ok(Self {
             opts,

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -7,6 +7,7 @@ use super::Operation;
 
 /// Forwards all implementation to the wrapped `Operation`, but returns the response unparsed and
 /// unvalidated as a `RawCommandResponse`.
+#[derive(Clone)]
 pub(crate) struct RawOutput<Op>(pub(crate) Op);
 
 impl<Op: Operation> Operation for RawOutput<Op> {

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     selection_criteria::SelectionCriteria,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct RunCommand<'conn> {
     db: String,
     command: RawDocumentBuf,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,6 +3,7 @@ mod http;
 #[cfg(feature = "async-std-runtime")]
 mod interval;
 mod join_handle;
+mod process;
 mod resolver;
 mod stream;
 mod sync_read_ext;
@@ -17,6 +18,7 @@ use std::{future::Future, net::SocketAddr, time::Duration};
 pub(crate) use self::{
     acknowledged_message::AcknowledgedMessage,
     join_handle::AsyncJoinHandle,
+    process::Process,
     resolver::AsyncResolver,
     stream::AsyncStream,
     sync_read_ext::SyncLittleEndianRead,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,6 +3,7 @@ mod http;
 #[cfg(feature = "async-std-runtime")]
 mod interval;
 mod join_handle;
+#[cfg(feature = "csfle")]
 mod process;
 mod resolver;
 mod stream;
@@ -15,10 +16,11 @@ mod worker_handle;
 
 use std::{future::Future, net::SocketAddr, time::Duration};
 
+#[cfg(feature = "csfle")]
+pub(crate) use self::process::Process;
 pub(crate) use self::{
     acknowledged_message::AcknowledgedMessage,
     join_handle::AsyncJoinHandle,
-    process::Process,
     resolver::AsyncResolver,
     stream::AsyncStream,
     sync_read_ext::SyncLittleEndianRead,

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,4 +1,7 @@
-use std::{ffi::OsStr, process::Stdio};
+use std::{
+    ffi::OsStr,
+    process::{ExitStatus, Stdio},
+};
 
 #[cfg(feature = "async-std-runtime")]
 use async_std::process::{Child, Command};
@@ -26,6 +29,13 @@ impl Process {
             .stderr(Stdio::null())
             .spawn()?;
         Ok(Self { child })
+    }
+
+    pub(crate) async fn wait(&mut self) -> Result<ExitStatus> {
+        #[cfg(feature = "tokio-runtime")]
+        return Ok(self.child.wait().await?);
+        #[cfg(feature = "async-std-runtime")]
+        return Ok(self.child.status().await?);
     }
 }
 

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,9 +1,9 @@
 use std::{ffi::OsStr, process::Stdio};
 
-#[cfg(feature = "tokio-runtime")]
-use tokio::process::{Child, Command};
 #[cfg(feature = "async-std-runtime")]
 use async_std::process::{Child, Command};
+#[cfg(feature = "tokio-runtime")]
+use tokio::process::{Child, Command};
 
 use crate::error::Result;
 
@@ -13,11 +13,11 @@ pub(crate) struct Process {
 }
 
 impl Process {
-    pub(crate) fn spawn<P, I, A>(path: P, args: I)
-        -> Result<Self>
-        where P: AsRef<OsStr>,
-            I: IntoIterator<Item = A>,
-            A: AsRef<OsStr>,
+    pub(crate) fn spawn<P, I, A>(path: P, args: I) -> Result<Self>
+    where
+        P: AsRef<OsStr>,
+        I: IntoIterator<Item = A>,
+        A: AsRef<OsStr>,
     {
         let mut command = Command::new(path);
         let child = command

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -1,0 +1,40 @@
+use std::{ffi::OsStr, process::Stdio};
+
+#[cfg(feature = "tokio-runtime")]
+use tokio::process::{Child, Command};
+#[cfg(feature = "async-std-runtime")]
+use async_std::process::{Child, Command};
+
+use crate::error::Result;
+
+#[derive(Debug)]
+pub(crate) struct Process {
+    child: Child,
+}
+
+impl Process {
+    pub(crate) fn spawn<P, I, A>(path: P, args: I)
+        -> Result<Self>
+        where P: AsRef<OsStr>,
+            I: IntoIterator<Item = A>,
+            A: AsRef<OsStr>,
+    {
+        let mut command = Command::new(path);
+        let child = command
+            .args(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(Self { child })
+    }
+}
+
+impl Drop for Process {
+    fn drop(&mut self) {
+        // Attempt to reap the process.
+        #[cfg(feature = "tokio-runtime")]
+        let _ = self.child.try_wait();
+        #[cfg(feature = "async-std-runtime")]
+        let _ = self.child.try_status();
+    }
+}


### PR DESCRIPTION
RUST-1396

[Spec](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#spawning-mongocryptd); this is the "If spawning is necessary..." clause.  Control of mongocryptd spawning moved into the `CryptExecutor`, which IMO mostly made things a bit cleaner.  The split between `CryptExecutor::new_implicit` and `::new_explicit` is a bit clunky, but because one needs async and the other doesn't it seemed necessary.  Sadly, we're probably a ways off from dependently typed function keywords :)