### PR TITLE
DRIVERS-2617 Test splitting of large changestream events

### DIFF
--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -744,8 +744,7 @@ async fn split_large_event() -> Result<()> {
 
     let coll = db.collection::<Document>("split_large_event");
     coll.insert_one(doc! { "value": "q".repeat(10 * 1024 * 1024) }, None)
-        .await?
-        .inserted_id;
+        .await?;
     let stream = coll
         .watch(
             [doc! { "$changeStreamSplitLargeEvent": {} }],


### PR DESCRIPTION
DRIVERS-2617

This adds a PoC for a simple prose test to validate that the driver handles the new `$changeStreamSplitLargeEvent` stage.