### PR TITLE
RUST-1604 Add custom bucketing fields to timeseries options

### DIFF
--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -98,11 +98,7 @@ pub struct CreateCollectionOptions {
     /// Used to automatically delete documents in time series collections. See the [`create`
     /// command documentation](https://www.mongodb.com/docs/manual/reference/command/create/) for more
     /// information.
-    #[serde(
-        default,
-        deserialize_with = "serde_util::deserialize_duration_option_from_u64_seconds",
-        serialize_with = "serde_util::serialize_duration_option_as_int_secs"
-    )]
+    #[serde(default, with = "serde_util::duration_option_as_int_seconds")]
     pub expire_after_seconds: Option<Duration>,
 
     /// Options for supporting change stream pre- and post-images.
@@ -218,8 +214,7 @@ pub struct TimeseriesOptions {
     /// This option is only available on MongoDB 6.3+.
     #[serde(
         default,
-        serialize_with = "bson_util::serialize_duration_option_as_int_secs",
-        deserialize_with = "bson_util::deserialize_duration_option_from_u64_seconds",
+        with = "serde_util::duration_option_as_int_seconds",
         rename = "bucketMaxSpanSeconds"
     )]
     pub bucket_max_span: Option<Duration>,
@@ -232,8 +227,7 @@ pub struct TimeseriesOptions {
     /// This option is only available on MongoDB 6.3+.
     #[serde(
         default,
-        serialize_with = "bson_util::serialize_duration_option_as_int_secs",
-        deserialize_with = "bson_util::deserialize_duration_option_from_u64_seconds",
+        with = "serde_util::duration_option_as_int_seconds",
         rename = "bucketRoundingSeconds"
     )]
     pub bucket_rounding: Option<Duration>,

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -191,7 +191,7 @@ pub struct IndexOptionDefaults {
 #[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
-#[builder(field_defaults(default, setter(into)))]
+#[builder(field_defaults(default))]
 #[non_exhaustive]
 pub struct TimeseriesOptions {
     /// Name of the top-level field to be used for time. Inserted documents must have this field,

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -192,8 +192,10 @@ pub struct IndexOptionDefaults {
 }
 
 /// Specifies options for creating a timeseries collection.
+#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
 pub struct TimeseriesOptions {
     /// Name of the top-level field to be used for time. Inserted documents must have this field,
@@ -208,6 +210,33 @@ pub struct TimeseriesOptions {
     /// The units you'd use to describe the expected interval between subsequent measurements for a
     /// time-series.  Defaults to `TimeseriesGranularity::Seconds` if unset.
     pub granularity: Option<TimeseriesGranularity>,
+
+    /// The maximum time between timestamps in the same bucket. This value must be between 1 and
+    /// 31,536,000 seconds. If this value is set, the same value should be set for
+    /// `bucket_rounding` and `granularity` should not be set.
+    ///
+    /// This option is only available on MongoDB 6.3+.
+    #[serde(
+        default,
+        serialize_with = "bson_util::serialize_duration_option_as_int_secs",
+        deserialize_with = "bson_util::deserialize_duration_option_from_u64_seconds",
+        rename = "bucketMaxSpanSeconds"
+    )]
+    pub bucket_max_span: Option<Duration>,
+
+    /// The time interval that determines the starting timestamp for a new bucket. When a document
+    /// requires a new bucket, MongoDB rounds down the document's timestamp value by this interval
+    /// to set the minimum time for the bucket.  If this value is set, the same value should be set
+    /// for `bucket_max_span` and `granularity` should not be set.
+    ///
+    /// This option is only available on MongoDB 6.3+.
+    #[serde(
+        default,
+        serialize_with = "bson_util::serialize_duration_option_as_int_secs",
+        deserialize_with = "bson_util::deserialize_duration_option_from_u64_seconds",
+        rename = "bucketRoundingSeconds"
+    )]
+    pub bucket_rounding: Option<Duration>,
 }
 
 /// The units you'd use to describe the expected interval between subsequent measurements for a

--- a/src/index/options.rs
+++ b/src/index/options.rs
@@ -29,8 +29,7 @@ pub struct IndexOptions {
     #[serde(
         rename = "expireAfterSeconds",
         default,
-        deserialize_with = "serde_util::deserialize_duration_option_from_u64_seconds",
-        serialize_with = "serde_util::serialize_duration_option_as_int_secs"
+        with = "serde_util::duration_option_as_int_seconds"
     )]
     pub expire_after: Option<Duration>,
 

--- a/src/selection_criteria.rs
+++ b/src/selection_criteria.rs
@@ -279,8 +279,7 @@ pub struct ReadPreferenceOptions {
     #[serde(
         rename = "maxStalenessSeconds",
         default,
-        deserialize_with = "serde_util::deserialize_duration_option_from_u64_seconds",
-        serialize_with = "serde_util::serialize_duration_option_as_int_secs"
+        with = "serde_util::duration_option_as_int_seconds"
     )]
     pub max_staleness: Option<Duration>,
 
@@ -390,7 +389,7 @@ impl ReadPreference {
 
             readpreferencetags: Option<&'a Vec<HashMap<String, String>>>,
 
-            #[serde(serialize_with = "serde_util::serialize_duration_option_as_int_secs")]
+            #[serde(serialize_with = "serde_util::duration_option_as_int_seconds::serialize")]
             maxstalenessseconds: Option<Duration>,
         }
 

--- a/src/test/spec/collection_management.rs
+++ b/src/test/spec/collection_management.rs
@@ -6,6 +6,6 @@ async fn run_unified() {
     let _guard = LOCK.run_exclusively().await;
     run_unified_tests(&["collection-management"])
         // The driver does not support modifyCollection.
-        .skip_files(&["modifyCollection-pre_and_post_images.json"])
+        .skip_files(&["modifyCollection-pre_and_post_images.json", "modifyCollection-errorResponse.json"])
         .await;
 }

--- a/src/test/spec/json/collection-management/modifyCollection-errorResponse.json
+++ b/src/test/spec/json/collection-management/modifyCollection-errorResponse.json
@@ -1,0 +1,118 @@
+{
+  "description": "modifyCollection-errorResponse",
+  "schemaVersion": "1.12",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "collMod-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "collMod-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 1
+        },
+        {
+          "_id": 2,
+          "x": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "modifyCollection prepareUnique violations are accessible",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.2"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "index": {
+              "keyPattern": {
+                "x": 1
+              },
+              "prepareUnique": true
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 11000
+          }
+        },
+        {
+          "name": "modifyCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "index": {
+              "keyPattern": {
+                "x": 1
+              },
+              "unique": true
+            }
+          },
+          "expectError": {
+            "isClientError": false,
+            "errorCode": 359,
+            "errorResponse": {
+              "violations": [
+                {
+                  "ids": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/collection-management/modifyCollection-errorResponse.yml
+++ b/src/test/spec/json/collection-management/modifyCollection-errorResponse.yml
@@ -1,0 +1,59 @@
+description: "modifyCollection-errorResponse"
+
+schemaVersion: "1.12"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name collMod-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData: &initialData
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 1 }
+      - { _id: 2, x: 1 }
+
+tests:
+  - description: "modifyCollection prepareUnique violations are accessible"
+    runOnRequirements:
+      - minServerVersion: "5.2" # SERVER-61158
+    operations:
+      - name: createIndex
+        object: *collection0
+        arguments:
+          keys: { x: 1 }
+      - name: modifyCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          index:
+            keyPattern: { x: 1 }
+            prepareUnique: true
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 1 }
+        expectError:
+          errorCode: 11000 # DuplicateKey
+      - name: modifyCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          index:
+            keyPattern: { x: 1 }
+            unique: true
+        expectError:
+          isClientError: false
+          errorCode: 359 # CannotConvertIndexToUnique
+          errorResponse:
+            violations:
+               - { ids: [ 1, 2 ] }

--- a/src/test/spec/json/collection-management/timeseries-collection.json
+++ b/src/test/spec/json/collection-management/timeseries-collection.json
@@ -250,6 +250,71 @@
           ]
         }
       ]
+    },
+    {
+      "description": "createCollection with bucketing options",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "7.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "test",
+            "timeseries": {
+              "timeField": "time",
+              "bucketMaxSpanSeconds": 3600,
+              "bucketRoundingSeconds": 3600
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "databaseName": "ts-tests",
+            "collectionName": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "test"
+                },
+                "databaseName": "ts-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "test",
+                  "timeseries": {
+                    "timeField": "time",
+                    "bucketMaxSpanSeconds": 3600,
+                    "bucketRoundingSeconds": 3600
+                  }
+                },
+                "databaseName": "ts-tests"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/test/spec/json/collection-management/timeseries-collection.yml
+++ b/src/test/spec/json/collection-management/timeseries-collection.yml
@@ -127,3 +127,38 @@ tests:
                 filter: {}
                 sort: { time: 1 }
               databaseName: *database0Name
+
+  - description: "createCollection with bucketing options"
+    runOnRequirements:
+      - minServerVersion: "7.0"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          timeseries: &timeseries1
+            timeField: "time"
+            bucketMaxSpanSeconds: 3600
+            bucketRoundingSeconds: 3600
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                timeseries: *timeseries1
+              databaseName: *database0Name
+

--- a/src/test/spec/mod.rs
+++ b/src/test/spec/mod.rs
@@ -62,7 +62,11 @@ pub(crate) fn deserialize_spec_tests<T: DeserializeOwned>(
         .unwrap_or_else(|e| panic!("Failed to read directory at {:?}: {}", &dir_path, e))
     {
         let path = entry.unwrap().path();
-        let Some(filename) = path.file_name().and_then(OsStr::to_str).filter(|name| name.ends_with(".json")) else {
+        let Some(filename) = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .filter(|name| name.ends_with(".json"))
+        else {
             continue;
         };
 


### PR DESCRIPTION
The drivers ticket description only details a test sync, but the new tests were using options we hadn't implemented yet.