### PR TITLE
RUST-1605 Remove fle2v2 calls

### DIFF
--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -97,9 +97,7 @@ impl ClientState {
     }
 
     fn make_crypt(opts: &AutoEncryptionOptions) -> Result<Crypt> {
-        let mut builder = Crypt::builder()
-            .kms_providers(&opts.kms_providers.credentials_doc()?)?
-            .fle2v2(true)?;
+        let mut builder = Crypt::builder().kms_providers(&opts.kms_providers.credentials_doc()?)?;
         if let Some(m) = &opts.schema_map {
             builder = builder.schema_map(&bson::to_document(m)?)?;
         }

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -74,7 +74,6 @@ impl ClientEncryption {
         let crypt = Crypt::builder()
             .kms_providers(&kms_providers.credentials_doc()?)?
             .use_need_kms_credentials_state()
-            .fle2v2(true)?
             .build()?;
         let exec = CryptExecutor::new_explicit(
             key_vault_client.weak(),


### PR DESCRIPTION
RUST-1605

As of 1.8.0-alpha1, the `fle2v2` method has been removed and libmongocrypt just defaults to using v2.