### PR TITLE
minor: skip session tests if mongocryptd fails to spawn

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -93,6 +93,8 @@ functions:
 
               export AZURE_IMDS_MOCK_PORT=44175
 
+              export SESSION_TEST_REQUIRE_MONGOCRYPTD=1
+
               if [ "Windows_NT" != "$OS" ]; then
                   ulimit -n 64000
               fi

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -210,6 +210,9 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let pid_file_path = format!("--pidfilepath={name}.pid");
     let args = vec!["--port=47017", &pid_file_path];
     let Ok(process) = Process::spawn("mongocryptd", args) else {
+        if std::env::var("SESSION_TEST_REQUIRE_MONGOCRYPTD").is_ok() {
+            panic!("Failed to spawn mongocryptd");
+        }
         log_uncaptured(format!("Skipping {name}: failed to spawn mongocryptd"));
         return None;
     };

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -209,7 +209,10 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
 
     let pid_file_path = format!("--pidfilepath={name}.pid");
     let args = vec!["--port=47017", &pid_file_path];
-    let process = Process::spawn("mongocryptd", args).expect("Failed to spawn mongocryptd");
+    let Ok(process) = Process::spawn("mongocryptd", args) else {
+        log_uncaptured(format!("Skipping {name}: failed to spawn mongocryptd"));
+        return None;
+    };
 
     let options = ClientOptions::parse("mongodb://localhost:47017")
         .await


### PR DESCRIPTION
`mongocryptd` doesn't need to be installed for 99% of work on the driver, and this way those tests don't fail in that case if run incidentally (i.e. as part of a full test run).