### PR TITLE
minor: remove expansion.yml after load

### DIFF
--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -31,6 +31,14 @@ functions:
       params:
         file: src/expansion.yml
 
+    # Delete the expansion file so cargo release doesn't complain about uncommitted changes
+    - command: shell.exec
+      params:
+        working_dir: "src"
+        script: |
+          ${PREPARE_SHELL}
+          rm expansion.yml
+
   "install dependencies":
     command: shell.exec
     params:


### PR DESCRIPTION
I'm not sure how to test this short of pushing another release, but this _should_ fix the problem we had with 2.3.1.