### PR TITLE
RUST-1100 Fix find_and_getmore_share_session flakiness

### DIFF
--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -19,5 +19,7 @@ if [[ "$OS" == "Windows_NT" ]]; then
     export PATH
     echo "updated path on windows PATH=$PATH"
 else
+    # Turn off tracing for the very-spammy nvm script.
+    set +o xtrace
     [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
 fi


### PR DESCRIPTION
RUST-1100

This uses a blunt hammer fix: the failure was the cursor immediately ending, so presumably there was still a race between replication and the test logic.  Since the point of the test isn't replication behavior but sessions, this just adds a loop until the cursor has data.