### PR TITLE
Add partial file retrieval when using GridFS stream download

### DIFF
--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -148,6 +148,7 @@ impl<T> Cursor<T> {
     }
 
     /// Whether this cursor has any additional items to return.
+    #[allow(dead_code)]
     pub(crate) fn has_next(&self) -> bool {
         !self.is_exhausted()
             || !self

--- a/src/error.rs
+++ b/src/error.rs
@@ -905,6 +905,15 @@ pub enum GridFsErrorKind {
     /// [`GridFsUploadStream`](crate::gridfs::GridFsUploadStream) while a write was still in
     /// progress.
     WriteInProgress,
+
+    /// Partial file download range is invalid when start is greater then end
+    InvalidPartialDownloadRange { start: u64, end: u64 },
+
+    /// Partial file download range is invalid when start or end are greater then file length
+    PartialDownloadRangeOutOfBounds {
+        out_of_bounds_value: u64,
+        file_length: u64,
+    },
 }
 
 /// An identifier for a file stored in a GridFS bucket.

--- a/src/gridfs/options.rs
+++ b/src/gridfs/options.rs
@@ -44,6 +44,20 @@ pub struct GridFsUploadOptions {
 }
 
 /// Contains the options for downloading a file from a [`GridFsBucket`](crate::gridfs::GridFsBucket)
+/// by id.
+#[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+pub struct GridFsDownloadByIdOptions {
+    /// 0-indexed non-negative byte offset from the beginning of the file.
+    pub start: Option<u64>,
+
+    /// 0-indexed non-negative byte offset to the end of the file contents to be returned by the
+    /// stream. end is non-inclusive.
+    pub end: Option<u64>,
+}
+
+/// Contains the options for downloading a file from a [`GridFsBucket`](crate::gridfs::GridFsBucket)
 /// by name.
 #[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
 #[builder(field_defaults(default, setter(into)))]
@@ -60,6 +74,13 @@ pub struct GridFsDownloadByNameOptions {
     /// -2 = the second most recent revision
     /// -1 = the most recent revision
     pub revision: Option<i32>,
+
+    /// 0-indexed non-negative byte offset from the beginning of the file.
+    pub start: Option<u64>,
+
+    /// 0-indexed non-negative byte offset to the end of the file contents to be returned by the
+    /// stream. end is non-inclusive.
+    pub end: Option<u64>,
 }
 
 /// Contains the options for finding

--- a/src/sync/gridfs.rs
+++ b/src/sync/gridfs.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 
 pub use crate::gridfs::FilesCollectionDocument;
+use crate::gridfs::GridFsDownloadByIdOptions;
 
 /// A `GridFsBucket` provides the functionality for storing and retrieving binary BSON data that
 /// exceeds the 16 MiB size limit of a MongoDB document. Users may upload and download large amounts
@@ -98,7 +99,7 @@ impl GridFsBucket {
 /// use std::io::Read;
 ///
 /// let mut buf = Vec::new();
-/// let mut download_stream = bucket.open_download_stream(id)?;
+/// let mut download_stream = bucket.open_download_stream(id, None)?;
 /// download_stream.read_to_end(&mut buf)?;
 /// # Ok(())
 /// # }
@@ -123,8 +124,13 @@ impl GridFsDownloadStream {
 impl GridFsBucket {
     /// Opens and returns a [`GridFsDownloadStream`] from which the application can read
     /// the contents of the stored file specified by `id`.
-    pub fn open_download_stream(&self, id: Bson) -> Result<GridFsDownloadStream> {
-        runtime::block_on(self.async_bucket.open_download_stream(id)).map(GridFsDownloadStream::new)
+    pub fn open_download_stream(
+        &self,
+        id: Bson,
+        options: impl Into<Option<GridFsDownloadByIdOptions>>,
+    ) -> Result<GridFsDownloadStream> {
+        runtime::block_on(self.async_bucket.open_download_stream(id, options))
+            .map(GridFsDownloadStream::new)
     }
 
     /// Opens and returns a [`GridFsDownloadStream`] from which the application can read

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -455,7 +455,7 @@ fn gridfs() {
     upload_stream.close().unwrap();
 
     let mut download_stream = bucket
-        .open_download_stream(upload_stream.id().clone())
+        .open_download_stream(upload_stream.id().clone(), None)
         .unwrap();
     download_stream.read_to_end(&mut download).unwrap();
 

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -2744,7 +2744,7 @@ impl TestOperation for Download {
 
             // Next, read via the open_download_stream API.
             let mut buf: Vec<u8> = vec![];
-            let mut stream = bucket.open_download_stream(self.id.clone()).await?;
+            let mut stream = bucket.open_download_stream(self.id.clone(), None).await?;
             stream.read_to_end(&mut buf).await?;
             let stream_data = hex::encode(buf);
 


### PR DESCRIPTION
Implemented support for partial file retrieval according to GridFS [spec](https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#partial-file-retrieval) for `GridFsBucket::open_download_stream` and `GridFsBucket::open_download_stream_by_name`.
**Unfortunately, there is a breaking change in `GridFsBucket::open_download_stream` interface - additional options argument to accept start/end range.**

- [x] start and end values are non negative (ensured by design using u64)
- [x] validate whether start is less than or equal to end
- [x] validate whether start and end are less than or equal to file length
- [x] file chunk size is being used to skip and limit chunks when performing partial reads