### PR TITLE
minor: fix csfle tests

### DIFF
--- a/src/test/spec/client_side_encryption.rs
+++ b/src/test/spec/client_side_encryption.rs
@@ -2,15 +2,29 @@ use tokio::sync::RwLockWriteGuard;
 
 use crate::test::LOCK;
 
-use super::{run_spec_test_with_path, run_unified_format_test};
+use super::{run_spec_test_with_path, run_unified_format_test_filtered, unified_runner::TestCase};
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run() {
     let _guard: RwLockWriteGuard<()> = LOCK.run_exclusively().await;
-    run_spec_test_with_path(
-        &["client-side-encryption", "unified"],
-        run_unified_format_test,
-    )
+    run_spec_test_with_path(&["client-side-encryption", "unified"], |path, test| {
+        run_unified_format_test_filtered(path, test, spec_predicate)
+    })
     .await;
+}
+
+#[allow(unused_variables)]
+fn spec_predicate(test: &TestCase) -> bool {
+    #[cfg(not(feature = "openssl-tls"))]
+    {
+        if test.description == "create datakey with KMIP KMS provider" {
+            crate::test::log_uncaptured(format!(
+                "Skipping {:?}: KMIP test requires openssl-tls",
+                test.description
+            ));
+            return false;
+        }
+    }
+    true
 }

--- a/src/test/spec/json/testdata/client-side-encryption/encryptedFields.json
+++ b/src/test/spec/json/testdata/client-side-encryption/encryptedFields.json
@@ -1,0 +1,33 @@
+{
+    "escCollection": "enxcol_.default.esc",
+    "eccCollection": "enxcol_.default.ecc",
+    "ecocCollection": "enxcol_.default.ecoc",
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedIndexed",
+        "bsonType": "string",
+        "queries": {
+          "queryType": "equality",
+          "contention": {
+            "$numberLong": "0"
+          }
+        }
+      },
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "q83vqxI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedUnindexed",
+        "bsonType": "string"
+      }
+    ]
+  }

--- a/src/test/spec/json/testdata/client-side-encryption/key1-document.json
+++ b/src/test/spec/json/testdata/client-side-encryption/key1-document.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}


### PR DESCRIPTION
This skips a spec test that requires openssl when that's not enabled, and includes a few accidentally-omitted data files.