### PR TITLE
RUST-1443 Stop executing server monitors after the server has been closed (2.3 backport)

### DIFF
--- a/src/runtime/worker_handle.rs
+++ b/src/runtime/worker_handle.rs
@@ -1,10 +1,10 @@
-use tokio::sync::mpsc;
+use tokio::sync::watch;
 
 /// Handle to a worker. Once all handles have been dropped, the worker
 /// will stop waiting for new requests.
 #[derive(Debug, Clone)]
 pub(crate) struct WorkerHandle {
-    _sender: mpsc::Sender<()>,
+    _receiver: watch::Receiver<()>,
 }
 
 impl WorkerHandle {
@@ -18,24 +18,31 @@ impl WorkerHandle {
 /// Listener used to determine when all handles have been dropped.
 #[derive(Debug)]
 pub(crate) struct WorkerHandleListener {
-    receiver: mpsc::Receiver<()>,
+    sender: watch::Sender<()>,
 }
 
 impl WorkerHandleListener {
     /// Listen until all handles are dropped.
     /// This will not return until all handles are dropped, so make sure to only poll this via
     /// select or with a timeout.
-    pub(crate) async fn wait_for_all_handle_drops(&mut self) {
-        self.receiver.recv().await;
+    pub(crate) async fn wait_for_all_handle_drops(&self) {
+        self.sender.closed().await
+    }
+
+    /// Returns whether there are handles still alive.
+    pub(crate) fn is_alive(&self) -> bool {
+        !self.sender.is_closed()
     }
 
     /// Constructs a new channel for for monitoring whether this worker still has references
     /// to it.
     pub(crate) fn channel() -> (WorkerHandle, WorkerHandleListener) {
-        let (sender, receiver) = mpsc::channel(1);
+        let (sender, receiver) = watch::channel(());
         (
-            WorkerHandle { _sender: sender },
-            WorkerHandleListener { receiver },
+            WorkerHandle {
+                _receiver: receiver,
+            },
+            WorkerHandleListener { sender },
         )
     }
 }

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -126,23 +126,6 @@ impl PartialEq for TopologyDescription {
 }
 
 impl TopologyDescription {
-    pub(crate) fn new_empty() -> Self {
-        Self {
-            single_seed: false,
-            topology_type: TopologyType::Unknown,
-            set_name: None,
-            max_set_version: None,
-            max_election_id: None,
-            compatibility_error: None,
-            session_support_status: SessionSupportStatus::Undetermined,
-            transaction_support_status: TransactionSupportStatus::Undetermined,
-            cluster_time: None,
-            local_threshold: None,
-            heartbeat_freq: None,
-            servers: HashMap::new(),
-        }
-    }
-
     pub(crate) fn initialized(options: &ClientOptions) -> crate::error::Result<Self> {
         verify_max_staleness(
             options
@@ -199,6 +182,23 @@ impl TopologyDescription {
             heartbeat_freq: options.heartbeat_freq,
             servers,
         })
+    }
+
+    pub(crate) fn new_empty() -> Self {
+        Self {
+            single_seed: false,
+            topology_type: TopologyType::Unknown,
+            set_name: None,
+            max_set_version: None,
+            max_election_id: None,
+            compatibility_error: None,
+            session_support_status: SessionSupportStatus::Undetermined,
+            transaction_support_status: TransactionSupportStatus::Undetermined,
+            cluster_time: None,
+            local_threshold: None,
+            heartbeat_freq: None,
+            servers: HashMap::new(),
+        }
     }
 
     /// Gets the topology type of the cluster.

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -440,26 +440,11 @@ impl TopologyDescription {
                 _ => None,
             });
 
-        #[allow(unused_mut)]
-        let mut diff = TopologyDescriptionDiff {
+        let diff = TopologyDescriptionDiff {
             removed_addresses: addresses.difference(&other_addresses).cloned().collect(),
             added_addresses: other_addresses.difference(&addresses).cloned().collect(),
             changed_servers: changed_servers.collect(),
         };
-
-        // For ordering of events in tests, sort the addresses.
-        #[cfg(test)]
-        {
-            diff.removed_addresses.sort_by_key(|addr| match addr {
-                ServerAddress::Tcp { host, port } => (host, port),
-            });
-            diff.added_addresses.sort_by_key(|addr| match addr {
-                ServerAddress::Tcp { host, port } => (host, port),
-            });
-            diff.changed_servers.sort_by_key(|(addr, _)| match addr {
-                ServerAddress::Tcp { host, port } => (host, port),
-            });
-        }
 
         Some(diff)
     }
@@ -871,12 +856,10 @@ impl Default for TransactionSupportStatus {
 /// Returned from `TopologyDescription::diff`.
 #[derive(Debug)]
 pub(crate) struct TopologyDescriptionDiff<'a> {
-    pub(crate) removed_addresses: Vec<&'a ServerAddress>,
-    pub(crate) added_addresses: Vec<&'a ServerAddress>,
-    pub(crate) changed_servers: Vec<(
-        &'a ServerAddress,
-        (&'a ServerDescription, &'a ServerDescription),
-    )>,
+    pub(crate) removed_addresses: HashSet<&'a ServerAddress>,
+    pub(crate) added_addresses: HashSet<&'a ServerAddress>,
+    pub(crate) changed_servers:
+        HashMap<&'a ServerAddress, (&'a ServerDescription, &'a ServerDescription)>,
 }
 
 fn verify_max_staleness(max_staleness: Option<Duration>) -> crate::error::Result<()> {

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -48,7 +48,6 @@ impl Monitor {
         update_request_receiver: TopologyCheckRequestReceiver,
         client_options: ClientOptions,
     ) -> WorkerHandle {
-        println!("starting monitor for {}", address);
         let handshaker = Handshaker::new(Some(client_options.clone().into()));
         let (handle, server_handle_listener) = WorkerHandleListener::channel();
         let monitor = Self {

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -8,6 +9,8 @@ use semver::VersionReq;
 use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 use crate::{
+    client::options::ClientOptions,
+    cmap::RawCommandResponse,
     error::{Error, ErrorKind},
     hello::{LEGACY_HELLO_COMMAND_NAME, LEGACY_HELLO_COMMAND_NAME_LOWERCASE},
     runtime,
@@ -27,6 +30,8 @@ use crate::{
     },
     Client,
 };
+
+use super::{ServerDescription, Topology};
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
@@ -481,6 +486,89 @@ async fn repl_set_name_mismatch() -> crate::error::Result<()> {
         },
         "Unexpected result {:?}",
         result
+    );
+
+    Ok(())
+}
+
+/// Test verifying that a server's monitor stops after the server has been removed from the
+/// topology.
+#[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn removed_server_monitor_stops() -> crate::error::Result<()> {
+    let _guard = LOCK.run_concurrently().await;
+
+    let handler = Arc::new(EventHandler::new());
+    let mut options =
+        ClientOptions::parse("mongodb://localhost:49152,localhost:49153,localhost:49154/").await?;
+    options.heartbeat_freq = Some(Duration::from_millis(50));
+    options.test_options_mut().heartbeat_freq = Some(Duration::from_millis(50));
+    options.sdam_event_handler = Some(handler.clone());
+    options.repl_set_name = Some("foo".to_string());
+
+    let hosts = options.hosts.clone();
+    let set_name = options.repl_set_name.clone().unwrap();
+
+    let mut subscriber = handler.subscribe();
+    let topology = Topology::new(options)?;
+
+    // Wait until all three monitors have started.
+    let mut seen_monitors = HashSet::new();
+    subscriber
+        .wait_for_event(Duration::from_millis(500), |event| {
+            if let Event::Sdam(SdamEvent::ServerHeartbeatStarted(e)) = event {
+                seen_monitors.insert(e.server_address.clone());
+            }
+            seen_monitors.len() == hosts.len()
+        })
+        .await
+        .expect("should see all three monitors start");
+
+    // Remove the third host from the topology.
+    let hello = doc! {
+        "ok": 1,
+        "isWritablePrimary": true,
+        "hosts": [
+            hosts[0].clone().to_string(),
+            hosts[1].clone().to_string(),
+        ],
+        "me": hosts[0].clone().to_string(),
+        "setName": set_name,
+        "maxBsonObjectSize": 1234,
+        "maxWriteBatchSize": 1234,
+        "maxMessageSizeBytes": 1234,
+        "minWireVersion": 0,
+        "maxWireVersion": 13,
+    };
+    let hello_reply = Some(Ok(RawCommandResponse::with_document_and_address(
+        hosts[0].clone(),
+        hello,
+    )
+    .unwrap()
+    .into_hello_reply(Duration::from_millis(10))
+    .unwrap()));
+
+    topology
+        .clone_updater()
+        .update(ServerDescription::new(hosts[0].clone(), hello_reply))
+        .await;
+
+    subscriber.wait_for_event(Duration::from_secs(1), |event| {
+        matches!(event, Event::Sdam(SdamEvent::ServerClosed(e)) if e.address == hosts[2])
+    }).await.expect("should see server closed event");
+
+    // Capture heartbeat events for 1 second. The monitor for the removed server should stop
+    // publishing them.
+    let events = subscriber.collect_events(Duration::from_secs(1), |event| {
+        matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatStarted(e)) if e.server_address == hosts[2])
+    }).await;
+
+    // Use 3 to account for any heartbeats that happen to start between emitting the ServerClosed
+    // event and actually publishing the state with the closed server.
+    assert!(
+        events.len() < 3,
+        "expected monitor for removed server to stop performing checks, but saw {} heartbeats",
+        events.len()
     );
 
     Ok(())

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -500,7 +500,7 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
     let _guard = LOCK.run_concurrently().await;
 
     let handler = Arc::new(EventHandler::new());
-    let mut options = ClientOptions::builder()
+    let options = ClientOptions::builder()
         .hosts(vec![
             ServerAddress::parse("localhost:49152")?,
             ServerAddress::parse("localhost:49153")?,
@@ -510,7 +510,6 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
         .sdam_event_handler(handler.clone() as Arc<dyn SdamEventHandler>)
         .repl_set_name("foo".to_string())
         .build();
-    options.heartbeat_freq = Some(Duration::from_millis(50));
 
     let hosts = options.hosts.clone();
     let set_name = options.repl_set_name.clone().unwrap();

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -421,11 +421,12 @@ impl TopologyWorker {
             let disable_monitoring_threads = self
                 .options
                 .load_balanced
-                .or(self
-                    .options
-                    .test_options
-                    .as_ref()
-                    .map(|to| to.disable_monitoring_threads))
+                .or_else(|| {
+                    self.options
+                        .test_options
+                        .as_ref()
+                        .map(|to| to.disable_monitoring_threads)
+                })
                 .unwrap_or(false);
             #[cfg(not(test))]
             let disable_monitoring_threads = self.options.load_balanced.unwrap_or(false);

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -420,12 +420,15 @@ impl TopologyWorker {
             #[cfg(test)]
             let disable_monitoring_threads = self
                 .options
-                .test_options
-                .as_ref()
-                .map(|to| to.disable_monitoring_threads)
+                .load_balanced
+                .or(self
+                    .options
+                    .test_options
+                    .as_ref()
+                    .map(|to| to.disable_monitoring_threads))
                 .unwrap_or(false);
             #[cfg(not(test))]
-            let disable_monitoring_threads = false;
+            let disable_monitoring_threads = self.options.load_balanced.unwrap_or(false);
 
             let monitor_handle = if !disable_monitoring_threads {
                 Monitor::start(

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -145,9 +145,10 @@ impl Topology {
 
             worker.process_topology_diff(&old_description);
             worker.publish_state();
+        } else {
+            SrvPollingMonitor::start(updater.clone(), watcher.clone(), options);
         }
 
-        SrvPollingMonitor::start(updater.clone(), watcher.clone(), options);
         worker.start();
 
         Ok(Topology {

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -490,9 +490,12 @@ impl EventSubscriber<'_> {
         F: FnMut(&Event) -> bool,
     {
         let mut events = Vec::new();
-        while let Some(event) = self.wait_for_event(timeout, &mut filter).await {
-            events.push(event);
-        }
+        let _ = runtime::timeout(timeout, async {
+            while let Some(event) = self.wait_for_event(timeout, &mut filter).await {
+                events.push(event);
+            }
+        })
+        .await;
         events
     }
 }


### PR DESCRIPTION
RUST-1443

This PR fixes a bug where server monitors would continue executing even after a server had been removed from the topology.