### PR TITLE
RUST-1442 On-demand Azure KMS credentials

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -91,6 +91,8 @@ functions:
               export TOPOLOGY=${TOPOLOGY}
               export MONGODB_VERSION=${MONGODB_VERSION}
 
+              export AZURE_IMDS_MOCK_PORT=44175
+
               if [ "Windows_NT" != "$OS" ]; then
                   ulimit -n 64000
               fi
@@ -487,6 +489,16 @@ functions:
         ${PREPARE_SHELL}
         export TLS_FEATURE=${TLS_FEATURE}
         .evergreen/run-csfle-kmip-servers.sh
+
+  "run mock azure imds server":
+  - command: shell.exec
+    params:
+      shell: bash
+      working_dir: "src"
+      background: true
+      script: |
+        ${PREPARE_SHELL}
+        .evergreen/run-csfle-mock-azure-imds.sh
 
   "build csfle expansions":
     - command: shell.exec
@@ -1214,6 +1226,7 @@ tasks:
       - func: "install junit dependencies"
       - func: "bootstrap mongo-orchestration"
       - func: "run kmip server"
+      - func: "run mock azure imds server"
       - func: "build csfle expansions"
       - func: "run csfle tests"
 
@@ -1229,6 +1242,7 @@ tasks:
       - func: "install junit dependencies"
       - func: "install libmongocrypt"
       - func: "run kmip server"
+      - func: "run mock azure imds server"
       - func: "build csfle expansions"
       - func: "run csfle serverless tests"
 

--- a/.evergreen/feature-combinations.sh
+++ b/.evergreen/feature-combinations.sh
@@ -5,7 +5,7 @@ export NO_FEATURES=''
 # async-std-related features that conflict with the library's default features.
 export ASYNC_STD_FEATURES='--no-default-features --features async-std-runtime,sync'
 # All additional features that do not conflict with the default features. New features added to the library should also be added to this list.
-export ADDITIONAL_FEATURES='--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth,tracing-unstable,in-use-encryption-unstable'
+export ADDITIONAL_FEATURES='--features tokio-sync,zstd-compression,snappy-compression,zlib-compression,openssl-tls,aws-auth,tracing-unstable,in-use-encryption-unstable,azure-kms'
 
 
 # Array of feature combinations that, in total, provides complete coverage of the driver.

--- a/.evergreen/run-csfle-mock-azure-imds.sh
+++ b/.evergreen/run-csfle-mock-azure-imds.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+. ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+PYTHON=$(find_python3)
+
+function prepend() { while read line; do echo "${1}${line}"; done; }
+
+cd ${DRIVERS_TOOLS}/.evergreen/csfle
+${PYTHON} bottle.py fake_azure:imds -b localhost:${AZURE_IMDS_MOCK_PORT} 2>&1 | prepend "[MOCK AZURE IMDS] "

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -7,7 +7,7 @@ source ./.evergreen/env.sh
 
 set -o xtrace
 
-FEATURE_FLAGS="in-use-encryption-unstable,aws-auth,${TLS_FEATURE}"
+FEATURE_FLAGS="in-use-encryption-unstable,aws-auth,azure-kms,${TLS_FEATURE}"
 OPTIONS="-- -Z unstable-options --format json --report-time"
 
 if [ "$SINGLE_THREAD" = true ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ bson-uuid-1 = ["bson/uuid-1"]
 # This can only be used with the tokio-runtime feature flag.
 aws-auth = ["reqwest"]
 
+# Enable support for on-demand Azure KMS credentials.
+azure-kms = ["reqwest"]
+
 zstd-compression = ["zstd"]
 zlib-compression = ["flate2"]
 snappy-compression = ["snap"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ bson-uuid-1 = ["bson/uuid-1"]
 aws-auth = ["reqwest"]
 
 # Enable support for on-demand Azure KMS credentials.
+# This can only be used with the tokio-runtime feature flag.
 azure-kms = ["reqwest"]
 
 zstd-compression = ["zstd"]

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -399,8 +399,7 @@ impl Credential {
         conn: &mut Connection,
         server_api: Option<&ServerApi>,
         first_round: Option<FirstRound>,
-        #[cfg(feature = "aws-auth")]
-        http_client: &crate::runtime::HttpClient,
+        #[cfg(feature = "aws-auth")] http_client: &crate::runtime::HttpClient,
     ) -> Result<()> {
         let stream_description = conn.stream_description()?;
 
@@ -431,7 +430,13 @@ impl Credential {
 
         // Authenticate according to the chosen mechanism.
         mechanism
-            .authenticate_stream(conn, self, server_api, #[cfg(feature = "aws-auth")] http_client)
+            .authenticate_stream(
+                conn,
+                self,
+                server_api,
+                #[cfg(feature = "aws-auth")]
+                http_client,
+            )
             .await
     }
 

--- a/src/client/auth/mod.rs
+++ b/src/client/auth/mod.rs
@@ -23,7 +23,6 @@ use crate::{
     client::options::ServerApi,
     cmap::{Command, Connection, StreamDescription},
     error::{Error, ErrorKind, Result},
-    runtime::HttpClient,
 };
 
 const SCRAM_SHA_1_STR: &str = "SCRAM-SHA-1";
@@ -253,7 +252,7 @@ impl AuthMechanism {
         stream: &mut Connection,
         credential: &Credential,
         server_api: Option<&ServerApi>,
-        #[cfg_attr(not(feature = "aws-auth"), allow(unused))] http_client: &HttpClient,
+        #[cfg(feature = "aws-auth")] http_client: &crate::runtime::HttpClient,
     ) -> Result<()> {
         self.validate_credential(credential)?;
 
@@ -398,9 +397,10 @@ impl Credential {
     pub(crate) async fn authenticate_stream(
         &self,
         conn: &mut Connection,
-        http_client: &HttpClient,
         server_api: Option<&ServerApi>,
         first_round: Option<FirstRound>,
+        #[cfg(feature = "aws-auth")]
+        http_client: &crate::runtime::HttpClient,
     ) -> Result<()> {
         let stream_description = conn.stream_description()?;
 
@@ -431,7 +431,7 @@ impl Credential {
 
         // Authenticate according to the chosen mechanism.
         mechanism
-            .authenticate_stream(conn, self, server_api, http_client)
+            .authenticate_stream(conn, self, server_api, #[cfg(feature = "aws-auth")] http_client)
             .await
     }
 

--- a/src/client/csfle.rs
+++ b/src/client/csfle.rs
@@ -1,7 +1,7 @@
 pub(crate) mod client_builder;
 pub mod client_encryption;
 pub mod options;
-mod state_machine;
+pub(crate) mod state_machine;
 
 use std::{path::Path, time::Duration};
 

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -428,6 +428,7 @@ pub(crate) mod azure {
                     &format!("invalid `expires_in` response field: {}", e),
                 )
             })?;
+            #[allow(clippy::redundant_clone)]
             Ok(CachedAccessToken {
                 token_doc: rawdoc! { "accessToken": server_response.access_token.clone() },
                 expire_time: now + Duration::from_secs(expires_in_secs),
@@ -452,7 +453,7 @@ pub(crate) mod azure {
                     url.set_host(Some(host))
                         .map_err(|e| Error::internal(format!("invalid test host: {}", e)))?;
                     url.set_port(Some(port))
-                        .map_err(|()| Error::internal(format!("invalid test port")))?;
+                        .map_err(|()| Error::internal(format!("invalid test port {}", port)))?;
                 }
                 url
             };

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -36,13 +36,7 @@ pub(crate) struct CryptExecutor {
     mongocryptd_client: Option<Client>,
     metadata_client: Option<WeakClient>,
     cached_azure_access_token: Mutex<Option<CachedAzureAccessToken>>,
-    azure_imds: Box<dyn AzureImds>,
-}
-
-#[derive(Debug)]
-struct CachedAzureAccessToken {
-    token_doc: RawDocumentBuf,
-    expire_time: Instant,
+    azure_imds: Box<dyn AzureImds + Send + Sync>,
 }
 
 impl CryptExecutor {
@@ -370,6 +364,12 @@ fn result_mut<T>(r: &mut Result<T>) -> Result<&mut T> {
 fn raw_to_doc(raw: &RawDocument) -> Result<Document> {
     raw.try_into()
         .map_err(|e| Error::internal(format!("could not parse raw document: {}", e)))
+}
+
+#[derive(Debug)]
+struct CachedAzureAccessToken {
+    token_doc: RawDocumentBuf,
+    expire_time: Instant,
 }
 
 #[async_trait::async_trait]

--- a/src/cmap/establish/handshake/mod.rs
+++ b/src/cmap/establish/handshake/mod.rs
@@ -332,7 +332,7 @@ pub(crate) struct Handshaker {
 
 impl Handshaker {
     /// Creates a new Handshaker.
-    pub(crate) fn new(http_client: HttpClient, options: HandshakerOptions) -> Self {
+    pub(crate) fn new(options: HandshakerOptions) -> Self {
         let mut metadata = BASE_CLIENT_METADATA.clone();
         let compressors = options.compressors;
 
@@ -383,7 +383,7 @@ impl Handshaker {
         command.body.insert("client", metadata.clone());
 
         Self {
-            http_client,
+            http_client: HttpClient::default(),
             command,
             compressors,
             server_api: options.server_api,

--- a/src/cmap/establish/handshake/test.rs
+++ b/src/cmap/establish/handshake/test.rs
@@ -3,13 +3,11 @@ use crate::{
     bson::doc,
     cmap::establish::handshake::HandshakerOptions,
     options::DriverInfo,
-    runtime::HttpClient,
 };
 
 #[test]
 fn metadata_no_options() {
     let handshaker = Handshaker::new(
-        HttpClient::default(),
         HandshakerOptions {
             app_name: None,
             compressors: None,
@@ -51,7 +49,7 @@ fn metadata_with_options() {
         load_balanced: false,
     };
 
-    let handshaker = Handshaker::new(HttpClient::default(), options);
+    let handshaker = Handshaker::new(options);
 
     let metadata = handshaker.command.body.get_document("client").unwrap();
     assert_eq!(

--- a/src/cmap/establish/handshake/test.rs
+++ b/src/cmap/establish/handshake/test.rs
@@ -1,21 +1,15 @@
 use super::Handshaker;
-use crate::{
-    bson::doc,
-    cmap::establish::handshake::HandshakerOptions,
-    options::DriverInfo,
-};
+use crate::{bson::doc, cmap::establish::handshake::HandshakerOptions, options::DriverInfo};
 
 #[test]
 fn metadata_no_options() {
-    let handshaker = Handshaker::new(
-        HandshakerOptions {
-            app_name: None,
-            compressors: None,
-            driver_info: None,
-            server_api: None,
-            load_balanced: false,
-        },
-    );
+    let handshaker = Handshaker::new(HandshakerOptions {
+        app_name: None,
+        compressors: None,
+        driver_info: None,
+        server_api: None,
+        load_balanced: false,
+    });
 
     let metadata = handshaker.command.body.get_document("client").unwrap();
     assert!(!metadata.contains_key("application"));

--- a/src/cmap/establish/mod.rs
+++ b/src/cmap/establish/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     error::{Error as MongoError, ErrorKind, Result},
     hello::HelloReply,
-    runtime::{self, stream::DEFAULT_CONNECT_TIMEOUT, AsyncStream, HttpClient, TlsConfig},
+    runtime::{self, stream::DEFAULT_CONNECT_TIMEOUT, AsyncStream, TlsConfig},
     sdam::HandshakePhase,
 };
 
@@ -56,8 +56,8 @@ impl EstablisherOptions {
 
 impl ConnectionEstablisher {
     /// Creates a new ConnectionEstablisher from the given options.
-    pub(crate) fn new(http_client: HttpClient, options: EstablisherOptions) -> Result<Self> {
-        let handshaker = Handshaker::new(http_client, options.handshake_options);
+    pub(crate) fn new(options: EstablisherOptions) -> Result<Self> {
+        let handshaker = Handshaker::new(options.handshake_options);
 
         let tls_config = if let Some(tls_options) = options.tls_options {
             Some(TlsConfig::new(tls_options)?)

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -51,7 +51,6 @@ async fn acquire_connection_and_send_command() {
     let pool = ConnectionPool::new(
         client_options.hosts[0].clone(),
         ConnectionEstablisher::new(
-            Default::default(),
             EstablisherOptions::from_client_options(&client_options),
         )
         .unwrap(),
@@ -133,7 +132,6 @@ async fn concurrent_connections() {
     let pool = ConnectionPool::new(
         CLIENT_OPTIONS.get().await.hosts[0].clone(),
         ConnectionEstablisher::new(
-            Default::default(),
             EstablisherOptions::from_client_options(&client_options),
         )
         .unwrap(),
@@ -226,7 +224,6 @@ async fn connection_error_during_establishment() {
     let pool = ConnectionPool::new(
         client_options.hosts[0].clone(),
         ConnectionEstablisher::new(
-            Default::default(),
             EstablisherOptions::from_client_options(&client_options),
         )
         .unwrap(),

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -50,10 +50,8 @@ async fn acquire_connection_and_send_command() {
 
     let pool = ConnectionPool::new(
         client_options.hosts[0].clone(),
-        ConnectionEstablisher::new(
-            EstablisherOptions::from_client_options(&client_options),
-        )
-        .unwrap(),
+        ConnectionEstablisher::new(EstablisherOptions::from_client_options(&client_options))
+            .unwrap(),
         TopologyUpdater::channel().0,
         bson::oid::ObjectId::new(),
         Some(pool_options),
@@ -131,10 +129,8 @@ async fn concurrent_connections() {
 
     let pool = ConnectionPool::new(
         CLIENT_OPTIONS.get().await.hosts[0].clone(),
-        ConnectionEstablisher::new(
-            EstablisherOptions::from_client_options(&client_options),
-        )
-        .unwrap(),
+        ConnectionEstablisher::new(EstablisherOptions::from_client_options(&client_options))
+            .unwrap(),
         TopologyUpdater::channel().0,
         bson::oid::ObjectId::new(),
         Some(options),
@@ -223,10 +219,8 @@ async fn connection_error_during_establishment() {
         Some(handler.clone() as Arc<dyn crate::event::cmap::CmapEventHandler>);
     let pool = ConnectionPool::new(
         client_options.hosts[0].clone(),
-        ConnectionEstablisher::new(
-            EstablisherOptions::from_client_options(&client_options),
-        )
-        .unwrap(),
+        ConnectionEstablisher::new(EstablisherOptions::from_client_options(&client_options))
+            .unwrap(),
         TopologyUpdater::channel().0,
         bson::oid::ObjectId::new(),
         Some(options),

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -159,9 +159,9 @@ impl Executor {
 
         let pool = ConnectionPool::new(
             CLIENT_OPTIONS.get().await.hosts[0].clone(),
-            ConnectionEstablisher::new(
-                EstablisherOptions::from_client_options(CLIENT_OPTIONS.get().await),
-            )
+            ConnectionEstablisher::new(EstablisherOptions::from_client_options(
+                CLIENT_OPTIONS.get().await,
+            ))
             .unwrap(),
             updater,
             bson::oid::ObjectId::new(),

--- a/src/cmap/test/mod.rs
+++ b/src/cmap/test/mod.rs
@@ -160,7 +160,6 @@ impl Executor {
         let pool = ConnectionPool::new(
             CLIENT_OPTIONS.get().await.hosts[0].clone(),
             ConnectionEstablisher::new(
-                Default::default(),
                 EstablisherOptions::from_client_options(CLIENT_OPTIONS.get().await),
             )
             .unwrap(),

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -1,4 +1,4 @@
-use reqwest::{Method, Response, IntoUrl};
+use reqwest::{IntoUrl, Method, Response};
 use serde::Deserialize;
 
 use crate::error::{Error, Result};

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -26,6 +26,7 @@ impl HttpClient {
     }
 
     /// Executes an HTTP GET request and returns the response body as a string.
+    #[allow(unused)]
     pub(crate) async fn get_and_read_string<'a>(
         &self,
         uri: &str,
@@ -36,6 +37,7 @@ impl HttpClient {
     }
 
     /// Executes an HTTP PUT request and returns the response body as a string.
+    #[allow(unused)]
     pub(crate) async fn put_and_read_string<'a>(
         &self,
         uri: &str,
@@ -46,6 +48,7 @@ impl HttpClient {
     }
 
     /// Executes an HTTP request and returns the response body as a string.
+    #[allow(unused)]
     pub(crate) async fn request_and_read_string<'a>(
         &self,
         method: Method,
@@ -57,7 +60,7 @@ impl HttpClient {
         Ok(text)
     }
 
-    /// Executes an HTTP equest and returns the response.
+    /// Executes an HTTP request and returns the response.
     pub(crate) async fn request<'a>(
         &self,
         method: Method,

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -1,15 +1,11 @@
-#[cfg(feature = "aws-auth")]
 use reqwest::{Method, Response};
-#[cfg(feature = "aws-auth")]
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct HttpClient {
-    #[cfg(feature = "aws-auth")]
     inner: reqwest::Client,
 }
 
-#[cfg(feature = "aws-auth")]
 impl HttpClient {
     /// Executes an HTTP GET request and deserializes the JSON response.
     pub(crate) async fn get_and_deserialize_json<'a, T>(

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -1,4 +1,4 @@
-use reqwest::{Method, Response};
+use reqwest::{Method, Response, IntoUrl};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Default)]
@@ -10,7 +10,7 @@ impl HttpClient {
     /// Executes an HTTP GET request and deserializes the JSON response.
     pub(crate) async fn get_and_deserialize_json<'a, T>(
         &self,
-        uri: &str,
+        uri: impl IntoUrl,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
     ) -> reqwest::Result<T>
     where
@@ -64,7 +64,7 @@ impl HttpClient {
     pub(crate) async fn request<'a>(
         &self,
         method: Method,
-        uri: &str,
+        uri: impl IntoUrl,
         headers: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
     ) -> reqwest::Result<Response> {
         let response = headers

--- a/src/runtime/http.rs
+++ b/src/runtime/http.rs
@@ -1,12 +1,22 @@
 use reqwest::{Method, Response, IntoUrl};
 use serde::Deserialize;
 
+use crate::error::{Error, Result};
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct HttpClient {
     inner: reqwest::Client,
 }
 
 impl HttpClient {
+    pub(crate) fn with_timeout(timeout: std::time::Duration) -> Result<Self> {
+        let inner = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|e| Error::internal(format!("error initializing http client: {}", e)))?;
+        Ok(Self { inner })
+    }
+
     /// Executes an HTTP GET request and deserializes the JSON response.
     pub(crate) async fn get_and_deserialize_json<'a, T>(
         &self,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 mod acknowledged_message;
+#[cfg(feature = "reqwest")]
 mod http;
 #[cfg(feature = "async-std-runtime")]
 mod interval;
@@ -28,6 +29,7 @@ pub(crate) use self::{
     worker_handle::{WorkerHandle, WorkerHandleListener},
 };
 use crate::{error::Result, options::ServerAddress};
+#[cfg(feature = "reqwest")]
 pub(crate) use http::HttpClient;
 #[cfg(feature = "async-std-runtime")]
 use interval::Interval;

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -92,9 +92,8 @@ impl Topology {
         };
         let (watcher, publisher) = TopologyWatcher::channel(state);
 
-        let connection_establisher = ConnectionEstablisher::new(
-            EstablisherOptions::from_client_options(&options),
-        )?;
+        let connection_establisher =
+            ConnectionEstablisher::new(EstablisherOptions::from_client_options(&options))?;
 
         let id = ObjectId::new();
 

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -35,7 +35,7 @@ use crate::{
         TopologyDescriptionChangedEvent,
         TopologyOpeningEvent,
     },
-    runtime::{self, AcknowledgedMessage, HttpClient, WorkerHandle, WorkerHandleListener},
+    runtime::{self, AcknowledgedMessage, WorkerHandle, WorkerHandleListener},
     selection_criteria::SelectionCriteria,
     ClusterTime,
     ServerInfo,
@@ -93,7 +93,6 @@ impl Topology {
         let (watcher, publisher) = TopologyWatcher::channel(state);
 
         let connection_establisher = ConnectionEstablisher::new(
-            HttpClient::default(),
             EstablisherOptions::from_client_options(&options),
         )?;
 

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2858,7 +2858,27 @@ async fn on_demand_aws_success() -> Result<()> {
 
 // TODO RUST-1417: implement prose test 17. On-demand GCP Credentials
 
-// TODO RUST-1442: implement prose test 18. Azure IMDS Credentials
+// Prose test 18. Azure IMDS Credentials
+#[cfg(feature = "azure-kms")]
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn azure_imds() -> Result<()> {
+    if !check_env("azure_imds", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_concurrently().await;
+
+    let mut azure_exec = crate::client::csfle::state_machine::azure::ExecutorState::new();
+    azure_exec.test_host = Some(("localhost", 8080));
+
+    // Case 1
+    let token = azure_exec.fetch_new_token().await?;
+    assert_eq!(token.access_token, "magic-cookie");
+    assert_eq!(token.expires_in, "70");
+    assert_eq!(token.resource, "https://vault.azure.net");
+
+    Ok(())
+}
 
 // TODO RUST-1442: implement prose test 19. Azure IMDS Credentials Integration Test
 

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2869,7 +2869,13 @@ async fn azure_imds() -> Result<()> {
     let _guard = LOCK.run_concurrently().await;
 
     let mut azure_exec = crate::client::csfle::state_machine::azure::ExecutorState::new()?;
-    azure_exec.test_host = Some(("localhost", std::env::var("AZURE_IMDS_MOCK_PORT").unwrap().parse().unwrap()));
+    azure_exec.test_host = Some((
+        "localhost",
+        std::env::var("AZURE_IMDS_MOCK_PORT")
+            .unwrap()
+            .parse()
+            .unwrap(),
+    ));
 
     // Case 1: Success
     {

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2869,7 +2869,7 @@ async fn azure_imds() -> Result<()> {
     let _guard = LOCK.run_concurrently().await;
 
     let mut azure_exec = crate::client::csfle::state_machine::azure::ExecutorState::new()?;
-    azure_exec.test_host = Some(("localhost", 8080));
+    azure_exec.test_host = Some(("localhost", std::env::var("AZURE_IMDS_MOCK_PORT").unwrap().parse().unwrap()));
 
     // Case 1: Success
     {

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2868,17 +2868,59 @@ async fn azure_imds() -> Result<()> {
     }
     let _guard = LOCK.run_concurrently().await;
 
-    let mut azure_exec = crate::client::csfle::state_machine::azure::ExecutorState::new();
+    let mut azure_exec = crate::client::csfle::state_machine::azure::ExecutorState::new()?;
     azure_exec.test_host = Some(("localhost", 8080));
 
-    // Case 1
-    let now = std::time::Instant::now();
-    let token = azure_exec.get_token().await?;
-    assert_eq!(token, rawdoc! { "accessToken": "magic-cookie" });
-    let cached = azure_exec.cached().await.expect("cached token");
-    assert_eq!(cached.server_response.expires_in, "70");
-    assert_eq!(cached.server_response.resource, "https://vault.azure.net");
-    assert!((65..75).contains(&cached.expire_time.duration_since(now).as_secs()));
+    // Case 1: Success
+    {
+        let now = std::time::Instant::now();
+        let token = azure_exec.get_token().await?;
+        assert_eq!(token, rawdoc! { "accessToken": "magic-cookie" });
+        let cached = azure_exec.take_cached().await.expect("cached token");
+        assert_eq!(cached.server_response.expires_in, "70");
+        assert_eq!(cached.server_response.resource, "https://vault.azure.net");
+        assert!((65..75).contains(&cached.expire_time.duration_since(now).as_secs()));
+    }
+
+    // Case 2: Empty JSON
+    {
+        azure_exec.test_param = Some("case=empty-json");
+        let result = azure_exec.get_token().await;
+        assert!(result.is_err(), "expected err got {:?}", result);
+        assert!(result.unwrap_err().is_auth_error());
+    }
+
+    // Case 3: Bad JSON
+    {
+        azure_exec.test_param = Some("case=bad-json");
+        let result = azure_exec.get_token().await;
+        assert!(result.is_err(), "expected err got {:?}", result);
+        assert!(result.unwrap_err().is_auth_error());
+    }
+
+    // Case 4: HTTP 404
+    {
+        azure_exec.test_param = Some("case=404");
+        let result = azure_exec.get_token().await;
+        assert!(result.is_err(), "expected err got {:?}", result);
+        assert!(result.unwrap_err().is_auth_error());
+    }
+
+    // Case 5: HTTP 500
+    {
+        azure_exec.test_param = Some("case=500");
+        let result = azure_exec.get_token().await;
+        assert!(result.is_err(), "expected err got {:?}", result);
+        assert!(result.unwrap_err().is_auth_error());
+    }
+
+    // Case 6: Slow Response
+    {
+        azure_exec.test_param = Some("case=slow");
+        let result = azure_exec.get_token().await;
+        assert!(result.is_err(), "expected err got {:?}", result);
+        assert!(result.unwrap_err().is_auth_error());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
RUST-1442

This adds support for fetching on-demand csfle credentials from the Azure IMDS service.  Notably, this requires an HTTP fetch, so this updates the internal `HttpClient` to not be aws auth only; this also means that azure auth has the same restriction as aws auth (i.e. tokio), and is behind a feature flag.

This PR includes the unit tests; integration tests to come in a follow-up PR.