### PR TITLE
RUST-412 Use sort when verifying the outcome of CRUD v1 tests

### DIFF
--- a/src/test/spec/crud_v1/mod.rs
+++ b/src/test/spec/crud_v1/mod.rs
@@ -18,7 +18,12 @@ use std::future::Future;
 use futures::stream::TryStreamExt;
 use serde::Deserialize;
 
-use crate::{bson::Document, test::log_uncaptured, Collection};
+use crate::{
+    bson::{doc, Document},
+    coll::options::FindOptions,
+    test::log_uncaptured,
+    Collection,
+};
 
 use super::{run_spec_test, Serverless};
 
@@ -58,7 +63,8 @@ pub struct CollectionOutcome {
 }
 
 pub async fn find_all(coll: &Collection<Document>) -> Vec<Document> {
-    coll.find(None, None)
+    let options = FindOptions::builder().sort(doc! { "_id": 1 }).build();
+    coll.find(None, options)
         .await
         .unwrap()
         .try_collect()


### PR DESCRIPTION
RUST-412

I checked and the v2 runner, retryable writes runner, and unified runner all do this already.