### PR TITLE
RUST-1544 sync valid-pass test for observeSensitiveCommands

### DIFF
--- a/src/test/spec/json/unified-test-format/valid-pass/observeSensitiveCommands.json
+++ b/src/test/spec/json/unified-test-format/valid-pass/observeSensitiveCommands.json
@@ -61,6 +61,11 @@
   "tests": [
     {
       "description": "getnonce is observed with observeSensitiveCommands=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -106,6 +111,11 @@
     },
     {
       "description": "getnonce is not observed with observeSensitiveCommands=false",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -127,6 +137,11 @@
     },
     {
       "description": "getnonce is not observed by default",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/src/test/spec/json/unified-test-format/valid-pass/observeSensitiveCommands.yml
+++ b/src/test/spec/json/unified-test-format/valid-pass/observeSensitiveCommands.yml
@@ -38,6 +38,8 @@ createEntities:
 
 tests:
   - description: "getnonce is observed with observeSensitiveCommands=true"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseObserveSensitiveCommands
@@ -57,6 +59,8 @@ tests:
                 nonce: { $$exists: false }
 
   - description: "getnonce is not observed with observeSensitiveCommands=false"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseDoNotObserveSensitiveCommands
@@ -68,6 +72,8 @@ tests:
         events: []
 
   - description: "getnonce is not observed by default"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseDoNotObserveSensitiveCommandsByDefault


### PR DESCRIPTION
I forgot to sync the changes I made to the unified runner valid pass tests for this ticket, and so these tests are now failing on evergreen against latest.