### PR TITLE
RUST-1576 Allow "timeseries"-typed collections in list_collections output (#814)

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -121,6 +121,9 @@ pub enum CollectionType {
 
     /// Indicates that the data store is a collection.
     Collection,
+
+    /// Indicates that the data store is a timeseries.
+    Timeseries,
 }
 
 /// Info about the collection that is contained in the `CollectionSpecification::info` field of a

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -15,6 +15,7 @@ mod index_management;
 #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
 mod lambda_examples;
 pub mod spec;
+mod timeseries;
 pub(crate) mod util;
 
 #[cfg(feature = "in-use-encryption-unstable")]

--- a/src/test/timeseries.rs
+++ b/src/test/timeseries.rs
@@ -1,0 +1,47 @@
+use bson::doc;
+use futures::TryStreamExt;
+
+use crate::{
+    db::options::{CreateCollectionOptions, TimeseriesOptions},
+    test::log_uncaptured,
+    Client,
+};
+
+use super::LOCK;
+
+type Result<T> = anyhow::Result<T>;
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn list_collections_timeseries() -> Result<()> {
+    let _guard = LOCK.run_exclusively();
+
+    let client = Client::test_builder().build().await;
+    if client.server_version_lt(5, 0) {
+        log_uncaptured("Skipping list_collections_timeseries: timeseries require server >= 5.0");
+        return Ok(());
+    }
+    let db = client.database("list_collections_timeseries");
+    db.drop(None).await?;
+    db.create_collection(
+        "test",
+        CreateCollectionOptions::builder()
+            .timeseries(
+                TimeseriesOptions::builder()
+                    .time_field("timestamp".to_string())
+                    .meta_field(None)
+                    .granularity(None)
+                    .build(),
+            )
+            .build(),
+    )
+    .await?;
+    let results: Vec<_> = db
+        .list_collections(doc! { "name": "test" }, None)
+        .await?
+        .try_collect()
+        .await?;
+    assert_eq!(results.len(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
Cherry-picking this from the `main` branch for RUST-1584.