### PR TITLE
RUST-1571 Update ServerId to be int64

### DIFF
--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -46,8 +46,8 @@ pub struct ConnectionInfo {
     pub id: u32,
 
     /// A server-generated identifier that uniquely identifies the connection. Available on server
-    /// versions 4.2+. This may be used to correlate driver connections with server logs. This
-    /// could be a truncated value based on input server_id.
+    /// versions 4.2+. This may be used to correlate driver connections with server logs. 
+    /// If the connection ID sent by the server is too large for an i32, this will be a truncated value.
     pub server_id: Option<i32>,
 
     /// A server-generated identifier that uniquely identifies the connection. Available on server

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -51,8 +51,8 @@ pub struct ConnectionInfo {
     pub server_id: Option<i32>,
 
     /// A server-generated identifier that uniquely identifies the connection. Available on server
-    /// versions 4.2+. This may be used to correlate driver connections with server logs. Reference
-    /// this for the full server_id
+    /// versions 4.2+. This may be used to correlate driver connections with server logs. This value
+    /// will not be truncated and should be used rather than `server_id`.
     pub server_id_i64: Option<i64>,
 
     /// The address that the connection is connected to.

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -46,13 +46,14 @@ pub struct ConnectionInfo {
     pub id: u32,
 
     /// A server-generated identifier that uniquely identifies the connection. Available on server
-    /// versions 4.2+. This may be used to correlate driver connections with server logs. 
-    /// If the connection ID sent by the server is too large for an i32, this will be a truncated value.
+    /// versions 4.2+. This may be used to correlate driver connections with server logs.
+    /// If the connection ID sent by the server is too large for an i32, this will be a truncated
+    /// value.
     pub server_id: Option<i32>,
 
     /// A server-generated identifier that uniquely identifies the connection. Available on server
-    /// versions 4.2+. This may be used to correlate driver connections with server logs. This value
-    /// will not be truncated and should be used rather than `server_id`.
+    /// versions 4.2+. This may be used to correlate driver connections with server logs. This
+    /// value will not be truncated and should be used rather than `server_id`.
     pub server_id_i64: Option<i64>,
 
     /// The address that the connection is connected to.

--- a/src/cmap/conn/mod.rs
+++ b/src/cmap/conn/mod.rs
@@ -46,8 +46,14 @@ pub struct ConnectionInfo {
     pub id: u32,
 
     /// A server-generated identifier that uniquely identifies the connection. Available on server
-    /// versions 4.2+. This may be used to correlate driver connections with server logs.
+    /// versions 4.2+. This may be used to correlate driver connections with server logs. This
+    /// could be a truncated value based on input server_id.
     pub server_id: Option<i32>,
+
+    /// A server-generated identifier that uniquely identifies the connection. Available on server
+    /// versions 4.2+. This may be used to correlate driver connections with server logs. Reference
+    /// this for the full server_id
+    pub server_id_i64: Option<i64>,
 
     /// The address that the connection is connected to.
     pub address: ServerAddress,
@@ -60,7 +66,7 @@ pub(crate) struct Connection {
     /// Driver-generated ID for the connection.
     pub(super) id: u32,
     /// Server-generated ID for the connection.
-    pub(crate) server_id: Option<i32>,
+    pub(crate) server_id: Option<i64>,
 
     pub(crate) address: ServerAddress,
     pub(crate) generation: ConnectionGeneration,
@@ -165,7 +171,8 @@ impl Connection {
     pub(crate) fn info(&self) -> ConnectionInfo {
         ConnectionInfo {
             id: self.id,
-            server_id: self.server_id,
+            server_id: self.server_id.map(|value| value as i32),
+            server_id_i64: self.server_id,
             address: self.address.clone(),
         }
     }

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -179,7 +179,7 @@ pub(crate) struct HelloCommandResponse {
 
     /// The server-generated ID for the connection the "hello" command was run on.
     /// Present on server versions 4.2+.
-    pub connection_id: Option<i32>,
+    pub connection_id: Option<i64>,
 }
 
 impl HelloCommandResponse {


### PR DESCRIPTION
ServerId is assigned to ConnectionId here: [https://github.com/mongodb/mongo-rust-driver/blob/main/src/cmap/establish/handshake/mod.rs#L457](https://github.com/mongodb/mongo-rust-driver/blob/main/src/cmap/establish/handshake/mod.rs#L457 ). To fix the int32 overflow issue, I added a new ServerId int64 value. 