### PR TITLE
RUST-1411 Move `create_encrypted_collection` helper to `ClientEncryption`

### DIFF
--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -719,7 +719,7 @@ impl<'a> CreateEncryptedCollectionAction<'a> {
         )
     }
 
-    /// Set the encrypted fields for the colllection.
+    /// Set the encrypted fields for the collection.
     pub fn encrypted_fields(mut self, encrypted_fields: Document) -> Self {
         self.options.encrypted_fields = Some(encrypted_fields);
         self

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -720,8 +720,8 @@ impl<'a> CreateEncryptedCollectionAction<'a> {
     }
 
     /// Set the encrypted fields for the colllection.
-    pub fn encrypted_fields(mut self, encrypted_fields: impl Into<Option<Document>>) -> Self {
-        self.options.encrypted_fields = encrypted_fields.into();
+    pub fn encrypted_fields(mut self, encrypted_fields: Document) -> Self {
+        self.options.encrypted_fields = Some(encrypted_fields);
         self
     }
 

--- a/src/sync/db.rs
+++ b/src/sync/db.rs
@@ -219,28 +219,6 @@ impl Database {
         ))
     }
 
-    /// Creates a new collection with encrypted fields, automatically creating new data encryption
-    /// keys when needed based on the configured [`CreateCollectionOptions::encrypted_fields`].
-    ///
-    /// Returns the potentially updated `encrypted_fields` along with status, as keys may have been
-    /// created even when a failure occurs.
-    ///
-    /// Does not affect any auto encryption settings on existing MongoClients that are already
-    /// configured with auto encryption.
-    #[cfg(feature = "in-use-encryption-unstable")]
-    pub fn create_encrypted_collection(
-        &self,
-        ce: &crate::client_encryption::ClientEncryption,
-        name: impl AsRef<str>,
-        options: impl Into<Option<CreateCollectionOptions>>,
-        master_key: crate::client_encryption::MasterKey,
-    ) -> (Document, Result<()>) {
-        runtime::block_on(
-            self.async_database
-                .create_encrypted_collection(ce, name, options, master_key),
-        )
-    }
-
     /// Runs a database-level command.
     ///
     /// Note that no inspection is done on `doc`, so the command will not use the database's default

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2928,7 +2928,7 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
     )?;
 
     // Case 1: Simple Creation and Validation
-    ce.create_encrypted_collection(&db, "case_1", master_key.clone())
+    let options = CreateCollectionOptions::builder()
         .encrypted_fields(doc! {
             "fields": [{
                 "path": "ssn",
@@ -2936,7 +2936,8 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
                 "keyId": Bson::Null,
             }],
         })
-        .run()
+        .build();
+    ce.create_encrypted_collection(&db, "case_1", master_key.clone(), options)
         .await
         .1?;
     let coll = db.collection::<Document>("case_1");
@@ -2949,8 +2950,12 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
 
     // Case 2: Missing encryptedFields
     let result = ce
-        .create_encrypted_collection(&db, "case_2", master_key.clone())
-        .run()
+        .create_encrypted_collection(
+            &db,
+            "case_2",
+            master_key.clone(),
+            CreateCollectionOptions::default(),
+        )
         .await
         .1;
     assert!(
@@ -2960,8 +2965,7 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
     );
 
     // Case 3: Invalid keyId
-    let result = ce
-        .create_encrypted_collection(&db, "case_1", master_key.clone())
+    let options = CreateCollectionOptions::builder()
         .encrypted_fields(doc! {
             "fields": [{
                 "path": "ssn",
@@ -2969,7 +2973,9 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
                 "keyId": false,
             }],
         })
-        .run()
+        .build();
+    let result = ce
+        .create_encrypted_collection(&db, "case_1", master_key.clone(), options)
         .await
         .1;
     assert!(
@@ -2979,8 +2985,7 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
     );
 
     // Case 4: Insert encrypted value
-    let (ef, result) = ce
-        .create_encrypted_collection(&db, "case_4", master_key.clone())
+    let options = CreateCollectionOptions::builder()
         .encrypted_fields(doc! {
             "fields": [{
                 "path": "ssn",
@@ -2988,7 +2993,9 @@ async fn auto_encryption_keys(master_key: MasterKey) -> Result<()> {
                 "keyId": Bson::Null,
             }],
         })
-        .run()
+        .build();
+    let (ef, result) = ce
+        .create_encrypted_collection(&db, "case_4", master_key.clone(), options)
         .await;
     result?;
     let key = match ef.get_array("fields")?[0]


### PR DESCRIPTION
RUST-1411

While writing up the release notes for 2.5.0, I realize that `create_encrypted_collection` is in the spec as a method on `ClientEncryption`, not (as I'd implemented it) `Database`.  While it makes some sense to be on the latter as a parallel to `create_collection`, since the spec and all other language drivers implement it the other way, I updated us to follow suit.