### PR TITLE
RUST-1413 Add Unicode-DFS-2016 to the list of allowed licenses (#718)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,8 +49,6 @@ notice = "deny"
 # output a note when they are encountered.
 ignore = [
     # TODO RUST-1293
-    "RUSTSEC-2020-0159",
-    # TODO RUST-1293
     "RUSTSEC-2020-0071",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
@@ -80,6 +78,7 @@ allow = [
     "OpenSSL",
     "BSD-3-Clause",
     "MPL-2.0",
+    "Unicode-DFS-2016",
 ]
 # List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
Backport from 342c35f646a96d905fd67c253f08422aa946dd7a.