### PR TITLE
RUST-1488 Populate inserted_ids when an insert_many fails

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -1235,6 +1235,10 @@ where
 
                             let failure_ref =
                                 cumulative_failure.get_or_insert_with(BulkWriteFailure::new);
+                            for (index, id) in bw.inserted_ids {
+                                failure_ref.inserted_ids.insert(index + n_attempted, id);
+                            }
+
                             if let Some(write_errors) = bw.write_errors {
                                 for err in write_errors {
                                     let index = n_attempted + err.index;

--- a/src/results.rs
+++ b/src/results.rs
@@ -41,10 +41,8 @@ pub struct InsertManyResult {
 }
 
 impl InsertManyResult {
-    pub(crate) fn new() -> Self {
-        InsertManyResult {
-            inserted_ids: HashMap::new(),
-        }
+    pub(crate) fn new(inserted_ids: HashMap<usize, Bson>) -> Self {
+        InsertManyResult { inserted_ids }
     }
 }
 


### PR DESCRIPTION
fixes #748 

The fix ended up being a little more complicated than I initially expected in order to get it work properly for multi-batch bulk writes but was still relatively straightforward; most of the diff here is just adding testing. @isabelatkinson we should consider adding automated tests around this type of thing as part of the new bulk spec