### PR TITLE
RUST-1358 Remove most type constraints on cursor values

### DIFF
--- a/src/change_stream/mod.rs
+++ b/src/change_stream/mod.rs
@@ -85,7 +85,7 @@ use crate::{
 #[derivative(Debug)]
 pub struct ChangeStream<T>
 where
-    T: DeserializeOwned + Unpin + Send + Sync,
+    T: DeserializeOwned,
 {
     /// The cursor to iterate over event instances.
     cursor: Cursor<T>,
@@ -103,7 +103,7 @@ where
 
 impl<T> ChangeStream<T>
 where
-    T: DeserializeOwned + Unpin + Send + Sync,
+    T: DeserializeOwned,
 {
     pub(crate) fn new(cursor: Cursor<T>, args: WatchArgs, data: ChangeStreamData) -> Self {
         let pending_resume: Option<BoxFuture<'static, Result<ChangeStream<T>>>> = None;
@@ -126,7 +126,7 @@ where
     }
 
     /// Update the type streamed values will be parsed as.
-    pub fn with_type<D: DeserializeOwned + Unpin + Send + Sync>(self) -> ChangeStream<D> {
+    pub fn with_type<D: DeserializeOwned>(self) -> ChangeStream<D> {
         ChangeStream {
             cursor: self.cursor.with_type(),
             args: self.args,
@@ -256,7 +256,7 @@ fn get_resume_token(
 
 impl<T> CursorStream for ChangeStream<T>
 where
-    T: DeserializeOwned + Unpin + Send + Sync,
+    T: DeserializeOwned,
 {
     fn poll_next_in_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<BatchValue>> {
         loop {
@@ -316,7 +316,7 @@ where
 
 impl<T> Stream for ChangeStream<T>
 where
-    T: DeserializeOwned + Unpin + Send + Sync,
+    T: DeserializeOwned,
 {
     type Item = Result<T>;
 

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -281,18 +281,6 @@ where
     }
 }
 
-// impl<P, T> Stream for GenericCursor<P, T>
-// where
-// P: GetMoreProvider,
-// T: DeserializeOwned,
-// {
-// type Item = Result<T>;
-//
-// fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-// stream_poll_next(Pin::into_inner(self), cx)
-// }
-// }
-
 /// A trait implemented by objects that can provide batches of documents to a cursor via the getMore
 /// command.
 pub(super) trait GetMoreProvider: Unpin {

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::VecDeque,
-    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -8,8 +7,7 @@ use std::{
 
 use bson::{RawDocument, RawDocumentBuf};
 use derivative::Derivative;
-use futures_core::{future::BoxFuture, Future, Stream};
-use serde::{de::DeserializeOwned, Deserialize};
+use futures_core::{future::BoxFuture, Future};
 #[cfg(test)]
 use tokio::sync::oneshot;
 
@@ -29,7 +27,7 @@ use crate::{
 /// An internal cursor that can be used in a variety of contexts depending on its `GetMoreProvider`.
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub(super) struct GenericCursor<P, T>
+pub(super) struct GenericCursor<P>
 where
     P: GetMoreProvider,
 {
@@ -40,10 +38,9 @@ where
     /// This is an `Option` to allow it to be "taken" when the cursor is no longer needed
     /// but may be resumed in the future for `SessionCursor`.
     state: Option<CursorState>,
-    _phantom: PhantomData<T>,
 }
 
-impl<P, T> GenericCursor<P, T>
+impl<P> GenericCursor<P>
 where
     P: GetMoreProvider,
 {
@@ -64,7 +61,6 @@ where
                 post_batch_resume_token: None,
                 pinned_connection,
             }),
-            _phantom: Default::default(),
         }
     }
 
@@ -78,7 +74,6 @@ where
             provider,
             client,
             info,
-            _phantom: Default::default(),
             state: state.into(),
         }
     }
@@ -192,19 +187,6 @@ where
     pub(super) fn provider_mut(&mut self) -> &mut P {
         &mut self.provider
     }
-
-    pub(super) fn with_type<'a, D>(self) -> GenericCursor<P, D>
-    where
-        D: Deserialize<'a>,
-    {
-        GenericCursor {
-            client: self.client,
-            provider: self.provider,
-            info: self.info,
-            state: self.state,
-            _phantom: Default::default(),
-        }
-    }
 }
 
 pub(crate) trait CursorStream {
@@ -217,10 +199,9 @@ pub(crate) enum BatchValue {
     Exhausted,
 }
 
-impl<P, T> CursorStream for GenericCursor<P, T>
+impl<P> CursorStream for GenericCursor<P>
 where
     P: GetMoreProvider,
-    T: DeserializeOwned + Unpin,
 {
     fn poll_next_in_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<BatchValue>> {
         // If there is a get more in flight, check on its status.
@@ -300,17 +281,17 @@ where
     }
 }
 
-impl<P, T> Stream for GenericCursor<P, T>
-where
-    P: GetMoreProvider,
-    T: DeserializeOwned + Unpin,
-{
-    type Item = Result<T>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        stream_poll_next(Pin::into_inner(self), cx)
-    }
-}
+// impl<P, T> Stream for GenericCursor<P, T>
+// where
+// P: GetMoreProvider,
+// T: DeserializeOwned,
+// {
+// type Item = Result<T>;
+//
+// fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+// stream_poll_next(Pin::into_inner(self), cx)
+// }
+// }
 
 /// A trait implemented by objects that can provide batches of documents to a cursor via the getMore
 /// command.


### PR DESCRIPTION
RUST-1358

Now that we're internally passing around `RawDocument` rather than the deserialized type, we don't need to carry around the final type for our internal cursor implementation bits, and in turn we don't need the `Sync + Send + Unpin` constraints on that type.

I think there's further opportunity for cleaning up the implementation, but that won't have any user-facing benefit, so I've filed RUST-1676 to track that.