### PR TITLE
RUST-1719 Fix panic after `SessionCursor::with_type` is called

### DIFF
--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -350,7 +350,9 @@ impl<T> SessionCursor<T> {
 
 impl<T> SessionCursor<T> {
     fn mark_exhausted(&mut self) {
-        self.state.as_mut().unwrap().exhausted = true;
+        if let Some(state) = self.state.as_mut() {
+            state.exhausted = true;
+        }
     }
 
     pub(crate) fn is_exhausted(&self) -> bool {

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -354,7 +354,7 @@ impl<T> SessionCursor<T> {
     }
 
     pub(crate) fn is_exhausted(&self) -> bool {
-        self.state.as_ref().unwrap().exhausted
+        self.state.as_ref().map_or(true, |state| state.exhausted)
     }
 
     #[cfg(test)]

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -321,7 +321,6 @@ impl<T> SessionCursor<T> {
             #[cfg(test)]
             kill_watcher: self.kill_watcher.take(),
         };
-        self.mark_exhausted(); // prevent a `kill_cursor` call in `drop`
         out
     }
 
@@ -349,10 +348,9 @@ impl<T> SessionCursor<T> {
 }
 
 impl<T> SessionCursor<T> {
+    #[allow(unused)]
     fn mark_exhausted(&mut self) {
-        if let Some(state) = self.state.as_mut() {
-            state.exhausted = true;
-        }
+        self.state.as_mut().unwrap().exhausted = true;
     }
 
     pub(crate) fn is_exhausted(&self) -> bool {

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -311,7 +311,7 @@ impl<T> SessionCursor<T> {
     where
         D: Deserialize<'a>,
     {
-        let out = SessionCursor {
+        SessionCursor {
             client: self.client.clone(),
             drop_token: self.drop_token.take(),
             info: self.info.clone(),
@@ -320,8 +320,7 @@ impl<T> SessionCursor<T> {
             _phantom: Default::default(),
             #[cfg(test)]
             kill_watcher: self.kill_watcher.take(),
-        };
-        out
+        }
     }
 
     pub(crate) fn address(&self) -> &ServerAddress {
@@ -348,11 +347,6 @@ impl<T> SessionCursor<T> {
 }
 
 impl<T> SessionCursor<T> {
-    #[allow(unused)]
-    fn mark_exhausted(&mut self) {
-        self.state.as_mut().unwrap().exhausted = true;
-    }
-
     pub(crate) fn is_exhausted(&self) -> bool {
         self.state.as_ref().map_or(true, |state| state.exhausted)
     }


### PR DESCRIPTION
Hello there,

when using the transaction API, I encountered unconditional panic and also panic while dropping in `SessionCursor::with_type`. The problem occurs because the `.state` is moved into new cursor and subsequently, `.unwrap()` is called on it when marking it exhausted and also when checking for exhaustion. This is the minimal code change to fix this problem