### PR TITLE
RUST-1607: allow uuidRepresentation in connection string

### DIFF
--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -815,9 +815,10 @@ pub struct ConnectionString {
     /// Default read preference for the client.
     pub read_preference: Option<ReadPreference>,
 
-    /// The [`UuidRepresentation`] to use when decoding [`Binary`] values with the UuidOld subtype.
-    /// This is not used by the driver; client code can use this when deserializing relevant
-    /// values with [`Binary::to_uuid_with_representation`].
+    /// The [`UuidRepresentation`] to use when decoding [`Binary`](bson::Binary) values with the
+    /// [`UuidOld`](bson::spec::BinarySubtype::UuidOld) subtype. This is not used by the
+    /// driver; client code can use this when deserializing relevant values with
+    /// [`Binary::to_uuid_with_representation`](bson::binary::Binary::to_uuid_with_representation).
     pub uuid_representation: Option<UuidRepresentation>,
 
     wait_queue_timeout: Option<Duration>,

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -2126,7 +2126,7 @@ impl ConnectionString {
                     "csharplegacy" => self.uuid_representation = Some(UuidRepresentation::CSharpLegacy),
                     "javalegacy" => self.uuid_representation = Some(UuidRepresentation::JavaLegacy),
                     "pythonlegacy" => self.uuid_representation = Some(UuidRepresentation::PythonLegacy),
-                    _ => return Err(ErrorKind::InvalidArgument { 
+                    _ => return Err(ErrorKind::InvalidArgument {
                         message: format!("connection string `uuidRepresentation` option can be one of `csharpLegacy`, `javaLegacy`, or `pythonLegacy`. Received invalid `{value}`") 
                     }
                     .into())

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -15,6 +15,7 @@ use std::{
     time::Duration,
 };
 
+use bson::UuidRepresentation;
 use derivative::Derivative;
 use lazy_static::lazy_static;
 use serde::{de::Unexpected, Deserialize, Deserializer, Serialize};
@@ -74,6 +75,7 @@ const URI_OPTIONS: &[&str] = &[
     "tlsallowinvalidcertificates",
     "tlscafile",
     "tlscertificatekeyfile",
+    "uuidRepresentation",
     "w",
     "waitqueuetimeoutms",
     "wtimeoutms",
@@ -812,6 +814,10 @@ pub struct ConnectionString {
 
     /// Default read preference for the client.
     pub read_preference: Option<ReadPreference>,
+
+    /// The `uuidRepresentation` to use when decoding UuidOld bindata types. This serves as a caching
+    /// mechanism. You must reference this option manually when you wish to use it with `to_uuid_with_representation`.
+    pub uuid_representation: Option<UuidRepresentation>,
 
     wait_queue_timeout: Option<Duration>,
     tls_insecure: Option<bool>,
@@ -2115,6 +2121,17 @@ impl ConnectionString {
                     ))
                 }
             },
+            "uuidrepresentation" => {
+                match value.to_lowercase().as_str() {
+                    "csharplegacy" => self.uuid_representation = Some(UuidRepresentation::CSharpLegacy),
+                    "javalegacy" => self.uuid_representation = Some(UuidRepresentation::JavaLegacy),
+                    "pythonlegacy" => self.uuid_representation = Some(UuidRepresentation::PythonLegacy),
+                    _ => return Err(ErrorKind::InvalidArgument { 
+                        message: format!("connection string `uuidRepresentation` option can be one of `csharpLegacy`, `javaLegacy`, or `pythonLegacy`. Received invalid `{value}`") 
+                    }
+                    .into())
+                }
+            }
             "w" => {
                 let mut write_concern = self.write_concern.get_or_insert_with(Default::default);
 

--- a/src/client/options/mod.rs
+++ b/src/client/options/mod.rs
@@ -815,9 +815,9 @@ pub struct ConnectionString {
     /// Default read preference for the client.
     pub read_preference: Option<ReadPreference>,
 
-    /// The `uuidRepresentation` to use when decoding UuidOld bindata types.  This is not used by
-    /// the driver; client code can use this when deserializing relevant values with
-    /// `to_uuid_with_representation`.
+    /// The [`UuidRepresentation`] to use when decoding [`Binary`] values with the UuidOld subtype.
+    /// This is not used by the driver; client code can use this when deserializing relevant
+    /// values with [`Binary::to_uuid_with_representation`].
     pub uuid_representation: Option<UuidRepresentation>,
 
     wait_queue_timeout: Option<Duration>,

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -240,7 +240,12 @@ async fn uuid_representations() {
     let uuid_err = parse_uri_with_uuid_representation("unknownLegacy")
         .await
         .expect_err("expect `unknownLegacy` to be an invalid argument for `uuidRepresentation`");
-    assert_eq!("connection string `uuidRepresentation` option can be one of `csharpLegacy`, `javaLegacy`, or `pythonLegacy`. Received invalid `unknownLegacy`".to_string(), uuid_err );
+    assert_eq!(
+        "connection string `uuidRepresentation` option can be one of `csharpLegacy`, \
+         `javaLegacy`, or `pythonLegacy`. Received invalid `unknownLegacy`"
+            .to_string(),
+        uuid_err
+    );
 }
 
 async fn parse_uri_with_uuid_representation(uuid_repr: &str) -> Result<UuidRepresentation, String> {

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -250,7 +250,8 @@ async fn uuid_representations() {
 
 async fn parse_uri_with_uuid_representation(uuid_repr: &str) -> Result<UuidRepresentation, String> {
     match ConnectionString::parse(format!(
-        "mongodb://localhost:27017/?uuidRepresentation={uuid_repr}"
+        "mongodb://localhost:27017/?uuidRepresentation={}",
+        uuid_repr
     ))
     .map_err(|e| e.message().unwrap())
     {


### PR DESCRIPTION
This adds `uuidRepresentation` to `ConnectionString`.

I wasn't sure what to put for the documentation comment, it could probably be cleaned up.