### PR TITLE
RUST-1386 Implement the remainder of the FLE prose tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -493,10 +493,7 @@ functions:
       background: true
       script: |
         ${PREPARE_SHELL}
-        cd ${DRIVERS_TOOLS}/.evergreen/csfle
-        . ./activate_venv.sh
-        # TMPDIR is required to avoid "AF_UNIX path too long" errors.
-        TMPDIR="$(dirname ${DRIVERS_TOOLS})" python3 kms_kmip_server.py
+        .evergreen/run-csfle-kmip-servers.sh
 
   "run csfle tests":
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -506,6 +506,7 @@ functions:
           export ASYNC_RUNTIME=${ASYNC_RUNTIME}
           export CSFLE_TLS_CERT_DIR=$DRIVERS_TOOLS_X509
           export CSFLE_SHARED_LIB_PATH=$(.evergreen/find-crypt_shared.sh "$PROJECT_DIRECTORY/crypt_shared/lib/")
+          export DISABLE_CRYPT_SHARED=${DISABLE_CRYPT_SHARED}
           # Exported without xtrace to avoid leaking credentials
           set +o xtrace
           export KMS_PROVIDERS=$(cat << "EOF"
@@ -1578,6 +1579,7 @@ axes:
         display_name: "5.0"
         variables:
           MONGODB_VERSION: "5.0"
+          DISABLE_CRYPT_SHARED: "true"
       - id: "4.4"
         display_name: "4.4"
         variables:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1575,11 +1575,6 @@ axes:
         variables:
           MONGODB_VERSION: "6.0"
           CRYPT_SHARED_VERSION: "6.0.0"
-      - id: "5.0"
-        display_name: "5.0"
-        variables:
-          MONGODB_VERSION: "5.0"
-          DISABLE_CRYPT_SHARED: "true"
       - id: "4.4"
         display_name: "4.4"
         variables:
@@ -1717,6 +1712,18 @@ axes:
         variables:
           REQUIRE_API_VERSION: "1"
           MONGODB_API_VERSION: "1"
+
+  - id: "crypt-shared"
+    display_name: "crypt_shared"
+    values:
+      - id: enabled
+        display_name: "crypt_shared enabled"
+        variables:
+          DISABLE_CRYPT_SHARED: ""
+      - id: disabled
+        display_name: "crypt_shared disabled"
+        variables:
+          DISABLE_CRYPT_SHARED: "true"
 
 task_groups:
   - name: serverless_task_group
@@ -1866,17 +1873,18 @@ buildvariants:
   tasks:
     - "serverless_task_group"
 
-- matrix_name: "csfle"
+- matrix_name: "csfle-topology"
   matrix_spec:
     os:
       - ubuntu-20.04
     mongodb-version:
       - "6.0"
-      - "latest"
     topology:
       - "standalone"
       - "replica-set"
-  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology}"
+    crypt-shared:
+      - "enabled"
+  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology} / ${crypt-shared}"
   tasks:
     - "test-csfle"
 
@@ -1889,7 +1897,23 @@ buildvariants:
       - "6.0"
     topology:
       - "standalone"
-  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology}"
+    crypt-shared:
+      - "enabled"
+  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology} / ${crypt-shared}"
+  tasks:
+    - "test-csfle"
+
+- matrix_name: "csfle-crypt-shared"
+  matrix_spec:
+    os:
+      - ubuntu-20.04
+    mongodb-version:
+      - "6.0"
+    topology:
+      - "standalone"
+    crypt-shared:
+      - "disabled"
+  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology} / ${crypt-shared}"
   tasks:
     - "test-csfle"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1658,7 +1658,7 @@ axes:
     display_name: "TLS Feature"
     values:
       - id: "default"
-        display_name: "default TLS"
+        display_name: "rustls TLS"
         variables:
           TLS_FEATURE: ""
       - id: "openssl"
@@ -1948,6 +1948,8 @@ buildvariants:
   matrix_spec:
     os:
       - ubuntu-20.04
+      - macos-11.00
+      - windows-64-vs2017
     mongodb-version:
       - "6.0"
     topology:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -481,7 +481,7 @@ functions:
       working_dir: "src"
       script: |
         ${PREPARE_SHELL}
-        python3 ${DRIVERS_TOOLS}/.evergreen/mongodl.py --component=crypt_shared --version=${CRYPT_SHARED_VERSION} --out=./crypt_shared/
+        ${PYTHON} ${DRIVERS_TOOLS}/.evergreen/mongodl.py --component=crypt_shared --version=${CRYPT_SHARED_VERSION} --out=./crypt_shared/
         ls -R ${PROJECT_DIRECTORY}/crypt_shared
 
   "run kmip server":
@@ -1564,6 +1564,7 @@ axes:
         display_name: "latest"
         variables:
            MONGODB_VERSION: "latest"
+           CRYPT_SHARED_VERSION: "latest"
       - id: "rapid"
         display_name: "rapid"
         variables:
@@ -1673,21 +1674,21 @@ axes:
         display_name: "Ubuntu 18.04"
         run_on: ubuntu1804-test
         variables:
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
           LIBMONGOCRYPT_OS: "ubuntu1804-64"
       - id: ubuntu-20.04
         display_name: "Ubuntu 20.04"
         run_on: ubuntu2004-test
         variables:
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
           LIBMONGOCRYPT_OS: "ubuntu2004-64"
       - id: ubuntu-18.04-arm64
         display_name: "ARM64 Ubuntu 18.04"
         run_on: ubuntu1804-arm64-test
         variables:
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
           LIBMONGOCRYPT_OS: "ubuntu1804-arm64"
       - id: macos-11.00
@@ -1695,7 +1696,7 @@ axes:
         run_on: macos-1100
         variables:
           SINGLE_THREAD: true
-          PYTHON: "/opt/mongodbtoolchain/v3/bin/python"
+          PYTHON: "/opt/mongodbtoolchain/v3/bin/python3"
           VENV_BIN_DIR: "bin"
           LIBMONGOCRYPT_OS: "macos"
       - id: windows-64-vs2017

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -475,24 +475,27 @@ functions:
 
   "fetch crypt_shared":
   - command: shell.exec
-    type: test
     params:
       shell: bash
       working_dir: "src"
       script: |
         ${PREPARE_SHELL}
-        ${PYTHON} ${DRIVERS_TOOLS}/.evergreen/mongodl.py --component=crypt_shared --version=${CRYPT_SHARED_VERSION} --out=./crypt_shared/
-        ls -R ${PROJECT_DIRECTORY}/crypt_shared
+        if [ "${DISABLE_CRYPT_SHARED}" == "true" ]; then
+          echo "crypt_shared is disabled, not fetching"
+        else
+          ${PYTHON} ${DRIVERS_TOOLS}/.evergreen/mongodl.py --component=crypt_shared --version=${CRYPT_SHARED_VERSION} --out=./crypt_shared/
+          ls -R ${PROJECT_DIRECTORY}/crypt_shared
+        fi
 
   "run kmip server":
   - command: shell.exec
-    type: test
     params:
       shell: bash
       working_dir: "src"
       background: true
       script: |
         ${PREPARE_SHELL}
+        export TLS_FEATURE=${TLS_FEATURE}
         .evergreen/run-csfle-kmip-servers.sh
 
   "run csfle tests":
@@ -507,6 +510,7 @@ functions:
           export CSFLE_TLS_CERT_DIR=$DRIVERS_TOOLS_X509
           export CSFLE_SHARED_LIB_PATH=$(.evergreen/find-crypt_shared.sh "$PROJECT_DIRECTORY/crypt_shared/lib/")
           export DISABLE_CRYPT_SHARED=${DISABLE_CRYPT_SHARED}
+          export TLS_FEATURE=${TLS_FEATURE}
           # Exported without xtrace to avoid leaking credentials
           set +o xtrace
           export KMS_PROVIDERS=$(cat << "EOF"
@@ -1575,6 +1579,10 @@ axes:
         variables:
           MONGODB_VERSION: "6.0"
           CRYPT_SHARED_VERSION: "6.0.0"
+      - id: "5.0"
+        display_name: "5.0"
+        variables:
+          MONGODB_VERSION: "5.0"
       - id: "4.4"
         display_name: "4.4"
         variables:
@@ -1645,6 +1653,18 @@ axes:
            AUTH: "noauth"
            SSL: "nossl"
            TLS_FEATURE: ""
+
+  - id: "tls-feature"
+    display_name: "TLS Feature"
+    values:
+      - id: "default"
+        display_name: "default TLS"
+        variables:
+          TLS_FEATURE: ""
+      - id: "openssl"
+        display_name: "OpenSSL TLS"
+        variables:
+          TLS_FEATURE: "openssl-tls"
 
   - id: "compressor"
     display_name: "Compressor"
@@ -1884,7 +1904,9 @@ buildvariants:
       - "replica-set"
     crypt-shared:
       - "enabled"
-  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology} / ${crypt-shared}"
+    tls-feature:
+      - "default"
+  display_name: "CSFLE (${crypt-shared}, ${tls-feature}) on mongodb ${mongodb-version} ${topology} / ${os}"
   tasks:
     - "test-csfle"
 
@@ -1899,7 +1921,9 @@ buildvariants:
       - "standalone"
     crypt-shared:
       - "enabled"
-  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology} / ${crypt-shared}"
+    tls-feature:
+      - "default"
+  display_name: "CSFLE (${crypt-shared}, ${tls-feature}) on mongodb ${mongodb-version} ${topology} / ${os}"
   tasks:
     - "test-csfle"
 
@@ -1908,12 +1932,31 @@ buildvariants:
     os:
       - ubuntu-20.04
     mongodb-version:
+      - "5.0"
       - "6.0"
     topology:
       - "standalone"
     crypt-shared:
       - "disabled"
-  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology} / ${crypt-shared}"
+    tls-feature:
+      - "default"
+  display_name: "CSFLE (${crypt-shared}, ${tls-feature}) on mongodb ${mongodb-version} ${topology} / ${os}"
+  tasks:
+    - "test-csfle"
+
+- matrix_name: "csfle-tls"
+  matrix_spec:
+    os:
+      - ubuntu-20.04
+    mongodb-version:
+      - "6.0"
+    topology:
+      - "standalone"
+    crypt-shared:
+      - "enabled"
+    tls-feature:
+      - "openssl"
+  display_name: "CSFLE (${crypt-shared}, ${tls-feature}) on mongodb ${mongodb-version} ${topology} / ${os}"
   tasks:
     - "test-csfle"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1174,8 +1174,6 @@ tasks:
       - func: "install junit dependencies"
       - func: "fetch crypt_shared"
       - func: "bootstrap mongo-orchestration"
-        vars:
-          TOPOLOGY: "server"
       - func: "run kmip server"
       - func: "run csfle tests"
 
@@ -1865,14 +1863,30 @@ buildvariants:
   tasks:
     - "serverless_task_group"
 
-# TODO(RUST-1386): Expand the os and version listing
 - matrix_name: "csfle"
   matrix_spec:
     os:
       - ubuntu-20.04
     mongodb-version:
       - "6.0"
-  display_name: "CSFLE on mongodb ${mongodb-version} / ${os}"
+      - "latest"
+    topology:
+      - "standalone"
+      - "replica-set"
+  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology}"
+  tasks:
+    - "test-csfle"
+
+- matrix_name: "csfle-os"
+  matrix_spec:
+    os:
+      - macos-11.00
+      - windows-64-vs2017
+    mongodb-version:
+      - "6.0"
+    topology:
+      - "standalone"
+  display_name: "CSFLE on mongodb ${mongodb-version} / ${os} / ${topology}"
   tasks:
     - "test-csfle"
 

--- a/.evergreen/configure-rust.sh
+++ b/.evergreen/configure-rust.sh
@@ -6,6 +6,9 @@ export CARGO_HOME="${PROJECT_DIRECTORY}/.cargo"
 export PATH="${CARGO_HOME}/bin:$PATH"
 
 if [[ "Windows_NT" == "$OS" ]]; then
+    # Update path for DLLs
+    export PATH="${MONGOCRYPT_LIB_DIR}/../bin:$PATH"
+
     # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
     export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
     export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)

--- a/.evergreen/configure-rust.sh
+++ b/.evergreen/configure-rust.sh
@@ -9,6 +9,7 @@ if [[ "Windows_NT" == "$OS" ]]; then
     # rustup/cargo need the native Windows paths; $PROJECT_DIRECTORY is a cygwin path
     export RUSTUP_HOME=$(cygpath ${RUSTUP_HOME} --windows)
     export CARGO_HOME=$(cygpath ${CARGO_HOME} --windows)
+    export MONGOCRYPT_LIB_DIR=$(cygpath ${MONGOCRYPT_LIB_DIR} --windows)
 fi
 
 . ${CARGO_HOME}/env

--- a/.evergreen/find-crypt_shared.sh
+++ b/.evergreen/find-crypt_shared.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-if [ "$1" = "" ]; then
-    echo "crypt_shared library directory required"
-    exit 1
+if [[ "Windows_NT" == "$OS" ]]; then
+    cygpath ${PROJECT_DIRECTORY}/crypt_shared/bin/mongo_crypt_v1.dll --windows
+else
+    CS_PATH=${PROJECT_DIRECTORY}/crypt_shared/lib
+    crypt_shared_glob=("$CS_PATH"/*)
+
+    if [ "${#crypt_shared_glob[@]}" != "1" ]; then
+        echo "Wrong number of files found: ${crypt_shared_glob[@]}"
+        exit 1
+    fi
+
+    echo ${crypt_shared_glob[0]}
 fi
-
-crypt_shared_glob=("$1"/*)
-
-if [ "${#crypt_shared_glob[@]}" != "1" ]; then
-    echo "Wrong number of files found: ${crypt_shared_glob[@]}"
-    exit 1
-fi
-
-echo ${crypt_shared_glob[0]}

--- a/.evergreen/run-csfle-kmip-servers.sh
+++ b/.evergreen/run-csfle-kmip-servers.sh
@@ -5,7 +5,7 @@ cd ${DRIVERS_TOOLS}/.evergreen/csfle
 # TMPDIR is required to avoid "AF_UNIX path too long" errors.
 export TMPDIR="$(dirname ${DRIVERS_TOOLS})"
 
-kmstlsvenv/bin/python kms_kmip_server.py &
-kmstlsvenv/bin/python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
-kmstlsvenv/bin/python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
-kmstlsvenv/bin/python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 9002 --require_client_cert
+python kms_kmip_server.py &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
+python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 9002 --require_client_cert

--- a/.evergreen/run-csfle-kmip-servers.sh
+++ b/.evergreen/run-csfle-kmip-servers.sh
@@ -5,7 +5,7 @@ cd ${DRIVERS_TOOLS}/.evergreen/csfle
 # TMPDIR is required to avoid "AF_UNIX path too long" errors.
 export TMPDIR="$(dirname ${DRIVERS_TOOLS})"
 
-python3 kms_kmip_server.py &
-python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
-python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
-python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 9002 --require_client_cert
+kmstlsvenv/bin/python kms_kmip_server.py &
+kmstlsvenv/bin/python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
+kmstlsvenv/bin/python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
+kmstlsvenv/bin/python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 9002 --require_client_cert

--- a/.evergreen/run-csfle-kmip-servers.sh
+++ b/.evergreen/run-csfle-kmip-servers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd ${DRIVERS_TOOLS}/.evergreen/csfle
+. ./activate_venv.sh
+# TMPDIR is required to avoid "AF_UNIX path too long" errors.
+export TMPDIR="$(dirname ${DRIVERS_TOOLS})"
+
+python3 kms_kmip_server.py &
+python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 9000 &
+python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 9001 &
+python3 -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/server.pem --port 9002 --require_client_cert

--- a/.evergreen/run-csfle-kmip-servers.sh
+++ b/.evergreen/run-csfle-kmip-servers.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$TLS_FEATURE" != "openssl-tls" ]; then
+    echo "Skipping kms servers: openssl-tls not enabled"
+    exit
+fi
+
 cd ${DRIVERS_TOOLS}/.evergreen/csfle
 . ./activate_venv.sh
 # TMPDIR is required to avoid "AF_UNIX path too long" errors.

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -8,7 +8,7 @@ source ./.evergreen/env.sh
 set -o xtrace
 
 FEATURE_FLAGS="openssl-tls,csfle"
-#OPTIONS="-- -Z unstable-options --format json --report-time"
+OPTIONS="-- -Z unstable-options --format json --report-time"
 
 
 if [ "$SINGLE_THREAD" = true ]; then
@@ -21,12 +21,12 @@ CARGO_RESULT=0
 
 cargo_test() {
     RUST_BACKTRACE=1 \
-        cargo test --features ${FEATURE_FLAGS} $1 # ${OPTIONS} | cargo2junit
+        cargo test --features ${FEATURE_FLAGS} $1 ${OPTIONS} | cargo2junit
     (( CARGO_RESULT = ${CARGO_RESULT} || $? ))
 }
 
 set +o errexit
 
-cargo_test test::csfle # > results.xml
+cargo_test test::csfle > results.xml
 
 exit ${CARGO_RESULT}

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -14,6 +14,10 @@ if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"
 fi
 
+if [ "$OS" = "Windows_NT" ]; then
+    CSFLE_TLS_CERT_DIR=$(cygpath ${CSFLE_TLS_CERT_DIR} --windows)
+fi
+
 echo "cargo test options: --features ${FEATURE_FLAGS} ${OPTIONS}"
 
 CARGO_RESULT=0

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -7,9 +7,8 @@ source ./.evergreen/env.sh
 
 set -o xtrace
 
-FEATURE_FLAGS="openssl-tls,csfle"
+FEATURE_FLAGS="csfle,${TLS_FEATURE}"
 OPTIONS="-- -Z unstable-options --format json --report-time"
-
 
 if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -8,7 +8,8 @@ source ./.evergreen/env.sh
 set -o xtrace
 
 FEATURE_FLAGS="openssl-tls,csfle"
-OPTIONS="-- -Z unstable-options --format json --report-time"
+#OPTIONS="-- -Z unstable-options --format json --report-time"
+
 
 if [ "$SINGLE_THREAD" = true ]; then
 	OPTIONS="$OPTIONS --test-threads=1"
@@ -20,12 +21,12 @@ CARGO_RESULT=0
 
 cargo_test() {
     RUST_BACKTRACE=1 \
-        cargo test --features ${FEATURE_FLAGS} $1 ${OPTIONS} | cargo2junit
+        cargo test --features ${FEATURE_FLAGS} $1 # ${OPTIONS} | cargo2junit
     (( CARGO_RESULT = ${CARGO_RESULT} || $? ))
 }
 
 set +o errexit
 
-cargo_test test::csfle > results.xml
+cargo_test test::csfle # > results.xml
 
 exit ${CARGO_RESULT}

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -15,7 +15,9 @@ if [ "$SINGLE_THREAD" = true ]; then
 fi
 
 if [ "$OS" = "Windows_NT" ]; then
-    CSFLE_TLS_CERT_DIR=$(cygpath ${CSFLE_TLS_CERT_DIR} --windows)
+    export CSFLE_TLS_CERT_DIR=$(cygpath ${CSFLE_TLS_CERT_DIR} --windows)
+    export SSL_CERT_FILE=$(cygpath /etc/ssl/certs/ca-bundle.crt --windows)
+    export SSL_CERT_DIR=$(cygpath /etc/ssl/certs --windows)
 fi
 
 echo "cargo test options: --features ${FEATURE_FLAGS} ${OPTIONS}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 # we install cargo and rustup in the project directory on Evergreen.
 .cargo
 .rustup
+mongocryptd.pid

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,8 @@ hmac = "0.12.1"
 lazy_static = "1.4.0"
 log = { version = "0.4.17", optional = true }
 md-5 = "0.10.1"
-mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
+#mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
+mongocrypt = { path = "../../libmongocrypt-rust/mongocrypt", optional = true }
 num_cpus = { version = "1.13.1", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,7 @@ hmac = "0.12.1"
 lazy_static = "1.4.0"
 log = { version = "0.4.17", optional = true }
 md-5 = "0.10.1"
-#mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
-mongocrypt = { path = "../../libmongocrypt-rust/mongocrypt", optional = true }
+mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true }
 num_cpus = { version = "1.13.1", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -48,11 +48,16 @@ impl ClientState {
         let crypt = Self::make_crypt(&opts)?;
         let mongocryptd_opts = Self::make_mongocryptd_opts(&opts, &crypt)?;
         let aux_clients = Self::make_aux_clients(client, &opts)?;
+        let mongocryptd_connect = opts.bypass_auto_encryption != Some(true)
+            && opts.bypass_query_analysis != Some(true)
+            && crypt.shared_lib_version().is_none()
+            && opts.extra_option(&EO_CRYPT_SHARED_REQUIRED)? != Some(true);
         let exec = CryptExecutor::new_implicit(
             aux_clients.key_vault_client,
             opts.key_vault_namespace.clone(),
             opts.tls_options.take(),
             mongocryptd_opts,
+            mongocryptd_connect,
             aux_clients.metadata_client,
         )
         .await?;

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -83,11 +83,17 @@ impl ClientState {
         if let Some(m) = &opts.schema_map {
             builder = builder.schema_map(&bson::to_document(m)?)?;
         }
-        if Some(true) != opts.bypass_auto_encryption {
-            builder = builder.append_crypt_shared_lib_search_path(Path::new("$SYSTEM"))?;
-        }
-        if let Some(p) = opts.extra_option(&EO_CRYPT_SHARED_LIB_PATH)? {
-            builder = builder.set_crypt_shared_lib_path_override(Path::new(p))?;
+        #[cfg(not(test))]
+        let disable_crypt_shared = false;
+        #[cfg(test)]
+        let disable_crypt_shared = opts.disable_crypt_shared.unwrap_or(false);
+        if !disable_crypt_shared {
+            if Some(true) != opts.bypass_auto_encryption {
+                builder = builder.append_crypt_shared_lib_search_path(Path::new("$SYSTEM"))?;
+            }
+            if let Some(p) = opts.extra_option(&EO_CRYPT_SHARED_LIB_PATH)? {
+                builder = builder.set_crypt_shared_lib_path_override(Path::new(p))?;
+            }
         }
         let crypt = builder.build()?;
         if opts.extra_option(&EO_CRYPT_SHARED_REQUIRED)? == Some(true)

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -95,6 +95,9 @@ impl ClientState {
                 builder = builder.set_crypt_shared_lib_path_override(Path::new(p))?;
             }
         }
+        if opts.bypass_query_analysis == Some(true) {
+            builder = builder.bypass_query_analysis();
+        }
         let crypt = builder.build()?;
         if opts.extra_option(&EO_CRYPT_SHARED_REQUIRED)? == Some(true)
             && crypt.shared_lib_version().is_none()
@@ -111,6 +114,7 @@ impl ClientState {
         crypt: &Crypt,
     ) -> Result<Option<MongocryptdOptions>> {
         if opts.bypass_auto_encryption == Some(true)
+            || opts.bypass_query_analysis == Some(true)
             || opts.extra_option(&EO_MONGOCRYPTD_BYPASS_SPAWN)? == Some(true)
             || crypt.shared_lib_version().is_some()
             || opts.extra_option(&EO_CRYPT_SHARED_REQUIRED)? == Some(true)

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -56,7 +56,9 @@ impl ClientState {
             && crypt.shared_lib_version().is_none()
             && opts.extra_option(&EO_CRYPT_SHARED_REQUIRED)? != Some(true);
         let mongocryptd_client = if mongocryptd_connect {
-            let uri = opts.extra_option(&EO_MONGOCRYPTD_URI)?.unwrap_or(Self::MONGOCRYPTD_DEFAULT_URI);
+            let uri = opts
+                .extra_option(&EO_MONGOCRYPTD_URI)?
+                .unwrap_or(Self::MONGOCRYPTD_DEFAULT_URI);
             let mut options = crate::options::ClientOptions::parse_uri(uri, None).await?;
             options.server_selection_timeout = Some(Self::MONGOCRYPTD_SERVER_SELECTION_TIMEOUT);
             Some(Client::with_options(options)?)

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -318,6 +318,19 @@ pub enum MasterKey {
     },
 }
 
+impl MasterKey {
+    /// Returns the `KmsProvider` associated with this key.
+    pub fn provider(&self) -> KmsProvider {
+        match self {
+            MasterKey::Aws { .. } => KmsProvider::Aws,
+            MasterKey::Azure { .. } => KmsProvider::Azure,
+            MasterKey::Gcp { .. } => KmsProvider::Gcp,
+            MasterKey::Kmip { .. } => KmsProvider::Kmip,
+            MasterKey::Local => KmsProvider::Local,
+        }
+    }
+}
+
 // #[non_exhaustive]
 // pub struct RewrapManyDataKeyOptions {
 // pub provider: KmsProvider,

--- a/src/client/csfle/options.rs
+++ b/src/client/csfle/options.rs
@@ -63,6 +63,10 @@ pub struct AutoEncryptionOptions {
     /// encryption with queryable encryption.
     #[builder(default)]
     pub bypass_query_analysis: Option<bool>,
+    /// Disable loading crypt_shared.
+    #[cfg(test)]
+    #[builder(default)]
+    pub(crate) disable_crypt_shared: Option<bool>,
 }
 
 /// Options specific to each KMS provider.

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -110,7 +110,7 @@ impl CryptExecutor {
                     let mongocryptd = self
                         .mongocryptd
                         .as_ref()
-                        .ok_or_else(|| Error::internal("mongocryptd client not found"))?;
+                        .ok_or_else(|| Error::invalid_argument("this operation requires mongocryptd"))?;
                     let result = mongocryptd.client.execute_operation(op.clone(), None).await;
                     let response = match result {
                         Ok(r) => r,

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -246,15 +246,15 @@ impl Mongocryptd {
         };
         let new_child = Self::spawn(&self.opts);
         if new_child.is_ok() {
-            let tmp = Err(Error::internal("mongocryptd respawn internal failure"));
-            if let Ok(mut old_child) = std::mem::replace(child.deref_mut(), tmp) {
+            if let Ok(mut old_child) = std::mem::replace(child.deref_mut(), new_child) {
                 crate::runtime::spawn(async move {
                     let _ = old_child.kill();
                     let _ = old_child.wait().await;
                 });
             }
+        } else {
+            *child = new_child;
         }
-        *child = new_child;
         unit_err(&*child)
     }
 

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -1,7 +1,7 @@
 use std::{
     convert::TryInto,
-    path::{Path, PathBuf},
     ops::DerefMut,
+    path::{Path, PathBuf},
 };
 
 use bson::{Document, RawDocument, RawDocumentBuf};
@@ -233,10 +233,7 @@ struct Mongocryptd {
 impl Mongocryptd {
     async fn new(opts: MongocryptdOptions) -> Result<Self> {
         let child = Mutex::new(Ok(Self::spawn(&opts)?));
-        Ok(Self {
-            opts,
-            child,
-        })
+        Ok(Self { opts, child })
     }
 
     async fn respawn(&self) -> Result<()> {

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -112,10 +112,9 @@ impl CryptExecutor {
                         Error::internal("db required for NeedMongoMarkings state")
                     })?;
                     let op = RawOutput(RunCommand::new_raw(db.to_string(), command, None, None)?);
-                    let mongocryptd = self
-                        .mongocryptd
-                        .as_ref()
-                        .ok_or_else(|| Error::invalid_argument("this operation requires mongocryptd"))?;
+                    let mongocryptd = self.mongocryptd.as_ref().ok_or_else(|| {
+                        Error::invalid_argument("this operation requires mongocryptd")
+                    })?;
                     let result = mongocryptd.client.execute_operation(op.clone(), None).await;
                     let response = match result {
                         Ok(r) => r,

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -72,6 +72,11 @@ impl CryptExecutor {
         Ok(exec)
     }
 
+    #[cfg(test)]
+    pub(crate) fn mongocryptd_spawned(&self) -> bool {
+        self.mongocryptd.is_some()
+    }
+
     pub(crate) async fn run_ctx(&self, ctx: Ctx, db: Option<&str>) -> Result<RawDocumentBuf> {
         let mut result = None;
         // This needs to be a `Result` so that the `Ctx` can be temporarily owned by the processing

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -779,12 +779,8 @@ impl Client {
                 let response = {
                     let guard = self.inner.csfle.read().await;
                     if let Some(ref csfle) = *guard {
-                        if csfle.opts().bypass_auto_encryption != Some(true) {
-                            let new_body = self.auto_decrypt(csfle, response.raw_body()).await?;
-                            RawCommandResponse::new_raw(response.source, new_body)
-                        } else {
-                            response
-                        }
+                        let new_body = self.auto_decrypt(csfle, response.raw_body()).await?;
+                        RawCommandResponse::new_raw(response.source, new_body)
                     } else {
                         response
                     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -153,6 +153,15 @@ impl Client {
         Ok(client)
     }
 
+    #[cfg(all(test, feature = "csfle"))]
+    pub(crate) async fn mongocryptd_spawned(&self) -> bool {
+        self.inner.csfle
+            .read()
+            .await
+            .as_ref()
+            .map_or(false, |cs| cs.exec().mongocryptd_spawned())
+    }
+
     #[cfg(not(feature = "tracing-unstable"))]
     pub(crate) fn emit_command_event(&self, generate_event: impl FnOnce() -> CommandEvent) {
         if let Some(ref handler) = self.inner.options.command_event_handler {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -155,7 +155,8 @@ impl Client {
 
     #[cfg(all(test, feature = "csfle"))]
     pub(crate) async fn mongocryptd_spawned(&self) -> bool {
-        self.inner.csfle
+        self.inner
+            .csfle
             .read()
             .await
             .as_ref()

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -262,14 +262,12 @@ impl RawCommandResponse {
                     raw_command_response: self.into_raw_document_buf(),
                 })
             }
-            err => match self.body::<CommandResponse<CommandErrorBody>>() {
+            _ => match self.body::<CommandResponse<CommandErrorBody>>() {
                 Ok(command_error_body) => Err(Error::new(
                     ErrorKind::Command(command_error_body.body.command_error),
                     command_error_body.body.error_labels,
                 )),
                 Err(_) => {
-                    let _ = dbg!(err);
-                    let _ = dbg!(self.body::<Document>());
                     Err(ErrorKind::InvalidResponse {
                         message: "invalid server response".into(),
                     }

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -262,15 +262,19 @@ impl RawCommandResponse {
                     raw_command_response: self.into_raw_document_buf(),
                 })
             }
-            _ => match self.body::<CommandResponse<CommandErrorBody>>() {
+            err => match self.body::<CommandResponse<CommandErrorBody>>() {
                 Ok(command_error_body) => Err(Error::new(
                     ErrorKind::Command(command_error_body.body.command_error),
                     command_error_body.body.error_labels,
                 )),
-                Err(_) => Err(ErrorKind::InvalidResponse {
-                    message: "invalid server response".into(),
+                Err(_) => {
+                    let _ = dbg!(err);
+                    let _ = dbg!(self.body::<Document>());
+                    Err(ErrorKind::InvalidResponse {
+                        message: "invalid server response".into(),
+                    }
+                    .into())
                 }
-                .into()),
             },
         }
     }

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -267,12 +267,10 @@ impl RawCommandResponse {
                     ErrorKind::Command(command_error_body.body.command_error),
                     command_error_body.body.error_labels,
                 )),
-                Err(_) => {
-                    Err(ErrorKind::InvalidResponse {
-                        message: "invalid server response".into(),
-                    }
-                    .into())
+                Err(_) => Err(ErrorKind::InvalidResponse {
+                    message: "invalid server response".into(),
                 }
+                .into()),
             },
         }
     }

--- a/src/cmap/conn/stream_description.rs
+++ b/src/cmap/conn/stream_description.rs
@@ -59,6 +59,9 @@ impl StreamDescription {
                 .logical_session_timeout_minutes
                 .map(|mins| Duration::from_secs(mins as u64 * 60)),
             max_bson_object_size: reply.command_response.max_bson_object_size,
+            // The defaulting to 100,000 is here because mongocryptd doesn't include this field in
+            // hello replies; this should never happen when talking to a real server.
+            // TODO RUST-1532 Remove the defaulting when mongocryptd support is dropped.
             max_write_batch_size: reply
                 .command_response
                 .max_write_batch_size

--- a/src/cmap/conn/stream_description.rs
+++ b/src/cmap/conn/stream_description.rs
@@ -59,7 +59,7 @@ impl StreamDescription {
                 .logical_session_timeout_minutes
                 .map(|mins| Duration::from_secs(mins as u64 * 60)),
             max_bson_object_size: reply.command_response.max_bson_object_size,
-            max_write_batch_size: reply.command_response.max_write_batch_size,
+            max_write_batch_size: reply.command_response.max_write_batch_size.unwrap_or(100_000),
             hello_ok: reply.command_response.hello_ok.unwrap_or(false),
             max_message_size_bytes: reply.command_response.max_message_size_bytes,
             service_id: reply.command_response.service_id,

--- a/src/cmap/conn/stream_description.rs
+++ b/src/cmap/conn/stream_description.rs
@@ -59,7 +59,10 @@ impl StreamDescription {
                 .logical_session_timeout_minutes
                 .map(|mins| Duration::from_secs(mins as u64 * 60)),
             max_bson_object_size: reply.command_response.max_bson_object_size,
-            max_write_batch_size: reply.command_response.max_write_batch_size.unwrap_or(100_000),
+            max_write_batch_size: reply
+                .command_response
+                .max_write_batch_size
+                .unwrap_or(100_000),
             hello_ok: reply.command_response.hello_ok.unwrap_or(false),
             max_message_size_bytes: reply.command_response.max_message_size_bytes,
             service_id: reply.command_response.service_id,

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -166,7 +166,7 @@ pub(crate) struct HelloCommandResponse {
     pub max_bson_object_size: i64,
 
     /// The maximum number of write operations permitted in a write batch.
-    pub max_write_batch_size: i64,
+    pub max_write_batch_size: Option<i64>,
 
     /// If the connection is to a load balancer, the id of the selected backend.
     pub service_id: Option<ObjectId>,

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -31,6 +31,8 @@ impl Process {
         Ok(Self { child })
     }
 
+    /// Issue a kill signal to the child process and immediately return; to wait for the process to
+    /// actually exit, use `wait`.
     pub(crate) fn kill(&mut self) -> Result<()> {
         #[cfg(feature = "tokio-runtime")]
         return Ok(self.child.start_kill()?);

--- a/src/runtime/process.rs
+++ b/src/runtime/process.rs
@@ -31,6 +31,13 @@ impl Process {
         Ok(Self { child })
     }
 
+    pub(crate) fn kill(&mut self) -> Result<()> {
+        #[cfg(feature = "tokio-runtime")]
+        return Ok(self.child.start_kill()?);
+        #[cfg(feature = "async-std-runtime")]
+        return Ok(self.child.kill()?);
+    }
+
     pub(crate) async fn wait(&mut self) -> Result<ExitStatus> {
         #[cfg(feature = "tokio-runtime")]
         return Ok(self.child.wait().await?);

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -122,7 +122,7 @@ impl From<TestHelloCommandResponse> for HelloCommandResponse {
             sasl_supported_mechs: test.sasl_supported_mechs,
             speculative_authenticate: test.speculative_authenticate,
             max_bson_object_size: test.max_bson_object_size.unwrap_or(1234),
-            max_write_batch_size: test.max_write_batch_size.unwrap_or(1234),
+            max_write_batch_size: Some(test.max_write_batch_size.unwrap_or(1234)),
             service_id: test.service_id,
             topology_version: test.topology_version,
             compressors: None,

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2497,3 +2497,11 @@ impl CommandEventHandler for DecryptionEventsHandler {
         }
     }
 }
+
+// TODO RUST-1314: implement prose test 15. On-demand AWS Credentials
+
+// TODO RUST-1441: implement prose test 16. Rewrap
+
+// TODO RUST-1417: implement prose test 17. On-demand GCP Credentials
+
+// TODO RUST-1442: implement prose test 18. Azure IMDS Credentials

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2052,6 +2052,35 @@ async fn explicit_encryption_case_3() -> Result<()> {
     Ok(())
 }
 
+// Prose test 11. Explicit Encryption (Case 4: can roundtrip encrypted indexed)
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn explicit_encryption_case_4() -> Result<()> {
+    if !check_env("explicit_encryption_case_4", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_exclusively().await;
+
+    let testdata = match explicit_encryption_setup().await? {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+
+    let raw_value = RawBson::String("encrypted indexed value".to_string());
+    let payload = testdata.client_encryption.encrypt(
+        raw_value.clone(),
+        EncryptOptions::builder()
+            .key(EncryptKey::Id(testdata.key1_id.clone()))
+            .algorithm(Algorithm::Indexed)
+            .contention_factor(0)
+            .build(),
+    ).await?;
+    let roundtrip = testdata.client_encryption.decrypt(payload.as_raw_binary()).await?;
+    assert_eq!(raw_value, roundtrip);
+
+    Ok(())
+}
+
 struct ExplicitEncryptionTestData {
     key1_id: Binary,
     client_encryption: ClientEncryption,

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1345,15 +1345,13 @@ async fn bypass_mongocryptd_via_bypass_spawn() -> Result<()> {
         Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
 
     // Test: insert fails.
-    let result = client_encrypted
+    let err = client_encrypted
         .database("db")
         .collection::<Document>("coll")
         .insert_one(doc! { "encrypted": "test" }, None)
-        .await;
-    assert!(matches!(
-        result.unwrap_err().kind.as_ref(),
-        ErrorKind::InvalidArgument { .. }
-    ));
+        .await
+        .unwrap_err();
+    assert!(err.is_server_selection_error(), "unexpected error: {}", err);
 
     Ok(())
 }

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1417,7 +1417,7 @@ impl DeadlockTestCase {
             .create_collection(
                 "coll",
                 CreateCollectionOptions::builder()
-                    .validator(load_testdata("external-schema.json")?)
+                    .validator(doc! { "$jsonSchema": load_testdata("external-schema.json")? })
                     .build(),
             )
             .await?;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1697,7 +1697,7 @@ impl DeadlockExpectation {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn kms_tls() -> Result<()> {
-    if !check_env("kms_tls", false) {
+    if !check_env("kms_tls", true) {
         return Ok(());
     }
     let _guard = LOCK.run_exclusively().await;
@@ -1753,7 +1753,7 @@ async fn run_kms_tls_test(endpoint: impl Into<String>) -> crate::error::Result<(
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn kms_tls_options() -> Result<()> {
-    if !check_env("kms_tls_options", false) {
+    if !check_env("kms_tls_options", true) {
         return Ok(());
     }
     let _guard = LOCK.run_exclusively().await;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -22,11 +22,12 @@ use crate::{
     coll::options::{CollectionOptions, InsertOneOptions},
     db::options::CreateCollectionOptions,
     error::ErrorKind,
+    event::command::CommandStartedEvent,
     options::{ReadConcern, WriteConcern},
     test::{Event, EventHandler, SdamEvent},
     Client,
     Collection,
-    Namespace, event::command::CommandStartedEvent,
+    Namespace,
 };
 
 use super::{log_uncaptured, EventClient, TestClient, CLIENT_OPTIONS, LOCK};
@@ -1289,7 +1290,7 @@ async fn bypass_mongocryptd_via_bypass_spawn() -> Result<()> {
     let extra_options = doc! {
         "mongocryptdBypassSpawn": true,
         "mongocryptdURI": "mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000",
-        "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],      
+        "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],
     };
     let auto_enc_opts = AutoEncryptionOptions::builder()
         .key_vault_namespace(KV_NAMESPACE.clone())
@@ -1299,22 +1300,30 @@ async fn bypass_mongocryptd_via_bypass_spawn() -> Result<()> {
         .disable_crypt_shared(true)
         .build();
     let client_encrypted =
-        Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts)
-            .await?;
+        Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
 
     // Test: insert fails.
-    let result = client_encrypted.database("db").collection::<Document>("coll").insert_one(doc! { "encrypted": "test" }, None).await;
-    assert!(matches!(result.unwrap_err().kind.as_ref(), ErrorKind::InvalidArgument { .. }));
+    let result = client_encrypted
+        .database("db")
+        .collection::<Document>("coll")
+        .insert_one(doc! { "encrypted": "test" }, None)
+        .await;
+    assert!(matches!(
+        result.unwrap_err().kind.as_ref(),
+        ErrorKind::InvalidArgument { .. }
+    ));
 
     Ok(())
 }
 
-async fn bypass_mongocryptd_unencrypted_insert(conf: impl FnOnce(&mut AutoEncryptionOptions)) -> Result<()> {
+async fn bypass_mongocryptd_unencrypted_insert(
+    conf: impl FnOnce(&mut AutoEncryptionOptions),
+) -> Result<()> {
     let _guard = LOCK.run_exclusively().await;
 
     // Setup: encrypted client.
     let extra_options = doc! {
-        "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],      
+        "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],
     };
     let mut auto_enc_opts = AutoEncryptionOptions::builder()
         .key_vault_namespace(KV_NAMESPACE.clone())
@@ -1324,15 +1333,19 @@ async fn bypass_mongocryptd_unencrypted_insert(conf: impl FnOnce(&mut AutoEncryp
         .build();
     conf(&mut auto_enc_opts);
     let client_encrypted =
-        Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts)
-            .await?;
+        Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
 
     // Test: insert succeeds.
-    client_encrypted.database("db").collection::<Document>("coll").insert_one(doc! { "unencrypted": "test" }, None).await?;
+    client_encrypted
+        .database("db")
+        .collection::<Document>("coll")
+        .insert_one(doc! { "unencrypted": "test" }, None)
+        .await?;
     // Test: mongocryptd not spawned.
     assert!(!client_encrypted.mongocryptd_spawned().await);
     // Test: attempting to connect fails.
-    let result = Client::with_uri_str("mongodb://localhost:27021/?serverSelectionTimeoutMS=1000").await;
+    let result =
+        Client::with_uri_str("mongodb://localhost:27021/?serverSelectionTimeoutMS=1000").await;
     assert!(result.unwrap_err().is_server_selection_error());
 
     Ok(())
@@ -1345,7 +1358,10 @@ async fn bypass_mongocryptd_via_bypass_auto_encryption() -> Result<()> {
     if !check_env("bypass_mongocryptd_via_bypass_auto_encryption", false) {
         return Ok(());
     }
-    bypass_mongocryptd_unencrypted_insert(|opts| { opts.bypass_auto_encryption = Some(true); }).await
+    bypass_mongocryptd_unencrypted_insert(|opts| {
+        opts.bypass_auto_encryption = Some(true);
+    })
+    .await
 }
 
 // Prose test 8. Bypass Spawning mongocryptd (Via bypassQueryAnalysis)
@@ -1355,7 +1371,10 @@ async fn bypass_mongocryptd_via_bypass_query_analysis() -> Result<()> {
     if !check_env("bypass_mongocryptd_via_bypass_query_analysis", false) {
         return Ok(());
     }
-    bypass_mongocryptd_unencrypted_insert(|opts| { opts.bypass_query_analysis = Some(true); }).await
+    bypass_mongocryptd_unencrypted_insert(|opts| {
+        opts.bypass_query_analysis = Some(true);
+    })
+    .await
 }
 
 // Prose test 9. Deadlock Tests
@@ -1392,7 +1411,9 @@ async fn deadlock() -> Result<()> {
         ],
         expected_keyvault_commands: vec![],
         expected_number_of_clients: 2,
-    }.run().await?;
+    }
+    .run()
+    .await?;
     // Case 2
     DeadlockTestCase {
         max_pool_size: 1,
@@ -1412,14 +1433,14 @@ async fn deadlock() -> Result<()> {
                 db: "db",
             },
         ],
-        expected_keyvault_commands: vec![
-            DeadlockExpectation {
-                command: "find",
-                db: "keyvault",
-            },
-        ],
+        expected_keyvault_commands: vec![DeadlockExpectation {
+            command: "find",
+            db: "keyvault",
+        }],
         expected_number_of_clients: 2,
-    }.run().await?;
+    }
+    .run()
+    .await?;
     // Case 3
     DeadlockTestCase {
         max_pool_size: 1,
@@ -1437,26 +1458,26 @@ async fn deadlock() -> Result<()> {
         ],
         expected_keyvault_commands: vec![],
         expected_number_of_clients: 2,
-    }.run().await?;
+    }
+    .run()
+    .await?;
     // Case 4
     DeadlockTestCase {
         max_pool_size: 1,
         bypass_auto_encryption: true,
         set_key_vault_client: true,
-        expected_encrypted_commands: vec![
-            DeadlockExpectation {
-                command: "find",
-                db: "db",
-            },
-        ],
-        expected_keyvault_commands: vec![
-            DeadlockExpectation {
-                command: "find",
-                db: "keyvault",
-            },
-        ],
+        expected_encrypted_commands: vec![DeadlockExpectation {
+            command: "find",
+            db: "db",
+        }],
+        expected_keyvault_commands: vec![DeadlockExpectation {
+            command: "find",
+            db: "keyvault",
+        }],
         expected_number_of_clients: 1,
-    }.run().await?;
+    }
+    .run()
+    .await?;
     // Case 5: skipped (unlimited max_pool_size not supported)
     // Case 6: skipped (unlimited max_pool_size not supported)
     // Case 7: skipped (unlimited max_pool_size not supported)
@@ -1482,10 +1503,19 @@ impl DeadlockTestCase {
             let mut opts = CLIENT_OPTIONS.get().await.clone();
             opts.max_pool_size = Some(1);
             opts
-        }).await;
+        })
+        .await;
         let mut keyvault_events = client_keyvault.subscribe_to_events();
-        client_test.database("keyvault").collection::<Document>("datakeys").drop(None).await?;
-        client_test.database("db").collection::<Document>("coll").drop(None).await?;
+        client_test
+            .database("keyvault")
+            .collection::<Document>("datakeys")
+            .drop(None)
+            .await?;
+        client_test
+            .database("db")
+            .collection::<Document>("coll")
+            .drop(None)
+            .await?;
         client_keyvault
             .database("keyvault")
             .collection::<Document>("datakeys")
@@ -1510,22 +1540,30 @@ impl DeadlockTestCase {
                 .key_vault_client(client_test.clone().into_client())
                 .key_vault_namespace(KV_NAMESPACE.clone())
                 .kms_providers(LOCAL_KMS.clone())
-                .build()
-        )?;
-        let ciphertext = client_encryption.encrypt(
-            RawBson::String("string0".to_string()),
-            EncryptOptions::builder()
-                .algorithm(Algorithm::AeadAes256CbcHmacSha512Deterministic)
-                .key(EncryptKey::AltName("local".to_string()))
                 .build(),
-        ).await?;
+        )?;
+        let ciphertext = client_encryption
+            .encrypt(
+                RawBson::String("string0".to_string()),
+                EncryptOptions::builder()
+                    .algorithm(Algorithm::AeadAes256CbcHmacSha512Deterministic)
+                    .key(EncryptKey::AltName("local".to_string()))
+                    .build(),
+            )
+            .await?;
 
         // Run test case
         let auto_enc_opts = AutoEncryptionOptions::builder()
             .key_vault_namespace(KV_NAMESPACE.clone())
             .kms_providers(LOCAL_KMS.clone())
             .bypass_auto_encryption(self.bypass_auto_encryption)
-            .key_vault_client(if self.set_key_vault_client { Some(client_keyvault.clone().into_client()) } else { None })
+            .key_vault_client(
+                if self.set_key_vault_client {
+                    Some(client_keyvault.clone().into_client())
+                } else {
+                    None
+                },
+            )
             .extra_options(EXTRA_OPTIONS.clone())
             .build();
         let event_handler = Arc::new(EventHandler::new());
@@ -1540,26 +1578,29 @@ impl DeadlockTestCase {
             client_test
                 .database("db")
                 .collection::<Document>("coll")
-                .insert_one(doc! { "_id": 0, "encrypted": ciphertext }, None).await?;
+                .insert_one(doc! { "_id": 0, "encrypted": ciphertext }, None)
+                .await?;
         } else {
             client_encrypted
                 .database("db")
                 .collection::<Document>("coll")
-                .insert_one(doc! { "_id": 0, "encrypted": "string0" }, None).await?;
+                .insert_one(doc! { "_id": 0, "encrypted": "string0" }, None)
+                .await?;
         }
 
         let found = client_encrypted
             .database("db")
             .collection::<Document>("coll")
-            .find_one(doc! { "_id": 0 }, None).await?;
+            .find_one(doc! { "_id": 0 }, None)
+            .await?;
         assert_eq!(found, Some(doc! { "_id": 0, "encrypted": "string0" }));
 
-        let encrypted_events = encrypted_events.collect_events(Duration::from_millis(500), |_| true).await;
+        let encrypted_events = encrypted_events
+            .collect_events(Duration::from_millis(500), |_| true)
+            .await;
         let client_count = encrypted_events
             .iter()
-            .filter(|ev| {
-                matches!(ev, Event::Sdam(SdamEvent::TopologyOpening(_)))
-            })
+            .filter(|ev| matches!(ev, Event::Sdam(SdamEvent::TopologyOpening(_))))
             .count();
         assert_eq!(self.expected_number_of_clients, client_count);
 
@@ -1572,7 +1613,9 @@ impl DeadlockTestCase {
         }
 
         let keyvault_commands = keyvault_events
-            .collect_events_map(Duration::from_millis(500), |ev| ev.into_command_started_event())
+            .collect_events_map(Duration::from_millis(500), |ev| {
+                ev.into_command_started_event()
+            })
             .await;
         for expected in &self.expected_keyvault_commands {
             expected.assert_matches_any("keyvault", &keyvault_commands);
@@ -1599,7 +1642,10 @@ impl DeadlockExpectation {
                 return;
             }
         }
-        panic!("No {} command matching {:?} found, events=\n{:?}", name, self, commands);
+        panic!(
+            "No {} command matching {:?} found, events=\n{:?}",
+            name, self, commands
+        );
     }
 }
 
@@ -1614,11 +1660,19 @@ async fn kms_tls() -> Result<()> {
 
     // Invalid KMS Certificate
     let err = run_kms_tls_test("127.0.0.1:9000").await.unwrap_err();
-    assert!(err.to_string().contains("certificate verify failed"), "unexpected error: {}", err);
+    assert!(
+        err.to_string().contains("certificate verify failed"),
+        "unexpected error: {}",
+        err
+    );
 
     // Invalid Hostname in KMS Certificate
     let err = run_kms_tls_test("127.0.0.1:9001").await.unwrap_err();
-    assert!(err.to_string().contains("certificate verify failed"), "unexpected error: {}", err);
+    assert!(
+        err.to_string().contains("certificate verify failed"),
+        "unexpected error: {}",
+        err
+    );
 
     Ok(())
 }
@@ -1634,14 +1688,160 @@ async fn run_kms_tls_test(endpoint: impl Into<String>) -> crate::error::Result<(
     let client_encryption = ClientEncryption::new(enc_opts)?;
 
     // Test
-    client_encryption.create_data_key(
-        &KmsProvider::Aws,
-        &DataKeyOptions::builder()
-            .master_key(MasterKey::Aws {
-                region: "us-east-1".to_string(),
-                key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0".to_string(),
-                endpoint: Some(endpoint.into()),
-            })
+    client_encryption
+        .create_data_key(
+            &KmsProvider::Aws,
+            DataKeyOptions::builder()
+                .master_key(MasterKey::Aws {
+                    region: "us-east-1".to_string(),
+                    key: "arn:aws:kms:us-east-1:579766882180:key/\
+                          89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+                        .to_string(),
+                    endpoint: Some(endpoint.into()),
+                })
+                .build(),
+        )
+        .await
+        .map(|_| ())
+}
+
+// Prose test 10. KMS TLS Options Tests
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn kms_tls_options() -> Result<()> {
+    if !check_env("kms_tls_options", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_exclusively().await;
+
+    // Setup
+    let mut providers = KMS_PROVIDERS.clone();
+    providers
+        .get_mut(&KmsProvider::Azure)
+        .unwrap()
+        .insert("identityPlatformEndpoint", "127.0.0.1:9002");
+    providers
+        .get_mut(&KmsProvider::Gcp)
+        .unwrap()
+        .insert("endpoint", "127.0.0.1:9002");
+    let cert_dir = PathBuf::from(std::env::var("CSFLE_TLS_CERT_DIR").unwrap());
+    let ca_path = cert_dir.join("ca.pem");
+    let key_path = cert_dir.join("client.pem");
+
+    fn build_kms_tls_opts(tls_opts: &TlsOptions) -> KmsProvidersTlsOptions {
+        [
+            (KmsProvider::Aws, tls_opts.clone()),
+            (KmsProvider::Azure, tls_opts.clone()),
+            (KmsProvider::Gcp, tls_opts.clone()),
+            (KmsProvider::Kmip, tls_opts.clone()),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    let client_encryption_no_client_cert = ClientEncryption::new(
+        ClientEncryptionOptions::builder()
+            .key_vault_namespace(KV_NAMESPACE.clone())
+            .key_vault_client(TestClient::new().await.into_client())
+            .kms_providers(providers.clone())
+            .tls_options(build_kms_tls_opts(
+                &TlsOptions::builder().ca_file_path(ca_path.clone()).build(),
+            ))
             .build(),
-    ).await.map(|_| ())
+    )?;
+
+    let client_encryption_with_tls = ClientEncryption::new(
+        ClientEncryptionOptions::builder()
+            .key_vault_namespace(KV_NAMESPACE.clone())
+            .key_vault_client(TestClient::new().await.into_client())
+            .kms_providers(providers.clone())
+            .tls_options(build_kms_tls_opts(
+                &TlsOptions::builder()
+                    .ca_file_path(ca_path.clone())
+                    .cert_key_file_path(key_path.clone())
+                    .build(),
+            ))
+            .build(),
+    )?;
+
+    let client_encryption_expired = {
+        let mut providers = providers.clone();
+        providers
+            .get_mut(&KmsProvider::Azure)
+            .unwrap()
+            .insert("identityPlatformEndpoint", "127.0.0.1:9000");
+        providers
+            .get_mut(&KmsProvider::Gcp)
+            .unwrap()
+            .insert("endpoint", "127.0.0.1:9000");
+        providers
+            .get_mut(&KmsProvider::Kmip)
+            .unwrap()
+            .insert("endpoint", "127.0.0.1:9000");
+
+        ClientEncryption::new(
+            ClientEncryptionOptions::builder()
+                .key_vault_namespace(KV_NAMESPACE.clone())
+                .key_vault_client(TestClient::new().await.into_client())
+                .kms_providers(providers)
+                .tls_options(build_kms_tls_opts(
+                    &TlsOptions::builder()
+                        .ca_file_path(ca_path.clone())
+                        .build(),
+                ))
+                .build(),
+        )?
+    };
+
+    let client_encryption_invalid_hostname = {
+        let mut providers = providers.clone();
+        providers
+            .get_mut(&KmsProvider::Azure)
+            .unwrap()
+            .insert("identityPlatformEndpoint", "127.0.0.1:9001");
+        providers
+            .get_mut(&KmsProvider::Gcp)
+            .unwrap()
+            .insert("endpoint", "127.0.0.1:9001");
+        providers
+            .get_mut(&KmsProvider::Kmip)
+            .unwrap()
+            .insert("endpoint", "127.0.0.1:9001");
+
+        ClientEncryption::new(
+            ClientEncryptionOptions::builder()
+                .key_vault_namespace(KV_NAMESPACE.clone())
+                .key_vault_client(TestClient::new().await.into_client())
+                .kms_providers(providers)
+                .tls_options(build_kms_tls_opts(
+                    &TlsOptions::builder()
+                        .ca_file_path(ca_path.clone())
+                        .build(),
+                ))
+                .build(),
+        )?
+    };
+
+    // Case 1: AWS
+    async fn aws_test(client_encryption: &ClientEncryption, endpoint: impl Into<String>, err_str: &str) {
+        let aws_key_opts = DataKeyOptions::builder()
+            .master_key(MasterKey::Aws {
+                    region: "us-east-1".to_string(),
+                    key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0".to_string(),
+                    endpoint: Some(endpoint.into()),
+                })
+            .build();
+        let err = client_encryption.create_data_key(
+            &KmsProvider::Aws,
+            aws_key_opts,
+        ).await.unwrap_err();
+        assert!(err.to_string().contains(err_str), "unexpected error: {}", err);
+    }
+
+    aws_test(&client_encryption_no_client_cert, "127.0.0.1:9002", "handshake failure").await;
+    aws_test(&client_encryption_with_tls, "127.0.0.1:9002", "parse error").await;
+    aws_test(&client_encryption_expired, "127.0.0.1:9000", "certificate verify failed").await;
+    aws_test(&client_encryption_invalid_hostname, "127.0.0.1:9001", "certificate verify failed").await;
+
+    Ok(())
 }

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2173,7 +2173,7 @@ async fn explicit_encryption_case_3() -> Result<()> {
     let insert_payload = testdata
         .client_encryption
         .encrypt(
-            RawBson::String("encrypted indexed value".to_string()),
+            RawBson::String("encrypted unindexed value".to_string()),
             EncryptOptions::builder()
                 .key(EncryptKey::Id(testdata.key1_id.clone()))
                 .algorithm(Algorithm::Unindexed)
@@ -2181,7 +2181,10 @@ async fn explicit_encryption_case_3() -> Result<()> {
         )
         .await?;
     enc_coll
-        .insert_one(doc! { "_id": 1, "encryptedIndexed": insert_payload }, None)
+        .insert_one(
+            doc! { "_id": 1, "encryptedUnindexed": insert_payload },
+            None,
+        )
         .await?;
 
     let found: Vec<_> = enc_coll
@@ -2191,8 +2194,8 @@ async fn explicit_encryption_case_3() -> Result<()> {
         .await?;
     assert_eq!(1, found.len());
     assert_eq!(
-        "encrypted indexed value",
-        found[0].get_str("encryptedIndexed")?
+        "encrypted unindexed value",
+        found[0].get_str("encryptedUnindexed")?
     );
 
     Ok(())
@@ -2247,7 +2250,7 @@ async fn explicit_encryption_case_5() -> Result<()> {
         None => return Ok(()),
     };
 
-    let raw_value = RawBson::String("encrypted indexed value".to_string());
+    let raw_value = RawBson::String("encrypted unindexed value".to_string());
     let payload = testdata
         .client_encryption
         .encrypt(

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -109,6 +109,8 @@ lazy_static! {
         let tls_options: KmsProvidersTlsOptions = [(KmsProvider::Kmip, kmip_opts)].into_iter().collect();
         tls_options
     };
+    static ref DISABLE_CRYPT_SHARED: bool = std::env::var("DISABLE_CRYPT_SHARED")
+        .map_or(false, |s| s == "true");
 }
 
 fn check_env(name: &str, kmip: bool) -> bool {
@@ -224,6 +226,7 @@ async fn data_key_double_encryption() -> Result<()> {
         .schema_map(schema_map)
         .tls_options(KMIP_TLS_OPTIONS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
+        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
         .build();
     let client_encrypted =
         Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
@@ -435,6 +438,7 @@ async fn external_key_vault() -> Result<()> {
             .kms_providers(LOCAL_KMS.clone())
             .schema_map(schema_map)
             .extra_options(EXTRA_OPTIONS.clone())
+            .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
             .build();
         let client_encrypted =
             Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts)
@@ -537,6 +541,7 @@ async fn bson_size_limits() -> Result<()> {
         .key_vault_namespace(KV_NAMESPACE.clone())
         .kms_providers(LOCAL_KMS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
+        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
         .build();
     let client_encrypted = Client::with_encryption_options(opts, auto_enc_opts).await?;
     let coll = client_encrypted
@@ -660,6 +665,7 @@ async fn views_prohibited() -> Result<()> {
         .key_vault_namespace(KV_NAMESPACE.clone())
         .kms_providers(LOCAL_KMS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
+        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
         .build();
     let client_encrypted =
         Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
@@ -766,6 +772,7 @@ async fn run_corpus_test(local_schema: bool) -> Result<()> {
         .kms_providers(KMS_PROVIDERS.clone())
         .tls_options(KMIP_TLS_OPTIONS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
+        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
         .schema_map(schema_map)
         .build();
     let client_encrypted =
@@ -1603,6 +1610,7 @@ impl DeadlockTestCase {
                 },
             )
             .extra_options(EXTRA_OPTIONS.clone())
+            .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
             .build();
         let event_handler = Arc::new(EventHandler::new());
         let mut encrypted_events = event_handler.subscribe();
@@ -2330,6 +2338,7 @@ async fn explicit_encryption_setup() -> Result<Option<ExplicitEncryptionTestData
             .kms_providers(LOCAL_KMS.clone())
             .bypass_query_analysis(true)
             .extra_options(EXTRA_OPTIONS.clone())
+            .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
             .build(),
     )
     .await?;
@@ -2684,6 +2693,7 @@ impl DecryptionEventsTestdata {
                 .key_vault_namespace(KV_NAMESPACE.clone())
                 .kms_providers(LOCAL_KMS.clone())
                 .extra_options(EXTRA_OPTIONS.clone())
+                .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
                 .build(),
         )
         .await?;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1884,7 +1884,7 @@ async fn kms_tls_options() -> Result<()> {
     aws_test(
         &client_encryption_no_client_cert,
         "127.0.0.1:9002",
-        "handshake failure",
+        "SSL routines",
     )
     .await;
     aws_test(&client_encryption_with_tls, "127.0.0.1:9002", "parse error").await;
@@ -1921,7 +1921,7 @@ async fn kms_tls_options() -> Result<()> {
         );
     }
 
-    azure_test(&client_encryption_no_client_cert, "handshake failure").await;
+    azure_test(&client_encryption_no_client_cert, "SSL routines").await;
     azure_test(&client_encryption_with_tls, "HTTP status=404").await;
     azure_test(&client_encryption_expired, "certificate verify failed").await;
     azure_test(
@@ -1953,7 +1953,7 @@ async fn kms_tls_options() -> Result<()> {
         );
     }
 
-    gcp_test(&client_encryption_no_client_cert, "handshake failure").await;
+    gcp_test(&client_encryption_no_client_cert, "SSL routines").await;
     gcp_test(&client_encryption_with_tls, "HTTP status=404").await;
     gcp_test(&client_encryption_expired, "certificate verify failed").await;
     gcp_test(
@@ -1981,7 +1981,7 @@ async fn kms_tls_options() -> Result<()> {
         );
     }
 
-    kmip_test(&client_encryption_no_client_cert, "handshake failure").await;
+    kmip_test(&client_encryption_no_client_cert, "SSL routines").await;
     // This one succeeds!
     client_encryption_with_tls
         .create_data_key(

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -226,7 +226,7 @@ async fn data_key_double_encryption() -> Result<()> {
         .schema_map(schema_map)
         .tls_options(KMIP_TLS_OPTIONS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
-        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+        .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
         .build();
     let client_encrypted =
         Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
@@ -438,7 +438,7 @@ async fn external_key_vault() -> Result<()> {
             .kms_providers(LOCAL_KMS.clone())
             .schema_map(schema_map)
             .extra_options(EXTRA_OPTIONS.clone())
-            .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+            .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
             .build();
         let client_encrypted =
             Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts)
@@ -541,7 +541,7 @@ async fn bson_size_limits() -> Result<()> {
         .key_vault_namespace(KV_NAMESPACE.clone())
         .kms_providers(LOCAL_KMS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
-        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+        .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
         .build();
     let client_encrypted = Client::with_encryption_options(opts, auto_enc_opts).await?;
     let coll = client_encrypted
@@ -665,7 +665,7 @@ async fn views_prohibited() -> Result<()> {
         .key_vault_namespace(KV_NAMESPACE.clone())
         .kms_providers(LOCAL_KMS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
-        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+        .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
         .build();
     let client_encrypted =
         Client::with_encryption_options(CLIENT_OPTIONS.get().await.clone(), auto_enc_opts).await?;
@@ -772,7 +772,7 @@ async fn run_corpus_test(local_schema: bool) -> Result<()> {
         .kms_providers(KMS_PROVIDERS.clone())
         .tls_options(KMIP_TLS_OPTIONS.clone())
         .extra_options(EXTRA_OPTIONS.clone())
-        .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+        .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
         .schema_map(schema_map)
         .build();
     let client_encrypted =
@@ -1608,7 +1608,7 @@ impl DeadlockTestCase {
                 },
             )
             .extra_options(EXTRA_OPTIONS.clone())
-            .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+            .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
             .build();
         let event_handler = Arc::new(EventHandler::new());
         let mut encrypted_events = event_handler.subscribe();
@@ -2336,7 +2336,7 @@ async fn explicit_encryption_setup() -> Result<Option<ExplicitEncryptionTestData
             .kms_providers(LOCAL_KMS.clone())
             .bypass_query_analysis(true)
             .extra_options(EXTRA_OPTIONS.clone())
-            .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+            .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
             .build(),
     )
     .await?;
@@ -2691,7 +2691,7 @@ impl DecryptionEventsTestdata {
                 .key_vault_namespace(KV_NAMESPACE.clone())
                 .kms_providers(LOCAL_KMS.clone())
                 .extra_options(EXTRA_OPTIONS.clone())
-                .disable_crypt_shared(DISABLE_CRYPT_SHARED.clone())
+                .disable_crypt_shared(*DISABLE_CRYPT_SHARED)
                 .build(),
         )
         .await?;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -93,7 +93,10 @@ lazy_static! {
         out.retain(|k, _| *k == KmsProvider::Local);
         out
     };
-    static ref EXTRA_OPTIONS: Document = doc! { "cryptSharedLibPath": std::env::var("CSFLE_SHARED_LIB_PATH").unwrap() };
+    static ref EXTRA_OPTIONS: Document = doc! {
+        "cryptSharedLibPath": std::env::var("CSFLE_SHARED_LIB_PATH").unwrap(),
+        "mongocryptdBypassSpawn": true,
+    };
     static ref KV_NAMESPACE: Namespace = Namespace::from_str("keyvault.datakeys").unwrap();
     static ref KMIP_TLS_OPTIONS: KmsProvidersTlsOptions = {
             /* If these options are used, the test will need a running KMIP server:

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1602,3 +1602,38 @@ impl DeadlockExpectation {
         panic!("No {} command matching {:?} found, events=\n{:?}", name, self, commands);
     }
 }
+
+// Prose test 10. KMS TLS Tests (Invalid KMS Certificate)
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn kms_tls_invalid_certificate() -> Result<()> {
+    if !check_env("kms_tls_invalid_certificate", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_exclusively().await;
+
+    // Setup
+    let kv_client = TestClient::new().await;
+    let enc_opts = ClientEncryptionOptions::builder()
+        .key_vault_namespace(KV_NAMESPACE.clone())
+        .key_vault_client(kv_client.clone().into_client())
+        .kms_providers(KMS_PROVIDERS.clone())
+        .build();
+    let client_encryption = ClientEncryption::new(enc_opts)?;
+
+    // Test
+    let result = client_encryption.create_data_key(
+        &KmsProvider::Aws,
+        &DataKeyOptions::builder()
+            .master_key(MasterKey::Aws {
+                region: "us-east-1".to_string(),
+                key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0".to_string(),
+                endpoint: Some("127.0.0.1:9000".to_string()),
+            })
+            .build(),
+    ).await;
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("certificate verify failed"), "unexpected error: {}", err);
+
+    Ok(())
+}

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1955,6 +1955,23 @@ async fn explicit_encryption_case_1() -> Result<()> {
     Ok(())
 }
 
+// Prose test 11. Explicit Encryption (Case 2: can insert encrypted indexed and find with non-zero contention)
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn explicit_encryption_case_2() -> Result<()> {
+    if !check_env("explicit_encryption", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_exclusively().await;
+
+    let testdata = match explicit_encryption_setup().await? {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+
+    Ok(())
+}
+
 struct ExplicitEncryptionTestData {
     key1_id: Binary,
     client_encryption: ClientEncryption,

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -377,7 +377,7 @@ async fn data_key_double_encryption() -> Result<()> {
             .await;
         let err = result.unwrap_err();
         assert!(
-            matches!(*err.kind, ErrorKind::Csfle(..)),
+            matches!(*err.kind, ErrorKind::Csfle(..)) || err.is_command_error(),
             "unexpected error: {}",
             err
         );

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1269,3 +1269,10 @@ async fn custom_endpoint_kmip_invalid_endpoint() -> Result<()> {
 
     Ok(())
 }
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn bypass_mongocryptd_via_bypass_spawn() -> Result<()> {
+
+    Ok(())
+}

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -19,7 +19,7 @@ use crate::{
         EncryptOptions,
         MasterKey,
     },
-    coll::options::{CollectionOptions, InsertOneOptions},
+    coll::options::{CollectionOptions, InsertOneOptions, DropCollectionOptions},
     db::options::CreateCollectionOptions,
     error::ErrorKind,
     event::command::CommandStartedEvent,
@@ -1969,7 +1969,11 @@ async fn explicit_encryption_setup() -> Result<Option<ExplicitEncryptionTestData
     };
 
     let db = key_vault_client.database("db");
-    db.collection::<Document>("explicit_encryption").drop(None).await?;
+    db.collection::<Document>("explicit_encryption").drop(
+        DropCollectionOptions::builder()
+            .encrypted_fields(encrypted_fields.clone())
+            .build()
+    ).await?;
     db.create_collection(
         "explicit_encryption",
         CreateCollectionOptions::builder()

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -93,10 +93,7 @@ lazy_static! {
         out.retain(|k, _| *k == KmsProvider::Local);
         out
     };
-    static ref EXTRA_OPTIONS: Document = doc! {
-        "cryptSharedLibPath": std::env::var("CSFLE_SHARED_LIB_PATH").unwrap(),
-        "mongocryptdBypassSpawn": true,
-    };
+    static ref EXTRA_OPTIONS: Document = doc! { "cryptSharedLibPath": std::env::var("CSFLE_SHARED_LIB_PATH").unwrap() };
     static ref KV_NAMESPACE: Namespace = Namespace::from_str("keyvault.datakeys").unwrap();
     static ref KMIP_TLS_OPTIONS: KmsProvidersTlsOptions = {
             /* If these options are used, the test will need a running KMIP server:

--- a/src/test/spec/json/client-side-encryption/testdata/encryptedFields.json
+++ b/src/test/spec/json/client-side-encryption/testdata/encryptedFields.json
@@ -1,0 +1,33 @@
+{
+    "escCollection": "enxcol_.default.esc",
+    "eccCollection": "enxcol_.default.ecc",
+    "ecocCollection": "enxcol_.default.ecoc",
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedIndexed",
+        "bsonType": "string",
+        "queries": {
+          "queryType": "equality",
+          "contention": {
+            "$numberLong": "0"
+          }
+        }
+      },
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "q83vqxI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedUnindexed",
+        "bsonType": "string"
+      }
+    ]
+  }

--- a/src/test/spec/json/client-side-encryption/testdata/key1-document.json
+++ b/src/test/spec/json/client-side-encryption/testdata/key1-document.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -80,7 +80,7 @@ impl Event {
         }
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "csfle")]
     pub(crate) fn as_command_started_event(&self) -> Option<&CommandStartedEvent> {
         match self {
             Event::Command(CommandEvent::Started(e)) => Some(e),
@@ -88,7 +88,7 @@ impl Event {
         }
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "csfle")]
     pub(crate) fn into_command_started_event(self) -> Option<CommandStartedEvent> {
         match self {
             Self::Command(CommandEvent::Started(ev)) => Some(ev),

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -87,6 +87,14 @@ impl Event {
             _ => None,
         }
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn into_command_started_event(self) -> Option<CommandStartedEvent> {
+        match self {
+            Self::Command(CommandEvent::Started(ev)) => Some(ev),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/test/util/failpoint.rs
+++ b/src/test/util/failpoint.rs
@@ -11,6 +11,8 @@ use crate::{
     Client,
 };
 
+// If you write a tokio test that uses this, make sure to annotate it with
+// tokio::test(flavor = "multi_thread").
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FailPoint {
     #[serde(flatten)]

--- a/src/test/util/failpoint.rs
+++ b/src/test/util/failpoint.rs
@@ -13,6 +13,7 @@ use crate::{
 
 // If you write a tokio test that uses this, make sure to annotate it with
 // tokio::test(flavor = "multi_thread").
+// TODO RUST-1530 Make the error message here better.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FailPoint {
     #[serde(flatten)]

--- a/src/test/util/subscriber.rs
+++ b/src/test/util/subscriber.rs
@@ -45,6 +45,20 @@ impl<H, E: Clone> EventSubscriber<'_, H, E> {
         events
     }
 
+    pub(crate) async fn collect_events_map<F, T>(&mut self, timeout: Duration, mut filter: F) -> Vec<T>
+    where
+        F: FnMut(E) -> Option<T>,
+    {
+        let mut events = Vec::new();
+        let _ = runtime::timeout(timeout, async {
+            while let Some(event) = self.filter_map_event(timeout, &mut filter).await {
+                events.push(event);
+            }
+        })
+        .await;
+        events
+    }
+
     #[allow(dead_code)]
     pub(crate) async fn clear_events(&mut self, timeout: Duration) {
         self.collect_events(timeout, |_| true).await;

--- a/src/test/util/subscriber.rs
+++ b/src/test/util/subscriber.rs
@@ -45,7 +45,7 @@ impl<H, E: Clone> EventSubscriber<'_, H, E> {
         events
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "csfle")]
     pub(crate) async fn collect_events_map<F, T>(
         &mut self,
         timeout: Duration,
@@ -64,7 +64,7 @@ impl<H, E: Clone> EventSubscriber<'_, H, E> {
         events
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "csfle")]
     pub(crate) async fn clear_events(&mut self, timeout: Duration) {
         self.collect_events(timeout, |_| true).await;
     }

--- a/src/test/util/subscriber.rs
+++ b/src/test/util/subscriber.rs
@@ -45,7 +45,12 @@ impl<H, E: Clone> EventSubscriber<'_, H, E> {
         events
     }
 
-    pub(crate) async fn collect_events_map<F, T>(&mut self, timeout: Duration, mut filter: F) -> Vec<T>
+    #[allow(dead_code)]
+    pub(crate) async fn collect_events_map<F, T>(
+        &mut self,
+        timeout: Duration,
+        mut filter: F,
+    ) -> Vec<T>
     where
         F: FnMut(E) -> Option<T>,
     {


### PR DESCRIPTION
RUST-1386

This adds the remaining prose tests, as well as expanding the Evergreen configuration to cover more cases.  I went with a sparse matrix for testing rather than every permutation, as there didn't seem to be much value in the latter.