### PR TITLE
RUST-1674 Use cargo-nextest as test runner

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,9 @@
+[profile.default]
+retries = 1
+
+[profile.ci]
+failure-output = "final"
+test-threads = 1
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,6 +4,7 @@ retries = 1
 [profile.ci]
 failure-output = "final"
 test-threads = 1
+fail-fast = false
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.evergreen/cargo-test.sh
+++ b/.evergreen/cargo-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CARGO_OPTIONS=()
-TEST_OPTIONS=("-Z unstable-options" "--format json" "--report-time")
+TEST_OPTIONS=()
 FEATURE_FLAGS=()
 CARGO_RESULT=0
 
@@ -26,17 +26,11 @@ cargo_test_options() {
     if (( ${#FILTERED[@]} != 0 )); then
         FEATURE_OPTION="--features $(join_by , "${FILTERED[@]}")"
     fi
-    local THREAD_OPTION=""
-    if [ "${SINGLE_THREAD}" = true ]; then
-        THREAD_OPTION="--test-threads=1"
-    fi
-    echo $1 ${CARGO_OPTIONS[@]} ${FEATURE_OPTION} -- ${TEST_OPTIONS[@]} ${THREAD_OPTION}
+    echo $1 ${CARGO_OPTIONS[@]} ${FEATURE_OPTION} -- ${TEST_OPTIONS[@]}
 }
 
 cargo_test() {
-    RUST_BACKTRACE=1 \
-        cargo test $(cargo_test_options $1) \
-        | grep -v '{"t":' \
-        | cargo2junit
+    RUST_BACKTRACE=1 cargo nextest run --profile ci $(cargo_test_options $1)
     (( CARGO_RESULT = ${CARGO_RESULT} || $? ))
+    mv target/nextest/ci/junit.xml $2
 }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -13,8 +13,8 @@ stepback: true
 command_type: system
 
 # Protect ourself against rogue test case, or curl gone wild, that runs forever
-# 12 minutes is the longest we'll ever run
-exec_timeout_secs: 3600 # 12 minutes is the longest we'll ever run
+# TODO RUST-1721 Reduce this
+exec_timeout_secs: 5400
 
 # What to do when evergreen hits the timeout (`post:` tasks are run automatically)
 timeout:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -453,8 +453,7 @@ functions:
           SNAPPY_COMPRESSION_ENABLED=${SNAPPY_COMPRESSION_ENABLED} \
           ZLIB_COMPRESSION_ENABLED=${ZLIB_COMPRESSION_ENABLED} \
           ZSTD_COMPRESSION_ENABLED=${ZSTD_COMPRESSION_ENABLED} \
-          SINGLE_THREAD=${SINGLE_THREAD} \
-            ASYNC_RUNTIME=${ASYNC_RUNTIME} \
+          ASYNC_RUNTIME=${ASYNC_RUNTIME} \
             MONGODB_API_VERSION=${MONGODB_API_VERSION} \
             TLS_FEATURE=${TLS_FEATURE} \
             .evergreen/run-tests.sh
@@ -477,9 +476,8 @@ functions:
           . .evergreen/generate-uri.sh
 
           SNAPPY_COMPRESSION_ENABLED="true" \
-          ZLIB_COMPRESSION_ENABLED="true" \
-          ZSTD_COMPRESSION_ENABLED="true" \
-          SINGLE_THREAD=${SINGLE_THREAD} \
+            ZLIB_COMPRESSION_ENABLED="true" \
+            ZSTD_COMPRESSION_ENABLED="true" \
             ASYNC_RUNTIME=${ASYNC_RUNTIME} \
             MONGODB_API_VERSION=${MONGODB_API_VERSION} \
             TLS_FEATURE=${TLS_FEATURE} \
@@ -1612,7 +1610,6 @@ axes:
         display_name: "MacOS 11.00"
         run_on: macos-1100
         variables:
-          SINGLE_THREAD: true
           VENV_BIN_DIR: "bin"
           LIBMONGOCRYPT_OS: "macos"
       - id: windows-64-vs2017

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -27,8 +27,6 @@ for arg; do
 
         source .evergreen/env.sh
         rustup toolchain install nightly -c rustfmt
-        # TODO RUST-1674: remove this workaround
-        rustup default 1.69
     elif [ $arg == "mdbook" ]; then
         source ${CARGO_HOME}/env
         # Install the manual rendering tool

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -35,13 +35,14 @@ for arg; do
         cargo install mdbook
     elif [ $arg == "junit-dependencies" ]; then
         source ${CARGO_HOME}/env
-        # Install tool for converting cargo test output to junit
-        cargo install cargo2junit
 
         # install npm/node
         ./.evergreen/install-node.sh
 
         source ./.evergreen/env.sh
+
+        # Install junit-compatible test runner
+        cargo install cargo-nextest --locked
 
         # Install tool for merging different junit reports into a single one
         set +o errexit

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -10,6 +10,6 @@ use_async_runtime
 
 set +o errexit
 
-cargo_test atlas_connectivity > results.xml
+cargo_test atlas_connectivity results.xml
 
 exit $CARGO_RESULT

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -49,8 +49,8 @@ FEATURE_FLAGS+=("aws-auth")
 
 set +o errexit
 
-cargo_test auth_aws > auth_aws.xml
-cargo_test lambda_examples::auth::test_handler > lambda_handler.xml
+cargo_test auth_aws auth_aws.xml
+cargo_test lambda_examples::auth::test_handler lambda_handler.xml
 
 junit-report-merger results.xml auth_aws.xml lambda_handler.xml
 

--- a/.evergreen/run-connection-string-tests.sh
+++ b/.evergreen/run-connection-string-tests.sh
@@ -11,9 +11,9 @@ FEATURE_FLAGS+=("aws-auth")
 
 set +o errexit
 
-cargo_test spec::auth > spec.xml
-cargo_test uri_options > uri_options.xml
-cargo_test connection_string > connection_string.xml
+cargo_test spec::auth spec.xml
+cargo_test uri_options uri_options.xml
+cargo_test connection_string connection_string.xml
 
 junit-report-merger results.xml spec.xml uri_options.xml connection_string.xml
 

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -23,13 +23,13 @@ echo "cargo test options: $(cargo_test_options)"
 
 set +o errexit
 
-cargo_test test::csfle > prose.xml
-cargo_test test::spec::client_side_encryption > spec.xml
+cargo_test test::csfle prose.xml
+cargo_test test::spec::client_side_encryption spec.xml
 
 # Unset variables for on-demand credential failure tests.
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
-cargo_test test::csfle::on_demand_aws_failure > failure.xml
+cargo_test test::csfle::on_demand_aws_failure failure.xml
 
 junit-report-merger results.xml prose.xml spec.xml failure.xml
 

--- a/.evergreen/run-oidc-tests.sh
+++ b/.evergreen/run-oidc-tests.sh
@@ -8,7 +8,7 @@ set -o xtrace
 
 set +o errexit
 
-cargo_test test::spec::oidc > prose.xml
+cargo_test test::spec::oidc prose.xml
 
 junit-report-merger results.xml prose.xml
 

--- a/.evergreen/run-plain-tests.sh
+++ b/.evergreen/run-plain-tests.sh
@@ -8,6 +8,6 @@ source .evergreen/cargo-test.sh
 
 set +o errexit
 
-MONGO_PLAIN_AUTH_TEST=1 cargo_test plain > results.xml
+MONGO_PLAIN_AUTH_TEST=1 cargo_test plain results.xml
 
 exit $CARGO_RESULT

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -16,16 +16,16 @@ export SERVERLESS="serverless"
 
 set +o errexit
 
-cargo_test test::spec::crud > crud.xml
-cargo_test test::spec::retryable_reads > retryable_reads.xml
-cargo_test test::spec::retryable_writes > retryable_writes.xml
-cargo_test test::spec::versioned_api > versioned_api.xml
-cargo_test test::spec::sessions > sessions.xml
-cargo_test test::spec::transactions > transactions.xml
-cargo_test test::spec::load_balancers > load_balancers.xml
-cargo_test test::cursor > cursor.xml
-cargo_test test::spec::collection_management > coll.xml
-cargo_test test::spec::command_monitoring_unified > monitoring.xml
+cargo_test test::spec::crud crud.xml
+cargo_test test::spec::retryable_reads retryable_reads.xml
+cargo_test test::spec::retryable_writes retryable_writes.xml
+cargo_test test::spec::versioned_api versioned_api.xml
+cargo_test test::spec::sessions sessions.xml
+cargo_test test::spec::transactions transactions.xml
+cargo_test test::spec::load_balancers load_balancers.xml
+cargo_test test::cursor cursor.xml
+cargo_test test::spec::collection_management coll.xml
+cargo_test test::spec::command_monitoring_unified monitoring.xml
 
 junit-report-merger results.xml crud.xml retryable_reads.xml retryable_writes.xml versioned_api.xml sessions.xml transactions.xml load_balancers.xml cursor.xml coll.xml monitoring.xml
 

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -34,12 +34,14 @@ echo "cargo test options: $(cargo_test_options)"
 
 set +o errexit
 
-cargo_test > async-tests.xml
+cargo_test "" async-tests.xml
 FEATURE_FLAGS+=("${SYNC_FEATURE}")
-cargo_test sync > sync-tests.xml
-CARGO_OPTIONS+=("--doc")
-cargo_test sync > sync-doc-tests.xml
+cargo_test sync sync-tests.xml
 
-junit-report-merger results.xml async-tests.xml sync-tests.xml sync-doc-tests.xml
+junit-report-merger results.xml async-tests.xml sync-tests.xml
+
+# cargo-nextest doesn't support doc tests
+RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)
+(( CARGO_RESULT = ${CARGO_RESULT} || $? ))
 
 exit $CARGO_RESULT

--- a/.evergreen/run-x509-tests.sh
+++ b/.evergreen/run-x509-tests.sh
@@ -21,6 +21,6 @@ FEATURE_FLAGS+=("${TLS_FEATURE}")
 
 set +o errexit
 
-MONGO_X509_USER="$SUBJECT" cargo_test > results.xml
+MONGO_X509_USER="$SUBJECT" cargo_test "" results.xml
 
 exit ${CARGO_RESULT}

--- a/src/change_stream.rs
+++ b/src/change_stream.rs
@@ -50,6 +50,7 @@ use crate::{
 ///
 /// ```
 /// # #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
+/// # {
 /// # use futures::stream::StreamExt;
 /// # use mongodb::{Client, error::Result, bson::doc,
 /// # change_stream::event::ChangeStreamEvent};
@@ -72,6 +73,7 @@ use crate::{
 /// }
 /// #
 /// # Ok(())
+/// # }
 /// # }
 /// ```
 ///

--- a/src/change_stream.rs
+++ b/src/change_stream.rs
@@ -54,7 +54,7 @@ use crate::{
 /// # use mongodb::{Client, error::Result, bson::doc,
 /// # change_stream::event::ChangeStreamEvent};
 /// # #[cfg(feature = "async-std-runtime")]
-/// # use async_std::task;
+/// # use async_std::{task, stream::StreamExt};
 /// # #[cfg(feature = "tokio-runtime")]
 /// # use tokio::task;
 /// #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@
 //! ## Using the async API
 //! ### Connecting to a MongoDB deployment
 //! ```no_run
+//! # #[cfg(not(any(feature = "sync", feature = "tokio-sync")))]
 //! # async fn foo() -> mongodb::error::Result<()> {
 //! use mongodb::{Client, options::ClientOptions};
 //!
@@ -218,7 +219,7 @@
 //!     title: String,
 //!     author: String,
 //! }
-//!
+//! # fn wrapper() -> mongodb::error::Result<()> {
 //! let client = Client::with_uri_str("mongodb://localhost:27017")?;
 //! let database = client.database("mydb");
 //! let collection = database.collection::<Book>("books");
@@ -245,6 +246,8 @@
 //! for result in cursor {
 //!     println!("title: {}", result?.title);
 //! }
+//! # Ok(())
+//! # }
 //! # }
 //! ```
 //!


### PR DESCRIPTION
RUST-1674

This switches to using `cargo-nextest`, with the immediate benefit of removing the need for the unstable output options and corresponding Rust version pinning.  Because `cargo-nextest` runs each test in its own process, our existing test lock no longer works; as a workaround, I've set `cargo-nextest` to only run one test at a time.  Future work for which I've filed tickets:
* RUST-1721 Use test profiles to regain parallelism
* RUST-1722 Remove now-defunct test locks
* RUST-1723 Take advantage of cargo-nextest flaky test detection