### PR TITLE
RUST-1069 Defer implicit session check out until after connection check out

### DIFF
--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -74,7 +74,7 @@ async fn implicit_session_after_connection() {
     let _guard: RwLockReadGuard<_> = LOCK.run_concurrently().await;
 
     let mut was_one_session = false;
-    for _ in 0..5 {
+    for _ in 0..10 {
         let client = Client::test_builder()
             .options({
                 let mut options = CLIENT_OPTIONS.get().await.clone();

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -156,10 +156,19 @@ async fn implicit_session_after_connection() {
             unique.push(lsid);
         }
 
-        min_lsids = std::cmp::min(min_lsids, dbg!(unique.len()));
+        min_lsids = std::cmp::min(min_lsids, unique.len());
         max_lsids = std::cmp::max(max_lsids, unique.len());
         lsids.clear();
     }
-    assert_eq!(min_lsids, 1);
-    assert!(max_lsids < 7, "max lsids is {}, expected < 7", max_lsids);
+    assert_eq!(
+        min_lsids, 2,
+        "min lsids is {}, expected 2 (max is {})",
+        min_lsids, max_lsids
+    );
+    assert!(
+        max_lsids < 7,
+        "max lsids is {}, expected < 7 (min is {})",
+        max_lsids,
+        min_lsids
+    );
 }

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -160,6 +160,9 @@ async fn implicit_session_after_connection() {
         max_lsids = std::cmp::max(max_lsids, unique.len());
         lsids.clear();
     }
+    // The spec says the minimum should be 1; however, the background async nature of the Rust
+    // driver's session cleanup means that sometimes a session has not yet been returned to the pool
+    // when the next one is checked out.
     assert!(
         min_lsids <= 2,
         "min lsids is {}, expected <= 2 (max is {})",

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -160,15 +160,16 @@ async fn implicit_session_after_connection() {
         max_lsids = std::cmp::max(max_lsids, unique.len());
         lsids.clear();
     }
-    assert_eq!(
-        min_lsids, 2,
-        "min lsids is {}, expected 2 (max is {})",
-        min_lsids, max_lsids
+    assert!(
+        min_lsids <= 2,
+        "min lsids is {}, expected <= 2 (max is {})",
+        min_lsids,
+        max_lsids,
     );
     assert!(
         max_lsids < 7,
         "max lsids is {}, expected < 7 (min is {})",
         max_lsids,
-        min_lsids
+        min_lsids,
     );
 }

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -1,10 +1,14 @@
+use bson::Document;
+use futures::TryStreamExt;
+use futures_util::{future::try_join_all, FutureExt};
 use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 use crate::{
     bson::doc,
-    error::ErrorKind,
+    error::{ErrorKind, Result},
     options::SessionOptions,
-    test::{TestClient, LOCK},
+    test::{TestClient, CLIENT_OPTIONS, LOCK},
+    Client,
 };
 
 use super::{run_spec_test_with_path, run_unified_format_test};
@@ -61,4 +65,87 @@ async fn explicit_session_created_on_same_client() {
         ErrorKind::InvalidArgument { message } => assert!(message.contains("session provided")),
         other => panic!("expected InvalidArgument error, got {:?}", other),
     }
+}
+
+// Sessions prose test 14
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn implicit_session_after_connection() {
+    let _guard: RwLockReadGuard<_> = LOCK.run_concurrently().await;
+
+    let mut was_one_session = false;
+    for _ in 0..5 {
+        let client = Client::test_builder()
+            .options({
+                let mut options = CLIENT_OPTIONS.get().await.clone();
+                options.max_pool_size = Some(1);
+                options.retry_writes = Some(true);
+                options.hosts.drain(1..);
+                options
+            })
+            .event_client()
+            .build()
+            .await;
+
+        let coll = client
+            .database("test_lazy_implicit")
+            .collection::<Document>("test");
+
+        let mut ops = vec![];
+        fn ignore_val<T>(r: Result<T>) -> Result<()> {
+            r.map(|_| ())
+        }
+        ops.push(coll.insert_one(doc! {}, None).map(ignore_val).boxed());
+        ops.push(coll.delete_one(doc! {}, None).map(ignore_val).boxed());
+        ops.push(
+            coll.update_one(doc! {}, doc! { "$set": { "a": 1 } }, None)
+                .map(ignore_val)
+                .boxed(),
+        );
+        ops.push(
+            coll.find_one_and_delete(doc! {}, None)
+                .map(ignore_val)
+                .boxed(),
+        );
+        ops.push(
+            coll.find_one_and_update(doc! {}, doc! { "$set": { "a": 1 } }, None)
+                .map(ignore_val)
+                .boxed(),
+        );
+        ops.push(
+            coll.find_one_and_replace(doc! {}, doc! { "a": 1 }, None)
+                .map(ignore_val)
+                .boxed(),
+        );
+        ops.push(
+            async {
+                let cursor = coll.find(doc! {}, None).await.unwrap();
+                let r: Result<Vec<_>> = cursor.try_collect().await;
+                r.map(|_| ())
+            }
+            .boxed(),
+        );
+        let ops_len = ops.len();
+
+        let _ = try_join_all(ops).await.unwrap();
+
+        let events = client.get_all_command_started_events();
+        let lsids: Vec<_> = events
+            .iter()
+            .map(|ev| ev.command.get_document("lsid").unwrap())
+            .collect();
+        let mut unique = vec![];
+        'outer: for lsid in lsids {
+            for u in &unique {
+                if lsid == *u {
+                    continue 'outer;
+                }
+            }
+            unique.push(lsid);
+        }
+
+        assert!(ops_len > unique.len());
+        was_one_session |= unique.len() == 1;
+    }
+    assert!(was_one_session);
 }


### PR DESCRIPTION
RUST-1069

Previously, retries were handled by a distinct `execute_retry` method; this was an issue for this change because there are two retry cases (connection check out failure and operation failure), and a retry should create an implicit session in the first case but not the second.  This PR changes it to have a loop inside `execute_operation_with_retry`; this makes the handling there a bit more complicated, but removes the `execute_retry` method entirely, and also collapses `ExecutionOutput` into `ExecutionDetails`, so I think it's a net wash on complexity.  Having the loop will also make executing multiple retries easier if/when we get to CSOT.