### PR TITLE
RUST-1712 Provide a connection pool warmup method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -619,7 +619,7 @@ impl Client {
     /// 
     /// Note that topology changes require rebuilding the connection pool, so this method cannot 
     /// guarantee that the pool will always be filled for the lifetime of the `Client`.
-    pub async fn warm_connection_pool(self) {
+    pub async fn warm_connection_pool(&self) {
         if !self.inner.options.min_pool_size.map_or(false, |s| s > 0) {
             // No-op when min_pool_size is zero.
             return;

--- a/src/client.rs
+++ b/src/client.rs
@@ -615,9 +615,10 @@ impl Client {
     /// Add connections to the connection pool up to `min_pool_size`.  This is normally not needed -
     /// the connection pool will be filled in the background, and new connections created as needed
     /// up to `max_pool_size`.  However, it can sometimes be preferable to pay the (larger) cost of
-    /// creating new connections up-front so that individual operations execute as quickly as possible.
-    /// 
-    /// Note that topology changes require rebuilding the connection pool, so this method cannot 
+    /// creating new connections up-front so that individual operations execute as quickly as
+    /// possible.
+    ///
+    /// Note that topology changes require rebuilding the connection pool, so this method cannot
     /// guarantee that the pool will always be filled for the lifetime of the `Client`.
     pub async fn warm_connection_pool(&self) {
         if !self.inner.options.min_pool_size.map_or(false, |s| s > 0) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -612,6 +612,21 @@ impl Client {
         self.inner.shutdown.executed.store(true, Ordering::SeqCst);
     }
 
+    /// Add connections to the connection pool up to `min_pool_size`.  This is normally not needed -
+    /// the connection pool will be filled in the background, and new connections created as needed
+    /// up to `max_pool_size`.  However, it can sometimes be preferable to pay the (larger) cost of
+    /// creating new connections up-front so that individual operations execute as quickly as possible.
+    /// 
+    /// Note that topology changes require rebuilding the connection pool, so this method cannot 
+    /// guarantee that the pool will always be filled for the lifetime of the `Client`.
+    pub async fn warm_connection_pool(self) {
+        if !self.inner.options.min_pool_size.map_or(false, |s| s > 0) {
+            // No-op when min_pool_size is zero.
+            return;
+        }
+        self.inner.topology.warm_pool().await;
+    }
+
     /// Check in a server session to the server session pool. The session will be discarded if it is
     /// expired or dirty.
     pub(crate) async fn check_in_server_session(&self, session: ServerSession) {

--- a/src/cmap.rs
+++ b/src/cmap.rs
@@ -134,6 +134,9 @@ impl ConnectionPool {
             ConnectionRequestResult::PoolCleared(e) => {
                 Err(Error::pool_cleared_error(&self.address, &e))
             }
+            ConnectionRequestResult::PoolWarmed => {
+                Err(Error::internal("Invalid result from connection requester"))
+            }
         };
 
         match conn {

--- a/src/cmap/connection_requester.rs
+++ b/src/cmap/connection_requester.rs
@@ -23,7 +23,7 @@ pub(super) fn channel(handle: WorkerHandle) -> (ConnectionRequester, ConnectionR
 /// the pool will stop servicing requests, drop its available connections, and close.
 #[derive(Clone, Debug)]
 pub(super) struct ConnectionRequester {
-    sender: mpsc::UnboundedSender<oneshot::Sender<ConnectionRequestResult>>,
+    sender: mpsc::UnboundedSender<ConnectionRequest>,
     _handle: WorkerHandle,
 }
 
@@ -34,18 +34,39 @@ impl ConnectionRequester {
 
         // this only errors if the receiver end is dropped, which can't happen because
         // we own a handle to the worker, keeping it alive.
-        self.sender.send(sender).unwrap();
+        self.sender.send(ConnectionRequest { sender, warm_pool: false }).unwrap();
 
         // similarly, the receiver only returns an error if the sender is dropped, which
         // can't happen due to the handle.
         receiver.await.unwrap()
+    }
+
+    pub(super) fn weak(&self) -> WeakConnectionRequester {
+        WeakConnectionRequester { sender: self.sender.clone() }
+    }
+}
+
+/// Handle for requesting Connections from the pool.  This does *not* keep the
+/// pool alive.
+#[derive(Clone, Debug)]
+pub(super) struct WeakConnectionRequester {
+    sender: mpsc::UnboundedSender<ConnectionRequest>,
+}
+
+impl WeakConnectionRequester {
+    pub(super) async fn request_warm_pool(&self) -> Option<ConnectionRequestResult> {
+        let (sender, receiver) = oneshot::channel();
+        if self.sender.send(ConnectionRequest { sender, warm_pool: true }).is_err() {
+            return None;
+        }
+        receiver.await.ok()
     }
 }
 
 /// Receiving end of a given ConnectionRequester.
 #[derive(Debug)]
 pub(super) struct ConnectionRequestReceiver {
-    receiver: mpsc::UnboundedReceiver<oneshot::Sender<ConnectionRequestResult>>,
+    receiver: mpsc::UnboundedReceiver<ConnectionRequest>,
 }
 
 impl ConnectionRequestReceiver {
@@ -53,7 +74,6 @@ impl ConnectionRequestReceiver {
         self.receiver
             .recv()
             .await
-            .map(|sender| ConnectionRequest { sender })
     }
 }
 
@@ -61,6 +81,7 @@ impl ConnectionRequestReceiver {
 #[derive(Debug)]
 pub(super) struct ConnectionRequest {
     sender: oneshot::Sender<ConnectionRequestResult>,
+    warm_pool: bool,
 }
 
 impl ConnectionRequest {
@@ -71,6 +92,10 @@ impl ConnectionRequest {
         result: ConnectionRequestResult,
     ) -> std::result::Result<(), ConnectionRequestResult> {
         self.sender.send(result)
+    }
+
+    pub(super) fn is_warm_pool(&self) -> bool {
+        self.warm_pool
     }
 }
 
@@ -86,6 +111,9 @@ pub(super) enum ConnectionRequestResult {
     /// The request was rejected because the pool was cleared before it could
     /// be fulfilled. The error that caused the pool to be cleared is returned.
     PoolCleared(Error),
+
+    /// The request set `warm_pool: true` and the pool has reached `min_pool_size`.
+    PoolWarmed,
 }
 
 impl ConnectionRequestResult {

--- a/src/cmap/connection_requester.rs
+++ b/src/cmap/connection_requester.rs
@@ -34,7 +34,12 @@ impl ConnectionRequester {
 
         // this only errors if the receiver end is dropped, which can't happen because
         // we own a handle to the worker, keeping it alive.
-        self.sender.send(ConnectionRequest { sender, warm_pool: false }).unwrap();
+        self.sender
+            .send(ConnectionRequest {
+                sender,
+                warm_pool: false,
+            })
+            .unwrap();
 
         // similarly, the receiver only returns an error if the sender is dropped, which
         // can't happen due to the handle.
@@ -42,7 +47,9 @@ impl ConnectionRequester {
     }
 
     pub(super) fn weak(&self) -> WeakConnectionRequester {
-        WeakConnectionRequester { sender: self.sender.clone() }
+        WeakConnectionRequester {
+            sender: self.sender.clone(),
+        }
     }
 }
 
@@ -56,7 +63,14 @@ pub(super) struct WeakConnectionRequester {
 impl WeakConnectionRequester {
     pub(super) async fn request_warm_pool(&self) -> Option<ConnectionRequestResult> {
         let (sender, receiver) = oneshot::channel();
-        if self.sender.send(ConnectionRequest { sender, warm_pool: true }).is_err() {
+        if self
+            .sender
+            .send(ConnectionRequest {
+                sender,
+                warm_pool: true,
+            })
+            .is_err()
+        {
             return None;
         }
         receiver.await.ok()
@@ -71,9 +85,7 @@ pub(super) struct ConnectionRequestReceiver {
 
 impl ConnectionRequestReceiver {
     pub(super) async fn recv(&mut self) -> Option<ConnectionRequest> {
-        self.receiver
-            .recv()
-            .await
+        self.receiver.recv().await
     }
 }
 

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -7,7 +7,8 @@ use super::{
         ConnectionRequest,
         ConnectionRequestReceiver,
         ConnectionRequestResult,
-        ConnectionRequester, WeakConnectionRequester,
+        ConnectionRequester,
+        WeakConnectionRequester,
     },
     establish::ConnectionEstablisher,
     manager,
@@ -318,7 +319,10 @@ impl ConnectionPoolWorker {
                                 break;
                             }
                             BroadcastMessage::FillPool => {
-                                crate::runtime::execute(fill_pool(self.weak_requester.clone(), ack));
+                                crate::runtime::execute(fill_pool(
+                                    self.weak_requester.clone(),
+                                    ack,
+                                ));
                             }
                             #[cfg(test)]
                             BroadcastMessage::SyncWorkers => {
@@ -392,7 +396,9 @@ impl ConnectionPoolWorker {
                 }
 
                 conn.mark_as_in_use(self.manager.clone());
-                if let Err(request) = request.fulfill(ConnectionRequestResult::Pooled(Box::new(conn))) {
+                if let Err(request) =
+                    request.fulfill(ConnectionRequestResult::Pooled(Box::new(conn)))
+                {
                     // checking out thread stopped listening, indicating it hit the WaitQueue
                     // timeout, so we put connection back into pool.
                     let mut connection = request.unwrap_pooled_connection();

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -7,7 +7,7 @@ use super::{
         ConnectionRequest,
         ConnectionRequestReceiver,
         ConnectionRequestResult,
-        ConnectionRequester,
+        ConnectionRequester, WeakConnectionRequester,
     },
     establish::ConnectionEstablisher,
     manager,
@@ -109,6 +109,10 @@ pub(crate) struct ConnectionPoolWorker {
     /// Receiver used to determine if any threads hold references to this pool. If all the
     /// sender ends of this receiver drop, this worker will be notified and drop too.
     handle_listener: WorkerHandleListener,
+
+    /// Sender for connection check out requests.  Does not keep the worker alive the way
+    /// a `ConnectionRequeter` would since it doesn't hold a `WorkerHandle`.
+    weak_requester: WeakConnectionRequester,
 
     /// Receiver for incoming connection check out requests.
     request_receiver: ConnectionRequestReceiver,
@@ -218,6 +222,7 @@ impl ConnectionPoolWorker {
             service_connection_count: HashMap::new(),
             available_connections: VecDeque::new(),
             max_pool_size,
+            weak_requester: connection_requester.weak(),
             request_receiver,
             wait_queue: Default::default(),
             management_receiver,
@@ -312,6 +317,9 @@ impl ConnectionPoolWorker {
                                 shutdown_ack = Some(ack);
                                 break;
                             }
+                            BroadcastMessage::FillPool => {
+                                crate::runtime::execute(fill_pool(self.weak_requester.clone(), ack));
+                            }
                             #[cfg(test)]
                             BroadcastMessage::SyncWorkers => {
                                 ack.acknowledge(());
@@ -363,30 +371,37 @@ impl ConnectionPoolWorker {
     }
 
     fn check_out(&mut self, request: ConnectionRequest) {
-        // first attempt to check out an available connection
-        while let Some(mut conn) = self.available_connections.pop_back() {
-            // Close the connection if it's stale.
-            if conn.generation.is_stale(&self.generation) {
-                self.close_connection(conn, ConnectionClosedReason::Stale);
-                continue;
+        if request.is_warm_pool() {
+            if self.total_connection_count >= self.min_pool_size.unwrap_or(0) {
+                let _ = request.fulfill(ConnectionRequestResult::PoolWarmed);
+                return;
             }
+        } else {
+            // first attempt to check out an available connection
+            while let Some(mut conn) = self.available_connections.pop_back() {
+                // Close the connection if it's stale.
+                if conn.generation.is_stale(&self.generation) {
+                    self.close_connection(conn, ConnectionClosedReason::Stale);
+                    continue;
+                }
 
-            // Close the connection if it's idle.
-            if conn.is_idle(self.max_idle_time) {
-                self.close_connection(conn, ConnectionClosedReason::Idle);
-                continue;
+                // Close the connection if it's idle.
+                if conn.is_idle(self.max_idle_time) {
+                    self.close_connection(conn, ConnectionClosedReason::Idle);
+                    continue;
+                }
+
+                conn.mark_as_in_use(self.manager.clone());
+                if let Err(request) = request.fulfill(ConnectionRequestResult::Pooled(Box::new(conn))) {
+                    // checking out thread stopped listening, indicating it hit the WaitQueue
+                    // timeout, so we put connection back into pool.
+                    let mut connection = request.unwrap_pooled_connection();
+                    connection.mark_as_available();
+                    self.available_connections.push_back(connection);
+                }
+
+                return;
             }
-
-            conn.mark_as_in_use(self.manager.clone());
-            if let Err(request) = request.fulfill(ConnectionRequestResult::Pooled(Box::new(conn))) {
-                // checking out thread stopped listening, indicating it hit the WaitQueue
-                // timeout, so we put connection back into pool.
-                let mut connection = request.unwrap_pooled_connection();
-                connection.mark_as_available();
-                self.available_connections.push_back(connection);
-            }
-
-            return;
         }
 
         // otherwise, attempt to create a connection.
@@ -667,6 +682,24 @@ async fn establish_connection(
     }
 
     establish_result.map_err(|e| e.cause)
+}
+
+async fn fill_pool(
+    requester: WeakConnectionRequester,
+    ack: crate::runtime::AcknowledgmentSender<()>,
+) {
+    loop {
+        let result = requester.request_warm_pool().await;
+        match result {
+            None => break,
+            Some(ConnectionRequestResult::Establishing(handle)) => {
+                let _ = handle.await;
+                // The connection will be dropped here, returning it to the pool.
+            }
+            _ => break,
+        };
+    }
+    ack.acknowledge(());
 }
 
 /// Enum modeling the possible pool states as described in the CMAP spec.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,7 +21,7 @@ mod worker_handle;
 use std::{future::Future, net::SocketAddr, time::Duration};
 
 pub(crate) use self::{
-    acknowledged_message::{AcknowledgedMessage, AcknowledgmentReceiver},
+    acknowledged_message::{AcknowledgedMessage, AcknowledgmentReceiver, AcknowledgmentSender},
     join_handle::AsyncJoinHandle,
     resolver::AsyncResolver,
     stream::AsyncStream,

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -214,6 +214,10 @@ impl Topology {
         self.updater.shutdown().await;
     }
 
+    pub(crate) async fn warm_pool(&self) {
+        self.updater.fill_pool().await;
+    }
+
     /// Gets the addresses of the servers in the cluster.
     #[cfg(test)]
     pub(crate) fn server_addresses(&mut self) -> HashSet<ServerAddress> {
@@ -278,6 +282,7 @@ pub(crate) enum UpdateMessage {
 #[derive(Debug, Clone)]
 pub(crate) enum BroadcastMessage {
     Shutdown,
+    FillPool,
     #[cfg(test)]
     SyncWorkers,
 }
@@ -874,6 +879,11 @@ impl TopologyUpdater {
 
     pub(crate) async fn shutdown(&self) {
         self.send_message(UpdateMessage::Broadcast(BroadcastMessage::Shutdown))
+            .await;
+    }
+
+    pub(crate) async fn fill_pool(&self) {
+        self.send_message(UpdateMessage::Broadcast(BroadcastMessage::FillPool))
             .await;
     }
 

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -980,7 +980,8 @@ async fn warm_connection_pool() {
             opts.min_pool_size = Some(10);
             opts
         })
-        .build().await;
+        .build()
+        .await;
 
     client.warm_connection_pool().await;
     // Validate that a command executes.

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -968,3 +968,21 @@ async fn manual_shutdown_immediate_with_resources() {
         .is_empty());
     assert!(events.get_command_started_events(&["delete"]).is_empty());
 }
+
+// Verifies that `Client::warm_connection_pool` succeeds.
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn warm_connection_pool() {
+    let _guard = LOCK.run_exclusively().await;
+    let client = Client::test_builder()
+        .options({
+            let mut opts = CLIENT_OPTIONS.get().await.clone();
+            opts.min_pool_size = Some(10);
+            opts
+        })
+        .build().await;
+
+    client.warm_connection_pool().await;
+    // Validate that a command executes.
+    client.list_database_names(None, None).await.unwrap();
+}


### PR DESCRIPTION
RUST-1712

This works by spawning a task that sends check out requests in a loop until the receiving worker reports that the pool has hit `min_pool_size`.  This is a little indirect but seems to have the fewest drawbacks compared to other methods I considered:
* because they're mostly-normal checkout requests, any constraints or other handling of those continues to apply
* allows the worker to continue to process other requests while the pool is warming; initially I was going to implement this loop directly in the worker but that would block requests during the warmup.