### PR TITLE
minor: document cursor/change stream `Drop` implementations

### DIFF
--- a/manual/src/reading.md
+++ b/manual/src/reading.md
@@ -99,3 +99,5 @@ while let Some(book) = cursor.try_next().await? {
 }
 # Ok(()) }
 ```
+
+If a [`Cursor`](https://docs.rs/mongodb/latest/mongodb/struct.Cursor.html) is still open when it goes out of scope, it will automatically be closed via an asynchronous [killCursors](https://www.mongodb.com/docs/manual/reference/command/killCursors/) command executed from its [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) implementation.

--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -75,6 +75,10 @@ use crate::{
 /// # }
 /// ```
 ///
+/// If a [`ChangeStream`] is still open when it goes out of scope, it will automatically be closed
+/// via an asynchronous [killCursors](https://www.mongodb.com/docs/manual/reference/command/killCursors/) command executed
+/// from its [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) implementation.
+///
 /// See the documentation [here](https://www.mongodb.com/docs/manual/changeStreams) for more
 /// details. Also see the documentation on [usage recommendations](https://www.mongodb.com/docs/manual/administration/change-streams-production-recommendations/).
 #[derive(Derivative)]

--- a/src/change_stream/session.rs
+++ b/src/change_stream/session.rs
@@ -34,6 +34,10 @@ use super::{
 /// # Ok(())
 /// # }
 /// ```
+///
+/// If a [`SessionChangeStream`] is still open when it goes out of scope, it will automatically be
+/// closed via an asynchronous [killCursors](https://www.mongodb.com/docs/manual/reference/command/killCursors/) command executed
+/// from its [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) implementation.
 pub struct SessionChangeStream<T>
 where
     T: DeserializeOwned + Unpin,

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -95,6 +95,10 @@ pub(crate) use common::{
 /// # Ok(())
 /// # }
 /// ```
+///
+/// If a [`Cursor`] is still open when it goes out of scope, it will automatically be closed via an
+/// asynchronous [killCursors](https://www.mongodb.com/docs/manual/reference/command/killCursors/) command executed
+/// from its [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) implementation.
 #[derive(Debug)]
 pub struct Cursor<T> {
     client: Client,

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -65,6 +65,10 @@ use crate::{
 /// # Ok(())
 /// # }
 /// ```
+///
+/// If a [`SessionCursor`] is still open when it goes out of scope, it will automatically be closed
+/// via an asynchronous [killCursors](https://www.mongodb.com/docs/manual/reference/command/killCursors/) command executed
+/// from its [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) implementation.
 #[derive(Debug)]
 pub struct SessionCursor<T> {
     client: Client,


### PR DESCRIPTION
This PR documents the fact that change streams and cursors are closed automatically via their drop implementations.

Addresses the question filed in #741.