### PR TITLE
RUST-1456 Ensure credentials from prior test runs are not used in EC2 AWS auth test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -204,6 +204,9 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
+          # Write an empty prepare_mongodb_aws so no auth environment variables
+          # are set.
+          echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
           ASYNC_RUNTIME=${ASYNC_RUNTIME} .evergreen/run-aws-tests.sh
 
   "run aws auth test with aws credentials as environment variables":


### PR DESCRIPTION
RUST-1456

This PR updates our evergreen config to create an empty file in the "run aws auth test with aws EC2 credentials" test so as to avoid ingesting environment variables from prior tests in the task.