### PR TITLE
RUST-1442 Azure KMS integration test

### DIFF
--- a/.evergreen/azure-kms-test/.gitignore
+++ b/.evergreen/azure-kms-test/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target

--- a/.evergreen/azure-kms-test/Cargo.toml
+++ b/.evergreen/azure-kms-test/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "azure-kms-test"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = "1.28.1"
+
+[dependencies.mongodb]
+path = "../.."
+features = ["in-use-encryption-unstable", "azure-kms"]

--- a/.evergreen/azure-kms-test/src/main.rs
+++ b/.evergreen/azure-kms-test/src/main.rs
@@ -6,9 +6,8 @@ use mongodb::{
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    /*
     let c = ClientEncryption::new(
-        Client::test_builder().build().await.into_client(),
+        Client::with_uri_str("mongodb://localhost:27017").await?,
         Namespace::new("keyvault", "datakeys"),
         [(KmsProvider::Azure, doc! { }, None)],
     )?;
@@ -20,7 +19,8 @@ async fn main() -> Result<()> {
     })
     .run()
     .await?;
-    */
+
+    println!("Azure KMS integration test passed!");
 
     Ok(())
 }

--- a/.evergreen/azure-kms-test/src/main.rs
+++ b/.evergreen/azure-kms-test/src/main.rs
@@ -1,0 +1,26 @@
+use mongodb::{
+    bson::doc,
+    Client, client_encryption::{ClientEncryption, MasterKey}, mongocrypt::ctx::KmsProvider, Namespace,
+    error::Result,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    /*
+    let c = ClientEncryption::new(
+        Client::test_builder().build().await.into_client(),
+        Namespace::new("keyvault", "datakeys"),
+        [(KmsProvider::Azure, doc! { }, None)],
+    )?;
+
+    c.create_data_key(MasterKey::Azure {
+        key_vault_endpoint: "https://keyvault-drivers-2411.vault.azure.net/keys/".to_string(),
+        key_name: "KEY-NAME".to_string(),
+        key_version: None,
+    })
+    .run()
+    .await?;
+    */
+
+    Ok(())
+}

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1246,6 +1246,15 @@ tasks:
       - func: "build csfle expansions"
       - func: "run csfle serverless tests"
 
+  - name: "test-azure-kms"
+    commands:
+      - command: shell.exec
+        params:
+          working_dir: "src"
+          script: |
+            ${PREPARE_SHELL}
+            .evergreen/run-azure-kms-test.sh
+
   - name: "test-atlas-connectivity"
     tags: ["atlas-connect"]
     commands:
@@ -1851,7 +1860,57 @@ task_groups:
 
     tasks:
       - ".serverless"
-
+  
+  - name: azurekms_task_group
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800 # 30 minutes
+    setup_group:
+      - func: "fetch source"
+      - func: "prepare resources"
+      - func: "windows fix"
+      - func: "fix absolute paths"
+      - func: "init test-results"
+      - func: "make files executable"
+      - func: "install rust"
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+              ${PREPARE_SHELL}
+              set +o xtrace
+              echo '${testazurekms_publickey}' > /tmp/testazurekms_publickey
+              echo '${testazurekms_privatekey}' > /tmp/testazurekms_privatekey
+              # Set 600 permissions on private key file. Otherwise ssh / scp may error with permissions "are too open".
+              chmod 600 /tmp/testazurekms_privatekey
+              export AZUREKMS_CLIENTID=${testazurekms_clientid}
+              export AZUREKMS_TENANTID=${testazurekms_tenantid}
+              export AZUREKMS_SECRET=${testazurekms_secret}
+              export AZUREKMS_DRIVERS_TOOLS=$DRIVERS_TOOLS
+              export AZUREKMS_RESOURCEGROUP=${testazurekms_resourcegroup}
+              export AZUREKMS_PUBLICKEYPATH=/tmp/testazurekms_publickey
+              export AZUREKMS_PRIVATEKEYPATH=/tmp/testazurekms_privatekey
+              export AZUREKMS_SCOPE=${testazurekms_scope}
+              export AZUREKMS_VMNAME_PREFIX=rustdriver
+              set -o xtrace
+              $DRIVERS_TOOLS/.evergreen/csfle/azurekms/create-and-setup-vm.sh
+      - command: expansions.update
+        params:
+          file: testazurekms-expansions.yml
+    teardown_group:
+      - command: expansions.update
+        params:
+          file: testazurekms-expansions.yml
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+            ${PREPARE_SHELL}
+            set -o errexit
+            export AZUREKMS_VMNAME=${AZUREKMS_VMNAME}
+            export AZUREKMS_RESOURCEGROUP=${testazurekms_resourcegroup}
+            $DRIVERS_TOOLS/.evergreen/csfle/azurekms/delete-vm.sh
+    tasks:
+      - test-azure-kms
 
 buildvariants:
 -
@@ -2159,8 +2218,7 @@ buildvariants:
     - ".6.0 .standalone"
     - ".5.0 .standalone"
 
--
-  name: "lint"
+- name: "lint"
   display_name: "! Lint"
   run_on:
     - ubuntu1804-test
@@ -2171,3 +2229,9 @@ buildvariants:
     - name: "check-manual"
     - name: "check-cargo-deny"
 
+- name: "azure-kms"
+  display_name: "Azure KMS"
+  run_on:
+    - ubuntu2004-test
+  tasks:
+    - name: "azurekms_task_group"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -2250,3 +2250,4 @@ buildvariants:
       - ubuntu-20.04
   tasks:
     - name: "azurekms_task_group"
+  batchtime: 20160

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1908,6 +1908,7 @@ task_groups:
             set -o errexit
             export AZUREKMS_VMNAME=${AZUREKMS_VMNAME}
             export AZUREKMS_RESOURCEGROUP=${testazurekms_resourcegroup}
+            export AZUREKMS_PRIVATEKEYPATH=/tmp/testazurekms_privatekey
             $DRIVERS_TOOLS/.evergreen/csfle/azurekms/delete-vm.sh
     tasks:
       - test-azure-kms

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1253,6 +1253,7 @@ tasks:
           working_dir: "src"
           script: |
             ${PREPARE_SHELL}
+            ${AZURE_SHELL}
             .evergreen/run-azure-kms-test.sh
 
   - name: "test-atlas-connectivity"
@@ -1872,6 +1873,7 @@ task_groups:
       - func: "init test-results"
       - func: "make files executable"
       - func: "install rust"
+      - func: "install libmongocrypt"
       - command: shell.exec
         params:
           shell: bash
@@ -1896,6 +1898,19 @@ task_groups:
       - command: expansions.update
         params:
           file: testazurekms-expansions.yml
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |-
+              cat <<EOT > azure_shell.yml
+              AZURE_SHELL: |
+                  export AZUREKMS_VMNAME=${AZUREKMS_VMNAME}
+                  export AZUREKMS_RESOURCEGROUP=${testazurekms_resourcegroup}
+                  export AZUREKMS_PRIVATEKEYPATH=/tmp/testazurekms_privatekey
+              EOT
+      - command: expansions.update
+        params:
+          file: azure_shell.yml
     teardown_group:
       - command: expansions.update
         params:
@@ -1905,10 +1920,8 @@ task_groups:
           shell: bash
           script: |-
             ${PREPARE_SHELL}
+            ${AZURE_SHELL}
             set -o errexit
-            export AZUREKMS_VMNAME=${AZUREKMS_VMNAME}
-            export AZUREKMS_RESOURCEGROUP=${testazurekms_resourcegroup}
-            export AZUREKMS_PRIVATEKEYPATH=/tmp/testazurekms_privatekey
             $DRIVERS_TOOLS/.evergreen/csfle/azurekms/delete-vm.sh
     tasks:
       - test-azure-kms
@@ -2230,9 +2243,10 @@ buildvariants:
     - name: "check-manual"
     - name: "check-cargo-deny"
 
-- name: "azure-kms"
+- matrix_name: "azure-kms"
   display_name: "Azure KMS"
-  run_on:
-    - ubuntu2004-test
+  matrix_spec:
+    os:
+      - ubuntu-20.04
   tasks:
     - name: "azurekms_task_group"

--- a/.evergreen/run-azure-kms-test.sh
+++ b/.evergreen/run-azure-kms-test.sh
@@ -7,4 +7,13 @@ source ./.evergreen/configure-rust.sh
 
 set -o xtrace
 
-echo "Azure KMS test placeholder"
+AZUREKMS_TOOLS=$DRIVERS_TOOLS/.evergreen/csfle/azurekms/
+
+pushd .evergreen/azure-kms-test
+cargo build
+AZUREKMS_SRC=target/debug/azure-kms-test \
+    AZUREKMS_DST="." \
+    $AZUREKMS_TOOLS/copy-file.sh
+popd
+
+AZUREKMS_CMD=azure-kms-test $AZUREKMS_TOOLS/run-command.sh

--- a/.evergreen/run-azure-kms-test.sh
+++ b/.evergreen/run-azure-kms-test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+source ./.evergreen/env.sh
+
+set -o xtrace
+
+echo "Azure KMS test placeholder"

--- a/.evergreen/run-azure-kms-test.sh
+++ b/.evergreen/run-azure-kms-test.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-source ./.evergreen/env.sh
+source ./.evergreen/configure-rust.sh
 
 set -o xtrace
 

--- a/.evergreen/run-azure-kms-test.sh
+++ b/.evergreen/run-azure-kms-test.sh
@@ -9,11 +9,18 @@ set -o xtrace
 
 AZUREKMS_TOOLS=$DRIVERS_TOOLS/.evergreen/csfle/azurekms/
 
+mkdir azurekms_remote
+cp -r $MONGOCRYPT_LIB_DIR azurekms_remote
+
 pushd .evergreen/azure-kms-test
 cargo build
-AZUREKMS_SRC=target/debug/azure-kms-test \
+popd
+cp .evergreen/azure-kms-test/target/debug/azure-kms-test azurekms_remote
+
+tar czf azurekms_remote.tgz azurekms_remote
+AZUREKMS_SRC=azurekms_remote.tgz \
     AZUREKMS_DST="." \
     $AZUREKMS_TOOLS/copy-file.sh
-popd
-
-AZUREKMS_CMD=azure-kms-test $AZUREKMS_TOOLS/run-command.sh
+AZUREKMS_CMD="tar xvf azurekms_remote.tgz" $AZUREKMS_TOOLS/run-command.sh
+AZUREKMS_CMD="LD_LIBRARY_PATH=./azurekms_remote/lib ./azurekms_remote/azure-kms-test" \
+    $AZUREKMS_TOOLS/run-command.sh

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2944,16 +2944,17 @@ async fn azure_imds_integration_failure() -> Result<()> {
     let c = ClientEncryption::new(
         Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
-        [(KmsProvider::Azure, doc! { }, None)],
+        [(KmsProvider::Azure, doc! {}, None)],
     )?;
 
-    let result = c.create_data_key(MasterKey::Azure {
-        key_vault_endpoint: "https://keyvault-drivers-2411.vault.azure.net/keys/".to_string(),
-        key_name: "KEY-NAME".to_string(),
-        key_version: None,
-    })
-    .run()
-    .await;
+    let result = c
+        .create_data_key(MasterKey::Azure {
+            key_vault_endpoint: "https://keyvault-drivers-2411.vault.azure.net/keys/".to_string(),
+            key_name: "KEY-NAME".to_string(),
+            key_version: None,
+        })
+        .run()
+        .await;
 
     assert!(result.is_err(), "expected error, got {:?}", result);
     assert!(result.unwrap_err().is_auth_error());

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2931,7 +2931,35 @@ async fn azure_imds() -> Result<()> {
     Ok(())
 }
 
-// TODO RUST-1442: implement prose test 19. Azure IMDS Credentials Integration Test
+// Prose test 19. Azure IMDS Credentials Integration Test (case 1: failure)
+#[cfg(feature = "azure-kms")]
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn azure_imds_integration_failure() -> Result<()> {
+    if !check_env("azure_imds_integration_failure", false) {
+        return Ok(());
+    }
+    let _guard = LOCK.run_concurrently().await;
+
+    let c = ClientEncryption::new(
+        Client::test_builder().build().await.into_client(),
+        KV_NAMESPACE.clone(),
+        [(KmsProvider::Azure, doc! { }, None)],
+    )?;
+
+    let result = c.create_data_key(MasterKey::Azure {
+        key_vault_endpoint: "https://keyvault-drivers-2411.vault.azure.net/keys/".to_string(),
+        key_name: "KEY-NAME".to_string(),
+        key_version: None,
+    })
+    .run()
+    .await;
+
+    assert!(result.is_err(), "expected error, got {:?}", result);
+    assert!(result.unwrap_err().is_auth_error());
+
+    Ok(())
+}
 
 // Prose test 20. Bypass creating mongocryptd client when shared library is loaded
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]


### PR DESCRIPTION
RUST-1442

This adds the integration tests for on-demand Azure KMS credentials; the failing one is just a normal test since we don't run those on Azure, the passing one is a binary that gets run on an Azure VM.