### PR TITLE
RUST-107 Convenient transactions

### DIFF
--- a/.evergreen/MSRV-Cargo.lock
+++ b/.evergreen/MSRV-Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "mongocrypt"
-version = "0.1.0"
+version = "0.1.1"
 source = "git+https://github.com/mongodb/libmongocrypt-rust.git?branch=main"
 dependencies = [
  "bson",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "mongocrypt-sys"
-version = "0.1.0+1.5.0-rc0"
+version = "0.1.1+1.8.0-alpha0"
 source = "git+https://github.com/mongodb/libmongocrypt-rust.git?branch=main#eee5a9817cdfb92204f6167ade5064f540e8b9e9"
 
 [[package]]

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -563,7 +563,7 @@ impl ClientSession {
     }
 
     /// TODO
-    pub async fn with_transaction<F, R, C>(&mut self, mut callback: F, options: impl Into<Option<TransactionOptions>>, mut context: C) -> Result<R>
+    pub async fn with_transaction<R, C, F>(&mut self, mut context: C, mut callback: F, options: impl Into<Option<TransactionOptions>>) -> Result<R>
         where F: for<'a> FnMut(&'a mut ClientSession, &'a mut C) -> BoxFuture<'a, Result<R>>,
     {
         let options = options.into();

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -9,6 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use futures_core::future::BoxFuture;
 use lazy_static::lazy_static;
 use uuid::Uuid;
 
@@ -558,6 +559,15 @@ impl ClientSession {
                     .await;
                 Ok(())
             }
+        }
+    }
+
+    /// TODO
+    pub async fn with_transaction<F, R>(&mut self, mut callback: F, _options: impl Into<Option<TransactionOptions>>) -> Result<R>
+        where F: for<'a> FnMut(&'a mut ClientSession) -> BoxFuture<'a, Result<R>>,
+    {
+        loop {
+            callback(self).await?;
         }
     }
 

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -566,15 +566,17 @@ impl ClientSession {
         }
     }
 
-    /// Runs a callback inside a transaction.  Transient transaction errors will cause the callback to be
-    /// re-run, other errors will abort the transaction and be returned to the caller.  If the callback needs
-    /// to provide its own error information, the [`Error::custom`](crate::error::Error::custom) method can accept an arbitrary payload that
+    /// Runs a callback inside a transaction.  Transient transaction errors will cause the callback
+    /// to be re-run, other errors will abort the transaction and be returned to the caller.  If
+    /// the callback needs to provide its own error information, the
+    /// [`Error::custom`](crate::error::Error::custom) method can accept an arbitrary payload that
     /// can be retrieved via [`Error::get_custom`](crate::error::Error::get_custom).
-    /// 
-    /// Because the callback can be repeatedly executed and because it returns a future, the rust closure borrowing
-    /// rules for captured values can be overly restrictive.  As a convenience, `with_transaction` accepts a context
-    /// argument that will be passed to the callback along with the session:
-    /// 
+    ///
+    /// Because the callback can be repeatedly executed and because it returns a future, the rust
+    /// closure borrowing rules for captured values can be overly restrictive.  As a
+    /// convenience, `with_transaction` accepts a context argument that will be passed to the
+    /// callback along with the session:
+    ///
     /// ```no_run
     /// # use mongodb::{bson::{doc, Document}, error::Result, Client};
     /// # use futures::FutureExt;

--- a/src/client/session/mod.rs
+++ b/src/client/session/mod.rs
@@ -617,10 +617,7 @@ impl ClientSession {
         let options = options.into();
         let timeout = Duration::from_secs(120);
         #[cfg(test)]
-        let timeout = self
-            .convenient_transaction_timeout
-            .clone()
-            .unwrap_or(timeout);
+        let timeout = self.convenient_transaction_timeout.unwrap_or(timeout);
         let start = Instant::now();
 
         use crate::error::{TRANSIENT_TRANSACTION_ERROR, UNKNOWN_TRANSACTION_COMMIT_RESULT};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,10 @@
 //! Contains the `Error` and `Result` types that `mongodb` uses.
 
 use std::{
+    any::Any,
     collections::{HashMap, HashSet},
     fmt::{self, Debug},
-    sync::Arc, any::Any,
+    sync::Arc,
 };
 
 use bson::Bson;
@@ -52,12 +53,14 @@ pub struct Error {
 }
 
 impl Error {
-    /// Create a new `Error` wrapping an arbitrary value.  Can be used to abort transactions in callbacks for [ClientSession::with_transaction].
+    /// Create a new `Error` wrapping an arbitrary value.  Can be used to abort transactions in
+    /// callbacks for [ClientSession::with_transaction].
     pub fn custom(e: impl Any + Send + Sync) -> Self {
         Self::new(ErrorKind::Custom(Arc::new(e)), None::<Option<String>>)
     }
 
-    /// Retrieve a reference to a value provided to `Error::custom`.  Returns `None` if this is not a custom error or if the payload types mismatch.
+    /// Retrieve a reference to a value provided to `Error::custom`.  Returns `None` if this is not
+    /// a custom error or if the payload types mismatch.
     pub fn get_custom<E: Any>(&self) -> Option<&E> {
         if let ErrorKind::Custom(c) = &*self.kind {
             c.downcast_ref()

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ pub struct Error {
 
 impl Error {
     /// Create a new `Error` wrapping an arbitrary value.  Can be used to abort transactions in
-    /// callbacks for [ClientSession::with_transaction].
+    /// callbacks for [`ClientSession::with_transaction`](crate::ClientSession::with_transaction).
     pub fn custom(e: impl Any + Send + Sync) -> Self {
         Self::new(ErrorKind::Custom(Arc::new(e)), None::<Option<String>>)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,6 +154,10 @@ impl Error {
         matches!(self.kind.as_ref(), ErrorKind::ServerSelection { .. })
     }
 
+    pub(crate) fn is_max_time_ms_expired_error(&self) -> bool {
+        self.code() == Some(50)
+    }
+
     /// Whether a read operation should be retried if this error occurs.
     pub(crate) fn is_read_retryable(&self) -> bool {
         if self.is_network_error() {

--- a/src/test/spec/json/transactions-convenient-api/README.rst
+++ b/src/test/spec/json/transactions-convenient-api/README.rst
@@ -1,0 +1,222 @@
+=====================================
+Convenient API for Transactions Tests
+=====================================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+The YAML and JSON files in this directory are platform-independent tests that
+drivers can use to prove their conformance to the Convenient API for
+Transactions spec.  They are designed with the intention of sharing some
+test-runner code with the CRUD, Command Monitoring, and Transaction spec tests.
+
+Several prose tests, which are not easily expressed in YAML, are also presented
+in this file. Those tests will need to be manually implemented by each driver.
+
+Server Fail Point
+=================
+
+See: `Server Fail Point <../../transactions/tests#server-fail-point>`_ in the
+Transactions spec test suite.
+
+Test Format
+===========
+
+Each YAML file has the following keys:
+
+- ``runOn`` (optional): An array of server version and/or topology requirements
+  for which the tests can be run. If the test environment satisfies one or more
+  of these requirements, the tests may be executed; otherwise, this file should
+  be skipped. If this field is omitted, the tests can be assumed to have no
+  particular requirements and should be executed. Each element will have some or
+  all of the following fields:
+
+  - ``minServerVersion`` (optional): The minimum server version (inclusive)
+    required to successfully run the tests. If this field is omitted, it should
+    be assumed that there is no lower bound on the required server version.
+
+  - ``maxServerVersion`` (optional): The maximum server version (inclusive)
+    against which the tests can be run successfully. If this field is omitted,
+    it should be assumed that there is no upper bound on the required server
+    version.
+
+  - ``topology`` (optional): An array of server topologies against which the
+    tests can be run successfully. Valid topologies are "single", "replicaset",
+    and "sharded". If this field is omitted, the default is all topologies (i.e.
+    ``["single", "replicaset", "sharded"]``).
+
+- ``database_name`` and ``collection_name``: The database and collection to use
+  for testing.
+
+- ``data``: The data that should exist in the collection under test before each
+  test run.
+
+- ``tests``: An array of tests that are to be run independently of each other.
+  Each test will have some or all of the following fields:
+
+  - ``description``: The name of the test.
+
+  - ``skipReason`` (optional): If present, the test should be skipped and the
+    string value will specify a reason.
+
+  - ``failPoint`` (optional): The ``configureFailPoint`` command document to run
+    to configure a fail point on the primary server. This option and
+    ``useMultipleMongoses: true`` are mutually exclusive.
+
+  - ``useMultipleMongoses`` (optional): If ``true``, the MongoClient for this
+    test should be initialized with multiple mongos seed addresses. If ``false``
+    or omitted, only a single mongos address should be specified. This field has
+    no effect for non-sharded topologies.
+
+  - ``clientOptions`` (optional): Names and values of options to pass to
+    ``MongoClient()``.
+
+  - ``sessionOptions`` (optional): Names and values of options to pass to
+    ``MongoClient.startSession()``.
+
+  - ``operations``: Array of documents, each describing an operation to be
+    executed. Each document has the following fields:
+
+    - ``name``: The name of the operation on ``object``.
+
+    - ``object``: The name of the object on which to perform the operation. The
+      value will be either "collection" or "session0".
+
+    - ``arguments`` (optional): Names and values of arguments to pass to the
+      operation.
+
+    - ``result`` (optional): The return value from the operation. This will
+      correspond to an operation's result object as defined in the CRUD
+      specification. If the operation is expected to return an error, the
+      ``result`` is a single document that has one or more of the following
+      fields:
+
+      - ``errorContains``: A substring of the expected error message.
+
+      - ``errorCodeName``: The expected "codeName" field in the server
+        error response.
+
+      - ``errorLabelsContain``: A list of error label strings that the
+        error is expected to have.
+
+      - ``errorLabelsOmit``: A list of error label strings that the
+        error is expected not to have.
+
+  - ``expectations`` (optional): List of command-started events.
+
+  - ``outcome``: Document describing the return value and/or expected state of
+    the collection after the operation is executed. Contains the following
+    fields:
+
+    - ``collection``:
+
+      - ``data``: The data that should exist in the collection after the
+        operations have run.
+
+``withTransaction`` Operation
+`````````````````````````````
+
+These tests introduce a ``withTransaction`` operation, which may have the
+following fields:
+
+- ``callback``: Document containing the following field:
+
+  - ``operations``: Array of documents, each describing an operation to be
+    executed. Elements in this array will follow the same structure as the
+    ``operations`` field defined above (and in the CRUD and Transactions specs).
+
+    Note that drivers are expected to evaluate ``error`` and ``result``
+    assertions when executing operations within ``callback.operations``.
+
+- ``options`` (optional): Names and values of options to pass to
+  ``withTransaction()``, which will in turn be used for ``startTransaction()``.
+
+Use as Integration Tests
+========================
+
+Testing against a replica set will require server version 4.0.0 or later. The
+replica set should include a primary, a secondary, and an arbiter. Including a
+secondary ensures that server selection in a transaction works properly.
+Including an arbiter helps ensure that no new bugs have been introduced related
+to arbiters.
+
+Testing against a sharded cluster will require server version 4.1.6 or later.
+A driver that implements support for sharded transactions MUST also run these
+tests against a MongoDB sharded cluster with multiple mongoses. Including
+multiple mongoses (and initializing the MongoClient with multiple mongos seeds!)
+ensures that mongos transaction pinning works properly.
+
+See: `Use as Integration Tests <../../transactions/tests#use-as-integration-tests>`_
+in the Transactions spec test suite for instructions on executing each test.
+
+Take note of the following:
+
+- Most tests will consist of a single "withTransaction" operation to be invoked
+  on the "session0" object. The ``callback`` argument of that operation will
+  resemble the ``operations`` array found in transaction spec tests.
+
+Command-Started Events
+``````````````````````
+
+See: `Command-Started Events <../../transactions/tests#command-started-events>`_
+in the Transactions spec test suite for instructions on asserting
+command-started events.
+
+Prose Tests
+===========
+
+Callback Raises a Custom Error
+``````````````````````````````
+
+Write a callback that raises a custom exception or error that does not include
+either UnknownTransactionCommitResult or TransientTransactionError error labels.
+Execute this callback using ``withTransaction`` and assert that the callback's
+error bypasses any retry logic within ``withTransaction`` and is propagated to
+the caller of ``withTransaction``.
+
+Callback Returns a Value
+````````````````````````
+
+Write a callback that returns a custom value (e.g. boolean, string, object).
+Execute this callback using ``withTransaction`` and assert that the callback's
+return value is propagated to the caller of ``withTransaction``.
+
+Retry Timeout is Enforced
+`````````````````````````
+
+Drivers should test that ``withTransaction`` enforces a non-configurable timeout
+before retrying both commits and entire transactions. Specifically, three cases
+should be checked:
+
+ * If the callback raises an error with the TransientTransactionError label and
+   the retry timeout has been exceeded, ``withTransaction`` should propagate the
+   error to its caller.
+ * If committing raises an error with the UnknownTransactionCommitResult label,
+   and the retry timeout has been exceeded, ``withTransaction`` should
+   propagate the error to its caller.
+ * If committing raises an error with the TransientTransactionError label and
+   the retry timeout has been exceeded, ``withTransaction`` should propagate the
+   error to its caller. This case may occur if the commit was internally retried
+   against a new primary after a failover and the second primary returned a
+   NoSuchTransaction error response.
+
+ If possible, drivers should implement these tests without requiring the test
+ runner to block for the full duration of the retry timeout. This might be done
+ by internally modifying the timeout value used by ``withTransaction`` with some
+ private API or using a mock timer.
+
+Changelog
+=========
+
+:2021-04-29: Remove text about write concern timeouts from prose test.
+
+:2019-03-01: Add top-level ``runOn`` field to denote server version and/or
+             topology requirements requirements for the test file. Removes the
+             ``minServerVersion`` top-level field, which is now expressed within
+             ``runOn`` elements.
+
+             Add test-level ``useMultipleMongoses`` field.

--- a/src/test/spec/json/transactions-convenient-api/callback-aborts.json
+++ b/src/test/spec/json/transactions-convenient-api/callback-aborts.json
@@ -1,0 +1,244 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction succeeds if callback aborts",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "abortTransaction",
+                  "object": "session0"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "withTransaction succeeds if callback aborts with no ops",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "abortTransaction",
+                  "object": "session0"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "withTransaction still succeeds if callback aborts and runs extra op",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "abortTransaction",
+                  "object": "session0"
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "autocommit": null,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/callback-aborts.yml
+++ b/src/test/spec/json/transactions-convenient-api/callback-aborts.yml
@@ -1,0 +1,170 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    # Session state will be ABORTED when callback returns to withTransaction
+    description: withTransaction succeeds if callback aborts
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: abortTransaction
+                object: session0
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data: []
+  -
+    # Session state will be ABORTED when callback returns to withTransaction
+    description: withTransaction succeeds if callback aborts with no ops
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: abortTransaction
+                object: session0
+    expectations: []
+    outcome:
+      collection:
+        data: []
+  -
+    # Session state will be NO_TXN when callback returns to withTransaction
+    description: withTransaction still succeeds if callback aborts and runs extra op
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: abortTransaction
+                object: session0
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            # This test is agnostic about retryWrites, so we do not assert the
+            # txnNumber. If retryWrites=true, the txnNumber will be incremented
+            # from the value used in the previous transaction; otherwise, the
+            # field will not be present at all.
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            # omitted fields
+            autocommit: ~
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - { _id: 2 }

--- a/src/test/spec/json/transactions-convenient-api/callback-commits.json
+++ b/src/test/spec/json/transactions-convenient-api/callback-commits.json
@@ -1,0 +1,303 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction succeeds if callback commits",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
+                },
+                {
+                  "name": "commitTransaction",
+                  "object": "session0"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction still succeeds if callback commits and runs extra op",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
+                },
+                {
+                  "name": "commitTransaction",
+                  "object": "session0"
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 3
+                    }
+                  },
+                  "result": {
+                    "insertedId": 3
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "autocommit": null,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/callback-commits.yml
+++ b/src/test/spec/json/transactions-convenient-api/callback-commits.yml
@@ -1,0 +1,204 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    # Session state will be COMMITTED when callback returns to withTransaction
+    description: withTransaction succeeds if callback commits
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+              -
+                name: commitTransaction
+                object: session0
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }
+  -
+    # Session state will be NO_TXN when callback returns to withTransaction
+    description: withTransaction still succeeds if callback commits and runs extra op
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+              -
+                name: commitTransaction
+                object: session0
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 3 }
+                result:
+                  insertedId: 3
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            # This test is agnostic about retryWrites, so we do not assert the
+            # txnNumber. If retryWrites=true, the txnNumber will be incremented
+            # from the value used in the previous transaction; otherwise, the
+            # field will not be present at all.
+            insert: *collection_name
+            documents:
+              - { _id: 3 }
+            ordered: true
+            lsid: session0
+            # omitted fields
+            autocommit: ~
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }
+          - { _id: 3 }

--- a/src/test/spec/json/transactions-convenient-api/callback-retry.json
+++ b/src/test/spec/json/transactions-convenient-api/callback-retry.json
@@ -1,0 +1,315 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "callback succeeds after multiple connection errors",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "callback is not retried after non-transient error (DuplicateKeyError)",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "errorLabelsOmit": [
+                      "TransientTransactionError",
+                      "UnknownTransactionCommitResult"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ],
+            "errorContains": "E11000"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/callback-retry.yml
+++ b/src/test/spec/json/transactions-convenient-api/callback-retry.yml
@@ -1,0 +1,215 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: callback succeeds after multiple connection errors
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["insert"]
+          closeConnection: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                # We do not assert the result here, as insertOne will fail for
+                # the first two executions of the callback before ultimately
+                # succeeding and returning a result. Asserting the state of the
+                # output collection after the test is sufficient.
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # third transaction will be causally consistent with the second
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "3" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "3" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: callback is not retried after non-transient error (DuplicateKeyError)
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+        result:
+          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+          # DuplicateKey error code included in the bulk write error message
+          # returned by the server
+          errorContains: E11000
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: abortTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data: []

--- a/src/test/spec/json/transactions-convenient-api/commit-retry.json
+++ b/src/test/spec/json/transactions-convenient-api/commit-retry.json
@@ -1,0 +1,531 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction succeeds after multiple connection errors",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction retry only overwrites write concern w option",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "writeConcern": {
+                "w": 2,
+                "j": true,
+                "wtimeout": 5000
+              }
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 2,
+                "j": true,
+                "wtimeout": 5000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "j": true,
+                "wtimeout": 5000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "j": true,
+                "wtimeout": 5000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commit is retried after commitTransaction UnknownTransactionCommitResult (NotWritablePrimary)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commit is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "maxCommitTimeMS": 60000
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "maxTimeMS": 60000,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/commit-retry.yml
+++ b/src/test/spec/json/transactions-convenient-api/commit-retry.yml
@@ -1,0 +1,325 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: commitTransaction succeeds after multiple connection errors
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          closeConnection: true
+    operations:
+      - &withTransaction
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: commitTransaction retry only overwrites write concern w option
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          closeConnection: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            writeConcern: { w: 2, j: true, wtimeout: 5000 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 2, j: true, wtimeout: 5000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, j: true, wtimeout: 5000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, j: true, wtimeout: 5000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: commit is retried after commitTransaction UnknownTransactionCommitResult (NotWritablePrimary)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 10107 # NotWritablePrimary
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          closeConnection: false
+    operations:
+      - *withTransaction
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: commit is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50 # MaxTimeMSExpired
+    operations:
+      - name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            maxCommitTimeMS: 60000
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            maxTimeMS: 60000
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        # In reality, the outcome of the commit is unknown but we fabricate
+        # the error with failCommand.errorCode which does not apply the commit
+        # operation.
+        data: []

--- a/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror-4.2.json
+++ b/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror-4.2.json
@@ -1,0 +1,197 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.6",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (PreparedTransactionInProgress)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 267,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror-4.2.yml
+++ b/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror-4.2.yml
@@ -1,0 +1,139 @@
+runOn:
+    -
+        minServerVersion: "4.1.6"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+# These tests use error codes where the TransientTransactionError label will be
+# applied to the error response for commitTransaction. This will cause the
+# entire transaction to be retried instead of commitTransaction.
+#
+# See: https://github.com/mongodb/mongo/blob/r4.1.6/src/mongo/db/handle_request_response.cpp
+tests:
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (PreparedTransactionInProgress)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 267 # PreparedTransactionInProgress
+          closeConnection: false
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # third transaction will be causally consistent with the second
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "3" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "3" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }

--- a/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror.json
+++ b/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror.json
@@ -1,0 +1,725 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (LockTimeout)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 24,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (WriteConflict)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 112,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (SnapshotUnavailable)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 246,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction is retried after commitTransaction TransientTransactionError (NoSuchTransaction)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 251,
+          "closeConnection": false
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "3"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror.yml
+++ b/src/test/spec/json/transactions-convenient-api/commit-transienttransactionerror.yml
@@ -1,0 +1,175 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+# These tests use error codes where the TransientTransactionError label will be
+# applied to the error response for commitTransaction. This will cause the
+# entire transaction to be retried instead of commitTransaction.
+#
+# See: https://github.com/mongodb/mongo/blob/r4.1.6/src/mongo/db/handle_request_response.cpp
+tests:
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (LockTimeout)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 24 # LockTimeout
+          closeConnection: false
+    operations: &operations
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+    expectations: &expectations
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            # third transaction will be causally consistent with the second
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented when retrying the transaction
+            txnNumber: { $numberLong: "3" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "3" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (WriteConflict)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 112 # WriteConflict
+          closeConnection: false
+    operations: *operations
+    expectations: *expectations
+    outcome: *outcome
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (SnapshotUnavailable)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 246 # SnapshotUnavailable
+          closeConnection: false
+    operations: *operations
+    expectations: *expectations
+    outcome: *outcome
+  -
+    description: transaction is retried after commitTransaction TransientTransactionError (NoSuchTransaction)
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 251 # NoSuchTransaction
+          closeConnection: false
+    operations: *operations
+    expectations: *expectations
+    outcome: *outcome

--- a/src/test/spec/json/transactions-convenient-api/commit-writeconcernerror.json
+++ b/src/test/spec/json/transactions-convenient-api/commit-writeconcernerror.json
@@ -1,0 +1,602 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "commitTransaction is retried after WriteConcernFailed timeout error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 64,
+            "codeName": "WriteConcernFailed",
+            "errmsg": "waiting for replication timed out",
+            "errInfo": {
+              "wtimeout": true
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is retried after WriteConcernFailed non-timeout error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 64,
+            "codeName": "WriteConcernFailed",
+            "errmsg": "multiple errors reported"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is not retried after UnknownReplWriteConcern error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 79,
+            "codeName": "UnknownReplWriteConcern",
+            "errmsg": "No write concern mode named 'foo' found in replica set configuration"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "UnknownReplWriteConcern",
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 100,
+            "codeName": "UnsatisfiableWriteConcern",
+            "errmsg": "Not enough data-bearing nodes"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "UnsatisfiableWriteConcern",
+            "errorLabelsOmit": [
+              "TransientTransactionError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "commitTransaction is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "codeName": "MaxTimeMSExpired",
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/commit-writeconcernerror.yml
+++ b/src/test/spec/json/transactions-convenient-api/commit-writeconcernerror.yml
@@ -1,0 +1,216 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: commitTransaction is retried after WriteConcernFailed timeout error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          # Do not specify closeConnection: false, since that would conflict
+          # with writeConcernError (see: SERVER-39292)
+          writeConcernError:
+            code: 64
+            codeName: WriteConcernFailed
+            errmsg: "waiting for replication timed out"
+            errInfo: { wtimeout: true }
+    operations:
+      - &operation
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+    expectations: &expectations_with_retries
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # commitTransaction applies w:majority on retries (SPEC-1185)
+            writeConcern: { w: majority, wtimeout: 10000 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    # The write operation is still applied despite the write concern error
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    # This test configures the fail point to return an error with the
+    # WriteConcernFailed code but without errInfo that would identify it as a
+    # wtimeout error. This tests that drivers do not assume that all
+    # WriteConcernFailed errors are due to a replication timeout.
+    description: commitTransaction is retried after WriteConcernFailed non-timeout error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 2 }
+      data:
+          failCommands: ["commitTransaction"]
+          # Do not specify closeConnection: false, since that would conflict
+          # with writeConcernError (see: SERVER-39292)
+          writeConcernError:
+            code: 64
+            codeName: WriteConcernFailed
+            errmsg: "multiple errors reported"
+    operations:
+      - *operation
+    expectations: *expectations_with_retries
+    outcome: *outcome
+  -
+    description: commitTransaction is not retried after UnknownReplWriteConcern error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 79
+            codeName: UnknownReplWriteConcern
+            errmsg: "No write concern mode named 'foo' found in replica set configuration"
+    operations:
+      - <<: *operation
+        result:
+          errorCodeName: UnknownReplWriteConcern
+          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+    expectations: &expectations_without_retries
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    # failCommand with writeConcernError still applies the write operation(s)
+    outcome: *outcome
+
+  -
+    description: commitTransaction is not retried after UnsatisfiableWriteConcern error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 100
+            codeName: UnsatisfiableWriteConcern
+            errmsg: "Not enough data-bearing nodes"
+    operations:
+      - <<: *operation
+        result:
+          errorCodeName: UnsatisfiableWriteConcern
+          errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
+    expectations: *expectations_without_retries
+    # failCommand with writeConcernError still applies the write operation(s)
+    outcome: *outcome
+
+  -
+    description: commitTransaction is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50
+            codeName: MaxTimeMSExpired
+            errmsg: "operation exceeded time limit"
+    operations:
+      - <<: *operation
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations: *expectations_without_retries
+    # failCommand with writeConcernError still applies the write operation(s)
+    outcome: *outcome

--- a/src/test/spec/json/transactions-convenient-api/commit.json
+++ b/src/test/spec/json/transactions-convenient-api/commit.json
@@ -1,0 +1,286 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction commits after callback returns",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction commits after callback returns (second transaction)",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                },
+                {
+                  "name": "commitTransaction",
+                  "object": "session0"
+                },
+                {
+                  "name": "startTransaction",
+                  "object": "session0"
+                },
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 2
+                    }
+                  },
+                  "result": {
+                    "insertedId": 2
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/commit.yml
+++ b/src/test/spec/json/transactions-convenient-api/commit.yml
@@ -1,0 +1,193 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: withTransaction commits after callback returns
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }
+  -
+    # In this scenario, the callback commits the transaction originally started
+    # by withTransaction and starts a second transaction before returning. Since
+    # withTransaction only examines the session's state, it should commit that
+    # second transaction after the callback returns.
+    description: withTransaction commits after callback returns (second transaction)
+    useMultipleMongoses: true
+    operations:
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+              -
+                name: commitTransaction
+                object: session0
+              -
+                name: startTransaction
+                object: session0
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 2 }
+                result:
+                  insertedId: 2
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 2 }
+            ordered: true
+            lsid: session0
+            # second transaction will be causally consistent with the first
+            readConcern: { afterClusterTime: 42 }
+            # txnNumber is incremented for the second transaction
+            txnNumber: { $numberLong: "2" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "2" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        data:
+          - { _id: 1 }
+          - { _id: 2 }

--- a/src/test/spec/json/transactions-convenient-api/transaction-options.json
+++ b/src/test/spec/json/transactions-convenient-api/transaction-options.json
@@ -1,0 +1,577 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "withTransaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "withTransaction and no transaction options set",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction inherits transaction options from client",
+      "useMultipleMongoses": true,
+      "clientOptions": {
+        "readConcernLevel": "local",
+        "w": 1
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "local"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction inherits transaction options from defaultTransactionOptions",
+      "useMultipleMongoses": true,
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction explicit transaction options",
+      "useMultipleMongoses": true,
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": {
+                "w": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction explicit transaction options override defaultTransactionOptions",
+      "useMultipleMongoses": true,
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": "majority"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": {
+                "w": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "withTransaction explicit transaction options override client options",
+      "useMultipleMongoses": true,
+      "clientOptions": {
+        "readConcernLevel": "local",
+        "w": "majority"
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            },
+            "options": {
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": {
+                "w": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "majority"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "writeConcern": {
+                "w": 1
+              },
+              "readConcern": null,
+              "startTransaction": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/transactions-convenient-api/transaction-options.yml
+++ b/src/test/spec/json/transactions-convenient-api/transaction-options.yml
@@ -1,0 +1,274 @@
+runOn:
+    -
+        minServerVersion: "4.0"
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.8"
+        topology: ["sharded"]
+
+database_name: &database_name "withTransaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  -
+    description: withTransaction and no transaction options set
+    useMultipleMongoses: true
+    operations: &operations
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1 }
+  -
+    description: withTransaction inherits transaction options from client
+    useMultipleMongoses: true
+    clientOptions:
+      readConcernLevel: local
+      w: 1
+    operations: *operations
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: local }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction inherits transaction options from defaultTransactionOptions
+    useMultipleMongoses: true
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readConcern: { level: majority }
+          writeConcern: { w: 1 }
+    operations: *operations
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: majority }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction explicit transaction options
+    useMultipleMongoses: true
+    operations: &operations_explicit_transactionOptions
+      -
+        name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            readConcern: { level: majority }
+            writeConcern: { w: 1 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: majority }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction explicit transaction options override defaultTransactionOptions
+    useMultipleMongoses: true
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readConcern: { level: snapshot }
+          writeConcern: { w: majority }
+    operations: *operations_explicit_transactionOptions
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: majority }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome
+  -
+    description: withTransaction explicit transaction options override client options
+    useMultipleMongoses: true
+    clientOptions:
+      readConcernLevel: local
+      w: majority
+    operations: *operations_explicit_transactionOptions
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            readConcern: { level: majority }
+            # omitted fields
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            writeConcern: { w: 1 }
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome: *outcome

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -95,16 +95,18 @@ async fn convenient_api_usage() {
     }
     let f = Foo;
     // This closure, by signature, must be callable repeatedly; when it is created, ownership of captured variables are moved into the closure
-    session.with_transaction(|session, (coll, f)| {
-        // This block also must take ownership of captured variables, but that would leave the original closure without values
-        async move {
-            f.thing();
-            let out = coll.find_one_with_session(None, None, session).await?;
-            f.thing();
-            Ok(out)
-        }.boxed()
-    },
-    None,
-    (coll, &f)).await.unwrap();
+    session.with_transaction(
+        (coll, &f),
+        |session, (coll, f)| {
+            // This block also must take ownership of captured variables, but that would leave the original closure without values
+            async move {
+                f.thing();
+                let out = coll.find_one_with_session(None, None, session).await?;
+                f.thing();
+                Ok(out)
+            }.boxed()
+        },
+        None,
+    ).await.unwrap();
     let _ = client.clone();
 }

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -87,35 +87,6 @@ async fn deserialize_recovery_token() {
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
-async fn convenient_api_usage() {
-    let _guard: _ = LOCK.run_concurrently().await;
-    let client = crate::Client::test_builder().build().await;
-    let mut session = client.start_session(None).await.unwrap();
-    let coll = client.database("test_convenient").collection::<Document>("test_convenient");
-    
-    struct Foo;
-    impl Foo {
-        fn thing(&self) { }
-    }
-    let f = Foo;
-    // This closure, by signature, must be callable repeatedly; when it is created, ownership of captured variables are moved into the closure
-    session.with_transaction(
-        (coll, &f),
-        |session, (coll, f)| {
-            // This block also must take ownership of captured variables, but that would leave the original closure without values
-            async move {
-                f.thing();
-                let out = coll.find_one_with_session(None, None, session).await?;
-                f.thing();
-                Ok(out)
-            }.boxed()
-        },
-        None,
-    ).await.unwrap();
-}
-
-#[cfg_attr(feature = "tokio-runtime", tokio::test)]
-#[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn convenient_api_custom_error() {
     let _guard: _ = LOCK.run_concurrently().await;
     let client = crate::Client::test_builder().event_client().build().await;

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -206,16 +206,7 @@ async fn convenient_api_retry_timeout_callback() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn convenient_api_retry_timeout_commit_unknown() {
     let _guard: _ = LOCK.run_exclusively().await;
-    let client = crate::Client::test_builder()
-        .options({
-            let mut options = CLIENT_OPTIONS.get().await.clone();
-            options.direct_connection = Some(true);
-            options.hosts.drain(1..);
-            options
-        })
-        .event_client()
-        .build()
-        .await;
+    let client = crate::Client::test_builder().event_client().build().await;
     if !client.supports_transactions() {
         log_uncaptured(
             "Skipping convenient_api_retry_timeout_commit_unknown: no transaction support.",

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -255,7 +255,7 @@ async fn convenient_api_retry_timeout_commit_unknown() {
         .await;
 
     let err = result.unwrap_err();
-    assert!(err.contains_label(UNKNOWN_TRANSACTION_COMMIT_RESULT));
+    assert_eq!(Some(251), err.code());
 }
 
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -22,6 +22,14 @@ async fn run_legacy() {
     run_v2_tests(&["transactions", "legacy"]).await;
 }
 
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn run_legacy_convenient_api() {
+    let _guard: RwLockWriteGuard<()> = LOCK.run_exclusively().await;
+    run_v2_tests(&["transactions-convenient-api"]).await;
+}
+
 // TODO RUST-902: Reduce transactionLifetimeLimitSeconds.
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
@@ -90,6 +98,10 @@ async fn deserialize_recovery_token() {
 async fn convenient_api_custom_error() {
     let _guard: _ = LOCK.run_concurrently().await;
     let client = crate::Client::test_builder().event_client().build().await;
+    if !client.supports_transactions() {
+        log_uncaptured("Skipping convenient_api_custom_error: no transaction support.");
+        return;
+    }
     let mut session = client.start_session(None).await.unwrap();
     let coll = client.database("test_convenient").collection::<Document>("test_convenient");
 
@@ -116,6 +128,10 @@ async fn convenient_api_custom_error() {
 async fn convenient_api_returned_value() {
     let _guard: _ = LOCK.run_concurrently().await;
     let client = crate::Client::test_builder().event_client().build().await;
+    if !client.supports_transactions() {
+        log_uncaptured("Skipping convenient_api_returned_value: no transaction support.");
+        return;
+    }
     let mut session = client.start_session(None).await.unwrap();
     let coll = client.database("test_convenient").collection::<Document>("test_convenient");
 
@@ -136,6 +152,10 @@ async fn convenient_api_returned_value() {
 async fn convenient_api_retry_timeout_callback() {
     let _guard: _ = LOCK.run_concurrently().await;
     let client = crate::Client::test_builder().event_client().build().await;
+    if !client.supports_transactions() {
+        log_uncaptured("Skipping convenient_api_retry_timeout_callback: no transaction support.");
+        return;
+    }
     let mut session = client.start_session(None).await.unwrap();
     session.convenient_transaction_timeout = Some(Duration::ZERO);
     let coll = client.database("test_convenient").collection::<Document>("test_convenient");
@@ -170,6 +190,10 @@ async fn convenient_api_retry_timeout_commit_unknown() {
         .event_client()
         .build()
         .await;
+    if !client.supports_transactions() {
+        log_uncaptured("Skipping convenient_api_retry_timeout_commit_unknown: no transaction support.");
+        return;
+    }
     let mut session = client.start_session(None).await.unwrap();
     session.convenient_transaction_timeout = Some(Duration::ZERO);
     let coll = client.database("test_convenient").collection::<Document>("test_convenient");
@@ -213,6 +237,10 @@ async fn convenient_api_retry_timeout_commit_transient() {
         .event_client()
         .build()
         .await;
+    if !client.supports_transactions() {
+        log_uncaptured("Skipping convenient_api_retry_timeout_commit_transient: no transaction support.");
+        return;
+    }
     let mut session = client.start_session(None).await.unwrap();
     session.convenient_transaction_timeout = Some(Duration::ZERO);
     let coll = client.database("test_convenient").collection::<Document>("test_convenient");

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -115,10 +115,13 @@ async fn convenient_api_custom_error() {
     let result: Result<()> = session
         .with_transaction(
             coll,
-            |session, coll| async move {
-                coll.find_one_with_session(None, None, session).await?;
-                Err(Error::custom(MyErr))
-            }.boxed(),
+            |session, coll| {
+                async move {
+                    coll.find_one_with_session(None, None, session).await?;
+                    Err(Error::custom(MyErr))
+                }
+                .boxed()
+            },
             None,
         )
         .await;
@@ -126,10 +129,7 @@ async fn convenient_api_custom_error() {
     assert!(result.is_err());
     assert!(result.unwrap_err().get_custom::<MyErr>().is_some());
     let events = client.get_all_command_started_events();
-    let commands: Vec<_> = events
-        .iter()
-        .map(|ev| &ev.command_name)
-        .collect();
+    let commands: Vec<_> = events.iter().map(|ev| &ev.command_name).collect();
     assert_eq!(&["find", "abortTransaction"], &commands[..]);
 }
 
@@ -150,10 +150,13 @@ async fn convenient_api_returned_value() {
     let value = session
         .with_transaction(
             coll,
-            |session, coll| async move {
-                coll.find_one_with_session(None, None, session).await?;
-                Ok(42)
-            }.boxed(),
+            |session, coll| {
+                async move {
+                    coll.find_one_with_session(None, None, session).await?;
+                    Ok(42)
+                }
+                .boxed()
+            },
             None,
         )
         .await
@@ -180,12 +183,15 @@ async fn convenient_api_retry_timeout_callback() {
     let result: Result<()> = session
         .with_transaction(
             coll,
-            |session, coll| async move {
-                coll.find_one_with_session(None, None, session).await?;
-                let mut err = Error::custom(42);
-                err.add_label(TRANSIENT_TRANSACTION_ERROR);
-                Err(err)
-            }.boxed(),
+            |session, coll| {
+                async move {
+                    coll.find_one_with_session(None, None, session).await?;
+                    let mut err = Error::custom(42);
+                    err.add_label(TRANSIENT_TRANSACTION_ERROR);
+                    Err(err)
+                }
+                .boxed()
+            },
             None,
         )
         .await;
@@ -227,10 +233,13 @@ async fn convenient_api_retry_timeout_commit_unknown() {
     let result = session
         .with_transaction(
             coll,
-            |session, coll| async move {
-                coll.find_one_with_session(None, None, session).await?;
-                Ok(())
-            }.boxed(),
+            |session, coll| {
+                async move {
+                    coll.find_one_with_session(None, None, session).await?;
+                    Ok(())
+                }
+                .boxed()
+            },
             None,
         )
         .await;
@@ -280,10 +289,13 @@ async fn convenient_api_retry_timeout_commit_transient() {
     let result = session
         .with_transaction(
             coll,
-            |session, coll| async move {
-                coll.find_one_with_session(None, None, session).await?;
-                Ok(())
-            }.boxed(),
+            |session, coll| {
+                async move {
+                    coll.find_one_with_session(None, None, session).await?;
+                    Ok(())
+                }
+                .boxed()
+            },
             None,
         )
         .await;

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -92,7 +92,7 @@ struct FileContext {
 }
 
 impl FileContext {
-    async fn new(path: &std::path::PathBuf) -> Self {
+    async fn new(path: &std::path::Path) -> Self {
         let internal_client = TestClient::new().await;
         let is_csfle_test = path.to_string_lossy().contains("client-side-encryption");
 
@@ -108,7 +108,7 @@ impl FileContext {
                 .iter()
                 .any(|run_on| run_on.can_run_on(&self.internal_client));
         }
-        return true;
+        true
     }
 }
 
@@ -478,7 +478,7 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         csfle::populate_key_vault(&file_ctx.internal_client, test_file.key_vault_data.as_ref())
             .await;
 
-        let mut test_ctx = TestContext::new(&test_file, &test, &file_ctx.internal_client).await;
+        let mut test_ctx = TestContext::new(&test_file, test, &file_ctx.internal_client).await;
         let session0_lsid = test_ctx.session0.as_ref().unwrap().id().clone();
         let session1_lsid = test_ctx.session1.as_ref().unwrap().id().clone();
 

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -6,14 +6,13 @@ pub(crate) mod test_file;
 
 use std::{future::IntoFuture, ops::Deref, sync::Arc, time::Duration};
 
-use bson::Document;
 use futures::{future::BoxFuture, FutureExt};
 use semver::VersionReq;
 
 use crate::{
     bson::{doc, from_bson},
     coll::options::{DistinctOptions, DropCollectionOptions},
-    concern::{Acknowledgment, WriteConcern},
+    concern::WriteConcern,
     options::{ClientOptions, CreateCollectionOptions, InsertManyOptions},
     runtime,
     sdam::{ServerInfo, MIN_HEARTBEAT_FREQUENCY},
@@ -29,14 +28,12 @@ use crate::{
         CLIENT_OPTIONS,
         SERVERLESS,
     },
-    Client, Collection, ClientSession, Database,
+    Client, ClientSession, Namespace,
 };
 
 use operation::{OperationObject, OperationResult};
 use test_event::CommandStartedEvent;
 use test_file::{TestData, TestFile};
-
-use self::test_file::Test;
 
 use super::Operation;
 
@@ -116,9 +113,7 @@ impl FileContext {
 
 struct TestContext {
     description: String,
-    db_name: String,
-    coll_name: String,
-    coll: Collection<Document>,
+    ns: Namespace,
     internal_client: TestClient,
     client: EventClient,
     fail_point_guards: Vec<FailPointGuard>,
@@ -211,6 +206,22 @@ impl TestContext {
         let builder = csfle::set_auto_enc(builder, &test);
         let client = builder.event_client().build().await;
 
+        // TODO RUST-900: Remove this extraneous call.
+        if internal_client.is_sharded()
+            && internal_client.server_version_lte(4, 2)
+            && test.operations.iter().any(|op| op.name == "distinct")
+        {
+            for server_address in internal_client.options().hosts.clone() {
+                let options = DistinctOptions::builder()
+                    .selection_criteria(Some(SelectionCriteria::Predicate(Arc::new(
+                        move |server_info: &ServerInfo| *server_info.address() == server_address,
+                    ))))
+                    .build();
+                coll.distinct("_id", None, options).await.unwrap();
+            }
+        }
+
+        // Persist fail point guards so they disable post-test.
         let mut fail_point_guards: Vec<FailPointGuard> = Vec::new();
         if let Some(fail_point) = &test.fail_point {
             fail_point_guards.push(fail_point.enable(client.deref(), None).await.unwrap());
@@ -231,9 +242,7 @@ impl TestContext {
 
         Self {
             description: test.description.clone(),
-            db_name,
-            coll_name,
-            coll,
+            ns: Namespace { db: db_name, coll: coll_name },
             internal_client: internal_client.clone(),
             client,
             fail_point_guards,
@@ -244,12 +253,12 @@ impl TestContext {
 
     async fn run_operation(&mut self, operation: &Operation) -> Option<Result<Option<bson::Bson>, crate::error::Error>> {
         let db = match &operation.database_options {
-            Some(options) => self.client.database_with_options(&self.db_name, options.clone()),
-            None => self.client.database(&self.db_name),
+            Some(options) => self.client.database_with_options(&self.ns.db, options.clone()),
+            None => self.client.database(&self.ns.db),
         };
         let coll = match &operation.collection_options {
-            Some(options) => db.collection_with_options(&self.coll_name, options.clone()),
-            None => db.collection(&self.coll_name),
+            Some(options) => db.collection_with_options(&self.ns.coll, options.clone()),
+            None => db.collection(&self.ns.coll),
         };
 
         let session = match operation.session.as_deref() {
@@ -364,7 +373,7 @@ impl TestContext {
     }
 }
 
-async fn run_v2_test_2(path: std::path::PathBuf, test_file: TestFile) {
+async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
     let file_ctx = FileContext::new(&path).await;
 
     file_level_log(format!("Running tests from {}", path.display(),));
@@ -414,6 +423,8 @@ async fn run_v2_test_2(path: std::path::PathBuf, test_file: TestFile) {
         csfle::populate_key_vault(&file_ctx.internal_client, test_file.key_vault_data.as_ref()).await;
 
         let mut test_ctx = TestContext::new(&test_file, &test, &file_ctx.internal_client).await;
+        let session0_lsid = test_ctx.session0.as_ref().unwrap().id().clone();
+        let session1_lsid = test_ctx.session1.as_ref().unwrap().id().clone();
 
         for operation in &test.operations {
             let result = match test_ctx.run_operation(operation).await {
@@ -421,67 +432,60 @@ async fn run_v2_test_2(path: std::path::PathBuf, test_file: TestFile) {
                 None => continue,
             };
 
-            if operation.error.is_none() && operation.result.is_none() && result.is_err() {
-                log_uncaptured(format!(
-                    "Ignoring operation error: {}",
-                    result.clone().unwrap_err()
-                ));
-            }
+            operation.assert_result_matches(&result, &test.description);
+        }
 
-            if let Some(error) = operation.error {
-                assert_eq!(error, result.is_err(), "{}", &test.description);
-            }
+        test_ctx.session0.take();
+        test_ctx.session1.take();
 
-            if let Some(expected_result) = &operation.result {
-                match expected_result {
-                    OperationResult::Success(expected) => {
-                        let result = result.unwrap().unwrap();
-                        assert_matches(&result, expected, Some(&test.description));
-                    }
-                    OperationResult::Error(operation_error) => {
-                        let error = result.unwrap_err();
-                        if let Some(error_contains) = &operation_error.error_contains {
-                            let message = error.message().unwrap();
-                            assert!(message.contains(error_contains));
-                        }
-                        if let Some(error_code_name) = &operation_error.error_code_name {
-                            let code_name = error.code_name().unwrap();
-                            assert_eq!(
-                                error_code_name, code_name,
-                                "{}: expected error with codeName {:?}, instead got {:#?}",
-                                test.description, error_code_name, error
-                            );
-                        }
-                        if let Some(error_code) = operation_error.error_code {
-                            let code = error.code().unwrap();
-                            assert_eq!(error_code, code);
-                        }
-                        if let Some(error_labels_contain) = &operation_error.error_labels_contain {
-                            let labels = error.labels();
-                            error_labels_contain
-                                .iter()
-                                .for_each(|label| assert!(labels.contains(label)));
-                        }
-                        if let Some(error_labels_omit) = &operation_error.error_labels_omit {
-                            let labels = error.labels();
-                            error_labels_omit
-                                .iter()
-                                .for_each(|label| assert!(!labels.contains(label)));
-                        }
-                        #[cfg(feature = "in-use-encryption-unstable")]
-                        if let Some(t) = &operation_error.is_timeout_error {
-                            assert_eq!(
-                                *t,
-                                error.is_network_timeout() || error.is_non_timeout_network_error()
-                            )
-                        }
-                    }
-                }
+        // wait for the transaction in progress to be aborted implicitly when the session is dropped
+        if test.description.as_str() == "implicit abort" {
+            runtime::delay_for(Duration::from_secs(1)).await;
+        }
+
+        if let Some(expectations) = &test.expectations {
+            let events: Vec<CommandStartedEvent> = test_ctx.client
+                .get_all_command_started_events()
+                .into_iter()
+                .map(Into::into)
+                .collect();
+
+            assert!(
+                events.len() >= expectations.len(),
+                "[{}] expected events \n{:#?}\n got events\n{:#?}",
+                test.description,
+                expectations,
+                events
+            );
+            for (actual_event, expected_event) in events.iter().zip(expectations.iter()) {
+                let result =
+                    actual_event.matches_expected(expected_event, &session0_lsid, &session1_lsid);
+                assert!(
+                    result.is_ok(),
+                    "[{}] {}",
+                    test.description,
+                    result.unwrap_err()
+                );
             }
+        }
+
+        if let Some(outcome) = &test.outcome {
+            outcome
+                .assert_matches_actual(
+                    &test_ctx.ns.db,
+                    &test_ctx.ns.coll,
+                    if file_ctx.is_csfle_test {
+                        &test_ctx.internal_client
+                    } else {
+                        &test_ctx.client
+                    },
+                )
+                .await;
         }
     }
 }
 
+/*
 async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
     let internal_client = TestClient::new().await;
 
@@ -872,8 +876,8 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         if let Some(outcome) = test.outcome {
             outcome
                 .assert_matches_actual(
-                    db_name,
-                    coll_name,
+                    &db_name,
+                    &coll_name,
                     if is_csfle_test {
                         &internal_client
                     } else {
@@ -884,6 +888,7 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         }
     }
 }
+*/
 
 fn assert_different_lsid_on_last_two_commands(client: &EventClient) {
     let events = client.get_all_command_started_events();

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -208,7 +208,7 @@ impl TestContext {
             .await
             .min_heartbeat_freq(Some(Duration::from_millis(50)));
         #[cfg(feature = "in-use-encryption-unstable")]
-        let builder = csfle::set_auto_enc(builder, &test);
+        let builder = csfle::set_auto_enc(builder, test);
         let client = builder.event_client().build().await;
 
         // TODO RUST-900: Remove this extraneous call.

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -18,7 +18,6 @@ use crate::{
     sdam::{ServerInfo, MIN_HEARTBEAT_FREQUENCY},
     selection_criteria::SelectionCriteria,
     test::{
-        assert_matches,
         file_level_log,
         log_uncaptured,
         spec::deserialize_spec_tests,
@@ -31,7 +30,7 @@ use crate::{
     Client, ClientSession, Namespace,
 };
 
-use operation::{OperationObject, OperationResult};
+use operation::OperationObject;
 use test_event::CommandStartedEvent;
 use test_file::{TestData, TestFile};
 
@@ -252,6 +251,56 @@ impl TestContext {
     }
 
     async fn run_operation(&mut self, operation: &Operation) -> Option<Result<Option<bson::Bson>, crate::error::Error>> {
+        if operation.name == "endSession" {
+            let session = match &operation.object {
+                Some(OperationObject::Session0) => &mut self.session0,
+                Some(OperationObject::Session1) => &mut self.session1,
+                other => panic!("invalid object for `endSession`: {:?}", other),
+            };
+            drop(session.take());
+            runtime::delay_for(Duration::from_secs(1)).await;
+            return None;
+        }
+
+        let sessions = OpSessions {
+            session0: self.session0.as_mut(),
+            session1: self.session1.as_mut(),
+        };
+
+        let mut runner = OpRunner {
+            description: self.description.clone(),
+            internal_client: self.internal_client.clone(),
+            client: self.client.clone(),
+            ns: self.ns.clone(),
+            fail_point_guards: &mut self.fail_point_guards,
+        };
+
+        runner.run_operation(operation, sessions).await
+    }
+}
+
+pub(crate) struct OpSessions<'a> {
+    session0: Option<&'a mut ClientSession>,
+    session1: Option<&'a mut ClientSession>,
+}
+
+pub(crate) struct OpRunner<'a> {
+    description: String,
+    internal_client: TestClient,
+    client: EventClient,
+    ns: Namespace,
+    fail_point_guards: &'a mut Vec<FailPointGuard>,
+}
+
+impl<'a> OpRunner<'a> {
+    pub(crate) async fn run_operation<'b>(&mut self, operation: &Operation, mut sessions: OpSessions<'b>) -> Option<Result<Option<bson::Bson>, crate::error::Error>> {
+        if operation.name == "withTransaction" {
+            if !matches!(&operation.object, Some(OperationObject::Session0)) {
+                panic!("invalid object for withTransaction: {:?}", operation.object);
+            }
+            return Some(operation.execute_recursive(self, sessions).await);
+        }
+
         let db = match &operation.database_options {
             Some(options) => self.client.database_with_options(&self.ns.db, options.clone()),
             None => self.client.database(&self.ns.db),
@@ -262,8 +311,8 @@ impl TestContext {
         };
 
         let session = match operation.session.as_deref() {
-            Some("session0") => self.session0.as_mut(),
-            Some("session1") => self.session1.as_mut(),
+            Some("session0") => sessions.session0.as_deref_mut(),
+            Some("session1") => sessions.session1.as_deref_mut(),
             Some(other) => panic!("unknown session name: {}", other),
             None => None,
         };
@@ -286,28 +335,14 @@ impl TestContext {
             }
             Some(OperationObject::Client) => operation.execute_on_client(&self.client).await,
             Some(OperationObject::Session0) => {
-                if operation.name == "endSession" {
-                    let session = &self.session0.take();
-                    drop(session);
-                    runtime::delay_for(Duration::from_secs(1)).await;
-                    return None;
-                } else {
-                    operation
-                        .execute_on_session(self.session0.as_mut().unwrap())
-                        .await
-                }
+                operation
+                    .execute_on_session(sessions.session0.as_mut().unwrap())
+                    .await
             }
             Some(OperationObject::Session1) => {
-                if operation.name == "endSession" {
-                    let session = self.session1.take();
-                    drop(session);
-                    runtime::delay_for(Duration::from_secs(1)).await;
-                    return None;
-                } else {
-                    operation
-                        .execute_on_session(self.session1.as_mut().unwrap())
-                        .await
-                }
+                operation
+                    .execute_on_session(sessions.session1.as_mut().unwrap())
+                    .await
             }
             Some(OperationObject::TestRunner) => {
                 match operation.name.as_str() {
@@ -484,411 +519,6 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         }
     }
 }
-
-/*
-async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
-    let internal_client = TestClient::new().await;
-
-    file_level_log(format!("Running tests from {}", path.display(),));
-    let is_csfle_test = path.to_string_lossy().contains("client-side-encryption");
-
-    if let Some(requirements) = test_file.run_on {
-        let can_run_on = requirements
-            .iter()
-            .any(|run_on| run_on.can_run_on(&internal_client));
-        if !can_run_on {
-            log_uncaptured("Client topology not compatible with test");
-            return;
-        }
-    }
-
-    for test in test_file.tests {
-        log_uncaptured(format!("Running {}", &test.description));
-
-        if test
-            .operations
-            .iter()
-            .any(|operation| SKIPPED_OPERATIONS.contains(&operation.name.as_str()))
-        {
-            log_uncaptured(format!(
-                "skipping {}: unsupported operation",
-                test.description
-            ));
-            continue;
-        }
-
-        if let Some(skip_reason) = test.skip_reason {
-            log_uncaptured(format!("skipping {}: {}", test.description, skip_reason));
-            continue;
-        }
-
-        // `killAllSessions` isn't supported on serverless.
-        // TODO CLOUDP-84298 remove this conditional.
-        if !*SERVERLESS {
-            match internal_client
-                .database("admin")
-                .run_command(doc! { "killAllSessions": [] }, None)
-                .await
-            {
-                Ok(_) => {}
-                Err(err) => match err.code() {
-                    Some(11601) => {}
-                    _ => panic!("{}: killAllSessions failed", test.description),
-                },
-            }
-        }
-
-        #[cfg(feature = "in-use-encryption-unstable")]
-        csfle::populate_key_vault(&internal_client, test_file.key_vault_data.as_ref()).await;
-
-        let db_name = test_file
-            .database_name
-            .clone()
-            .unwrap_or_else(|| get_default_name(&test.description));
-        let coll_name = test_file
-            .collection_name
-            .clone()
-            .unwrap_or_else(|| get_default_name(&test.description));
-
-        let coll = internal_client.database(&db_name).collection(&coll_name);
-        #[allow(unused_mut)]
-        let mut options = DropCollectionOptions::builder()
-            .write_concern(WriteConcern::MAJORITY)
-            .build();
-        #[cfg(feature = "in-use-encryption-unstable")]
-        if let Some(enc_fields) = &test_file.encrypted_fields {
-            options.encrypted_fields = Some(enc_fields.clone());
-        }
-        let req = VersionReq::parse(">=4.7").unwrap();
-        if !(db_name.as_str() == "admin"
-            && internal_client.is_sharded()
-            && req.matches(&internal_client.server_version))
-        {
-            coll.drop(options).await.unwrap();
-        }
-
-        #[allow(unused_mut)]
-        let mut options = CreateCollectionOptions::builder()
-            .write_concern(WriteConcern::MAJORITY)
-            .build();
-        #[cfg(feature = "in-use-encryption-unstable")]
-        {
-            if let Some(schema) = &test_file.json_schema {
-                options.validator = Some(doc! { "$jsonSchema": schema });
-            }
-            if let Some(enc_fields) = &test_file.encrypted_fields {
-                options.encrypted_fields = Some(enc_fields.clone());
-            }
-        }
-        internal_client
-            .database(&db_name)
-            .create_collection(&coll_name, options)
-            .await
-            .unwrap();
-
-        if let Some(data) = &test_file.data {
-            match data {
-                TestData::Single(data) => {
-                    if !data.is_empty() {
-                        let options = InsertManyOptions::builder()
-                            .write_concern(WriteConcern::MAJORITY)
-                            .build();
-                        coll.insert_many(data.clone(), options).await.unwrap();
-                    }
-                }
-                TestData::Many(_) => panic!("{}: invalid data format", &test.description),
-            }
-        }
-
-        let mut additional_options = match &test.client_options {
-            Some(opts) => ClientOptions::parse_uri(&opts.uri, None).await.unwrap(),
-            None => ClientOptions::builder()
-                .hosts(CLIENT_OPTIONS.get().await.hosts.clone())
-                .build(),
-        };
-        if additional_options.heartbeat_freq.is_none() {
-            additional_options.heartbeat_freq = Some(MIN_HEARTBEAT_FREQUENCY);
-        }
-        let builder = Client::test_builder()
-            .additional_options(
-                additional_options,
-                test.use_multiple_mongoses.unwrap_or(false),
-            )
-            .await
-            .min_heartbeat_freq(Some(Duration::from_millis(50)));
-        #[cfg(feature = "in-use-encryption-unstable")]
-        let builder = csfle::set_auto_enc(builder, &test);
-        let client = builder.event_client().build().await;
-
-        // TODO RUST-900: Remove this extraneous call.
-        if internal_client.is_sharded()
-            && internal_client.server_version_lte(4, 2)
-            && test.operations.iter().any(|op| op.name == "distinct")
-        {
-            for server_address in internal_client.options().hosts.clone() {
-                let options = DistinctOptions::builder()
-                    .selection_criteria(Some(SelectionCriteria::Predicate(Arc::new(
-                        move |server_info: &ServerInfo| *server_info.address() == server_address,
-                    ))))
-                    .build();
-                coll.distinct("_id", None, options).await.unwrap();
-            }
-        }
-
-        let mut fail_point_guards: Vec<FailPointGuard> = Vec::new();
-        if let Some(fail_point) = test.fail_point {
-            fail_point_guards.push(fail_point.enable(client.deref(), None).await.unwrap());
-        }
-
-        let options = match test.session_options {
-            Some(ref options) => options.get("session0").cloned(),
-            None => None,
-        };
-        let mut session0 = Some(client.start_session(options).await.unwrap());
-        let session0_lsid = session0.as_ref().unwrap().id().clone();
-
-        let options = match test.session_options {
-            Some(ref options) => options.get("session1").cloned(),
-            None => None,
-        };
-        let mut session1 = Some(client.start_session(options).await.unwrap());
-        let session1_lsid = session1.as_ref().unwrap().id().clone();
-
-        for operation in test.operations {
-            let db = match &operation.database_options {
-                Some(options) => client.database_with_options(&db_name, options.clone()),
-                None => client.database(&db_name),
-            };
-            let coll = match &operation.collection_options {
-                Some(options) => db.collection_with_options(&coll_name, options.clone()),
-                None => db.collection(&coll_name),
-            };
-
-            let session = match operation.session.as_deref() {
-                Some("session0") => session0.as_mut(),
-                Some("session1") => session1.as_mut(),
-                Some(other) => panic!("unknown session name: {}", other),
-                None => None,
-            };
-
-            let result = match operation.object {
-                Some(OperationObject::Collection) | None => {
-                    let result = operation.execute_on_collection(&coll, session).await;
-                    // This test (in src/test/spec/json/sessions/server-support.json) runs two
-                    // operations with implicit sessions in sequence and then checks to see if they
-                    // used the same lsid. We delay for one second to ensure that the
-                    // implicit session used in the first operation is returned to the pool before
-                    // the second operation is executed.
-                    if test.description == "Server supports implicit sessions" {
-                        runtime::delay_for(Duration::from_secs(1)).await;
-                    }
-                    result
-                }
-                Some(OperationObject::Database) => {
-                    operation.execute_on_database(&db, session).await
-                }
-                Some(OperationObject::Client) => operation.execute_on_client(&client).await,
-                Some(OperationObject::Session0) => {
-                    if operation.name == "endSession" {
-                        let session = session0.take();
-                        drop(session);
-                        runtime::delay_for(Duration::from_secs(1)).await;
-                        continue;
-                    } else {
-                        operation
-                            .execute_on_session(session0.as_mut().unwrap())
-                            .await
-                    }
-                }
-                Some(OperationObject::Session1) => {
-                    if operation.name == "endSession" {
-                        let session = session1.take();
-                        drop(session);
-                        runtime::delay_for(Duration::from_secs(1)).await;
-                        continue;
-                    } else {
-                        operation
-                            .execute_on_session(session1.as_mut().unwrap())
-                            .await
-                    }
-                }
-                Some(OperationObject::TestRunner) => {
-                    match operation.name.as_str() {
-                        "assertDifferentLsidOnLastTwoCommands" => {
-                            assert_different_lsid_on_last_two_commands(&client)
-                        }
-                        "assertSameLsidOnLastTwoCommands" => {
-                            assert_same_lsid_on_last_two_commands(&client)
-                        }
-                        "assertSessionDirty" => {
-                            assert!(session.unwrap().is_dirty())
-                        }
-                        "assertSessionNotDirty" => {
-                            assert!(!session.unwrap().is_dirty())
-                        }
-                        "assertSessionTransactionState"
-                        | "assertSessionPinned"
-                        | "assertSessionUnpinned" => {
-                            operation
-                                .execute_on_session(session.unwrap())
-                                .await
-                                .unwrap();
-                        }
-                        "assertCollectionExists"
-                        | "assertCollectionNotExists"
-                        | "assertIndexExists"
-                        | "assertIndexNotExists" => {
-                            operation.execute_on_client(&internal_client).await.unwrap();
-                        }
-                        "targetedFailPoint" => {
-                            let fail_point = from_bson(
-                                operation
-                                    .execute_on_client(&internal_client)
-                                    .await
-                                    .unwrap()
-                                    .unwrap(),
-                            )
-                            .unwrap();
-
-                            let selection_criteria = session
-                                .unwrap()
-                                .transaction
-                                .pinned_mongos()
-                                .cloned()
-                                .unwrap_or_else(|| panic!("ClientSession is not pinned"));
-
-                            fail_point_guards.push(
-                                client
-                                    .deref()
-                                    .enable_failpoint(fail_point, Some(selection_criteria))
-                                    .await
-                                    .unwrap(),
-                            );
-                        }
-                        other => panic!("unknown operation: {}", other),
-                    }
-                    continue;
-                }
-                Some(OperationObject::GridfsBucket) => {
-                    panic!("unsupported operation: {}", operation.name)
-                }
-            };
-
-            if operation.error.is_none() && operation.result.is_none() && result.is_err() {
-                log_uncaptured(format!(
-                    "Ignoring operation error: {}",
-                    result.clone().unwrap_err()
-                ));
-            }
-
-            if let Some(error) = operation.error {
-                assert_eq!(error, result.is_err(), "{}", &test.description);
-            }
-
-            if let Some(expected_result) = operation.result {
-                match expected_result {
-                    OperationResult::Success(expected) => {
-                        let result = result.unwrap().unwrap();
-                        assert_matches(&result, &expected, Some(&test.description));
-                    }
-                    OperationResult::Error(operation_error) => {
-                        let error = result.unwrap_err();
-                        if let Some(error_contains) = operation_error.error_contains {
-                            let message = error.message().unwrap().to_lowercase();
-                            assert!(
-                                message.contains(&error_contains.to_lowercase()),
-                                "{}: expected error message to contain \"{}\" but got \"{}\"",
-                                test.description,
-                                error_contains,
-                                message
-                            );
-                        }
-                        if let Some(error_code_name) = operation_error.error_code_name {
-                            let code_name = error.code_name().unwrap();
-                            assert_eq!(
-                                error_code_name, code_name,
-                                "{}: expected error with codeName {:?}, instead got {:#?}",
-                                test.description, error_code_name, error
-                            );
-                        }
-                        if let Some(error_code) = operation_error.error_code {
-                            let code = error.code().unwrap();
-                            assert_eq!(error_code, code);
-                        }
-                        if let Some(error_labels_contain) = operation_error.error_labels_contain {
-                            let labels = error.labels();
-                            error_labels_contain
-                                .iter()
-                                .for_each(|label| assert!(labels.contains(label)));
-                        }
-                        if let Some(error_labels_omit) = operation_error.error_labels_omit {
-                            let labels = error.labels();
-                            error_labels_omit
-                                .iter()
-                                .for_each(|label| assert!(!labels.contains(label)));
-                        }
-                        #[cfg(feature = "in-use-encryption-unstable")]
-                        if let Some(t) = operation_error.is_timeout_error {
-                            assert_eq!(
-                                t,
-                                error.is_network_timeout() || error.is_non_timeout_network_error()
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        drop(session0);
-        drop(session1);
-
-        // wait for the transaction in progress to be aborted implicitly when the session is dropped
-        if test.description.as_str() == "implicit abort" {
-            runtime::delay_for(Duration::from_secs(1)).await;
-        }
-
-        if let Some(expectations) = test.expectations {
-            let events: Vec<CommandStartedEvent> = client
-                .get_all_command_started_events()
-                .into_iter()
-                .map(Into::into)
-                .collect();
-
-            assert!(
-                events.len() >= expectations.len(),
-                "[{}] expected events \n{:#?}\n got events\n{:#?}",
-                test.description,
-                expectations,
-                events
-            );
-            for (actual_event, expected_event) in events.iter().zip(expectations.iter()) {
-                let result =
-                    actual_event.matches_expected(expected_event, &session0_lsid, &session1_lsid);
-                assert!(
-                    result.is_ok(),
-                    "[{}] {}",
-                    test.description,
-                    result.unwrap_err()
-                );
-            }
-        }
-
-        if let Some(outcome) = test.outcome {
-            outcome
-                .assert_matches_actual(
-                    &db_name,
-                    &coll_name,
-                    if is_csfle_test {
-                        &internal_client
-                    } else {
-                        &client
-                    },
-                )
-                .await;
-        }
-    }
-}
-*/
 
 fn assert_different_lsid_on_last_two_commands(client: &EventClient) {
     let events = client.get_all_command_started_events();

--- a/src/test/spec/v2_runner/mod.rs
+++ b/src/test/spec/v2_runner/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod test_file;
 
 use std::{future::IntoFuture, ops::Deref, sync::Arc, time::Duration};
 
+use bson::Document;
 use futures::{future::BoxFuture, FutureExt};
 use semver::VersionReq;
 
@@ -28,12 +29,16 @@ use crate::{
         CLIENT_OPTIONS,
         SERVERLESS,
     },
-    Client,
+    Client, Collection, ClientSession, Database,
 };
 
 use operation::{OperationObject, OperationResult};
 use test_event::CommandStartedEvent;
 use test_file::{TestData, TestFile};
+
+use self::test_file::Test;
+
+use super::Operation;
 
 const SKIPPED_OPERATIONS: &[&str] = &[
     "bulkWrite",
@@ -80,6 +85,400 @@ impl IntoFuture for RunV2TestsAction {
             }
         }
         .boxed()
+    }
+}
+
+struct FileContext {
+    internal_client: TestClient,
+    is_csfle_test: bool,
+}
+
+impl FileContext {
+    async fn new(path: &std::path::PathBuf) -> Self {
+        let internal_client = TestClient::new().await;
+        let is_csfle_test = path.to_string_lossy().contains("client-side-encryption");
+
+        Self {
+            internal_client,
+            is_csfle_test,
+        }
+    }
+
+    fn check_topology(&self, test_file: &TestFile) -> bool {
+        if let Some(requirements) = &test_file.run_on {
+            return requirements
+                .iter()
+                .any(|run_on| run_on.can_run_on(&self.internal_client));
+        }
+        return true;
+    }
+}
+
+struct TestContext {
+    description: String,
+    db_name: String,
+    coll_name: String,
+    coll: Collection<Document>,
+    internal_client: TestClient,
+    client: EventClient,
+    fail_point_guards: Vec<FailPointGuard>,
+    session0: Option<ClientSession>,
+    session1: Option<ClientSession>,
+}
+
+impl TestContext {
+    async fn new(test_file: &TestFile, test: &test_file::Test, internal_client: &TestClient) -> Self {
+        // Get the test target collection
+        let db_name = test_file
+            .database_name
+            .clone()
+            .unwrap_or_else(|| get_default_name(&test.description));
+        let coll_name = test_file
+            .collection_name
+            .clone()
+            .unwrap_or_else(|| get_default_name(&test.description));
+        let coll = internal_client.database(&db_name).collection(&coll_name);
+
+        // Reset the test collection as needed
+        #[allow(unused_mut)]
+        let mut options = DropCollectionOptions::builder()
+            .write_concern(WriteConcern::MAJORITY)
+            .build();
+        #[cfg(feature = "in-use-encryption-unstable")]
+        if let Some(enc_fields) = &test_file.encrypted_fields {
+            options.encrypted_fields = Some(enc_fields.clone());
+        }
+        let req = VersionReq::parse(">=4.7").unwrap();
+        if !(db_name.as_str() == "admin"
+            && internal_client.is_sharded()
+            && req.matches(&internal_client.server_version))
+        {
+            coll.drop(options).await.unwrap();
+        }
+
+        #[allow(unused_mut)]
+        let mut options = CreateCollectionOptions::builder()
+            .write_concern(WriteConcern::MAJORITY)
+            .build();
+        #[cfg(feature = "in-use-encryption-unstable")]
+        {
+            if let Some(schema) = &test_file.json_schema {
+                options.validator = Some(doc! { "$jsonSchema": schema });
+            }
+            if let Some(enc_fields) = &test_file.encrypted_fields {
+                options.encrypted_fields = Some(enc_fields.clone());
+            }
+        }
+        internal_client
+            .database(&db_name)
+            .create_collection(&coll_name, options)
+            .await
+            .unwrap();
+
+        // Insert test data
+        if let Some(data) = &test_file.data {
+            match data {
+                TestData::Single(data) => {
+                    if !data.is_empty() {
+                        let options = InsertManyOptions::builder()
+                            .write_concern(WriteConcern::MAJORITY)
+                            .build();
+                        coll.insert_many(data.clone(), options).await.unwrap();
+                    }
+                }
+                TestData::Many(_) => panic!("{}: invalid data format", &test.description),
+            }
+        }
+
+        // Construct the test client
+        let mut additional_options = match &test.client_options {
+            Some(opts) => ClientOptions::parse_uri(&opts.uri, None).await.unwrap(),
+            None => ClientOptions::builder()
+                .hosts(CLIENT_OPTIONS.get().await.hosts.clone())
+                .build(),
+        };
+        if additional_options.heartbeat_freq.is_none() {
+            additional_options.heartbeat_freq = Some(MIN_HEARTBEAT_FREQUENCY);
+        }
+        let builder = Client::test_builder()
+            .additional_options(
+                additional_options,
+                test.use_multiple_mongoses.unwrap_or(false),
+            )
+            .await
+            .min_heartbeat_freq(Some(Duration::from_millis(50)));
+        #[cfg(feature = "in-use-encryption-unstable")]
+        let builder = csfle::set_auto_enc(builder, &test);
+        let client = builder.event_client().build().await;
+
+        let mut fail_point_guards: Vec<FailPointGuard> = Vec::new();
+        if let Some(fail_point) = &test.fail_point {
+            fail_point_guards.push(fail_point.enable(client.deref(), None).await.unwrap());
+        }
+
+        // Start the test sessions
+        let options = match test.session_options {
+            Some(ref options) => options.get("session0").cloned(),
+            None => None,
+        };
+        let session0 = Some(client.start_session(options).await.unwrap());
+
+        let options = match test.session_options {
+            Some(ref options) => options.get("session1").cloned(),
+            None => None,
+        };
+        let session1 = Some(client.start_session(options).await.unwrap());
+
+        Self {
+            description: test.description.clone(),
+            db_name,
+            coll_name,
+            coll,
+            internal_client: internal_client.clone(),
+            client,
+            fail_point_guards,
+            session0,
+            session1,
+        }
+    }
+
+    async fn run_operation(&mut self, operation: &Operation) -> Option<Result<Option<bson::Bson>, crate::error::Error>> {
+        let db = match &operation.database_options {
+            Some(options) => self.client.database_with_options(&self.db_name, options.clone()),
+            None => self.client.database(&self.db_name),
+        };
+        let coll = match &operation.collection_options {
+            Some(options) => db.collection_with_options(&self.coll_name, options.clone()),
+            None => db.collection(&self.coll_name),
+        };
+
+        let session = match operation.session.as_deref() {
+            Some("session0") => self.session0.as_mut(),
+            Some("session1") => self.session1.as_mut(),
+            Some(other) => panic!("unknown session name: {}", other),
+            None => None,
+        };
+
+        Some(match operation.object {
+            Some(OperationObject::Collection) | None => {
+                let result = operation.execute_on_collection(&coll, session).await;
+                // This test (in src/test/spec/json/sessions/server-support.json) runs two
+                // operations with implicit sessions in sequence and then checks to see if they
+                // used the same lsid. We delay for one second to ensure that the
+                // implicit session used in the first operation is returned to the pool before
+                // the second operation is executed.
+                if self.description == "Server supports implicit sessions" {
+                    runtime::delay_for(Duration::from_secs(1)).await;
+                }
+                result
+            }
+            Some(OperationObject::Database) => {
+                operation.execute_on_database(&db, session).await
+            }
+            Some(OperationObject::Client) => operation.execute_on_client(&self.client).await,
+            Some(OperationObject::Session0) => {
+                if operation.name == "endSession" {
+                    let session = &self.session0.take();
+                    drop(session);
+                    runtime::delay_for(Duration::from_secs(1)).await;
+                    return None;
+                } else {
+                    operation
+                        .execute_on_session(self.session0.as_mut().unwrap())
+                        .await
+                }
+            }
+            Some(OperationObject::Session1) => {
+                if operation.name == "endSession" {
+                    let session = self.session1.take();
+                    drop(session);
+                    runtime::delay_for(Duration::from_secs(1)).await;
+                    return None;
+                } else {
+                    operation
+                        .execute_on_session(self.session1.as_mut().unwrap())
+                        .await
+                }
+            }
+            Some(OperationObject::TestRunner) => {
+                match operation.name.as_str() {
+                    "assertDifferentLsidOnLastTwoCommands" => {
+                        assert_different_lsid_on_last_two_commands(&self.client)
+                    }
+                    "assertSameLsidOnLastTwoCommands" => {
+                        assert_same_lsid_on_last_two_commands(&self.client)
+                    }
+                    "assertSessionDirty" => {
+                        assert!(session.unwrap().is_dirty())
+                    }
+                    "assertSessionNotDirty" => {
+                        assert!(!session.unwrap().is_dirty())
+                    }
+                    "assertSessionTransactionState"
+                    | "assertSessionPinned"
+                    | "assertSessionUnpinned" => {
+                        operation
+                            .execute_on_session(session.unwrap())
+                            .await
+                            .unwrap();
+                    }
+                    "assertCollectionExists"
+                    | "assertCollectionNotExists"
+                    | "assertIndexExists"
+                    | "assertIndexNotExists" => {
+                        operation.execute_on_client(&self.internal_client).await.unwrap();
+                    }
+                    "targetedFailPoint" => {
+                        let fail_point = from_bson(
+                            operation
+                                .execute_on_client(&self.internal_client)
+                                .await
+                                .unwrap()
+                                .unwrap(),
+                        )
+                        .unwrap();
+
+                        let selection_criteria = session
+                            .unwrap()
+                            .transaction
+                            .pinned_mongos()
+                            .cloned()
+                            .unwrap_or_else(|| panic!("ClientSession is not pinned"));
+
+                        self.fail_point_guards.push(
+                            self.client
+                                .deref()
+                                .enable_failpoint(fail_point, Some(selection_criteria))
+                                .await
+                                .unwrap(),
+                        );
+                    }
+                    other => panic!("unknown operation: {}", other),
+                }
+                return None;
+            }
+            Some(OperationObject::GridfsBucket) => {
+                panic!("unsupported operation: {}", operation.name)
+            }
+        })
+    }
+}
+
+async fn run_v2_test_2(path: std::path::PathBuf, test_file: TestFile) {
+    let file_ctx = FileContext::new(&path).await;
+
+    file_level_log(format!("Running tests from {}", path.display(),));
+
+    if !file_ctx.check_topology(&test_file) {
+        log_uncaptured("Client topology not compatible with test");
+            return;
+    }
+
+    for test in &test_file.tests {
+        log_uncaptured(format!("Running {}", &test.description));
+
+        if test
+            .operations
+            .iter()
+            .any(|operation| SKIPPED_OPERATIONS.contains(&operation.name.as_str()))
+        {
+            log_uncaptured(format!(
+                "skipping {}: unsupported operation",
+                test.description
+            ));
+            continue;
+        }
+
+        if let Some(skip_reason) = &test.skip_reason {
+            log_uncaptured(format!("skipping {}: {}", test.description, skip_reason));
+            continue;
+        }
+
+        // `killAllSessions` isn't supported on serverless.
+        // TODO CLOUDP-84298 remove this conditional.
+        if !*SERVERLESS {
+            match file_ctx.internal_client
+                .database("admin")
+                .run_command(doc! { "killAllSessions": [] }, None)
+                .await
+            {
+                Ok(_) => {}
+                Err(err) => match err.code() {
+                    Some(11601) => {}
+                    _ => panic!("{}: killAllSessions failed", test.description),
+                },
+            }
+        }
+
+        #[cfg(feature = "in-use-encryption-unstable")]
+        csfle::populate_key_vault(&file_ctx.internal_client, test_file.key_vault_data.as_ref()).await;
+
+        let mut test_ctx = TestContext::new(&test_file, &test, &file_ctx.internal_client).await;
+
+        for operation in &test.operations {
+            let result = match test_ctx.run_operation(operation).await {
+                Some(r) => r,
+                None => continue,
+            };
+
+            if operation.error.is_none() && operation.result.is_none() && result.is_err() {
+                log_uncaptured(format!(
+                    "Ignoring operation error: {}",
+                    result.clone().unwrap_err()
+                ));
+            }
+
+            if let Some(error) = operation.error {
+                assert_eq!(error, result.is_err(), "{}", &test.description);
+            }
+
+            if let Some(expected_result) = &operation.result {
+                match expected_result {
+                    OperationResult::Success(expected) => {
+                        let result = result.unwrap().unwrap();
+                        assert_matches(&result, expected, Some(&test.description));
+                    }
+                    OperationResult::Error(operation_error) => {
+                        let error = result.unwrap_err();
+                        if let Some(error_contains) = &operation_error.error_contains {
+                            let message = error.message().unwrap();
+                            assert!(message.contains(error_contains));
+                        }
+                        if let Some(error_code_name) = &operation_error.error_code_name {
+                            let code_name = error.code_name().unwrap();
+                            assert_eq!(
+                                error_code_name, code_name,
+                                "{}: expected error with codeName {:?}, instead got {:#?}",
+                                test.description, error_code_name, error
+                            );
+                        }
+                        if let Some(error_code) = operation_error.error_code {
+                            let code = error.code().unwrap();
+                            assert_eq!(error_code, code);
+                        }
+                        if let Some(error_labels_contain) = &operation_error.error_labels_contain {
+                            let labels = error.labels();
+                            error_labels_contain
+                                .iter()
+                                .for_each(|label| assert!(labels.contains(label)));
+                        }
+                        if let Some(error_labels_omit) = &operation_error.error_labels_omit {
+                            let labels = error.labels();
+                            error_labels_omit
+                                .iter()
+                                .for_each(|label| assert!(!labels.contains(label)));
+                        }
+                        #[cfg(feature = "in-use-encryption-unstable")]
+                        if let Some(t) = &operation_error.is_timeout_error {
+                            assert_eq!(
+                                *t,
+                                error.is_network_timeout() || error.is_non_timeout_network_error()
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -150,7 +549,7 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
         let coll = internal_client.database(&db_name).collection(&coll_name);
         #[allow(unused_mut)]
         let mut options = DropCollectionOptions::builder()
-            .write_concern(majority_write_concern())
+            .write_concern(WriteConcern::MAJORITY)
             .build();
         #[cfg(feature = "in-use-encryption-unstable")]
         if let Some(enc_fields) = &test_file.encrypted_fields {
@@ -166,7 +565,7 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
 
         #[allow(unused_mut)]
         let mut options = CreateCollectionOptions::builder()
-            .write_concern(majority_write_concern())
+            .write_concern(WriteConcern::MAJORITY)
             .build();
         #[cfg(feature = "in-use-encryption-unstable")]
         {
@@ -188,7 +587,7 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
                 TestData::Single(data) => {
                     if !data.is_empty() {
                         let options = InsertManyOptions::builder()
-                            .write_concern(majority_write_concern())
+                            .write_concern(WriteConcern::MAJORITY)
                             .build();
                         coll.insert_many(data.clone(), options).await.unwrap();
                     }
@@ -484,10 +883,6 @@ async fn run_v2_test(path: std::path::PathBuf, test_file: TestFile) {
                 .await;
         }
     }
-}
-
-fn majority_write_concern() -> WriteConcern {
-    WriteConcern::builder().w(Acknowledgment::Majority).build()
 }
 
 fn assert_different_lsid_on_last_two_commands(client: &EventClient) {

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -280,6 +280,7 @@ impl<'de> Deserialize<'de> for Operation {
             "assertIndexExists" => deserialize_op::<AssertIndexExists>(definition.arguments),
             "assertIndexNotExists" => deserialize_op::<AssertIndexNotExists>(definition.arguments),
             "watch" => deserialize_op::<Watch>(definition.arguments),
+            "withTransaction" => deserialize_op::<WithTransaction>(definition.arguments),
             _ => Ok(Box::new(UnimplementedOperation) as Box<dyn TestOperation>),
         }
         .map_err(|e| serde::de::Error::custom(format!("{}", e)))?;
@@ -1608,6 +1609,8 @@ impl TestOperation for WithTransaction {
                                 None => continue,
                             };
                             op.assert_result_matches(&result, "withTransaction nested operation");
+                            // Propagate sub-operation errors after validating the result.
+                            let _ = result?;
                         }
                         return Ok(());
                     }.boxed()

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -78,8 +78,8 @@ pub(crate) trait TestOperation: Debug + Send + Sync {
 
     fn execute_recursive<'a>(
         &'a self,
-        runner: &'a mut OpRunner,
-        sessions: OpSessions<'a>,
+        _runner: &'a mut OpRunner,
+        _sessions: OpSessions<'a>,
     ) -> BoxFuture<'a, Result<Option<Bson>>> {
         todo!()
     }
@@ -1603,7 +1603,11 @@ impl TestOperation for WithTransaction {
                                 session0: Some(session),
                                 session1: session1.as_deref_mut(),
                             };
-                            let result = runner.run_operation(op, sessions).await;
+                            let result = match runner.run_operation(op, sessions).await {
+                                Some(r) => r,
+                                None => continue,
+                            };
+                            op.assert_result_matches(&result, "withTransaction nested operation");
                         }
                         return Ok(());
                     }.boxed()
@@ -1613,7 +1617,6 @@ impl TestOperation for WithTransaction {
             Ok(None)
         }.boxed()
     }
-
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1494,6 +1494,17 @@ impl TestOperation for AssertIndexNotExists {
 }
 
 #[derive(Debug, Deserialize)]
+pub(super) struct WithTransaction {
+    callback: WithTransactionCallback,
+    options: Option<TransactionOptions>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WithTransactionCallback {
+    operations: Vec<Operation>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(super) struct UnimplementedOperation;
 
 impl TestOperation for UnimplementedOperation {}

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1612,7 +1612,7 @@ impl TestOperation for WithTransaction {
                                 // Propagate sub-operation errors after validating the result.
                                 let _ = result?;
                             }
-                            return Ok(());
+                            Ok(())
                         }
                         .boxed()
                     },

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -123,11 +123,11 @@ impl Operation {
                         assert!(
                             message.contains(&error_contains.to_lowercase()),
                             "{}: expected error message to contain \"{}\" but got \"{}\"",
-                            test.description,
+                            description,
                             error_contains,
                             message
                         );
-                }
+                    }
                     if let Some(error_code_name) = &operation_error.error_code_name {
                         let code_name = error.code_name().unwrap();
                         assert_eq!(

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -156,8 +156,8 @@ impl Outcome {
             .read_concern(crate::options::ReadConcern::LOCAL)
             .build();
         let coll = client
-            .database(&db_name)
-            .collection_with_options(&coll_name, coll_opts);
+            .database(db_name)
+            .collection_with_options(coll_name, coll_opts);
         let selection_criteria = SelectionCriteria::ReadPreference(ReadPreference::Primary);
         let options = FindOptions::builder()
             .sort(doc! { "_id": 1 })

--- a/src/test/spec/v2_runner/test_file.rs
+++ b/src/test/spec/v2_runner/test_file.rs
@@ -138,14 +138,14 @@ pub(crate) struct Outcome {
 
 impl Outcome {
     pub(crate) async fn assert_matches_actual(
-        self,
-        db_name: String,
-        coll_name: String,
+        &self,
+        db_name: &str,
+        coll_name: &str,
         client: &Client,
     ) {
         use crate::coll::options::CollectionOptions;
 
-        let coll_name = match self.collection.name {
+        let coll_name = match self.collection.name.as_deref() {
             Some(name) => name,
             None => coll_name,
         };


### PR DESCRIPTION
RUST-107

This adds the convenient transactions API and associated tests.  Running the v2 spec tests required quite a bit of refactoring in order to allow recursively running operations within the `withTransaction` operation.