### PR TITLE
RUST-1487 Rename "csfle" to "in-use-encryption-unstable"

### DIFF
--- a/.evergreen/feature-combinations.sh
+++ b/.evergreen/feature-combinations.sh
@@ -6,5 +6,5 @@
 export FEATURE_COMBINATIONS=(
     '' # default features
     '--no-default-features --features async-std-runtime,sync' # features that conflict w/ default features
-    '--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth,tracing-unstable,csfle' # additive features
+    '--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth,tracing-unstable,in-use-encryption-unstable' # additive features
 )

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -7,7 +7,7 @@ source ./.evergreen/env.sh
 
 set -o xtrace
 
-FEATURE_FLAGS="csfle,${TLS_FEATURE}"
+FEATURE_FLAGS="in-use-encryption-unstable,${TLS_FEATURE}"
 OPTIONS="-- -Z unstable-options --format json --report-time"
 
 if [ "$SINGLE_THREAD" = true ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ zstd-compression = ["zstd"]
 zlib-compression = ["flate2"]
 snappy-compression = ["snap"]
 
-# DO NOT USE; see https://jira.mongodb.org/browse/RUST-569 for the status of CSFLE support in the Rust driver.
-csfle = ["mongocrypt", "rayon", "num_cpus"]
+# The In Use Encryption API is unstable and may have backwards-incompatible changes in minor version updates.
+in-use-encryption-unstable = ["mongocrypt", "rayon", "num_cpus"]
 
 # DO NOT USE; see https://jira.mongodb.org/browse/RUST-580 for the status of tracing/logging support in the Rust driver.
 # Enables support for emitting tracing events.

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -1,7 +1,7 @@
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 use bson::RawDocumentBuf;
 use bson::{doc, RawBsonRef, RawDocument, Timestamp};
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 use futures_core::future::BoxFuture;
 use lazy_static::lazy_static;
 use serde::de::DeserializeOwned;
@@ -607,7 +607,7 @@ impl Client {
         let target_db = cmd.target_db.clone();
 
         let serialized = op.serialize_command(cmd)?;
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let serialized = {
             let guard = self.inner.csfle.read().await;
             if let Some(ref csfle) = *guard {
@@ -775,7 +775,7 @@ impl Client {
                     })
                 });
 
-                #[cfg(feature = "csfle")]
+                #[cfg(feature = "in-use-encryption-unstable")]
                 let response = {
                     let guard = self.inner.csfle.read().await;
                     if let Some(ref csfle) = *guard {
@@ -801,7 +801,7 @@ impl Client {
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     fn auto_encrypt<'a>(
         &'a self,
         csfle: &'a super::csfle::ClientState,
@@ -817,7 +817,7 @@ impl Client {
         })
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     fn auto_decrypt<'a>(
         &'a self,
         csfle: &'a super::csfle::ClientState,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,5 @@
 pub mod auth;
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 pub(crate) mod csfle;
 mod executor;
 pub mod options;
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 pub use self::csfle::client_builder::*;
 use derivative::Derivative;
 
@@ -113,7 +113,7 @@ struct ClientInner {
     topology: Topology,
     options: ClientOptions,
     session_pool: ServerSessionPool,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     csfle: tokio::sync::RwLock<Option<csfle::ClientState>>,
 }
 
@@ -136,7 +136,7 @@ impl Client {
         let inner = Arc::new(ClientInner {
             topology: Topology::new(options.clone())?,
             session_pool: ServerSessionPool::new(),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             csfle: Default::default(),
             options,
         });
@@ -166,7 +166,7 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub fn encrypted_builder(
         client_options: ClientOptions,
         key_vault_namespace: crate::Namespace,
@@ -187,7 +187,7 @@ impl Client {
         ))
     }
 
-    #[cfg(all(test, feature = "csfle"))]
+    #[cfg(all(test, feature = "in-use-encryption-unstable"))]
     pub(crate) async fn mongocryptd_spawned(&self) -> bool {
         self.inner
             .csfle
@@ -558,14 +558,14 @@ impl Client {
         &self.inner.topology
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) fn weak(&self) -> WeakClient {
         WeakClient {
             inner: Arc::downgrade(&self.inner),
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) async fn auto_encryption_opts(
         &self,
     ) -> Option<tokio::sync::RwLockReadGuard<'_, csfle::options::AutoEncryptionOptions>> {
@@ -581,13 +581,13 @@ impl Client {
     }
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 #[derive(Clone, Debug)]
 pub(crate) struct WeakClient {
     inner: std::sync::Weak<ClientInner>,
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 impl WeakClient {
     #[allow(dead_code)]
     pub(crate) fn upgrade(&self) -> Option<Client> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -197,7 +197,7 @@ impl Client {
             .map_or(false, |cs| cs.exec().mongocryptd_spawned())
     }
 
-    #[cfg(all(test, feature = "csfle"))]
+    #[cfg(all(test, feature = "in-use-encryption-unstable"))]
     pub(crate) async fn has_mongocryptd_client(&self) -> bool {
         self.inner
             .csfle

--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -228,7 +228,7 @@ impl<T> Collection<T> {
         let mut options: Option<DropCollectionOptions> = options.into();
         resolve_options!(self, options, [write_concern]);
 
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         self.drop_aux_collections(options.as_ref(), session.as_deref_mut())
             .await?;
 
@@ -253,7 +253,7 @@ impl<T> Collection<T> {
         self.drop_common(options, session).await
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     #[allow(clippy::needless_option_as_deref)]
     async fn drop_aux_collections(
         &self,
@@ -1189,9 +1189,9 @@ where
         }
 
         let ordered = options.as_ref().and_then(|o| o.ordered).unwrap_or(true);
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let encrypted = self.client().auto_encryption_opts().await.is_some();
-        #[cfg(not(feature = "csfle"))]
+        #[cfg(not(feature = "in-use-encryption-unstable"))]
         let encrypted = false;
 
         let mut cumulative_failure: Option<BulkWriteFailure> = None;

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1070,7 +1070,7 @@ pub struct DropCollectionOptions {
     /// Map of encrypted fields for the collection.
     // Serialization is skipped because the server doesn't accept this option; it's needed for
     // preprocessing.  Deserialization needs to remain because it's used in test files.
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     #[serde(skip_serializing)]
     pub encrypted_fields: Option<Document>,
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,7 +2,7 @@ pub mod options;
 
 use std::{fmt::Debug, sync::Arc};
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 use bson::doc;
 use futures_util::stream::TryStreamExt;
 
@@ -304,7 +304,7 @@ impl Database {
             coll: name.as_ref().to_string(),
         };
 
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let has_encrypted_fields = {
             self.resolve_encrypted_fields(&ns, &mut options).await;
             self.create_aux_collections(&ns, &options, session.as_deref_mut())
@@ -320,7 +320,7 @@ impl Database {
             .execute_operation(create, session.as_deref_mut())
             .await?;
 
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         if has_encrypted_fields {
             let coll = self.collection::<Document>(&ns.coll);
             coll.create_index_common(
@@ -337,7 +337,7 @@ impl Database {
         Ok(())
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     async fn resolve_encrypted_fields(
         &self,
         base_ns: &Namespace,
@@ -363,7 +363,7 @@ impl Database {
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     #[allow(clippy::needless_option_as_deref)]
     async fn create_aux_collections(
         &self,

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -118,7 +118,7 @@ pub struct CreateCollectionOptions {
     pub comment: Option<Bson>,
 
     /// Map of encrypted fields for the created collection.
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub encrypted_fields: Option<Document>,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -231,9 +231,9 @@ impl Error {
         )
     }
 
-    #[cfg(all(test, feature = "csfle"))]
+    #[cfg(all(test, feature = "in-use-encryption-unstable"))]
     pub(crate) fn is_csfle_error(&self) -> bool {
-        matches!(self.kind.as_ref(), ErrorKind::Csfle(..),)
+        matches!(self.kind.as_ref(), ErrorKind::Encryption(..))
     }
 
     /// Gets the code from this error for performing SDAM updates, if applicable.
@@ -287,8 +287,8 @@ impl Error {
             ErrorKind::Transaction { message } => Some(message.clone()),
             ErrorKind::IncompatibleServer { message } => Some(message.clone()),
             ErrorKind::InvalidArgument { message } => Some(message.clone()),
-            #[cfg(feature = "csfle")]
-            ErrorKind::Csfle(err) => err.message.clone(),
+            #[cfg(feature = "in-use-encryption-unstable")]
+            ErrorKind::Encryption(err) => err.message.clone(),
             _ => None,
         }
     }
@@ -424,8 +424,8 @@ impl Error {
             | ErrorKind::MissingResumeToken
             | ErrorKind::Authentication { .. }
             | ErrorKind::GridFs(_) => {}
-            #[cfg(feature = "csfle")]
-            ErrorKind::Csfle(_) => {}
+            #[cfg(feature = "in-use-encryption-unstable")]
+            ErrorKind::Encryption(_) => {}
         }
     }
 }
@@ -471,10 +471,10 @@ impl From<std::io::ErrorKind> for ErrorKind {
     }
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 impl From<mongocrypt::error::Error> for ErrorKind {
     fn from(err: mongocrypt::error::Error) -> Self {
-        Self::Csfle(err)
+        Self::Encryption(err)
     }
 }
 
@@ -575,9 +575,9 @@ pub enum ErrorKind {
     MissingResumeToken,
 
     /// An error occurred during encryption or decryption.
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     #[error("An error occurred during client-side encryption: {0}")]
-    Csfle(mongocrypt::error::Error),
+    Encryption(mongocrypt::error::Error),
 }
 
 impl ErrorKind {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ pub use crate::{
     db::Database,
     gridfs::{GridFsDownloadStream, GridFsBucket, GridFsUploadStream},
 };
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 pub use crate::client::csfle::client_encryption;
 
 pub use {client::session::ClusterTime, coll::Namespace, index::IndexModel, sdam::public::*};

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -68,7 +68,7 @@ pub(crate) use insert::Insert;
 pub(crate) use list_collections::ListCollections;
 pub(crate) use list_databases::ListDatabases;
 pub(crate) use list_indexes::ListIndexes;
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 pub(crate) use raw_output::RawOutput;
 pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -45,7 +45,7 @@ impl<'conn> RunCommand<'conn> {
         })
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) fn new_raw(
         db: String,
         command: RawDocumentBuf,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -3,7 +3,7 @@ mod http;
 #[cfg(feature = "async-std-runtime")]
 mod interval;
 mod join_handle;
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 mod process;
 mod resolver;
 pub(crate) mod stream;
@@ -16,7 +16,7 @@ mod worker_handle;
 
 use std::{future::Future, net::SocketAddr, time::Duration};
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 pub(crate) use self::process::Process;
 pub(crate) use self::{
     acknowledged_message::AcknowledgedMessage,

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -412,7 +412,7 @@ async fn data_key_double_encryption() -> Result<()> {
             .await;
         let err = result.unwrap_err();
         assert!(
-            matches!(*err.kind, ErrorKind::Csfle(..)) || err.is_command_error(),
+            matches!(*err.kind, ErrorKind::Encryption(..)) || err.is_command_error(),
             "unexpected error: {}",
             err
         );

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -5,7 +5,7 @@ mod auth_aws;
 mod change_stream;
 mod client;
 mod coll;
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 mod csfle;
 mod cursor;
 mod db;
@@ -17,7 +17,7 @@ mod lambda_examples;
 pub mod spec;
 pub(crate) mod util;
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 pub(crate) use self::csfle::{KmsProviderList, KMS_PROVIDERS_MAP};
 pub(crate) use self::{
     spec::{run_single_test, run_spec_test, run_spec_test_with_path, RunOn, Serverless, Topology},

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
 mod auth;
 mod change_streams;
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 mod client_side_encryption;
 mod collection_management;
 mod command_monitoring;

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -45,12 +45,12 @@ pub(crate) enum Entity {
     EventList(EventList),
     Thread(ThreadEntity),
     TopologyDescription(TopologyDescription),
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     ClientEncryption(Arc<crate::client_encryption::ClientEncryption>),
     None,
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 impl std::fmt::Debug for crate::client_encryption::ClientEncryption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ClientEncryption").finish()
@@ -218,7 +218,7 @@ impl ClientEntity {
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) fn client(&self) -> Option<&Client> {
         self.client.as_ref()
     }
@@ -434,7 +434,7 @@ impl Entity {
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub fn as_client_encryption(&self) -> &Arc<crate::client_encryption::ClientEncryption> {
         match self {
             Self::ClientEncryption(ce) => ce,

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 mod csfle;
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 use self::csfle::*;
 
 use std::{
@@ -362,19 +362,19 @@ impl<'de> Deserialize<'de> for Operation {
             "downloadByName" => deserialize_op::<DownloadByName>(definition.arguments),
             "delete" => deserialize_op::<Delete>(definition.arguments),
             "upload" => deserialize_op::<Upload>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "getKeyByAltName" => deserialize_op::<GetKeyByAltName>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "deleteKey" => deserialize_op::<DeleteKey>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "getKey" => deserialize_op::<GetKey>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "addKeyAltName" => deserialize_op::<AddKeyAltName>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "createDataKey" => deserialize_op::<CreateDataKey>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "getKeys" => deserialize_op::<GetKeys>(definition.arguments),
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             "removeKeyAltName" => deserialize_op::<RemoveKeyAltName>(definition.arguments),
             s => Ok(Box::new(UnimplementedOperation {
                 _name: s.to_string(),

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -164,7 +164,7 @@ pub(crate) enum TestFileEntity {
     Session(Session),
     Bucket(Bucket),
     Thread(Thread),
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     ClientEncryption(ClientEncryption),
 }
 
@@ -329,7 +329,7 @@ pub(crate) struct Thread {
     pub(crate) id: String,
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct ClientEncryption {
@@ -337,7 +337,7 @@ pub(crate) struct ClientEncryption {
     pub(crate) client_encryption_opts: ClientEncryptionOpts,
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct ClientEncryptionOpts {

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -54,7 +54,7 @@ use super::{
     TestFileEntity,
 };
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 use crate::test::KmsProviderList;
 
 #[cfg(feature = "tracing-unstable")]
@@ -546,7 +546,7 @@ impl TestRunner {
                     });
                     (thread.id.clone(), Entity::Thread(ThreadEntity { sender }))
                 }
-                #[cfg(feature = "csfle")]
+                #[cfg(feature = "in-use-encryption-unstable")]
                 TestFileEntity::ClientEncryption(client_enc) => {
                     let id = client_enc.id.clone();
                     let opts = &client_enc.client_encryption_opts;
@@ -660,7 +660,7 @@ impl TestRunner {
             .clone()
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) async fn get_client_encryption(
         &self,
         id: impl AsRef<str>,
@@ -675,7 +675,7 @@ impl TestRunner {
     }
 }
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 fn fill_kms_placeholders(
     kms_providers: HashMap<mongocrypt::ctx::KmsProvider, Document>,
 ) -> KmsProviderList {

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 mod csfle;
 pub(crate) mod operation;
 pub(crate) mod test_event;
@@ -95,7 +95,7 @@ pub(crate) async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
             }
         }
 
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         csfle::populate_key_vault(&internal_client, test_file.key_vault_data.as_ref()).await;
 
         let db_name = test_file
@@ -112,7 +112,7 @@ pub(crate) async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         let mut options = DropCollectionOptions::builder()
             .write_concern(majority_write_concern())
             .build();
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         if let Some(enc_fields) = &test_file.encrypted_fields {
             options.encrypted_fields = Some(enc_fields.clone());
         }
@@ -128,7 +128,7 @@ pub(crate) async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         let mut options = CreateCollectionOptions::builder()
             .write_concern(majority_write_concern())
             .build();
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         {
             if let Some(schema) = &test_file.json_schema {
                 options.validator = Some(doc! { "$jsonSchema": schema });
@@ -173,7 +173,7 @@ pub(crate) async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
             )
             .await
             .min_heartbeat_freq(Some(Duration::from_millis(50)));
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let builder = csfle::set_auto_enc(builder, &test);
         let client = builder.event_client().build().await;
 
@@ -378,7 +378,7 @@ pub(crate) async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
                                 .iter()
                                 .for_each(|label| assert!(!labels.contains(label)));
                         }
-                        #[cfg(feature = "csfle")]
+                        #[cfg(feature = "in-use-encryption-unstable")]
                         if let Some(t) = operation_error.is_timeout_error {
                             assert_eq!(
                                 t,

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -115,7 +115,7 @@ pub(crate) struct OperationError {
     pub(crate) error_code: Option<i32>,
     pub(crate) error_labels_contain: Option<Vec<String>>,
     pub(crate) error_labels_omit: Option<Vec<String>>,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) is_timeout_error: Option<bool>,
 }
 

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -31,11 +31,11 @@ pub(crate) struct TestFile {
     #[allow(unused)]
     pub(crate) bucket_name: Option<String>,
     pub(crate) data: Option<TestData>,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) json_schema: Option<Document>,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) encrypted_fields: Option<Document>,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) key_vault_data: Option<Vec<Document>>,
     pub(crate) tests: Vec<Test>,
 }
@@ -103,7 +103,7 @@ pub(crate) struct Test {
 #[derive(Debug)]
 pub(crate) struct ClientOptions {
     pub(crate) uri: String,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) auto_encrypt_opts: Option<crate::client::csfle::options::AutoEncryptionOptions>,
 }
 
@@ -112,11 +112,11 @@ impl<'de> Deserialize<'de> for ClientOptions {
     where
         D: Deserializer<'de>,
     {
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         use serde::de::Error;
         #[allow(unused_mut)]
         let mut uri_options = Document::deserialize(deserializer)?;
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let auto_encrypt_opts = uri_options
             .remove("autoEncryptOpts")
             .map(bson::from_bson)
@@ -125,7 +125,7 @@ impl<'de> Deserialize<'de> for ClientOptions {
         let uri = merge_uri_options(&DEFAULT_URI, Some(&uri_options), true);
         Ok(Self {
             uri,
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             auto_encrypt_opts,
         })
     }
@@ -149,9 +149,9 @@ impl Outcome {
             Some(name) => name,
             None => coll_name,
         };
-        #[cfg(not(feature = "csfle"))]
+        #[cfg(not(feature = "in-use-encryption-unstable"))]
         let coll_opts = CollectionOptions::default();
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let coll_opts = CollectionOptions::builder()
             .read_concern(crate::options::ReadConcern::LOCAL)
             .build();

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -82,7 +82,7 @@ impl Event {
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) fn as_command_started_event(&self) -> Option<&CommandStartedEvent> {
         match self {
             Event::Command(CommandEvent::Started(e)) => Some(e),
@@ -90,7 +90,7 @@ impl Event {
         }
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) fn into_command_started_event(self) -> Option<CommandStartedEvent> {
         match self {
             Self::Command(CommandEvent::Started(ev)) => Some(ev),

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use self::trace::{
 
 use std::{fmt::Debug, sync::Arc, time::Duration};
 
-#[cfg(feature = "csfle")]
+#[cfg(feature = "in-use-encryption-unstable")]
 use crate::client::EncryptedClientBuilder;
 use crate::{
     bson::{doc, Bson},
@@ -74,7 +74,7 @@ impl Client {
             options: None,
             handler: None,
             min_heartbeat_freq: None,
-            #[cfg(feature = "csfle")]
+            #[cfg(feature = "in-use-encryption-unstable")]
             encrypted: None,
         }
     }
@@ -84,7 +84,7 @@ pub(crate) struct TestClientBuilder {
     options: Option<ClientOptions>,
     handler: Option<Arc<EventHandler>>,
     min_heartbeat_freq: Option<Duration>,
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     encrypted: Option<crate::client::csfle::options::AutoEncryptionOptions>,
 }
 
@@ -117,7 +117,7 @@ impl TestClientBuilder {
         self
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) fn encrypted_options(
         mut self,
         encrypted: crate::client::csfle::options::AutoEncryptionOptions,
@@ -153,7 +153,7 @@ impl TestClientBuilder {
             options.test_options_mut().min_heartbeat_freq = Some(freq);
         }
 
-        #[cfg(feature = "csfle")]
+        #[cfg(feature = "in-use-encryption-unstable")]
         let client = match self.encrypted {
             None => Client::with_options(options).unwrap(),
             Some(aeo) => EncryptedClientBuilder::new(options, aeo)
@@ -161,7 +161,7 @@ impl TestClientBuilder {
                 .await
                 .unwrap(),
         };
-        #[cfg(not(feature = "csfle"))]
+        #[cfg(not(feature = "in-use-encryption-unstable"))]
         let client = Client::with_options(options).unwrap();
 
         TestClient::from_client(client).await

--- a/src/test/util/subscriber.rs
+++ b/src/test/util/subscriber.rs
@@ -45,7 +45,7 @@ impl<H, E: Clone> EventSubscriber<'_, H, E> {
         events
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) async fn collect_events_map<F, T>(
         &mut self,
         timeout: Duration,
@@ -64,7 +64,7 @@ impl<H, E: Clone> EventSubscriber<'_, H, E> {
         events
     }
 
-    #[cfg(feature = "csfle")]
+    #[cfg(feature = "in-use-encryption-unstable")]
     pub(crate) async fn clear_events(&mut self, timeout: Duration) {
         self.collect_events(timeout, |_| true).await;
     }


### PR DESCRIPTION
RUST-1487 / RUST-1347

This renames the `csfle` feature to `in-use-encryption-unstable`; this combines the naming guidance of RUST-1487 and the "preview" factor from RUST-1347.  The latter encourages using language-specific conventions, which for Rust maps nicely to "unstable" vs "stabilized".  While only the queryable encryption API needs to be flagged as unstable, I think it'll be valuable to keep the whole encryption API unstable so we have room for iteration based on user feedback.

I didn't rename any of the internal stuff (e.g. `csfle.rs`) because that felt like a lot of churn for little benefit.