### PR TITLE
RUST-1273 Increase timeout for retry pool cleared tests

### DIFF
--- a/src/runtime/join_handle.rs
+++ b/src/runtime/join_handle.rs
@@ -21,7 +21,7 @@ pub(crate) enum AsyncJoinHandle<T> {
 }
 
 impl<T> Future for AsyncJoinHandle<T> {
-    // tokio wraps the Output of its JoinHandle in a Result that conatins an error if the task
+    // tokio wraps the Output of its JoinHandle in a Result that contains an error if the task
     // panicked, while async-std does not.
     //
     // Given that async-std will panic or abort the task in this scenario, there is not a

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -130,7 +130,7 @@ async fn retry_read_pool_cleared() {
         .await
         .into_iter()
         .collect::<Result<Vec<_>>>()
-        .expect("all should succeeed");
+        .expect("all should succeed");
 
     let _ = subscriber
         .wait_for_event(Duration::from_millis(500), |event| {
@@ -147,7 +147,7 @@ async fn retry_read_pool_cleared() {
         .expect("pool clear should occur");
 
     let _ = subscriber
-        .wait_for_event(Duration::from_millis(500), |event| match event {
+        .wait_for_event(Duration::from_millis(1000), |event| match event {
             Event::Cmap(CmapEvent::ConnectionCheckoutFailed(e)) => {
                 matches!(e.reason, ConnectionCheckoutFailedReason::ConnectionError)
             }

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -479,7 +479,7 @@ async fn retry_write_pool_cleared() {
         .expect("pool clear should occur");
 
     let _ = subscriber
-        .wait_for_event(Duration::from_millis(500), |event| match event {
+        .wait_for_event(Duration::from_millis(1000), |event| match event {
             Event::Cmap(CmapEvent::ConnectionCheckoutFailed(e)) => {
                 matches!(e.reason, ConnectionCheckoutFailedReason::ConnectionError)
             }

--- a/src/test/spec/retryable_writes/mod.rs
+++ b/src/test/spec/retryable_writes/mod.rs
@@ -478,15 +478,25 @@ async fn retry_write_pool_cleared() {
         .await
         .expect("pool clear should occur");
 
-    let _ = subscriber
-        .wait_for_event(Duration::from_millis(1000), |event| match event {
-            Event::Cmap(CmapEvent::ConnectionCheckoutFailed(e)) => {
-                matches!(e.reason, ConnectionCheckoutFailedReason::ConnectionError)
-            }
+    let next_cmap_events = subscriber
+        .collect_events(Duration::from_millis(1000), |event| match event {
+            Event::Cmap(_) => true,
             _ => false,
         })
-        .await
-        .expect("second checkout should fail");
+        .await;
+
+    if !next_cmap_events.iter().any(|event| match event {
+        Event::Cmap(CmapEvent::ConnectionCheckoutFailed(e)) => {
+            matches!(e.reason, ConnectionCheckoutFailedReason::ConnectionError)
+        }
+        _ => false,
+    }) {
+        panic!(
+            "Expected second checkout to fail, but no ConnectionCheckoutFailed event observed. \
+             CMAP events:\n{:?}",
+            next_cmap_events
+        );
+    }
 
     assert_eq!(handler.get_command_started_events(&["insert"]).len(), 3);
 }


### PR DESCRIPTION
This PR bumps the timeout used to wait for a `ConnectionCheckoutFailed` event. I also added some error messages to make debugging this test easier in the future if we run into more failures.