### PR TITLE
RUST-1582 Expose collection.client() as public

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -180,7 +180,7 @@ impl<T> Collection<T> {
     }
 
     /// Get the `Client` that this collection descended from.
-    pub(crate) fn client(&self) -> &Client {
+    pub fn client(&self) -> &Client {
         &self.inner.client
     }
 


### PR DESCRIPTION
This aims to address https://jira.mongodb.org/browse/RUST-1582 as originally filed as an issue in https://github.com/mongodb/mongo-rust-driver/issues/812.

There was already a member function in the collection object which allowed client access but it was only accessible from within the driver crate. So the only changes needed are to make it externally accessible.