### PR TITLE
RUST-1588: Add RunCursorCommand

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -78,7 +78,7 @@ impl Hint {
 }
 
 /// Specifies the type of cursor to return from a find operation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 #[non_exhaustive]
 pub enum CursorType {
     /// Default; close the cursor after the last document is received from the server.

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -78,7 +78,7 @@ impl Hint {
 }
 
 /// Specifies the type of cursor to return from a find operation.
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum CursorType {
     /// Default; close the cursor after the last document is received from the server.

--- a/src/db.rs
+++ b/src/db.rs
@@ -501,7 +501,9 @@ impl Database {
         options: RunCursorCommandOptions,
         session: &mut ClientSession,
     ) -> Result<SessionCursor<Document>> {
-        let mut selection_criteria = SelectionCriteria::ReadPreference(options.read_preference.clone().unwrap()).into();
+        let mut selection_criteria = options.read_preference
+            .clone()
+            .map(SelectionCriteria::ReadPreference);        
         match session.transaction.state {
             TransactionState::Starting | TransactionState::InProgress => {
                 selection_criteria = match selection_criteria {

--- a/src/db.rs
+++ b/src/db.rs
@@ -485,7 +485,10 @@ impl Database {
         command: Document,
         options: RunCursorCommandOptions,
     ) -> Result<Cursor<Document>> {
-        let rcc = RunCommand::new(self.name().to_string(), command, None, None)?;
+        let selection_criteria = options.read_preference
+            .clone()
+            .map(SelectionCriteria::ReadPreference);
+        let rcc = RunCommand::new(self.name().to_string(), command, selection_criteria, None)?;
         let rc_command = RunCursorCommand {
             run_command: rcc,
             options,
@@ -744,7 +747,7 @@ impl<'conn> Operation for RunCursorCommand<'conn> {
             cursor_info,
             description.server_address.clone(),
             self.options.batch_size,
-            self.options.max_time_ms,
+            self.options.max_time,
             self.options.comment.clone(),
         ))
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -482,7 +482,7 @@ impl Database {
     pub async fn run_cursor_command(
         &self,
         command: Document,
-        options: RunCursorCommandOptions,
+        options: impl Into<Option<RunCursorCommandOptions>>,
     ) -> Result<Cursor<Document>> {
         let rcc = RunCommand::new(self.name().to_string(), command, options.read_preference.clone(), None)?;
         let rc_command = RunCursorCommand::new(rcc, options)?; 

--- a/src/db.rs
+++ b/src/db.rs
@@ -48,8 +48,6 @@ use crate::{
     SessionCursor,
 };
 
-use self::options::RunCursorCommandWithSessionOptions;
-
 /// `Database` is the client-side abstraction of a MongoDB database. It can be used to perform
 /// database-level operations or to obtain handles to specific collections within the database. A
 /// `Database` can only be obtained through a [`Client`](struct.Client.html) by calling either
@@ -500,9 +498,9 @@ impl Database {
     pub async fn run_cursor_command_with_session(
         &self,
         command: Document,
-        options: RunCursorCommandWithSessionOptions,
+        options: RunCursorCommandOptions,
         session: &mut ClientSession,
-    ) -> Result<Cursor<Document>> {
+    ) -> Result<SessionCursor<Document>> {
         match session.transaction.state {
             TransactionState::Starting | TransactionState::InProgress => {
                 if command.contains_key("readConcern") {
@@ -515,13 +513,12 @@ impl Database {
             _ => {}
         }
         let rcc = RunCommand::new(self.name().to_string(), command, options.read_preference.clone(), None)?;
-        let rc_command = RunCursorCommandWithSession {
+        let rc_command = RunCursorCommand {
             run_command: rcc,
             options,
-            session,
         };
         let client = self.client();
-        client.execute_cursor_operation(rc_command).await
+        client.execute_session_cursor_operation(rc_command, session).await
     }
 
     /// Runs a database-level command using the provided `ClientSession`.
@@ -669,90 +666,6 @@ pub(super) struct RunCursorCommand<'conn> {
 }
 
 impl<'conn> Operation for RunCursorCommand<'conn> {
-    type O = CursorSpecification;
-    type Command = RawDocumentBuf;
-
-    const NAME: &'static str = "run_cursor_command";
-
-    fn build(&mut self, _description: &StreamDescription) -> Result<Command<Self::Command>> {
-        self.run_command.build(_description)
-    }
-
-    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
-        self.run_command.serialize_command(cmd)
-    }
-
-    fn extract_at_cluster_time(
-        &self,
-        _response: &bson::RawDocument,
-    ) -> Result<Option<bson::Timestamp>> {
-        self.run_command.extract_at_cluster_time(_response)
-    }
-
-    fn handle_error(&self, error: Error) -> Result<Self::O> {
-        Err(error)
-    }
-
-    fn selection_criteria(&self) -> Option<&SelectionCriteria> {
-        self.run_command.selection_criteria()
-    }
-
-    fn is_acknowledged(&self) -> bool {
-        self.run_command.is_acknowledged()
-    }
-
-    fn write_concern(&self) -> Option<&WriteConcern> {
-        self.run_command.write_concern()
-    }
-
-    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
-        self.run_command.supports_read_concern(_description)
-    }
-
-    fn supports_sessions(&self) -> bool {
-        self.run_command.supports_sessions()
-    }
-
-    fn retryability(&self) -> crate::operation::Retryability {
-        self.run_command.retryability()
-    }
-
-    fn update_for_retry(&mut self) {
-        self.run_command.update_for_retry()
-    }
-
-    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
-        self.run_command.pinned_connection()
-    }
-
-    fn name(&self) -> &str {
-        self.run_command.name()
-    }
-
-    fn handle_response(
-        &self,
-        response: RawCommandResponse,
-        description: &StreamDescription,
-    ) -> Result<Self::O> {
-        let doc = Operation::handle_response(&self.run_command, response, description)?;
-        let cursor_info = bson::from_document(doc)?;
-        Ok(CursorSpecification::new(
-            cursor_info,
-            description.server_address.clone(),
-            self.options.batch_size,
-            self.options.max_time_ms,
-            self.options.comment.clone(),
-        ))
-    }
-}
-
-pub(super) struct RunCursorCommandWithSession<'conn> {
-    run_command: RunCommand<'conn>,
-    options: RunCursorCommandWithSessionOptions,
-    session: &'conn mut ClientSession,
-}
-
-impl<'conn> Operation for RunCursorCommandWithSession<'conn> {
     type O = CursorSpecification;
     type Command = RawDocumentBuf;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -484,10 +484,7 @@ impl Database {
         command: Document,
         options: RunCursorCommandOptions,
     ) -> Result<Cursor<Document>> {
-        let selection_criteria = options.read_preference
-            .clone()
-            .map(SelectionCriteria::ReadPreference);
-        let rcc = RunCommand::new(self.name().to_string(), command, selection_criteria, None)?;
+        let rcc = RunCommand::new(self.name().to_string(), command, options.read_preference.clone(), None)?;
         let rc_command = RunCursorCommand::new(rcc, options)?; 
         let client = self.client();
         client.execute_cursor_operation(rc_command).await
@@ -500,9 +497,7 @@ impl Database {
         options: RunCursorCommandOptions,
         session: &mut ClientSession,
     ) -> Result<SessionCursor<Document>> {
-        let mut selection_criteria = options.read_preference
-            .clone()
-            .map(SelectionCriteria::ReadPreference);        
+        let mut selection_criteria = options.read_preference.clone();      
         match session.transaction.state {
             TransactionState::Starting | TransactionState::InProgress => {
                 selection_criteria = match selection_criteria {

--- a/src/db.rs
+++ b/src/db.rs
@@ -484,7 +484,7 @@ impl Database {
         command: Document,
         options: impl Into<Option<RunCursorCommandOptions>>,
     ) -> Result<Cursor<Document>> {
-        let options: Option<RunCursorCommandOptions> = options.into().clone();
+        let options: Option<RunCursorCommandOptions> = options.into();
         let selection_criteria = options
             .as_ref()
             .and_then(|options| options.selection_criteria.clone());

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,8 +3,8 @@ pub mod options;
 use std::{fmt::Debug, sync::Arc};
 
 #[cfg(feature = "in-use-encryption-unstable")]
+use bson::doc;
 use futures_util::stream::TryStreamExt;
-use futures_util::TryStreamExt;
 
 use crate::{
     bson::{Bson, Document},

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -320,7 +320,7 @@ pub struct ChangeStreamPreAndPostImages {
 #[non_exhaustive]
 pub struct RunCursorCommandOptions {
     /// The default read preference for operations.
-    pub read_preference: Option<SelectionCriteria>,
+    pub selection_criteria: Option<SelectionCriteria>,
     /// The type of cursor to return.
     pub cursor_type: Option<CursorType>,
     /// Number of documents to return per batch.

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -8,7 +8,7 @@ use typed_builder::TypedBuilder;
 use crate::{
     bson::{Bson, Document},
     concern::{ReadConcern, WriteConcern},
-    options::Collation,
+    options::{Collation, CursorType},
     selection_criteria::SelectionCriteria,
     serde_util,
 };
@@ -311,4 +311,23 @@ pub struct ListDatabasesOptions {
 pub struct ChangeStreamPreAndPostImages {
     /// If `true`, change streams will be able to include pre- and post-images.
     pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[non_exhaustive]
+pub enum TimeoutMode {
+    Iteration,
+    CursorLifetime,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+pub struct RunCursorCommandOptions {
+    pub timeout_mode: Option<TimeoutMode>,
+    pub cursor_type: Option<CursorType>,
+    pub batch_size: Option<u32>,
+    pub max_time_ms: Option<Duration>,
+    pub comment: Option<Bson>,
 }

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -346,28 +346,3 @@ pub struct RunCursorCommandOptions {
     /// The session to run this command with.
     pub session: Option<String>,
 }
-
-
-/// Specifies the options to a
-/// [`Database::RunCursorCommand`](../struct.Database.html#method.run_cursor_command_with_session) operation.
-#[derive(Clone, Debug, Default, TypedBuilder)]
-#[builder(field_defaults(default, setter(into)))]
-#[non_exhaustive]
-pub struct RunCursorCommandWithSessionOptions {
-    /// Optional string enum value, one of 'iteration' | 'cursorLifetime'.
-    pub timeout_mode: Option<TimeoutMode>,
-    /// The default read preference for operations.
-    pub read_preference: Option<SelectionCriteria>,
-    /// Optional string enum value, one of 'tailable' | 'tailableAwait' | 'nonTailable'.
-    pub cursor_type: Option<CursorType>,
-    /// Number of documents to return per batch.
-    pub batch_size: Option<u32>,
-    /// Optional non-negative integer value. Use this value to configure the maxTimeMS option sent
-    /// on subsequent getMore commands.
-    pub max_time_ms: Option<Duration>,
-    /// Optional BSON value. Use this value to configure the comment option sent on subsequent
-    /// getMore commands.
-    pub comment: Option<Bson>,
-    /// The session to run this command with.
-    pub session: Option<String>,
-}

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -313,21 +313,33 @@ pub struct ChangeStreamPreAndPostImages {
     pub enabled: bool,
 }
 
+/// Determines the lifetime of a cursor.
 #[derive(Clone, Debug, Deserialize)]
 #[non_exhaustive]
 pub enum TimeoutMode {
+    /// Times out after one Iteration.
     Iteration,
+    /// Times out after the end of the Cursor Lifetime.
     CursorLifetime,
 }
 
+/// Specifies the options to a
+/// [`Database::RunCursorCommand`](../struct.Database.html#method.run_cursor_command) operation.
 #[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
 pub struct RunCursorCommandOptions {
+    /// Optional string enum value, one of 'iteration' | 'cursorLifetime'.
     pub timeout_mode: Option<TimeoutMode>,
+    /// Optional string enum value, one of 'tailable' | 'tailableAwait' | 'nonTailable'.
     pub cursor_type: Option<CursorType>,
+    /// Number of documents to return per batch.
     pub batch_size: Option<u32>,
+    /// Optional non-negative integer value. Use this value to configure the maxTimeMS option sent
+    /// on subsequent getMore commands.
     pub max_time_ms: Option<Duration>,
+    /// Optional BSON value. Use this value to configure the comment option sent on subsequent
+    /// getMore commands.
     pub comment: Option<Bson>,
 }

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -9,7 +9,7 @@ use crate::{
     bson::{Bson, Document},
     concern::{ReadConcern, WriteConcern},
     options::{Collation, CursorType},
-    selection_criteria::SelectionCriteria,
+    selection_criteria::{SelectionCriteria, ReadPreference},
     serde_util,
 };
 
@@ -332,7 +332,7 @@ pub struct RunCursorCommandOptions {
     /// Optional string enum value, one of 'iteration' | 'cursorLifetime'.
     pub timeout_mode: Option<TimeoutMode>,
     /// The default read preference for operations.
-    pub read_preference: Option<SelectionCriteria>,
+    pub read_preference: Option<ReadPreference>,
     /// Optional string enum value, one of 'tailable' | 'tailableAwait' | 'nonTailable'.
     pub cursor_type: Option<CursorType>,
     /// Number of documents to return per batch.
@@ -343,6 +343,4 @@ pub struct RunCursorCommandOptions {
     /// Optional BSON value. Use this value to configure the comment option sent on subsequent
     /// getMore commands.
     pub comment: Option<Bson>,
-    /// The session to run this command with.
-    pub session: Option<String>,
 }

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -320,7 +320,7 @@ pub struct ChangeStreamPreAndPostImages {
 #[non_exhaustive]
 pub struct RunCursorCommandOptions {
     /// The default read preference for operations.
-    pub read_preference: Option<ReadPreference>,
+    pub read_preference: Option<SelectionCriteria>,
     /// The type of cursor to return.
     pub cursor_type: Option<CursorType>,
     /// Number of documents to return per batch.

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -313,33 +313,21 @@ pub struct ChangeStreamPreAndPostImages {
     pub enabled: bool,
 }
 
-/// Determines the lifetime of a cursor.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum TimeoutMode {
-    /// Times out after one Iteration.
-    Iteration,
-    /// Times out after the end of the Cursor Lifetime.
-    CursorLifetime,
-}
-
 /// Specifies the options to a
 /// [`Database::RunCursorCommand`](../struct.Database.html#method.run_cursor_command) operation.
 #[derive(Clone, Debug, Default, TypedBuilder)]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
 pub struct RunCursorCommandOptions {
-    /// Optional string enum value, one of 'iteration' | 'cursorLifetime'.
-    pub timeout_mode: Option<TimeoutMode>,
     /// The default read preference for operations.
     pub read_preference: Option<ReadPreference>,
-    /// Optional string enum value, one of 'tailable' | 'tailableAwait' | 'nonTailable'.
+    /// The type of cursor to return.
     pub cursor_type: Option<CursorType>,
     /// Number of documents to return per batch.
     pub batch_size: Option<u32>,
     /// Optional non-negative integer value. Use this value to configure the maxTimeMS option sent
     /// on subsequent getMore commands.
-    pub max_time_ms: Option<Duration>,
+    pub max_time: Option<Duration>,
     /// Optional BSON value. Use this value to configure the comment option sent on subsequent
     /// getMore commands.
     pub comment: Option<Bson>,

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -314,7 +314,7 @@ pub struct ChangeStreamPreAndPostImages {
 }
 
 /// Determines the lifetime of a cursor.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum TimeoutMode {
     /// Times out after one Iteration.
@@ -325,13 +325,14 @@ pub enum TimeoutMode {
 
 /// Specifies the options to a
 /// [`Database::RunCursorCommand`](../struct.Database.html#method.run_cursor_command) operation.
-#[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Default, TypedBuilder)]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
 pub struct RunCursorCommandOptions {
     /// Optional string enum value, one of 'iteration' | 'cursorLifetime'.
     pub timeout_mode: Option<TimeoutMode>,
+    /// The default read preference for operations.
+    pub read_preference: Option<SelectionCriteria>,
     /// Optional string enum value, one of 'tailable' | 'tailableAwait' | 'nonTailable'.
     pub cursor_type: Option<CursorType>,
     /// Number of documents to return per batch.
@@ -342,4 +343,31 @@ pub struct RunCursorCommandOptions {
     /// Optional BSON value. Use this value to configure the comment option sent on subsequent
     /// getMore commands.
     pub comment: Option<Bson>,
+    /// The session to run this command with.
+    pub session: Option<String>,
+}
+
+
+/// Specifies the options to a
+/// [`Database::RunCursorCommand`](../struct.Database.html#method.run_cursor_command_with_session) operation.
+#[derive(Clone, Debug, Default, TypedBuilder)]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+pub struct RunCursorCommandWithSessionOptions {
+    /// Optional string enum value, one of 'iteration' | 'cursorLifetime'.
+    pub timeout_mode: Option<TimeoutMode>,
+    /// The default read preference for operations.
+    pub read_preference: Option<SelectionCriteria>,
+    /// Optional string enum value, one of 'tailable' | 'tailableAwait' | 'nonTailable'.
+    pub cursor_type: Option<CursorType>,
+    /// Number of documents to return per batch.
+    pub batch_size: Option<u32>,
+    /// Optional non-negative integer value. Use this value to configure the maxTimeMS option sent
+    /// on subsequent getMore commands.
+    pub max_time_ms: Option<Duration>,
+    /// Optional BSON value. Use this value to configure the comment option sent on subsequent
+    /// getMore commands.
+    pub comment: Option<Bson>,
+    /// The session to run this command with.
+    pub session: Option<String>,
 }

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -9,7 +9,7 @@ use crate::{
     bson::{Bson, Document},
     concern::{ReadConcern, WriteConcern},
     options::{Collation, CursorType},
-    selection_criteria::{SelectionCriteria},
+    selection_criteria::SelectionCriteria,
     serde_util,
 };
 

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -9,7 +9,7 @@ use crate::{
     bson::{Bson, Document},
     concern::{ReadConcern, WriteConcern},
     options::{Collation, CursorType},
-    selection_criteria::{SelectionCriteria, ReadPreference},
+    selection_criteria::{SelectionCriteria},
     serde_util,
 };
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -74,7 +74,7 @@ pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;
 
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
-pub const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
+const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
 
 /// A trait modeling the behavior of a server side operation.
 ///

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -19,6 +19,7 @@ mod list_databases;
 mod list_indexes;
 mod raw_output;
 mod run_command;
+mod run_cursor_command;
 mod update;
 
 #[cfg(test)]
@@ -71,6 +72,7 @@ pub(crate) use list_indexes::ListIndexes;
 #[cfg(feature = "in-use-encryption-unstable")]
 pub(crate) use raw_output::RawOutput;
 pub(crate) use run_command::RunCommand;
+pub(crate) use run_cursor_command::RunCursorCommand;
 pub(crate) use update::Update;
 
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -74,7 +74,7 @@ pub(crate) use run_command::RunCommand;
 pub(crate) use update::Update;
 
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
-const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
+pub const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
 
 /// A trait modeling the behavior of a server side operation.
 ///

--- a/src/operation/run_cursor_command.rs
+++ b/src/operation/run_cursor_command.rs
@@ -1,0 +1,117 @@
+
+
+#[cfg(feature = "in-use-encryption-unstable")]
+use bson::doc;
+use bson::RawDocumentBuf;
+
+
+use crate::{
+    cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
+    concern::{WriteConcern},
+    cursor::{CursorSpecification},
+    error::{Error, Result},
+    operation::{
+        Operation,
+        RunCommand,
+    },
+    options::{
+        RunCursorCommandOptions,
+    },
+    selection_criteria::SelectionCriteria,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct RunCursorCommand<'conn> {
+    run_command: RunCommand<'conn>,
+    options: RunCursorCommandOptions,
+}
+
+impl<'conn> RunCursorCommand<'conn>{
+    pub(crate) fn new (
+        run_command: RunCommand<'conn>,
+        options: RunCursorCommandOptions,
+    ) -> Result<Self> {
+        Ok(Self{
+            run_command,
+            options,
+        })
+    }
+}
+
+impl<'conn> Operation for RunCursorCommand<'conn> {
+    type O = CursorSpecification;
+    type Command = RawDocumentBuf;
+
+    const NAME: &'static str = "run_cursor_command";
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command<Self::Command>> {
+        self.run_command.build(_description)
+    }
+
+    fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
+        self.run_command.serialize_command(cmd)
+    }
+
+    fn extract_at_cluster_time(
+        &self,
+        _response: &bson::RawDocument,
+    ) -> Result<Option<bson::Timestamp>> {
+        self.run_command.extract_at_cluster_time(_response)
+    }
+
+    fn handle_error(&self, error: Error) -> Result<Self::O> {
+        Err(error)
+    }
+
+    fn selection_criteria(&self) -> Option<&SelectionCriteria> {
+        self.run_command.selection_criteria()
+    }
+
+    fn is_acknowledged(&self) -> bool {
+        self.run_command.is_acknowledged()
+    }
+
+    fn write_concern(&self) -> Option<&WriteConcern> {
+        self.run_command.write_concern()
+    }
+
+    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
+        self.run_command.supports_read_concern(_description)
+    }
+
+    fn supports_sessions(&self) -> bool {
+        self.run_command.supports_sessions()
+    }
+
+    fn retryability(&self) -> crate::operation::Retryability {
+        self.run_command.retryability()
+    }
+
+    fn update_for_retry(&mut self) {
+        self.run_command.update_for_retry()
+    }
+
+    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
+        self.run_command.pinned_connection()
+    }
+
+    fn name(&self) -> &str {
+        self.run_command.name()
+    }
+
+    fn handle_response(
+        &self,
+        response: RawCommandResponse,
+        description: &StreamDescription,
+    ) -> Result<Self::O> {
+        let doc = Operation::handle_response(&self.run_command, response, description)?;
+        let cursor_info = bson::from_document(doc)?;
+        Ok(CursorSpecification::new(
+            cursor_info,
+            description.server_address.clone(),
+            self.options.batch_size,
+            self.options.max_time,
+            self.options.comment.clone(),
+        ))
+    }
+}

--- a/src/operation/run_cursor_command.rs
+++ b/src/operation/run_cursor_command.rs
@@ -44,8 +44,8 @@ impl<'conn> Operation for RunCursorCommand<'conn> {
 
     const NAME: &'static str = "run_cursor_command";
 
-    fn build(&mut self, _description: &StreamDescription) -> Result<Command<Self::Command>> {
-        self.run_command.build(_description)
+    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+        self.run_command.build(description)
     }
 
     fn serialize_command(&mut self, cmd: Command<Self::Command>) -> Result<Vec<u8>> {
@@ -54,9 +54,9 @@ impl<'conn> Operation for RunCursorCommand<'conn> {
 
     fn extract_at_cluster_time(
         &self,
-        _response: &bson::RawDocument,
+        response: &bson::RawDocument,
     ) -> Result<Option<bson::Timestamp>> {
-        self.run_command.extract_at_cluster_time(_response)
+        self.run_command.extract_at_cluster_time(response)
     }
 
     fn handle_error(&self, error: Error) -> Result<Self::O> {
@@ -75,8 +75,8 @@ impl<'conn> Operation for RunCursorCommand<'conn> {
         self.run_command.write_concern()
     }
 
-    fn supports_read_concern(&self, _description: &StreamDescription) -> bool {
-        self.run_command.supports_read_concern(_description)
+    fn supports_read_concern(&self, description: &StreamDescription) -> bool {
+        self.run_command.supports_read_concern(description)
     }
 
     fn supports_sessions(&self) -> bool {

--- a/src/results.rs
+++ b/src/results.rs
@@ -6,8 +6,8 @@ use crate::{
     bson::{serde_helpers, Bson, Document},
     change_stream::event::ResumeToken,
     db::options::CreateCollectionOptions,
-    Namespace,
     serde_util,
+    Namespace,
 };
 
 use bson::{Binary, RawDocumentBuf};


### PR DESCRIPTION
added operation `RunCursorCommand` (spec: https://github.com/mongodb/specifications/blob/c09f979ad296400552a98c9b784197ec648c2096/source/run-command/run-command.rst#runcursorcommand)
- implemented Operation which uses default RunCommand behavior for every method but handle_response