### PR TITLE
RUST-1219, RUST-863: Assert that a ping succeeds in DNS seedlist tests; sync DB name with comma tests

### DIFF
--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLockReadGuard;
 
 use crate::{
     bson::doc,
-    client::{auth::AuthMechanism, Client},
+    client::Client,
     options::{ClientOptions, ResolverConfig},
     runtime,
     test::{log_uncaptured, run_spec_test, TestClient, CLIENT_OPTIONS, LOCK},
@@ -137,26 +137,6 @@ async fn run_test(mut test_file: TestFile) {
             "skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch",
         )
     } else {
-        // If the connection URI provides authentication information, manually create the user
-        // before connecting.
-        // if let Some(ParsedOptions {
-        //     user: Some(ref user),
-        //     password: Some(ref pwd),
-        //     ref db,
-        // }) = test_file.parsed_options
-        // {
-        //     client
-        //         .drop_and_create_user(
-        //             user,
-        //             pwd.as_str(),
-        //             &[],
-        //             &[AuthMechanism::ScramSha1, AuthMechanism::ScramSha256],
-        //             db.as_deref(),
-        //         )
-        //         .await
-        //         .unwrap();
-        // }
-
         let mut options_with_tls = options.clone();
         if requires_tls {
             options_with_tls.tls = CLIENT_OPTIONS.get().await.tls.clone();

--- a/src/test/spec/json/initial-dns-seedlist-discovery/README.rst
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/README.rst
@@ -114,31 +114,49 @@ These YAML and JSON files contain the following fields:
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
+- ``ping``: if true, the test runner should run a "ping" operation after
+  initializing a MongoClient.
 
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
 .. _`URI options`: ../../uri-options/uri-options.rst
 
-For each file, create a MongoClient initialized with the ``mongodb+srv``
-connection string.
+For each YAML file:
 
-If ``seeds`` is specified, drivers SHOULD verify that the set of hosts in the
-client's initial seedlist matches the list in ``seeds``. If ``numSeeds`` is
-specified, drivers SHOULD verify that the size of that set matches ``numSeeds``.
+- Create a MongoClient initialized with the ``mongodb+srv``
+  connection string.
+- Run run a "ping" operation if ``ping`` in the test file is true.
 
-If ``hosts`` is specified, drivers MUST verify that the set of
-ServerDescriptions in the client's TopologyDescription eventually matches the
-list in ``hosts``. If ``numHosts`` is specified, drivers MUST verify that the
-size of that set matches ``numHosts``.
+Assertions:
 
-If ``options`` is specified, drivers MUST verify each of the values under
-``options`` match the MongoClient's parsed value for that option. There may be
-other options parsed by the MongoClient as well, which a test does not verify.
+- If ``seeds`` is specified, drivers SHOULD verify that the set of hosts in the
+  client's initial seedlist matches the list in ``seeds``. If ``numSeeds`` is
+  specified, drivers SHOULD verify that the size of that set matches
+  ``numSeeds``.
 
-If ``parsed_options`` is specified, drivers MUST verify that each of the values
-under ``parsed_options`` match the MongoClient's parsed value for that option.
-Supported values include, but are not limited to, ``user`` and ``password``
-(parsed from ``UserInfo``) and ``auth_database`` (parsed from
-``Auth database``).
+- If ``hosts`` is specified, drivers MUST verify that the set of
+  ServerDescriptions in the client's TopologyDescription eventually matches the
+  list in ``hosts``. If ``numHosts`` is specified, drivers MUST verify that the
+  size of that set matches ``numHosts``.
 
-If ``error`` is specified and ``true``, drivers MUST verify that an error has
-been thrown.
+- If ``options`` is specified, drivers MUST verify each of the values under
+  ``options`` match the MongoClient's parsed value for that option. There may be
+  other options parsed by the MongoClient as well, which a test does not verify.
+
+- If ``parsed_options`` is specified, drivers MUST verify that each of the
+  values under ``parsed_options`` match the MongoClient's parsed value for that
+  option. Supported values include, but are not limited to, ``user`` and
+  ``password`` (parsed from ``UserInfo``) and ``auth_database`` (parsed from
+  ``Auth database``).
+
+- If ``error`` is specified and ``true``, drivers MUST verify that initializing
+  the MongoClient throws an error. If ``error`` is not specified or is
+  ``false``, both initializing the MongoClient and running a ping operation must
+  succeed without throwing any errors.
+
+- If ``ping`` is specified and ``true``, drivers MUST verify that running a
+  "ping" operation using the initialized MongoClient succeeds. If ``ping`` is
+  not specified or is ``false``, drivers MUST NOT run a "ping" operation.
+  **Note:** These tests are expected to be run against MongoDB databases with
+  and without authentication enabled. The "ping" operation does not require
+  authentication so should succeed, even though the test URIs do not have
+  correct authentication information.

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "ssl": true,
     "directConnection": false
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-directConnection.yml
@@ -11,3 +11,4 @@ options:
     loadBalanced: true
     ssl: true
     directConnection: false
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.json
@@ -9,5 +9,6 @@
   "options": {
     "loadBalanced": true,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/loadBalanced-true-txt.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     loadBalanced: true
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero-txt.yml
@@ -8,3 +8,4 @@ options:
     loadBalanced: true
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/load-balanced/srvMaxHosts-zero.yml
@@ -8,3 +8,4 @@ options:
     loadBalanced: true
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/some%2Cdb?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "defaultDatabase": "some,db"
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas-escaped.yml
@@ -1,0 +1,13 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/some%2Cdb?replicaSet=repl0"
+seeds:
+  - localhost.test.build.10gen.cc:27017
+  - localhost.test.build.10gen.cc:27018
+hosts:
+  - localhost:27017
+  - localhost:27018
+  - localhost:27019
+options:
+  replicaSet: repl0
+  ssl: true
+parsed_options:
+  defaultDatabase: some,db

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/some,db?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
+  "parsed_options": {
+    "defaultDatabase": "some,db"
+  }
+}

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/dbname-with-commas.yml
@@ -1,0 +1,13 @@
+uri: "mongodb+srv://test1.test.build.10gen.cc/some,db?replicaSet=repl0"
+seeds:
+  - localhost.test.build.10gen.cc:27017
+  - localhost.test.build.10gen.cc:27018
+hosts:
+  - localhost:27017
+  - localhost:27018
+  - localhost:27019
+options:
+  replicaSet: repl0
+  ssl: true
+parsed_options:
+  defaultDatabase: some,db

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/direct-connection-false.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/direct-connection-false.json
@@ -11,5 +11,6 @@
   "options": {
     "ssl": true,
     "directConnection": false
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/direct-connection-false.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/direct-connection-false.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     ssl: true
     directConnection: false
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
@@ -17,6 +17,6 @@
     "password": "$4to@L8=MC",
     "db": "mydb?"
   },
-  "ping": true,
+  "ping": false,
   "comment": "Encoded user, pass, and DB parse correctly"
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.json
@@ -17,5 +17,6 @@
     "password": "$4to@L8=MC",
     "db": "mydb?"
   },
+  "ping": true,
   "comment": "Encoded user, pass, and DB parse correctly"
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
@@ -12,5 +12,8 @@ parsed_options:
     user: "b*b@f3tt="
     password: "$4to@L8=MC"
     db: "mydb?"
-ping: true
+# Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
+# userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
+# provided but incorrect.
+ping: false
 comment: Encoded user, pass, and DB parse correctly

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/encoded-userinfo-and-db.yml
@@ -12,4 +12,5 @@ parsed_options:
     user: "b*b@f3tt="
     password: "$4to@L8=MC"
     db: "mydb?"
+ping: true
 comment: Encoded user, pass, and DB parse correctly

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.json
@@ -11,5 +11,6 @@
   "options": {
     "loadBalanced": false,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/loadBalanced-false-txt.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     loadBalanced: false
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "ssl": true
   },
+  "ping": true,
   "comment": "Is correct, as returned host name shared the URI root \"test.build.10gen.cc\"."
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/longer-parent-in-return.yml
@@ -8,4 +8,5 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true
 comment: Is correct, as returned host name shared the URI root "test.build.10gen.cc".

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-result-default-port.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-result-default-port.json
@@ -11,5 +11,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-result-default-port.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-result-default-port.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.json
@@ -11,5 +11,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record-multiple-strings.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "thisDB",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/one-txt-record.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: thisDB
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.json
@@ -12,5 +12,6 @@
   "options": {
     "ssl": true,
     "srvServiceName": "customname"
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srv-service-name.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     ssl: true
     srvServiceName: "customname"
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -13,5 +13,6 @@
   "options": {
     "srvMaxHosts": 2,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-equal_to_srv_records.yml
@@ -14,3 +14,4 @@ hosts:
 options:
     srvMaxHosts: 2
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.json
@@ -12,5 +12,6 @@
   "options": {
     "srvMaxHosts": 3,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-greater_than_srv_records.yml
@@ -13,3 +13,4 @@ hosts:
 options:
     srvMaxHosts: 3
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -9,5 +9,6 @@
   "options": {
     "srvMaxHosts": 1,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-less_than_srv_records.yml
@@ -13,3 +13,4 @@ hosts:
 options:
     srvMaxHosts: 1
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.json
@@ -13,5 +13,6 @@
     "replicaSet": "repl0",
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero-txt.yml
@@ -13,3 +13,4 @@ options:
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.json
@@ -13,5 +13,6 @@
     "replicaSet": "repl0",
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/srvMaxHosts-zero.yml
@@ -13,3 +13,4 @@ options:
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-default-port.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-default-port.json
@@ -12,5 +12,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-default-port.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-default-port.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.json
@@ -12,5 +12,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/two-results-nonstandard-port.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "thisDB",
     "ssl": false
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-ssl-option.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: thisDB
     ssl: false
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "otherDB",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/txt-record-with-overridden-uri-option.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: otherDB
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.json
@@ -15,5 +15,6 @@
   },
   "parsed_options": {
     "auth_database": "adminDB"
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-admin-database.yml
@@ -11,3 +11,4 @@ options:
     ssl: true
 parsed_options:
     auth_database: adminDB
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.json
@@ -17,6 +17,6 @@
     "user": "auser",
     "password": "apass"
   },
-  "ping": true,
+  "ping": false,
   "comment": "Should preserve auth credentials"
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.json
@@ -9,9 +9,14 @@
     "localhost:27018",
     "localhost:27019"
   ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
   "parsed_options": {
     "user": "auser",
     "password": "apass"
   },
+  "ping": true,
   "comment": "Should preserve auth credentials"
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.yml
@@ -12,5 +12,8 @@ options:
 parsed_options:
     user: auser
     password: apass
-ping: true
+# Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
+# userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
+# provided but incorrect.
+ping: false
 comment: Should preserve auth credentials

--- a/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/replica-set/uri-with-auth.yml
@@ -6,7 +6,11 @@ hosts:
     - localhost:27017
     - localhost:27018
     - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true
 parsed_options:
     user: auser
     password: apass
+ping: true
 comment: Should preserve auth credentials

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.json
@@ -12,5 +12,6 @@
   "options": {
     "srvMaxHosts": 2,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-equal_to_srv_records.yml
@@ -11,3 +11,4 @@ hosts:
 options:
     srvMaxHosts: 2
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.json
@@ -11,5 +11,6 @@
   "options": {
     "srvMaxHosts": 3,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-greater_than_srv_records.yml
@@ -10,3 +10,4 @@ hosts:
 options:
     srvMaxHosts: 3
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.json
@@ -5,5 +5,6 @@
   "options": {
     "srvMaxHosts": 1,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-less_than_srv_records.yml
@@ -8,3 +8,4 @@ numHosts: 1
 options:
     srvMaxHosts: 1
     ssl: true
+ping: true

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.json
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.json
@@ -11,5 +11,6 @@
   "options": {
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.yml
+++ b/src/test/spec/json/initial-dns-seedlist-discovery/sharded/srvMaxHosts-zero.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/src/test/util/mod.rs
+++ b/src/test/util/mod.rs
@@ -273,30 +273,6 @@ impl TestClient {
         Ok(())
     }
 
-    #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
-    pub(crate) async fn drop_and_create_user(
-        &self,
-        user: &str,
-        pwd: impl Into<Option<&str>>,
-        roles: &[Bson],
-        mechanisms: &[AuthMechanism],
-        db: Option<&str>,
-    ) -> Result<()> {
-        let drop_user_result = self
-            .database(db.unwrap_or("admin"))
-            .run_command(doc! { "dropUser": user }, None)
-            .await;
-
-        match drop_user_result.map_err(|e| *e.kind) {
-            Err(ErrorKind::Command(CommandError { code: 11, .. })) | Ok(_) => {}
-            e @ Err(_) => {
-                e.unwrap();
-            }
-        };
-
-        self.create_user(user, pwd, roles, mechanisms, db).await
-    }
-
     pub(crate) fn get_coll(&self, db_name: &str, coll_name: &str) -> Collection<Document> {
         self.database(db_name).collection(coll_name)
     }


### PR DESCRIPTION
I POCed RUST-1219 when the DRIVERS ticket was done, and reviewed the PR + confirmed the tests worked in Rust for RUST-863, so figured I'd get those changes merged in.