### PR TITLE
RUST-1566 Sync (and skip) command logging unacknowledged write test

### DIFF
--- a/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.json
+++ b/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.json
@@ -1,0 +1,134 @@
+{
+  "description": "unacknowledged-write",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "logging-tests-collection",
+      "databaseName": "logging-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "An unacknowledged write generates a succeeded log message with ok: 1 reply",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "insert",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "insert": "logging-tests-collection",
+                      "$db": "logging-tests"
+                    }
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "ok": 1
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.yml
+++ b/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.yml
@@ -1,0 +1,65 @@
+description: "unacknowledged-write"
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client client
+      observeLogMessages:
+        command: debug
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName logging-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName logging-tests-collection
+      collectionOptions:
+        writeConcern: { w: 0 }
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "An unacknowledged write generates a succeeded log message with ok: 1 reply"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+          document: { _id: 2 }
+    expectLogMessages:
+      - client: *client
+        messages:
+          - level: debug
+            component: command
+            data:
+              message: "Command started"
+              databaseName: *databaseName
+              commandName: insert
+              command:
+                $$matchAsDocument:
+                  $$matchAsRoot:
+                    insert: *collectionName
+                    $db: *databaseName
+              requestId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+
+          - level: debug
+            component: command
+            data:
+              message: "Command succeeded"
+              commandName: insert
+              reply:
+                $$matchAsDocument:
+                  ok: 1
+              requestId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
+        
+

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -22,7 +22,6 @@ use crate::{
     test::{
         log_uncaptured,
         run_spec_test_with_path,
-        spec::run_unified_format_test,
         TestClient,
         CLIENT_OPTIONS,
         DEFAULT_GLOBAL_TRACING_HANDLER,
@@ -498,9 +497,15 @@ fn topology_description_tracing_representation() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn command_logging_unified() {
     let _guard = LOCK.run_exclusively().await;
+    // Rust does not (and does not plan to) support unacknowledged writes; see RUST-9.
+    let test_predicate = |tc: &TestCase| {
+        tc.description
+            != "An unacknowledged write generates a succeeded log message with ok: 1 reply"
+    };
+
     run_spec_test_with_path(
         &["command-logging-and-monitoring", "logging"],
-        run_unified_format_test,
+        |path, file| run_unified_format_test_filtered(path, file, test_predicate),
     )
     .await;
 }


### PR DESCRIPTION
This test was added after our implementation. We can't run it since we don't support uancknowledged writes but syncing the file nonetheless to keep us up-to-date. 