### PR TITLE
RUST-1636 Add RunCommand Test Specification

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -458,7 +458,8 @@ impl Database {
     /// Note that no inspection is done on `doc`, so the command will not use the database's default
     /// read concern or write concern. If specific read concern or write concern is desired, it must
     /// be specified manually.
-    /// Please note that run_command doesn't validate WriteConcerns passed into the body of the command document.
+    /// Please note that run_command doesn't validate WriteConcerns passed into the body of the
+    /// command document.
     pub async fn run_command(
         &self,
         command: Document,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -458,6 +458,7 @@ impl Database {
     /// Note that no inspection is done on `doc`, so the command will not use the database's default
     /// read concern or write concern. If specific read concern or write concern is desired, it must
     /// be specified manually.
+    /// Please note that run_command doesn't validate WriteConcerns passed into the body of the command document.
     pub async fn run_command(
         &self,
         command: Document,

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -1,10 +1,8 @@
 #[cfg(test)]
 mod test;
 
-use std::convert::TryInto;
-
-use crate::operation::WriteConcern;
 use bson::{RawBsonRef, RawDocumentBuf};
+use std::convert::TryInto;
 
 use super::{CursorBody, OperationWithDefaults};
 use crate::{
@@ -45,17 +43,10 @@ impl<'conn> RunCommand<'conn> {
         selection_criteria: Option<SelectionCriteria>,
         pinned_connection: Option<&'conn PinnedConnectionHandle>,
     ) -> Result<Self> {
-        let write_concern = command
-            .get("writeConcern")?
-            .and_then(|b| b.as_document())
-            .map(|doc| bson::from_slice::<WriteConcern>(doc.as_bytes()))
-            .transpose()?;
-
         Ok(Self {
             db,
             command,
             selection_criteria,
-            write_concern,
             pinned_connection,
         })
     }

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod test;
 
-use bson::{RawBsonRef, RawDocumentBuf};
 use std::convert::TryInto;
+
+use bson::{RawBsonRef, RawDocumentBuf};
 
 use super::{CursorBody, OperationWithDefaults};
 use crate::{

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -3,6 +3,7 @@ mod test;
 
 use std::convert::TryInto;
 
+use crate::operation::WriteConcern;
 use bson::{RawBsonRef, RawDocumentBuf};
 
 use super::{CursorBody, OperationWithDefaults};

--- a/src/operation/run_command/mod.rs
+++ b/src/operation/run_command/mod.rs
@@ -11,7 +11,6 @@ use crate::{
     client::SESSIONS_UNSUPPORTED_COMMANDS,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::{ErrorKind, Result},
-    options::WriteConcern,
     selection_criteria::SelectionCriteria,
 };
 
@@ -20,7 +19,6 @@ pub(crate) struct RunCommand<'conn> {
     db: String,
     command: RawDocumentBuf,
     selection_criteria: Option<SelectionCriteria>,
-    write_concern: Option<WriteConcern>,
     pinned_connection: Option<&'conn PinnedConnectionHandle>,
 }
 
@@ -31,16 +29,10 @@ impl<'conn> RunCommand<'conn> {
         selection_criteria: Option<SelectionCriteria>,
         pinned_connection: Option<&'conn PinnedConnectionHandle>,
     ) -> Result<Self> {
-        let write_concern = command
-            .get("writeConcern")
-            .map(|doc| bson::from_bson::<WriteConcern>(doc.clone()))
-            .transpose()?;
-
         Ok(Self {
             db,
             command: RawDocumentBuf::from_document(&command)?,
             selection_criteria,
-            write_concern,
             pinned_connection,
         })
     }
@@ -119,10 +111,6 @@ impl<'conn> OperationWithDefaults for RunCommand<'conn> {
 
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {
         self.selection_criteria.as_ref()
-    }
-
-    fn write_concern(&self) -> Option<&WriteConcern> {
-        self.write_concern.as_ref()
     }
 
     fn supports_sessions(&self) -> bool {

--- a/src/sdam/description/topology/mod.rs
+++ b/src/sdam/description/topology/mod.rs
@@ -228,8 +228,9 @@ impl TopologyDescription {
                     },
                     Some(other) => other,
                 };
-
-                command.set_read_preference(resolved_read_pref)
+                if resolved_read_pref != ReadPreference::Primary {
+                    command.set_read_preference(resolved_read_pref)
+                }
             }
             _ => {
                 let read_pref = match criteria {
@@ -239,7 +240,9 @@ impl TopologyDescription {
                     },
                     None => ReadPreference::Primary,
                 };
-                command.set_read_preference(read_pref)
+                if read_pref != ReadPreference::Primary {
+                    command.set_read_preference(read_pref)
+                }
             }
         }
     }

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -187,8 +187,8 @@ impl<'de> Deserialize<'de> for ReadPreference {
         }
         let preference = ReadPreferenceHelper::deserialize(deserializer)?;
 
-        match preference.mode.as_str() {
-            "Primary" => {
+        match preference.mode.to_ascii_lowercase().as_str() {
+            "primary" => {
                 if !preference.options.is_default() {
                     return Err(D::Error::custom(&format!(
                         "no options can be specified with read preference mode = primary, but got \
@@ -198,16 +198,16 @@ impl<'de> Deserialize<'de> for ReadPreference {
                 }
                 Ok(ReadPreference::Primary)
             }
-            "Secondary" => Ok(ReadPreference::Secondary {
+            "secondary" => Ok(ReadPreference::Secondary {
                 options: preference.options,
             }),
-            "PrimaryPreferred" => Ok(ReadPreference::PrimaryPreferred {
+            "primarypreferred" => Ok(ReadPreference::PrimaryPreferred {
                 options: preference.options,
             }),
-            "SecondaryPreferred" | "secondaryPreferred" => Ok(ReadPreference::SecondaryPreferred {
+            "secondarypreferred" => Ok(ReadPreference::SecondaryPreferred {
                 options: preference.options,
             }),
-            "Nearest" => Ok(ReadPreference::Nearest {
+            "nearest" => Ok(ReadPreference::Nearest {
                 options: preference.options,
             }),
             other => Err(D::Error::custom(format!(

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -186,7 +186,6 @@ impl<'de> Deserialize<'de> for ReadPreference {
             options: ReadPreferenceOptions,
         }
         let preference = ReadPreferenceHelper::deserialize(deserializer)?;
-
         match preference.mode.to_ascii_lowercase().as_str() {
             "primary" => {
                 if !preference.options.is_default() {
@@ -231,7 +230,6 @@ impl Serialize for ReadPreference {
             #[serde(flatten)]
             options: Option<&'a ReadPreferenceOptions>,
         }
-
         let helper = match self {
             ReadPreference::Primary => ReadPreferenceHelper {
                 mode: "primary",

--- a/src/test/spec/json/run-command/README.rst
+++ b/src/test/spec/json/run-command/README.rst
@@ -1,0 +1,14 @@
+=================
+Run Command Tests
+=================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+The YAML and JSON files in the ``unified`` sub-directories are platform-independent tests
+that drivers can use to prove their conformance to the RunCommand spec. Tests in the
+``unified`` directory are written using the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`_.

--- a/src/test/spec/json/run-command/unified/runCommand.json
+++ b/src/test/spec/json/run-command/unified/runCommand.json
@@ -1,0 +1,635 @@
+{
+  "description": "runCommand",
+  "schemaVersion": "1.3",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "db",
+        "collectionName": "collection"
+      }
+    },
+    {
+      "database": {
+        "id": "dbWithRC",
+        "client": "client",
+        "databaseName": "dbWithRC",
+        "databaseOptions": {
+          "readConcern": {
+            "level": "local"
+          }
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "dbWithWC",
+        "client": "client",
+        "databaseName": "dbWithWC",
+        "databaseOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    },
+    {
+      "session": {
+        "id": "session",
+        "client": "client"
+      }
+    },
+    {
+      "client": {
+        "id": "clientWithStableApi",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "serverApi": {
+          "version": "1",
+          "strict": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "dbWithStableApi",
+        "client": "clientWithStableApi",
+        "databaseName": "dbWithStableApi"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection",
+      "databaseName": "db",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "always attaches $db and implicit lsid to given command and omits default readPreference",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  },
+                  "$readPreference": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "always gossips the $clusterTime on the sent command",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ping"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$clusterTime": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "attaches the provided session lsid to given command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "session": "session"
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "attaches the provided $readPreference to given command",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset",
+            "load-balanced",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "nearest"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "mode": "nearest"
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not attach $readPreference to given command on standalone",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "single"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "nearest"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not attach primary $readPreference to given command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "primary"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not inherit readConcern specified at the db level",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "dbWithRC",
+          "arguments": {
+            "commandName": "aggregate",
+            "command": {
+              "aggregate": "collection",
+              "pipeline": [],
+              "cursor": {}
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "$db": "dbWithRC"
+                },
+                "commandName": "aggregate"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not inherit writeConcern specified at the db level",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "dbWithWC",
+          "arguments": {
+            "commandName": "insert",
+            "command": {
+              "insert": "collection",
+              "documents": [
+                {
+                  "foo": "bar"
+                }
+              ],
+              "ordered": true
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection",
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "$db": "dbWithWC"
+                },
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not retry retryable errors on given command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "ping"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "attaches transaction fields to given command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.0",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.2",
+          "topologies": [
+            "sharded-replicaset",
+            "load-balanced"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session",
+          "arguments": {
+            "callback": [
+              {
+                "name": "runCommand",
+                "object": "db",
+                "arguments": {
+                  "session": "session",
+                  "commandName": "insert",
+                  "command": {
+                    "insert": "collection",
+                    "documents": [
+                      {
+                        "foo": "transaction"
+                      }
+                    ],
+                    "ordered": true
+                  }
+                },
+                "expectResult": {
+                  "$$unsetOrMatches": {
+                    "insertedId": {
+                      "$$unsetOrMatches": 1
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection",
+                  "documents": [
+                    {
+                      "foo": "transaction"
+                    }
+                  ],
+                  "ordered": true,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "txnNumber": 1,
+                  "startTransaction": true,
+                  "autocommit": false,
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "insert",
+                "databaseName": "db"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "commitTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "txnNumber": 1,
+                  "autocommit": false,
+                  "writeConcern": {
+                    "$$exists": false
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "commitTransaction",
+                "databaseName": "admin"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "attaches apiVersion fields to given command when stableApi is configured on the client",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "dbWithStableApi",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "clientWithStableApi",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$db": "dbWithStableApi",
+                  "apiVersion": "1",
+                  "apiStrict": true,
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/run-command/unified/runCommand.yml
+++ b/src/test/spec/json/run-command/unified/runCommand.yml
@@ -1,0 +1,319 @@
+description: runCommand
+
+schemaVersion: "1.3"
+
+createEntities:
+  - client:
+      id: &client client
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &db db
+      client: *client
+      databaseName: *db
+  - collection:
+      id: &collection collection
+      database: *db
+      collectionName: *collection
+  - database:
+      id: &dbWithRC dbWithRC
+      client: *client
+      databaseName: *dbWithRC
+      databaseOptions:
+        readConcern: { level: 'local' }
+  - database:
+      id: &dbWithWC dbWithWC
+      client: *client
+      databaseName: *dbWithWC
+      databaseOptions:
+        writeConcern: { w: 0 }
+  - session:
+      id: &session session
+      client: *client
+  # Stable API test
+  - client:
+      id: &clientWithStableApi clientWithStableApi
+      observeEvents: [commandStartedEvent]
+      serverApi:
+        version: "1"
+        strict: true
+  - database:
+      id: &dbWithStableApi dbWithStableApi
+      client: *clientWithStableApi
+      databaseName: *dbWithStableApi
+
+initialData:
+- collectionName: *collection
+  databaseName: *db
+  documents: []
+
+tests:
+  - description: always attaches $db and implicit lsid to given command and omits default readPreference
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $db: *db
+                lsid: { $$exists: true }
+                $readPreference: { $$exists: false }
+              commandName: ping
+
+  - description: always gossips the $clusterTime on the sent command
+    runOnRequirements:
+      # Only replicasets and sharded clusters have a $clusterTime
+      - topologies: [ replicaset, sharded ]
+    operations:
+      # We have to run one command to obtain a clusterTime to gossip
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectResult: { ok: 1 }
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: ping
+          # Only check the shape of the second ping which should have the $clusterTime received from the first operation
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $clusterTime: { $$exists: true }
+              commandName: ping
+
+  - description: attaches the provided session lsid to given command
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          session: *session
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                lsid: { $$sessionLsid: *session }
+                $db: *db
+              commandName: ping
+
+  - description: attaches the provided $readPreference to given command
+    runOnRequirements:
+      # Exclude single topology, which is most likely a standalone server
+      - topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          readPreference:  &readPreference { mode: 'nearest' }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $readPreference: *readPreference
+                $db: *db
+              commandName: ping
+
+  - description: does not attach $readPreference to given command on standalone
+    runOnRequirements:
+      # This test assumes that the single topology contains a standalone server;
+      # however, it is possible for a single topology to contain a direct
+      # connection to another server type.
+      # See: https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#topology-type-single
+      - topologies: [ single ]
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          readPreference: { mode: 'nearest' }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $readPreference: { $$exists: false }
+                $db: *db
+              commandName: ping
+
+  - description: does not attach primary $readPreference to given command
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          readPreference: { mode: 'primary' }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $readPreference: { $$exists: false }
+                $db: *db
+              commandName: ping
+
+  - description: does not inherit readConcern specified at the db level
+    operations:
+      - name: runCommand
+        object: *dbWithRC
+        # Test with a command that supports a readConcern option.
+        # expectResult is intentionally omitted because some drivers
+        # may automatically convert command responses into cursors.
+        arguments:
+          commandName: aggregate
+          command: { aggregate: *collection, pipeline: [], cursor: {} }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection
+                readConcern: { $$exists: false }
+                $db: *dbWithRC
+              commandName: aggregate
+
+  - description: does not inherit writeConcern specified at the db level
+    operations:
+      - name: runCommand
+        object: *dbWithWC
+        arguments:
+          commandName: insert
+          command:
+            insert: *collection
+            documents: [ { foo: 'bar' } ]
+            ordered: true
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection
+                writeConcern: { $$exists: false }
+                $db: *dbWithWC
+              commandName: insert
+
+  - description: does not retry retryable errors on given command
+    runOnRequirements:
+      - minServerVersion: "4.2"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ping]
+              closeConnection: true
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectError:
+          isClientError: true
+
+  - description: attaches transaction fields to given command
+    runOnRequirements:
+      - minServerVersion: "4.0"
+        topologies: [ replicaset ]
+      - minServerVersion: "4.2"
+        topologies: [ sharded-replicaset, load-balanced ]
+    operations:
+      - name: withTransaction
+        object: *session
+        arguments:
+          callback:
+            - name: runCommand
+              object: *db
+              arguments:
+                session: *session
+                commandName: insert
+                command:
+                  insert: *collection
+                  documents: [ { foo: 'transaction' } ]
+                  ordered: true
+              expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } } }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection
+                documents: [ { foo: 'transaction' } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session }
+                txnNumber: 1
+                startTransaction: true
+                autocommit: false
+                # omitted fields
+                readConcern: { $$exists: false }
+                writeConcern: { $$exists: false }
+              commandName: insert
+              databaseName: *db
+          - commandStartedEvent:
+              command:
+                commitTransaction: 1
+                lsid: { $$sessionLsid: *session }
+                txnNumber: 1
+                autocommit: false
+                # omitted fields
+                writeConcern: { $$exists: false }
+                readConcern: { $$exists: false }
+              commandName: commitTransaction
+              databaseName: admin
+
+  - description: attaches apiVersion fields to given command when stableApi is configured on the client
+    runOnRequirements:
+      - minServerVersion: "5.0"
+    operations:
+      - name: runCommand
+        object: *dbWithStableApi
+        arguments:
+          commandName: ping
+          command:
+            ping: 1
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *clientWithStableApi
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $db: *dbWithStableApi
+                apiVersion: "1"
+                apiStrict: true
+                apiDeprecationErrors: { $$unsetOrMatches: false }
+              commandName: ping

--- a/src/test/spec/json/run-command/unified/runCursorCommand.json
+++ b/src/test/spec/json/run-command/unified/runCursorCommand.json
@@ -1,0 +1,877 @@
+{
+  "description": "runCursorCommand",
+  "schemaVersion": "1.9",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent",
+          "connectionReadyEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckedInEvent"
+        ]
+      }
+    },
+    {
+      "session": {
+        "id": "session",
+        "client": "client"
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "db",
+        "collectionName": "collection"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection",
+      "databaseName": "db",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "successfully executes checkMetadataConsistency cursor creating command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "7.0",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "checkMetadataConsistency",
+            "command": {
+              "checkMetadataConsistency": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "checkMetadataConsistency": 1,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "checkMetadataConsistency"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "errors if the command response is not a cursor",
+      "operations": [
+        {
+          "name": "createCommandCursor",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    },
+    {
+      "description": "creates an implicit session that is reused across getMores",
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "command": {
+              "find": "collection",
+              "batchSize": 2
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            }
+          ]
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "batchSize": 2,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "accepts an explicit session that is reused across getMores",
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "session": "session",
+            "command": {
+              "find": "collection",
+              "batchSize": 2
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            }
+          ]
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "batchSize": 2,
+                  "$db": "db",
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "returns pinned connections to the pool when the cursor is exhausted",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "load-balanced"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createCommandCursor",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "batchSize": 2,
+            "session": "session",
+            "command": {
+              "find": "collection",
+              "batchSize": 2
+            }
+          },
+          "saveResultAsEntity": "cursor"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "connections": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor",
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor",
+          "expectResult": {
+            "_id": 2,
+            "x": 22
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor",
+          "expectResult": {
+            "_id": 3,
+            "x": 33
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor",
+          "expectResult": {
+            "_id": 4,
+            "x": 44
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor",
+          "expectResult": {
+            "_id": 5,
+            "x": 55
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "batchSize": 2,
+                  "$db": "db",
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  }
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "returns pinned connections to the pool when the cursor is closed",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "load-balanced"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createCommandCursor",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "command": {
+              "find": "collection",
+              "batchSize": 2
+            }
+          },
+          "saveResultAsEntity": "cursor"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "connections": 0
+          }
+        }
+      ]
+    },
+    {
+      "description": "supports configuring getMore batchSize",
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "batchSize": 5,
+            "command": {
+              "find": "collection",
+              "batchSize": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "batchSize": 1,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "batchSize": 5,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "supports configuring getMore maxTimeMS",
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "maxTimeMS": 300,
+            "command": {
+              "find": "collection",
+              "maxTimeMS": 200,
+              "batchSize": 1
+            }
+          },
+          "ignoreResultAndError": true
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "maxTimeMS": 200,
+                  "batchSize": 1,
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "$db": "db",
+                  "maxTimeMS": 300,
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "supports configuring getMore comment",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4"
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCursorCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "find",
+            "comment": {
+              "hello": "getMore"
+            },
+            "command": {
+              "find": "collection",
+              "batchSize": 1,
+              "comment": {
+                "hello": "find"
+              }
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "collection",
+                  "batchSize": 1,
+                  "comment": {
+                    "hello": "find"
+                  },
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "collection",
+                  "comment": {
+                    "hello": "getMore"
+                  },
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not close the cursor when receiving an empty batch",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "db",
+          "arguments": {
+            "collection": "cappedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "db",
+          "arguments": {
+            "collection": "cappedCollection",
+            "capped": true,
+            "size": 4096,
+            "max": 3
+          },
+          "saveResultAsEntity": "cappedCollection"
+        },
+        {
+          "name": "insertMany",
+          "object": "cappedCollection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1,
+                "x": 11
+              },
+              {
+                "_id": 2,
+                "x": 22
+              }
+            ]
+          }
+        },
+        {
+          "name": "createCommandCursor",
+          "object": "db",
+          "arguments": {
+            "cursorType": "tailable",
+            "commandName": "find",
+            "batchSize": 2,
+            "command": {
+              "find": "cappedCollection",
+              "tailable": true
+            }
+          },
+          "saveResultAsEntity": "cursor"
+        },
+        {
+          "name": "iterateOnce",
+          "object": "cursor"
+        },
+        {
+          "name": "iterateOnce",
+          "object": "cursor"
+        },
+        {
+          "name": "iterateOnce",
+          "object": "cursor"
+        },
+        {
+          "name": "close",
+          "object": "cursor"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "cappedCollection"
+                },
+                "commandName": "drop"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "cappedCollection"
+                },
+                "commandName": "create"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "cappedCollection"
+                },
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "cappedCollection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
+                  },
+                  "collection": "cappedCollection",
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  }
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "killCursors": "cappedCollection",
+                  "cursors": {
+                    "$$type": "array"
+                  }
+                },
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/run-command/unified/runCursorCommand.yml
+++ b/src/test/spec/json/run-command/unified/runCursorCommand.yml
@@ -1,0 +1,391 @@
+description: runCursorCommand
+
+schemaVersion: '1.9'
+
+createEntities:
+  - client:
+      id: &client client
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent, connectionReadyEvent, connectionCheckedOutEvent, connectionCheckedInEvent]
+  - session:
+      id: &session session
+      client: *client
+  - database:
+      id: &db db
+      client: *client
+      databaseName: *db
+  - collection:
+      id: &collection collection
+      database: *db
+      collectionName: *collection
+
+initialData:
+  - collectionName: collection
+    databaseName: *db
+    documents: &documents
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+
+tests:
+  # This is what this API was invented to do.
+  - description: successfully executes checkMetadataConsistency cursor creating command
+    runOnRequirements:
+      - minServerVersion: '7.0'
+        topologies: [sharded]
+    operations:
+      - name: runCursorCommand
+        object: *db
+        arguments:
+          commandName: checkMetadataConsistency
+          command: { checkMetadataConsistency: 1 }
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                checkMetadataConsistency: 1
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: checkMetadataConsistency
+
+  - description: errors if the command response is not a cursor
+    operations:
+      - name: createCommandCursor
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectError:
+          isClientError: true
+
+
+  # Driver Sessions
+  - description: creates an implicit session that is reused across getMores
+    operations:
+      - name: runCursorCommand
+        object: *db
+        arguments:
+          commandName: find
+          command: { find: *collection, batchSize: 2 }
+        expectResult: *documents
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection
+                batchSize: 2
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: getMore
+
+  - description: accepts an explicit session that is reused across getMores
+    operations:
+      - name: runCursorCommand
+        object: *db
+        arguments:
+          commandName: find
+          session: *session
+          command: { find: *collection, batchSize: 2 }
+        expectResult: *documents
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection
+                batchSize: 2
+                $db: *db
+                lsid: { $$sessionLsid: *session }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                $db: *db
+                lsid: { $$sessionLsid: *session }
+              commandName: getMore
+
+  # Load Balancers
+  - description: returns pinned connections to the pool when the cursor is exhausted
+    runOnRequirements:
+      - topologies: [ load-balanced ]
+    operations:
+      - name: createCommandCursor
+        object: *db
+        arguments:
+          commandName: find
+          batchSize: 2
+          session: *session
+          command: { find: *collection, batchSize: 2 }
+        saveResultAsEntity: &cursor cursor
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client
+          connections: 1
+      - name: iterateUntilDocumentOrError
+        object: *cursor
+        expectResult: { _id: 1, x: 11 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor
+        expectResult: { _id: 2, x: 22 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor
+        expectResult: { _id: 3, x: 33 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor
+        expectResult: { _id: 4, x: 44 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor
+        expectResult: { _id: 5, x: 55 }
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client
+          connections: 0
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection
+                batchSize: 2
+                $db: *db
+                lsid: { $$sessionLsid: *session }
+              commandName: find # 2 documents
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                $db: *db
+                lsid: { $$sessionLsid: *session }
+              commandName: getMore # 2 documents
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                $db: *db
+                lsid: { $$sessionLsid: *session }
+              commandName: getMore # 1 document
+              # Total documents: 5
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: returns pinned connections to the pool when the cursor is closed
+    runOnRequirements:
+      - topologies: [ load-balanced ]
+    operations:
+      - name: createCommandCursor
+        object: *db
+        arguments:
+          commandName: find
+          command: { find: *collection, batchSize: 2 }
+        saveResultAsEntity: *cursor
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client
+          connections: 1
+      - name: close
+        object: *cursor
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client
+          connections: 0
+
+  # Iterating the Cursor / Executing GetMores
+  - description: supports configuring getMore batchSize
+    operations:
+      - name: runCursorCommand
+        object: *db
+        arguments:
+          commandName: find
+          batchSize: 5
+          command: { find: *collection, batchSize: 1 }
+        expectResult: *documents
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection
+                batchSize: 1
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                batchSize: 5
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: getMore
+
+  - description: supports configuring getMore maxTimeMS
+    operations:
+      - name: runCursorCommand
+        object: *db
+        arguments:
+          commandName: find
+          maxTimeMS: 300
+          command: { find: *collection, maxTimeMS: 200, batchSize: 1 }
+        ignoreResultAndError: true
+    expectEvents:
+      - client: *client
+        eventType: command
+        # The getMore should receive an error here because we do not have the right kind of cursor
+        # So drivers should run a killCursors, but neither the error nor the killCursors command is relevant to this test
+        ignoreExtraEvents: true
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection
+                maxTimeMS: 200
+                batchSize: 1
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                $db: *db
+                maxTimeMS: 300
+                lsid: { $$exists: true }
+              commandName: getMore
+
+  - description: supports configuring getMore comment
+    runOnRequirements:
+      - minServerVersion: '4.4'
+    operations:
+      - name: runCursorCommand
+        object: *db
+        arguments:
+          commandName: find
+          comment: { hello: 'getMore' }
+          command: { find: *collection, batchSize: 1, comment: { hello: 'find' } }
+        expectResult: *documents
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection
+                batchSize: 1
+                comment: { hello: 'find' }
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *collection
+                comment: { hello: 'getMore' }
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: getMore
+
+  # Tailable cursor
+  - description: does not close the cursor when receiving an empty batch
+    runOnRequirements:
+      - serverless: forbid
+    operations:
+      - name: dropCollection
+        object: *db
+        arguments:
+          collection: &cappedCollection cappedCollection
+      - name: createCollection
+        object: *db
+        arguments:
+          collection: *cappedCollection
+          capped: true
+          size: 4096
+          max: 3
+        saveResultAsEntity: *cappedCollection
+      - name: insertMany
+        object: *cappedCollection
+        arguments:
+          documents:
+            - { _id: 1, x: 11 }
+            - { _id: 2, x: 22 }
+      - name: createCommandCursor
+        object: *db
+        arguments:
+          cursorType: tailable
+          commandName: find
+          batchSize: 2
+          command: { find: *cappedCollection, tailable: true }
+        saveResultAsEntity: &cursor cursor
+      - name: iterateOnce
+        object: *cursor
+      - name: iterateOnce
+        object: *cursor
+      - name: iterateOnce
+        object: *cursor
+      - name: close
+        object: *cursor
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *cappedCollection
+              commandName: drop
+          - commandStartedEvent:
+              command:
+                create: *cappedCollection
+              commandName: create
+          - commandStartedEvent:
+              command:
+                insert: *cappedCollection
+              commandName: insert
+          - commandStartedEvent:
+              command:
+                find: *cappedCollection
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: [int, long] }
+                collection: *cappedCollection
+                $db: *db
+                lsid: { $$exists: true }
+              commandName: getMore
+          - commandStartedEvent:
+              command:
+                killCursors: *cappedCollection
+                cursors: { $$type: array }
+              commandName: killCursors

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -19,6 +19,7 @@ mod oidc;
 mod read_write_concern;
 mod retryable_reads;
 mod retryable_writes;
+mod run_command;
 mod sdam;
 #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
 mod sessions;
@@ -29,7 +30,6 @@ pub mod unified_runner;
 mod v2_runner;
 mod versioned_api;
 mod write_error;
-mod run_command;
 
 use std::{
     any::type_name,

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -29,6 +29,7 @@ pub mod unified_runner;
 mod v2_runner;
 mod versioned_api;
 mod write_error;
+mod run_command;
 
 use std::{
     any::type_name,

--- a/src/test/spec/run_command.rs
+++ b/src/test/spec/run_command.rs
@@ -4,10 +4,11 @@ use crate::test::{spec::unified_runner::run_unified_tests, LOCK};
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn run_unified() {
     let _guard = LOCK.run_exclusively().await;
-    run_unified_tests(&["run-command", "unified"]).skip_files(&[
-        "runCursorCommand.json",
-    ]).skip_tests(&[
-        //TODO: fix withTransaction for new test runner
-        "attaches transaction fields to given command"
-    ]).await;
-} 
+    run_unified_tests(&["run-command", "unified"])
+        .skip_files(&["runCursorCommand.json"])
+        .skip_tests(&[
+            // TODO: fix withTransaction for new test runner
+            "attaches transaction fields to given command",
+        ])
+        .await;
+}

--- a/src/test/spec/run_command.rs
+++ b/src/test/spec/run_command.rs
@@ -5,9 +5,10 @@ use crate::test::{spec::unified_runner::run_unified_tests, LOCK};
 async fn run_unified() {
     let _guard = LOCK.run_exclusively().await;
     run_unified_tests(&["run-command", "unified"])
+        // TODO RUST-1588: Unskip this file
         .skip_files(&["runCursorCommand.json"])
         .skip_tests(&[
-            // TODO: fix withTransaction for new test runner
+            // TODO re: RUST-1649: fix withTransaction for new test runner
             "attaches transaction fields to given command",
         ])
         .await;

--- a/src/test/spec/run_command.rs
+++ b/src/test/spec/run_command.rs
@@ -1,0 +1,13 @@
+use crate::test::{spec::unified_runner::run_unified_tests, LOCK};
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))] // multi_thread required for FailPoint
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn run_unified() {
+    let _guard = LOCK.run_exclusively().await;
+    run_unified_tests(&["run-command", "unified"]).skip_files(&[
+        "runCursorCommand.json",
+    ]).skip_tests(&[
+        //TODO: fix withTransaction for new test runner
+        "attaches transaction fields to given command"
+    ]).await;
+} 

--- a/src/test/spec/run_command.rs
+++ b/src/test/spec/run_command.rs
@@ -10,6 +10,8 @@ async fn run_unified() {
         .skip_tests(&[
             // TODO re: RUST-1649: fix withTransaction for new test runner
             "attaches transaction fields to given command",
+            "always attaches $db and implicit lsid to given command and omits default readPreference",
+            "does not attach primary $readPreference to given command",
         ])
         .await;
 }

--- a/src/test/spec/run_command.rs
+++ b/src/test/spec/run_command.rs
@@ -10,8 +10,6 @@ async fn run_unified() {
         .skip_tests(&[
             // TODO re: RUST-1649: fix withTransaction for new test runner
             "attaches transaction fields to given command",
-            "always attaches $db and implicit lsid to given command and omits default readPreference",
-            "does not attach primary $readPreference to given command",
         ])
         .await;
 }

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -449,7 +449,7 @@ fn special_operator_matches(
     entities: Option<&EntityMap>,
 ) -> Result<(), String> {
     match key.as_ref() {
-        "$$exists" => match_eq(&value.as_bool().unwrap(), &actual.is_some()),
+        "$$exists" => match_eq(&actual.is_some(), &value.as_bool().unwrap()),
         "$$type" => type_matches(value, actual.unwrap()),
         "$$unsetOrMatches" => {
             if actual.is_some() {

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1621,7 +1621,7 @@ impl TestOperation for RunCommand {
         test_runner: &'a TestRunner,
     ) -> BoxFuture<'a, Result<Option<Entity>>> {
         async move {
-            let mut command = self.command.clone();
+            let command = self.command.clone();
 
             let db = test_runner.get_database(id).await;
             let result = match &self.session {

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1610,10 +1610,8 @@ pub(super) struct RunCommand {
     // we can use the deny_unknown_fields tag.
     #[serde(rename = "commandName")]
     _command_name: String,
-    read_concern: Option<Document>,
     read_preference: Option<SelectionCriteria>,
     session: Option<String>,
-    write_concern: Option<Document>,
 }
 
 impl TestOperation for RunCommand {
@@ -1624,12 +1622,6 @@ impl TestOperation for RunCommand {
     ) -> BoxFuture<'a, Result<Option<Entity>>> {
         async move {
             let mut command = self.command.clone();
-            if let Some(ref read_concern) = self.read_concern {
-                command.insert("readConcern", read_concern.clone());
-            }
-            if let Some(ref write_concern) = self.write_concern {
-                command.insert("writeConcern", write_concern.clone());
-            }
 
             let db = test_runner.get_database(id).await;
             let result = match &self.session {

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -84,6 +84,7 @@ pub(crate) struct RunOnRequirement {
 pub(crate) enum Topology {
     Single,
     ReplicaSet,
+    #[serde(alias = "sharded-replicaset")]
     Sharded,
     #[serde(rename = "load-balanced")]
     LoadBalanced,


### PR DESCRIPTION
1. Removed `write_concern` and `read_concern` from RunCommand API to update with the new specification: https://github.com/mongodb/specifications/commit/ab66eaf6f7e2bbeb5218672bebaf5118faf8209c
2. Added in new spec tests for RunCommand