### PR TITLE
RUST-1450 Bump pretty_assertions dependency to 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ function_name = "0.2.1"
 futures = "0.3"
 home = "0.5"
 lambda_runtime = "0.6.0"
-pretty_assertions = "1.1.0"
+pretty_assertions = "1.3.0"
 serde = { version = "*", features = ["rc"] }
 serde_json = "1.0.64"
 semver = "1.0.0"


### PR DESCRIPTION
RUST-1450

This release no longer depends on the now unmaintained ansi_term crate.