### PR TITLE
RUST-1536: tidy the client-side encryption API

### DIFF
--- a/src/client/csfle/client_builder.rs
+++ b/src/client/csfle/client_builder.rs
@@ -36,7 +36,7 @@ use super::options::KmsProviders;
 /// # Ok(())
 /// # }
 /// ```
-pub struct EncryptedClientBuilder<const KV_NAMESPACE: bool, const KMS_PROVIDERS: bool> {
+pub struct EncryptedClientBuilder<const KV_NAMESPACE_SET: bool, const KMS_PROVIDERS_SET: bool> {
     client_options: ClientOptions,
     key_vault_namespace: Option<Namespace>,
     kms_providers: Option<KmsProviders>,

--- a/src/client/csfle/client_builder.rs
+++ b/src/client/csfle/client_builder.rs
@@ -14,12 +14,14 @@ use super::options::{AutoEncryptionOptions, KmsProviders};
 /// # let key_vault_namespace = todo!();
 /// # let key_vault_client: Client = todo!();
 /// # let local_key: bson::Binary = todo!();
-/// let encrypted_client = Client::encrypted_builder(client_options)
-///     .key_vault_namespace(key_vault_namespace)
-///     .kms_providers([(KmsProvider::Local, doc! { "key": local_key }, None)])?
-///     .key_vault_client(key_vault_client)
-///     .build()
-///     .await?;
+/// let encrypted_client = Client::encrypted_builder(
+///     client_options,
+///     key_vault_namespace,
+///     [(KmsProvider::Local, doc! { "key": local_key }, None)],
+/// )?
+/// .key_vault_client(key_vault_client)
+/// .build()
+/// .await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/client/csfle/client_builder.rs
+++ b/src/client/csfle/client_builder.rs
@@ -1,0 +1,188 @@
+use std::collections::HashMap;
+
+use mongocrypt::ctx::KmsProvider;
+
+use crate::{
+    bson::Document,
+    client::options::TlsOptions,
+    client_encryption::{BUILDER_SET, BUILDER_UNSET},
+    error::{Error, Result},
+    options::ClientOptions,
+    Client,
+    Namespace,
+};
+
+use super::options::KmsProviders;
+
+/// A builder for constructing a `Client` with auto-encryption enabled.  At least one KMS provider
+/// will need to be set to complete the build.
+///
+/// ```no_run
+/// # use bson::doc;
+/// # use mongocrypt::ctx::KmsProvider;
+/// # use mongodb::Client;
+/// # use mongodb::error::Result;
+/// # async fn func() -> Result<()> {
+/// # let client_options = todo!();
+/// # let key_vault_namespace = todo!();
+/// # let key_vault_client: Client = todo!();
+/// # let local_key: bson::Binary = todo!();
+/// let encrypted_client = Client::encrypted_builder(client_options)
+///     .key_vault_namespace(key_vault_namespace)
+///     .kms_providers([(KmsProvider::Local, doc! { "key": local_key }, None)])?
+///     .key_vault_client(key_vault_client)
+///     .build()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct EncryptedClientBuilder<const KV_NAMESPACE: bool, const KMS_PROVIDERS: bool> {
+    client_options: ClientOptions,
+    key_vault_namespace: Option<Namespace>,
+    kms_providers: Option<KmsProviders>,
+    optional: Optional,
+}
+
+#[derive(Default)]
+struct Optional {
+    key_vault_client: Option<crate::Client>,
+    schema_map: Option<HashMap<String, Document>>,
+    bypass_auto_encryption: Option<bool>,
+    extra_options: Option<Document>,
+    encrypted_fields_map: Option<HashMap<String, Document>>,
+    bypass_query_analysis: Option<bool>,
+    #[cfg(test)]
+    disable_crypt_shared: Option<bool>,    
+}
+
+impl EncryptedClientBuilder<BUILDER_UNSET, BUILDER_UNSET> {
+    pub(crate) fn new(client_options: ClientOptions) -> Self {
+        EncryptedClientBuilder {
+            client_options,
+            key_vault_namespace: None,
+            kms_providers: None,
+            optional: Optional::default(),
+        }
+    }
+}
+
+impl<const KMS_PROVIDERS: bool> EncryptedClientBuilder<BUILDER_UNSET, KMS_PROVIDERS> {
+    /// Set the key vault `Namespace`, referring to a collection that contains all data keys used
+    /// for encryption and decryption.
+    pub fn key_vault_namespace(
+        self,
+        namespace: Namespace,
+    ) -> EncryptedClientBuilder<BUILDER_SET, KMS_PROVIDERS> {
+        EncryptedClientBuilder {
+            client_options: self.client_options,
+            key_vault_namespace: Some(namespace),
+            kms_providers: self.kms_providers,
+            optional: self.optional,
+        }
+    }
+}
+
+impl<const KV_NAMESPACE: bool> EncryptedClientBuilder<KV_NAMESPACE, BUILDER_UNSET> {
+    /// Add configuration for multiple KMS providers.
+    pub fn kms_providers(
+        self,
+        providers: impl IntoIterator<Item = (KmsProvider, bson::Document, Option<TlsOptions>)>,
+    ) -> Result<EncryptedClientBuilder<KV_NAMESPACE, BUILDER_SET>> {
+        Ok(EncryptedClientBuilder {
+            client_options: self.client_options,
+            key_vault_namespace: self.key_vault_namespace,
+            kms_providers: Some(KmsProviders::new(providers)?),
+            optional: self.optional,
+        })
+    }
+}
+
+impl<const KV_NAMESPACE: bool, const KMS_PROVIDERS: bool>
+    EncryptedClientBuilder<KV_NAMESPACE, KMS_PROVIDERS>
+{
+    /// Set the client used for data key queries.  Will default to an internal client if not set.
+    pub fn key_vault_client(mut self, client: impl Into<Option<Client>>) -> Self {
+        self.optional.key_vault_client = client.into();
+        self
+    }
+
+    /// Specify a JSONSchema locally.
+    ///
+    /// Supplying a `schema_map` provides more security than relying on JSON Schemas obtained from
+    /// the server. It protects against a malicious server advertising a false JSON Schema, which
+    /// could trick the client into sending unencrypted data that should be encrypted.
+    ///
+    /// Schemas supplied in the `schema_map` only apply to configuring automatic encryption for
+    /// client side encryption. Other validation rules in the JSON schema will not be enforced by
+    /// the driver and will result in an error.
+    pub fn schema_map(mut self, map: impl IntoIterator<Item = (String, Document)>) -> Self {
+        self.optional.schema_map = Some(map.into_iter().collect());
+        self
+    }
+
+    /// Disable automatic encryption and do not spawn mongocryptd.  Defaults to false.
+    pub fn bypass_auto_encryption(mut self, bypass: impl Into<Option<bool>>) -> Self {
+        self.optional.bypass_auto_encryption = bypass.into();
+        self
+    }
+
+    /// Set options related to mongocryptd.
+    pub fn extra_options(mut self, extra_opts: impl Into<Option<Document>>) -> Self {
+        self.optional.extra_options = extra_opts.into();
+        self
+    }
+
+    /// Maps namespace to encrypted fields.
+    ///
+    /// Supplying an `encrypted_fields_map` provides more security than relying on an
+    /// encryptedFields obtained from the server. It protects against a malicious server
+    /// advertising a false encryptedFields.
+    pub fn encrypted_fields_map(
+        mut self,
+        map: impl IntoIterator<Item = (String, Document)>,
+    ) -> Self {
+        self.optional.encrypted_fields_map = Some(map.into_iter().collect());
+        self
+    }
+
+    /// Disable serverside processing of encrypted indexed fields, allowing use of explicit
+    /// encryption with queryable encryption.
+    pub fn bypass_query_analysis(mut self, bypass: impl Into<Option<bool>>) -> Self {
+        self.optional.bypass_query_analysis = bypass.into();
+        self
+    }
+
+    /// Disable loading crypt_shared.
+    #[cfg(test)]
+    pub(crate) fn disable_crypt_shared(mut self, disable: bool) -> Self {
+        self.optional.disable_crypt_shared = Some(disable);
+        self
+    }
+}
+
+impl EncryptedClientBuilder<BUILDER_SET, BUILDER_SET> {
+    /// Constructs a new `Client` using automatic encryption.  May perform DNS lookups as part of
+    /// `Client` initialization.
+    pub async fn build(self) -> Result<Client> {
+        let client = Client::with_options(self.client_options)?;
+        let enc_options = super::options::AutoEncryptionOptions {
+            key_vault_client: self.optional.key_vault_client,
+            key_vault_namespace: self
+                .key_vault_namespace
+                .ok_or_else(|| Error::internal("missing key_vault_namespace"))?,
+            kms_providers: self
+                .kms_providers
+                .ok_or_else(|| Error::internal("missing kms_providers"))?,
+            schema_map: self.optional.schema_map,
+            bypass_auto_encryption: self.optional.bypass_auto_encryption,
+            extra_options: self.optional.extra_options,
+            encrypted_fields_map: self.optional.encrypted_fields_map,
+            bypass_query_analysis: self.optional.bypass_query_analysis,
+            #[cfg(test)]
+            disable_crypt_shared: self.optional.disable_crypt_shared,
+        };
+        *client.inner.csfle.write().await =
+            Some(super::ClientState::new(&client, enc_options).await?);
+        Ok(client)
+    }
+}

--- a/src/client/csfle/client_builder.rs
+++ b/src/client/csfle/client_builder.rs
@@ -52,7 +52,7 @@ struct Optional {
     encrypted_fields_map: Option<HashMap<String, Document>>,
     bypass_query_analysis: Option<bool>,
     #[cfg(test)]
-    disable_crypt_shared: Option<bool>,    
+    disable_crypt_shared: Option<bool>,
 }
 
 impl EncryptedClientBuilder<BUILDER_UNSET, BUILDER_UNSET> {

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -90,7 +90,7 @@ impl ClientEncryption {
         }
     }
 
-    async fn create_data_key_final(
+    pub(crate) async fn create_data_key_final(
         &self,
         kms_provider: &KmsProvider,
         opts: impl Into<Option<DataKeyOptions>>,
@@ -572,8 +572,8 @@ impl<'a> EncryptAction<'a> {
 
     /// Set the query type.
     #[allow(clippy::redundant_clone)]
-    pub fn query_type(mut self, qtype: impl ToOwned<Owned = String>) -> Self {
-        self.opts.query_type = Some(qtype.to_owned());
+    pub fn query_type(mut self, qtype: impl Into<String>) -> Self {
+        self.opts.query_type = Some(qtype.into());
         self
     }
 }

--- a/src/client/csfle/options.rs
+++ b/src/client/csfle/options.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 
 use bson::Array;
 use mongocrypt::ctx::KmsProvider;
-use typed_builder::TypedBuilder;
 
 use crate::{
-    bson::{doc, Bson, Document},
+    bson::{Bson, Document},
     client::options::TlsOptions,
     error::{Error, Result},
     Namespace,
@@ -20,18 +19,16 @@ use crate::{
 /// https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-allow-list
 /// )). To bypass automatic encryption for all operations, set bypassAutoEncryption=true in
 /// AutoEncryptionOpts.
-#[derive(Debug, TypedBuilder, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
-#[builder(field_defaults(setter(into)))]
-pub struct AutoEncryptionOptions {
+pub(crate) struct AutoEncryptionOptions {
     /// Used for data key queries.  Will default to an internal client if not set.
-    #[builder(default)]
-    pub key_vault_client: Option<crate::Client>,
+    pub(crate) key_vault_client: Option<crate::Client>,
     /// A collection that contains all data keys used for encryption and decryption (aka the key
     /// vault collection).
-    pub key_vault_namespace: Namespace,
+    pub(crate) key_vault_namespace: Namespace,
     /// Options individual to each KMS provider.
-    pub kms_providers: KmsProviders,
+    pub(crate) kms_providers: KmsProviders,
     /// Specify a JSONSchema locally.
     ///
     /// Supplying a `schema_map` provides more security than relying on JSON Schemas obtained from
@@ -41,38 +38,64 @@ pub struct AutoEncryptionOptions {
     /// Schemas supplied in the `schema_map` only apply to configuring automatic encryption for
     /// client side encryption. Other validation rules in the JSON schema will not be enforced by
     /// the driver and will result in an error.
-    #[builder(default)]
-    pub schema_map: Option<HashMap<String, Document>>,
+    pub(crate) schema_map: Option<HashMap<String, Document>>,
     /// Disable automatic encryption and do not spawn mongocryptd.  Defaults to false.
-    #[builder(default)]
-    pub bypass_auto_encryption: Option<bool>,
+    pub(crate) bypass_auto_encryption: Option<bool>,
     /// Options related to mongocryptd.
-    #[builder(default)]
-    pub extra_options: Option<Document>,
-    /// Configure TLS for connections to KMS providers.
-    #[builder(default)]
-    pub tls_options: Option<KmsProvidersTlsOptions>,
+    pub(crate) extra_options: Option<Document>,
     /// Maps namespace to encrypted fields.
     ///
     /// Supplying an `encrypted_fields_map` provides more security than relying on an
     /// encryptedFields obtained from the server. It protects against a malicious server
     /// advertising a false encryptedFields.
-    #[builder(default)]
-    pub encrypted_fields_map: Option<HashMap<String, Document>>,
+    pub(crate) encrypted_fields_map: Option<HashMap<String, Document>>,
     /// Disable serverside processing of encrypted indexed fields, allowing use of explicit
     /// encryption with queryable encryption.
-    #[builder(default)]
-    pub bypass_query_analysis: Option<bool>,
+    pub(crate) bypass_query_analysis: Option<bool>,
     /// Disable loading crypt_shared.
     #[cfg(test)]
-    #[builder(default)]
     pub(crate) disable_crypt_shared: Option<bool>,
 }
 
-/// Options specific to each KMS provider.
-pub type KmsProviders = HashMap<KmsProvider, Document>;
-/// TLS options for connections to each KMS provider.
-pub type KmsProvidersTlsOptions = HashMap<KmsProvider, TlsOptions>;
+#[derive(Debug, Clone)]
+pub(crate) struct KmsProviders {
+    credentials: HashMap<KmsProvider, Document>,
+    tls_options: Option<KmsProvidersTlsOptions>,
+}
+
+pub(crate) type KmsProvidersTlsOptions = HashMap<KmsProvider, TlsOptions>;
+
+impl KmsProviders {
+    pub(crate) fn new(
+        providers: impl IntoIterator<Item = (KmsProvider, bson::Document, Option<TlsOptions>)>,
+    ) -> Result<Self> {
+        let mut credentials = HashMap::new();
+        let mut tls_options = None;
+        for (provider, conf, tls) in providers.into_iter() {
+            credentials.insert(provider.clone(), conf);
+            if let Some(tls) = tls {
+                tls_options
+                    .get_or_insert_with(KmsProvidersTlsOptions::new)
+                    .insert(provider, tls);
+            }
+        }
+        if credentials.is_empty() {
+            return Err(crate::error::Error::invalid_argument("empty kms_providers"));
+        }
+        Ok(Self {
+            credentials,
+            tls_options,
+        })
+    }
+
+    pub(crate) fn credentials(&self) -> Result<Document> {
+        Ok(bson::to_document(&self.credentials)?)
+    }
+
+    pub(crate) fn tls_options(&self) -> &Option<KmsProvidersTlsOptions> {
+        &self.tls_options
+    }
+}
 
 impl AutoEncryptionOptions {
     pub(crate) fn extra_option<'a, Opt: ExtraOption<'a>>(

--- a/src/client/csfle/options.rs
+++ b/src/client/csfle/options.rs
@@ -57,6 +57,23 @@ pub(crate) struct AutoEncryptionOptions {
     pub(crate) disable_crypt_shared: Option<bool>,
 }
 
+impl AutoEncryptionOptions {
+    pub(crate) fn new(key_vault_namespace: Namespace, kms_providers: KmsProviders) -> Self {
+        Self {
+            key_vault_namespace,
+            kms_providers,
+            key_vault_client: None,
+            schema_map: None,
+            bypass_auto_encryption: None,
+            extra_options: None,
+            encrypted_fields_map: None,
+            bypass_query_analysis: None,
+            #[cfg(test)]
+            disable_crypt_shared: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct KmsProviders {
     credentials: HashMap<KmsProvider, Document>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -155,12 +155,14 @@ impl Client {
     /// # let key_vault_namespace = todo!();
     /// # let key_vault_client: Client = todo!();
     /// # let local_key: bson::Binary = todo!();
-    /// let encrypted_client = Client::encrypted_builder(client_options)
-    ///     .key_vault_namespace(key_vault_namespace)
-    ///     .kms_providers([(KmsProvider::Local, doc! { "key": local_key }, None)])?
-    ///     .key_vault_client(key_vault_client)
-    ///     .build()
-    ///     .await?;
+    /// let encrypted_client = Client::encrypted_builder(
+    ///     client_options,
+    ///     key_vault_namespace,
+    ///     [(KmsProvider::Local, doc! { "key": local_key }, None)],
+    /// )?
+    /// .key_vault_client(key_vault_client)
+    /// .build()
+    /// .await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -43,9 +43,6 @@ use crate::runtime;
 
 pub use resolver_config::ResolverConfig;
 
-#[cfg(feature = "csfle")]
-pub use crate::client::csfle::options::AutoEncryptionOptions;
-
 pub(crate) const DEFAULT_PORT: u16 = 27017;
 
 const URI_OPTIONS: &[&str] = &[

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -18,15 +18,8 @@ use lazy_static::lazy_static;
 use mongocrypt::ctx::{Algorithm, KmsProvider};
 
 use crate::{
-    client::{
-        auth::Credential,
-        options::{TlsOptions},
-    },
-    client_encryption::{
-        ClientEncryption,
-        EncryptKey,
-        MasterKey,
-    },
+    client::{auth::Credential, options::TlsOptions},
+    client_encryption::{ClientEncryption, EncryptKey, MasterKey},
     coll::options::{
         CollectionOptions,
         CreateIndexOptions,
@@ -109,7 +102,10 @@ lazy_static! {
         .filter(|(p, ..)| p == &KmsProvider::Local)
         .cloned()
         .collect();
-    pub(crate) static ref KMS_PROVIDERS_MAP: HashMap<mongocrypt::ctx::KmsProvider, (bson::Document, Option<crate::client::options::TlsOptions>)> = {
+    pub(crate) static ref KMS_PROVIDERS_MAP: HashMap<
+        mongocrypt::ctx::KmsProvider,
+        (bson::Document, Option<crate::client::options::TlsOptions>),
+    > = {
         let mut map = HashMap::new();
         for (prov, conf, tls) in KMS_PROVIDERS.clone() {
             map.insert(prov, (conf, tls));
@@ -1319,9 +1315,7 @@ enum Bypass {
     QueryAnalysis,
 }
 
-async fn bypass_mongocryptd_unencrypted_insert(
-    bypass: Bypass,
-) -> Result<()> {
+async fn bypass_mongocryptd_unencrypted_insert(bypass: Bypass) -> Result<()> {
     let _guard = LOCK.run_exclusively().await;
 
     // Setup: encrypted client.
@@ -1685,15 +1679,12 @@ async fn run_kms_tls_test(endpoint: impl Into<String>) -> crate::error::Result<(
 
     // Test
     client_encryption
-        .create_data_key(
-            MasterKey::Aws {
-                    region: "us-east-1".to_string(),
-                    key: "arn:aws:kms:us-east-1:579766882180:key/\
-                          89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
-                        .to_string(),
-                    endpoint: Some(endpoint.into()),
-                }
-        )
+        .create_data_key(MasterKey::Aws {
+            region: "us-east-1".to_string(),
+            key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+                .to_string(),
+            endpoint: Some(endpoint.into()),
+        })
         .run()
         .await
         .map(|_| ())
@@ -1708,14 +1699,19 @@ async fn kms_tls_options() -> Result<()> {
     }
     let _guard = LOCK.run_exclusively().await;
 
-    fn providers_with_tls(mut providers: HashMap<KmsProvider, (Document, Option<TlsOptions>)>, tls_opts: TlsOptions) -> KmsProviderList {
-        for provider in [KmsProvider::Aws, KmsProvider::Azure, KmsProvider::Gcp, KmsProvider::Kmip] {
+    fn providers_with_tls(
+        mut providers: HashMap<KmsProvider, (Document, Option<TlsOptions>)>,
+        tls_opts: TlsOptions,
+    ) -> KmsProviderList {
+        for provider in [
+            KmsProvider::Aws,
+            KmsProvider::Azure,
+            KmsProvider::Gcp,
+            KmsProvider::Kmip,
+        ] {
             providers.get_mut(&provider).unwrap().1 = Some(tls_opts.clone());
         }
-        providers
-            .into_iter()
-            .map(|(p, (o, t))| (p, o, t))
-            .collect()
+        providers.into_iter().map(|(p, (o, t))| (p, o, t)).collect()
     }
 
     // Setup
@@ -1740,7 +1736,7 @@ async fn kms_tls_options() -> Result<()> {
         .key_vault_client(TestClient::new().await.into_client())
         .kms_providers(providers_with_tls(
             base_providers.clone(),
-            TlsOptions::builder().ca_file_path(ca_path.clone()).build()
+            TlsOptions::builder().ca_file_path(ca_path.clone()).build(),
         ))?
         .build()?;
 
@@ -1987,7 +1983,7 @@ async fn explicit_encryption_case_1() -> Result<()> {
         .encrypt(
             "encrypted indexed value",
             EncryptKey::Id(testdata.key1_id.clone()),
-            Algorithm::Indexed
+            Algorithm::Indexed,
         )
         .contention_factor(0)
         .run()

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -35,8 +35,8 @@ pub(crate) use self::{
         TestClient,
     },
 };
-#[cfg(csfle)]
-pub(crate) use self::csfle::{KMIP_TLS_OPTIONS, KMS_PROVIDERS};
+#[cfg(feature = "csfle")]
+pub(crate) use self::csfle::{KmsProviderList, KMS_PROVIDERS_MAP};
 
 use async_once::AsyncOnce;
 use home::home_dir;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -35,6 +35,8 @@ pub(crate) use self::{
         TestClient,
     },
 };
+#[cfg(csfle)]
+pub(crate) use self::csfle::{KMIP_TLS_OPTIONS, KMS_PROVIDERS};
 
 use async_once::AsyncOnce;
 use home::home_dir;
@@ -87,22 +89,6 @@ lazy_static! {
         std::env::var("SERVERLESS_ATLAS_USER").ok();
     pub(crate) static ref SERVERLESS_ATLAS_PASSWORD: Option<String> =
         std::env::var("SERVERLESS_ATLAS_PASSWORD").ok();
-}
-
-#[cfg(feature = "csfle")]
-lazy_static! {
-    pub(crate) static ref KMS_PROVIDERS: crate::client::csfle::options::KmsProviders =
-        serde_json::from_str(&std::env::var("KMS_PROVIDERS").unwrap()).unwrap();
-    pub(crate) static ref KMIP_TLS_OPTIONS: crate::client::csfle::options::KmsProvidersTlsOptions = {
-        let cert_dir = std::path::PathBuf::from(std::env::var("CSFLE_TLS_CERT_DIR").unwrap());
-        let kmip_opts = crate::client::options::TlsOptions::builder()
-            .ca_file_path(cert_dir.join("ca.pem"))
-            .cert_key_file_path(cert_dir.join("client.pem"))
-            .build();
-        [(mongocrypt::ctx::KmsProvider::Kmip, kmip_opts)]
-            .into_iter()
-            .collect()
-    };
 }
 
 // conditional definitions do not work within the lazy_static! macro, so this

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -17,6 +17,8 @@ mod lambda_examples;
 pub mod spec;
 pub(crate) mod util;
 
+#[cfg(feature = "csfle")]
+pub(crate) use self::csfle::{KmsProviderList, KMS_PROVIDERS_MAP};
 pub(crate) use self::{
     spec::{run_single_test, run_spec_test, run_spec_test_with_path, RunOn, Serverless, Topology},
     util::{
@@ -35,8 +37,6 @@ pub(crate) use self::{
         TestClient,
     },
 };
-#[cfg(feature = "csfle")]
-pub(crate) use self::csfle::{KmsProviderList, KMS_PROVIDERS_MAP};
 
 use async_once::AsyncOnce;
 use home::home_dir;

--- a/src/test/spec/unified_runner/operation/csfle.rs
+++ b/src/test/spec/unified_runner/operation/csfle.rs
@@ -145,7 +145,7 @@ impl TestOperation for CreateDataKey {
         async move {
             let ce = test_runner.get_client_encryption(id).await;
             let key = ce
-                .create_data_key(&self.kms_provider, self.opts.clone())
+                .create_data_key_final(&self.kms_provider, self.opts.clone())
                 .await?;
             Ok(Some(Entity::Bson(Bson::Binary(key))))
         }

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -680,7 +680,9 @@ impl TestRunner {
 }
 
 #[cfg(feature = "csfle")]
-fn fill_kms_placeholders(kms_providers: HashMap<mongocrypt::ctx::KmsProvider, Document>) -> KmsProviderList {
+fn fill_kms_placeholders(
+    kms_providers: HashMap<mongocrypt::ctx::KmsProvider, Document>,
+) -> KmsProviderList {
     use crate::test::KMS_PROVIDERS_MAP;
 
     let placeholder = bson::Bson::Document(doc! { "$$placeholder": 1 });

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -702,7 +702,10 @@ fn fill_kms_placeholders(
                 *value = new_value;
             }
         }
-        out.push((provider, config, None))
+        let tls = KMS_PROVIDERS_MAP
+            .get(&provider)
+            .and_then(|(_, t)| t.clone());
+        out.push((provider, config, tls));
     }
     out
 }

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -562,13 +562,12 @@ impl TestRunner {
                     let kms_providers: HashMap<mongocrypt::ctx::KmsProvider, Document> =
                         bson::from_document(opts.kms_providers.clone()).unwrap();
                     let kms_providers = fill_kms_placeholders(kms_providers);
-                    let client_enc = crate::client_encryption::ClientEncryption::builder()
-                        .key_vault_client(kv_client)
-                        .key_vault_namespace(opts.key_vault_namespace.clone())
-                        .kms_providers(kms_providers)
-                        .unwrap()
-                        .build()
-                        .unwrap();
+                    let client_enc = crate::client_encryption::ClientEncryption::new(
+                        kv_client,
+                        opts.key_vault_namespace.clone(),
+                        kms_providers,
+                    )
+                    .unwrap();
                     (id, Entity::ClientEncryption(Arc::new(client_enc)))
                 }
             };


### PR DESCRIPTION
This adds convenience builders for the two entry points (`Client` and `ClientEncryption`), and updates methods on the latter to use the action pattern.