### PR TITLE
chaging replace document serialization

### DIFF
--- a/src/coll/mod.rs
+++ b/src/coll/mod.rs
@@ -2,6 +2,7 @@ pub mod options;
 
 use std::{borrow::Borrow, collections::HashSet, fmt, fmt::Debug, sync::Arc};
 
+use bson::{to_document_with_options, SerializerOptions};
 use futures_util::{
     future,
     stream::{StreamExt, TryStreamExt},
@@ -15,7 +16,7 @@ use serde::{
 
 use self::options::*;
 use crate::{
-    bson::{doc, to_document, Bson, Document},
+    bson::{doc, Bson, Document},
     bson_util,
     change_stream::{
         event::ChangeStreamEvent,
@@ -1119,7 +1120,12 @@ where
         options: impl Into<Option<FindOneAndReplaceOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<Option<T>> {
-        let replacement = to_document(replacement.borrow())?;
+        let replacement = to_document_with_options(
+            replacement.borrow(),
+            SerializerOptions::builder()
+                .human_readable(Some(false))
+                .build(),
+        )?;
 
         let session = session.into();
 
@@ -1379,7 +1385,12 @@ where
         options: impl Into<Option<ReplaceOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<UpdateResult> {
-        let replacement = to_document(replacement.borrow())?;
+        let replacement = to_document_with_options(
+            replacement.borrow(),
+            SerializerOptions::builder()
+                .human_readable(Some(false))
+                .build(),
+        )?;
 
         bson_util::replacement_document_check(&replacement)?;
 


### PR DESCRIPTION
The Insert uses `human_readable = false` option to serialize documents, but the Replace uses `bson::to_document` that uses `human_readable = true`.

This PR aims to make this consistent across both operations.

Regards,
Maicon

