### PR TITLE
RUST-1712 Support User Configuration for `max_connecting`

### DIFF
--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -491,6 +491,12 @@ pub struct ClientOptions {
     #[builder(default)]
     pub min_pool_size: Option<u32>,
 
+    /// The maximum number of new connections that can be created concurrently.
+    ///
+    /// The default is 2.
+    #[builder(default)]
+    pub max_connecting: Option<u32>,
+
     /// Specifies the default read concern for operations performed on the Client. See the
     /// ReadConcern type documentation for more details.
     #[builder(default)]
@@ -1298,6 +1304,7 @@ impl ClientOptions {
             max_pool_size: conn_str.max_pool_size,
             min_pool_size: conn_str.min_pool_size,
             max_idle_time: conn_str.max_idle_time,
+            max_connecting: None,
             server_selection_timeout: conn_str.server_selection_timeout,
             compressors: conn_str.compressors,
             connect_timeout: conn_str.connect_timeout,

--- a/src/cmap/options.rs
+++ b/src/cmap/options.rs
@@ -62,6 +62,11 @@ pub(crate) struct ConnectionPoolOptions {
 
     /// Whether or not the client is connecting to a MongoDB cluster through a load balancer.
     pub(crate) load_balanced: Option<bool>,
+
+    /// The maximum number of new connections that can be created concurrently.
+    ///
+    /// The default is 2.
+    pub(crate) max_connecting: Option<u32>,
 }
 
 impl ConnectionPoolOptions {
@@ -77,6 +82,7 @@ impl ConnectionPoolOptions {
             ready: None,
             load_balanced: options.load_balanced,
             credential: options.credential.clone(),
+            max_connecting: options.max_connecting,
         }
     }
 

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -40,7 +40,7 @@ use std::{
     time::Duration,
 };
 
-const MAX_CONNECTING: u32 = 2;
+const DEFAULT_MAX_CONNECTING: u32 = 2;
 const MAINTENACE_FREQUENCY: Duration = Duration::from_millis(500);
 
 /// A worker task that manages the shared state of the pool.
@@ -129,6 +129,9 @@ pub(crate) struct ConnectionPoolWorker {
     /// A handle used to notify SDAM that a connection establishment error happened. This will
     /// allow the server to transition to Unknown and clear the pool as necessary.
     server_updater: TopologyUpdater,
+
+    /// The maximum number of new connections that can be created concurrently.
+    max_connecting: u32,
 }
 
 impl ConnectionPoolWorker {
@@ -153,6 +156,10 @@ impl ConnectionPoolWorker {
             .as_ref()
             .and_then(|opts| opts.max_pool_size)
             .unwrap_or(DEFAULT_MAX_POOL_SIZE);
+        let max_connecting = options
+            .as_ref()
+            .and_then(|opts| opts.max_connecting)
+            .unwrap_or(DEFAULT_MAX_CONNECTING);
 
         let min_pool_size = options.as_ref().and_then(|opts| opts.min_pool_size);
 
@@ -227,6 +234,7 @@ impl ConnectionPoolWorker {
             generation_publisher,
             maintenance_frequency,
             server_updater,
+            max_connecting,
         };
 
         runtime::execute(async move {
@@ -346,7 +354,7 @@ impl ConnectionPoolWorker {
             return true;
         }
 
-        self.below_max_connections() && self.pending_connection_count < MAX_CONNECTING
+        self.below_max_connections() && self.pending_connection_count < self.max_connecting
     }
 
     fn check_out(&mut self, request: ConnectionRequest) {
@@ -578,7 +586,7 @@ impl ConnectionPoolWorker {
     fn ensure_min_connections(&mut self) {
         if let Some(min_pool_size) = self.min_pool_size {
             while self.total_connection_count < min_pool_size
-                && self.pending_connection_count < MAX_CONNECTING
+                && self.pending_connection_count < self.max_connecting
             {
                 let pending_connection = self.create_pending_connection();
                 let event_handler = self.event_emitter.clone();


### PR DESCRIPTION
Adds `max_connecting` as a configureable variable in `ClientOptions` which is then piped through down to `ConnectionPoolWorker` which utilizes it to determine the maximum number of pending connections that can be created