### PR TITLE
RUST-1687 Add `human_readable_serialization` option to `Collection`

### DIFF
--- a/src/coll.rs
+++ b/src/coll.rs
@@ -1119,14 +1119,16 @@ where
         options: impl Into<Option<FindOneAndReplaceOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<Option<T>> {
+        let mut options = options.into();
         let replacement = to_document_with_options(
             replacement.borrow(),
-            SerializerOptions::builder().human_readable(false).build(),
+            SerializerOptions::builder()
+                .human_readable(options.as_ref().and_then(|opts| opts.human_readable))
+                .build(),
         )?;
 
         let session = session.into();
 
-        let mut options = options.into();
         resolve_write_concern_with_session!(self, options, session.as_ref())?;
 
         let op = FindAndModify::<T>::with_replace(self.namespace(), filter, replacement, options)?;
@@ -1382,16 +1384,18 @@ where
         options: impl Into<Option<ReplaceOptions>>,
         session: impl Into<Option<&mut ClientSession>>,
     ) -> Result<UpdateResult> {
+        let mut options = options.into();
         let replacement = to_document_with_options(
             replacement.borrow(),
-            SerializerOptions::builder().human_readable(false).build(),
+            SerializerOptions::builder()
+                .human_readable(options.as_ref().and_then(|opts| opts.human_readable))
+                .build(),
         )?;
 
         bson_util::replacement_document_check(&replacement)?;
 
         let session = session.into();
 
-        let mut options = options.into();
         resolve_write_concern_with_session!(self, options, session.as_ref())?;
 
         let update = Update::new(

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -31,6 +31,7 @@ pub struct CollectionOptions {
 
     /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
     /// The default value is `false`.
+    /// Note: Specifying `true` for this value will decrease the performance of insert operations.
     pub human_readable_serialization: Option<bool>,
 }
 

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -299,6 +299,10 @@ pub struct ReplaceOptions {
     ///
     /// This option is only available on server versions 4.4+.
     pub comment: Option<Bson>,
+
+    /// Sets the [`SerializerOptions::human_readable`] option for the [`Bson`] serializer.
+    /// The default value is true.
+    pub human_readable: Option<bool>,
 }
 
 /// Specifies the options to a
@@ -443,6 +447,10 @@ pub struct FindOneAndReplaceOptions {
     ///
     /// This option is only available on server versions 4.4+.
     pub comment: Option<Bson>,
+
+    /// Sets the [`SerializerOptions::human_readable`] option for the [`Bson`] serializer.
+    /// The default value is true.
+    pub human_readable: Option<bool>,
 }
 
 /// Specifies the options to a

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -28,6 +28,10 @@ pub struct CollectionOptions {
 
     /// The default write concern for operations.
     pub write_concern: Option<WriteConcern>,
+
+    /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
+    /// The default value is `false`.
+    pub human_readable_serialization: Option<bool>,
 }
 
 /// Specifies whether a
@@ -299,10 +303,6 @@ pub struct ReplaceOptions {
     ///
     /// This option is only available on server versions 4.4+.
     pub comment: Option<Bson>,
-
-    /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
-    /// The default value is true.
-    pub human_readable: Option<bool>,
 }
 
 /// Specifies the options to a
@@ -447,10 +447,6 @@ pub struct FindOneAndReplaceOptions {
     ///
     /// This option is only available on server versions 4.4+.
     pub comment: Option<Bson>,
-
-    /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
-    /// The default value is true.
-    pub human_readable: Option<bool>,
 }
 
 /// Specifies the options to a

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -300,7 +300,7 @@ pub struct ReplaceOptions {
     /// This option is only available on server versions 4.4+.
     pub comment: Option<Bson>,
 
-    /// Sets the [`SerializerOptions::human_readable`] option for the [`Bson`] serializer.
+    /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
     /// The default value is true.
     pub human_readable: Option<bool>,
 }
@@ -448,7 +448,7 @@ pub struct FindOneAndReplaceOptions {
     /// This option is only available on server versions 4.4+.
     pub comment: Option<Bson>,
 
-    /// Sets the [`SerializerOptions::human_readable`] option for the [`Bson`] serializer.
+    /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
     /// The default value is true.
     pub human_readable: Option<bool>,
 }

--- a/src/operation/insert/test.rs
+++ b/src/operation/insert/test.rs
@@ -49,6 +49,7 @@ fn fixtures(opts: Option<InsertManyOptions>) -> TestFixtures {
         },
         DOCUMENTS.iter().collect(),
         Some(options.clone()),
+        false,
     );
 
     TestFixtures {
@@ -116,7 +117,7 @@ fn build() {
 #[test]
 fn build_ordered() {
     let docs = vec![Document::new()];
-    let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None);
+    let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None, false);
     let cmd = insert
         .build(&StreamDescription::new_testing())
         .expect("should succeed");
@@ -128,6 +129,7 @@ fn build_ordered() {
         Namespace::empty(),
         docs.iter().collect(),
         Some(InsertManyOptions::builder().ordered(false).build()),
+        false,
     );
     let cmd = insert
         .build(&StreamDescription::new_testing())
@@ -140,6 +142,7 @@ fn build_ordered() {
         Namespace::empty(),
         docs.iter().collect(),
         Some(InsertManyOptions::builder().ordered(true).build()),
+        false,
     );
     let cmd = insert
         .build(&StreamDescription::new_testing())
@@ -152,6 +155,7 @@ fn build_ordered() {
         Namespace::empty(),
         docs.iter().collect(),
         Some(InsertManyOptions::builder().build()),
+        false,
     );
     let cmd = insert
         .build(&StreamDescription::new_testing())
@@ -170,7 +174,7 @@ struct Documents<D> {
 fn generate_ids() {
     let docs = vec![doc! { "x": 1 }, doc! { "_id": 1_i32, "x": 2 }];
 
-    let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None);
+    let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None, false);
     let cmd = insert.build(&StreamDescription::new_testing()).unwrap();
     let serialized = insert.serialize_command(cmd).unwrap();
 
@@ -253,7 +257,7 @@ fn serialize_all_types() {
         "_id": ObjectId::new(),
     }];
 
-    let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None);
+    let mut insert = Insert::new(Namespace::empty(), docs.iter().collect(), None, false);
     let cmd = insert.build(&StreamDescription::new_testing()).unwrap();
     let serialized = insert.serialize_command(cmd).unwrap();
     let cmd: Documents<Document> = bson::from_slice(serialized.as_slice()).unwrap();

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -378,6 +378,7 @@ impl CollectionOrDatabaseOptions {
             read_concern: self.read_concern.clone(),
             selection_criteria: self.selection_criteria.clone(),
             write_concern: self.write_concern.clone(),
+            human_readable_serialization: None,
         }
     }
 }


### PR DESCRIPTION
…`find_one_and_replace_common`

This was a solution proposed by @isabelatkinson for the problem described in the following [PR](https://github.com/mongodb/mongo-rust-driver/pull/883) and the [Task](https://jira.mongodb.org/browse/RUST-1687)

Regards,
Maicon Pavi.