### PR TITLE
RUST-1314 Support on-demand AWS credentials for in-use encryption (#831)

### DIFF
--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -7,7 +7,7 @@ source ./.evergreen/env.sh
 
 set -o xtrace
 
-FEATURE_FLAGS="in-use-encryption-unstable,${TLS_FEATURE}"
+FEATURE_FLAGS="in-use-encryption-unstable,aws-auth,${TLS_FEATURE}"
 OPTIONS="-- -Z unstable-options --format json --report-time"
 
 if [ "$SINGLE_THREAD" = true ]; then
@@ -38,6 +38,11 @@ set +o errexit
 cargo_test test::csfle > prose.xml
 cargo_test test::spec::client_side_encryption > spec.xml
 
-junit-report-merger results.xml prose.xml spec.xml
+# Unset variables for on-demand credential failure tests.
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+cargo_test test::csfle::on_demand_aws_failure > failure.xml
+
+junit-report-merger results.xml prose.xml spec.xml failure.xml
 
 exit ${CARGO_RESULT}

--- a/src/client/auth/aws.rs
+++ b/src/client/auth/aws.rs
@@ -115,7 +115,7 @@ pub(super) async fn authenticate_stream(
 
 /// Contains the credentials for MONGODB-AWS authentication.
 #[derive(Debug, Deserialize)]
-struct AwsCredential {
+pub(crate) struct AwsCredential {
     #[serde(rename = "AccessKeyId")]
     access_key: String,
 
@@ -129,7 +129,7 @@ struct AwsCredential {
 impl AwsCredential {
     /// Derives the credentials for an authentication attempt given the set of credentials the user
     /// passed in.
-    async fn get(credential: &Credential, http_client: &HttpClient) -> Result<Self> {
+    pub(crate) async fn get(credential: &Credential, http_client: &HttpClient) -> Result<Self> {
         let access_key = credential
             .username
             .clone()
@@ -347,6 +347,18 @@ impl AwsCredential {
         );
 
         Ok(auth_header)
+    }
+
+    pub(crate) fn access_key(&self) -> &str {
+        &self.access_key
+    }
+
+    pub(crate) fn secret_key(&self) -> &str {
+        &self.secret_key
+    }
+
+    pub(crate) fn session_token(&self) -> Option<&str> {
+        self.session_token.as_deref()
     }
 }
 

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -2,7 +2,7 @@
 //! [`Client`](struct.Client.html).
 
 #[cfg(feature = "aws-auth")]
-mod aws;
+pub(crate) mod aws;
 mod plain;
 mod sasl;
 mod scram;

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -69,7 +69,7 @@ impl ClientState {
         let exec = CryptExecutor::new_implicit(
             aux_clients.key_vault_client,
             opts.key_vault_namespace.clone(),
-            opts.kms_providers.tls_options().clone(),
+            opts.kms_providers.clone(),
             mongocryptd_opts,
             mongocryptd_client,
             aux_clients.metadata_client,

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -60,11 +60,12 @@ impl ClientEncryption {
         let kms_providers = KmsProviders::new(kms_providers)?;
         let crypt = Crypt::builder()
             .kms_providers(&kms_providers.credentials_doc()?)?
+            .use_need_kms_credentials_state()
             .build()?;
         let exec = CryptExecutor::new_explicit(
             key_vault_client.weak(),
             key_vault_namespace.clone(),
-            kms_providers.tls_options().clone(),
+            kms_providers,
         )?;
         let key_vault = key_vault_client
             .database(&key_vault_namespace.db)

--- a/src/client/csfle/options.rs
+++ b/src/client/csfle/options.rs
@@ -122,11 +122,10 @@ impl KmsProviders {
         Ok(bson::to_document(&self.credentials)?)
     }
 
-    pub(crate) fn tls_options(&self) -> &Option<KmsProvidersTlsOptions> {
-        &self.tls_options
+    pub(crate) fn tls_options(&self) -> Option<&KmsProvidersTlsOptions> {
+        self.tls_options.as_ref()
     }
 
-    #[cfg(test)]
     pub(crate) fn credentials(&self) -> &HashMap<KmsProvider, Document> {
         &self.credentials
     }

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2749,7 +2749,70 @@ impl CommandEventHandler for DecryptionEventsHandler {
     }
 }
 
-// TODO RUST-1314: implement prose test 15. On-demand AWS Credentials
+// Prose test 15. On-demand AWS Credentials (failure)
+#[cfg(feature = "aws-auth")]
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn on_demand_aws_failure() -> Result<()> {
+    if !check_env("on_demand_aws_failure", false) {
+        return Ok(());
+    }
+    if std::env::var("AWS_ACCESS_KEY_ID").is_ok() && std::env::var("AWS_SECRET_ACCESS_KEY").is_ok()
+    {
+        log_uncaptured("Skipping on_demand_aws_failure: credentials set");
+        return Ok(());
+    }
+    let _guard = LOCK.run_exclusively().await;
+
+    let ce = ClientEncryption::new(
+        Client::test_builder().build().await.into_client(),
+        KV_NAMESPACE.clone(),
+        [(KmsProvider::Aws, doc! {}, None)],
+    )?;
+    let result = ce
+        .create_data_key(MasterKey::Aws {
+            region: "us-east-1".to_string(),
+            key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+                .to_string(),
+            endpoint: None,
+        })
+        .run()
+        .await;
+    assert!(
+        result.as_ref().unwrap_err().is_auth_error(),
+        "Expected auth error, got {:?}",
+        result
+    );
+
+    Ok(())
+}
+
+// Prose test 15. On-demand AWS Credentials (success)
+#[cfg(feature = "aws-auth")]
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn on_demand_aws_success() -> Result<()> {
+    if !check_env("on_demand_aws_success", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_exclusively().await;
+
+    let ce = ClientEncryption::new(
+        Client::test_builder().build().await.into_client(),
+        KV_NAMESPACE.clone(),
+        [(KmsProvider::Aws, doc! {}, None)],
+    )?;
+    ce.create_data_key(MasterKey::Aws {
+        region: "us-east-1".to_string(),
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+            .to_string(),
+        endpoint: None,
+    })
+    .run()
+    .await?;
+
+    Ok(())
+}
 
 // TODO RUST-1441: implement prose test 16. Rewrap
 


### PR DESCRIPTION
Cherry-pick from main for the 2.4.0 release.