### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ In async Rust, it is common to implement cancellation and timeouts by dropping a
 certain period of time instead of polling it to completion. This is how
 [`tokio::time::timeout`](https://docs.rs/tokio/1.10.1/tokio/time/fn.timeout.html) works, for
 example. However, doing this with futures returned by the driver can leave the driver's internals in
-an inconsistent state, which may lead to unpredictable or incorrect behavior (see RUST-937 for more
+an inconsistent state, which may lead to unpredictable or incorrect behavior (see [RUST-937](https://jira.mongodb.org/browse/RUST-937) for more
 details). As such, it is **_highly_** recommended to poll all futures returned from the driver to
 completion. In order to still use timeout mechanisms like `tokio::time::timeout` with the driver,
 one option is to spawn tasks and time out on their

--- a/README.md
+++ b/README.md
@@ -72,20 +72,20 @@ Using the `"sync"` feature also requires using `default-features = false`.
 
 ### All Feature Flags
 
-| Feature              | Description                                                                                                                           | Extra dependencies                  | Default |
-|:---------------------|:--------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------|:--------|
-| `tokio-runtime`      | Enable support for the `tokio` async runtime                                                                                          | `tokio` 1.0 with the `full` feature | yes     |
-| `async-std-runtime`  | Enable support for the `async-std` runtime                                                                                            | `async-std` 1.0                     | no      |
-| `sync`               | Expose the synchronous API (`mongodb::sync`). This flag cannot be used in conjunction with either of the async runtime feature flags. | `async-std` 1.0                     | no      |
-| `aws-auth`           | Enable support for the MONGODB-AWS authentication mechanism.                                                                          | `reqwest` 0.11                      | no      |
-| `bson-uuid-0_8`      | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API of the re-exported `bson` crate.                    | n/a                                 | no      |
-| `bson-uuid-1`        | Enable support for v1.x of the [`uuid`](docs.rs/uuid/1.0) crate in the public API of the re-exported `bson` crate.                    | n/a                                 | no      |
-| `bson-chrono-0_4`    | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API of the re-exported `bson` crate.                | n/a                                 | no      |
-| `bson-serde_with`    | Enable support for the [`serde_with`](docs.rs/serde_with/latest) crate in the public API of the re-exported `bson` crate.             | `serde_with` 1.0                    | no      |
-| `zlib-compression`   | Enable support for compressing messages with [`zlib`](https://zlib.net/)                                                              | `flate2` 1.0                        | no      |
-| `zstd-compression`   | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).                                               | `zstd` 0.9.0                        | no      |
-| `snappy-compression` | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/)                                              | `snap` 1.0.5                        | no      |
-| `openssl-tls`        | Switch TLS connection handling to use ['openssl'](https://docs.rs/openssl/0.10.38/).                                                  | `openssl` 0.10.38                   | no      |
+| Feature              | Description                                                                                                                           | Extra dependencies              | Default |
+|:---------------------|:--------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------|:--------|
+| `tokio-runtime`      | Enable support for the `tokio` async runtime                                                                                          | `tokio` with the `full` feature | yes     |
+| `async-std-runtime`  | Enable support for the `async-std` runtime                                                                                            | `async-std`                     | no      |
+| `sync`               | Expose the synchronous API (`mongodb::sync`). This flag cannot be used in conjunction with either of the async runtime feature flags. | `async-std`                     | no      |
+| `aws-auth`           | Enable support for the MONGODB-AWS authentication mechanism.                                                                          | `reqwest`                       | no      |
+| `bson-uuid-0_8`      | Enable support for v0.8 of the [`uuid`](docs.rs/uuid/0.8) crate in the public API of the re-exported `bson` crate.                    | n/a                             | no      |
+| `bson-uuid-1`        | Enable support for v1.x of the [`uuid`](docs.rs/uuid/1.0) crate in the public API of the re-exported `bson` crate.                    | n/a                             | no      |
+| `bson-chrono-0_4`    | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API of the re-exported `bson` crate.                | n/a                             | no      |
+| `bson-serde_with`    | Enable support for the [`serde_with`](docs.rs/serde_with/latest) crate in the public API of the re-exported `bson` crate.             | `serde_with`                    | no      |
+| `zlib-compression`   | Enable support for compressing messages with [`zlib`](https://zlib.net/)                                                              | `flate2`                        | no      |
+| `zstd-compression`   | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).                                               | `zstd`                          | no      |
+| `snappy-compression` | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/)                                              | `snap`                          | no      |
+| `openssl-tls`        | Switch TLS connection handling to use ['openssl'](https://docs.rs/openssl/0.10.38/).                                                  | `openssl`                       | no      |
 
 ## Example Usage
 Below are simple examples of using the driver. For more specific examples and the API reference, see the driver's [docs.rs page](https://docs.rs/mongodb/latest).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Using the `"sync"` feature also requires using `default-features = false`.
 | `bson-chrono-0_4`    | Enable support for v0.4 of the [`chrono`](docs.rs/chrono/0.4) crate in the public API of the re-exported `bson` crate.                | n/a                                 | no      |
 | `bson-serde_with`    | Enable support for the [`serde_with`](docs.rs/serde_with/latest) crate in the public API of the re-exported `bson` crate.             | `serde_with` 1.0                    | no      |
 | `zlib-compression`   | Enable support for compressing messages with [`zlib`](https://zlib.net/)                                                              | `flate2` 1.0                        | no      |
-| `zstd-compression`   | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).  This flag requires Rust version 1.54.        | `zstd` 0.9.0                        | no      |
+| `zstd-compression`   | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).                                               | `zstd` 0.9.0                        | no      |
 | `snappy-compression` | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/)                                              | `snap` 1.0.5                        | no      |
 | `openssl-tls`        | Switch TLS connection handling to use ['openssl'](https://docs.rs/openssl/0.10.38/).                                                  | `openssl` 0.10.38                       | no      |
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Using the `"sync"` feature also requires using `default-features = false`.
 | `zlib-compression`   | Enable support for compressing messages with [`zlib`](https://zlib.net/)                                                              | `flate2` 1.0                        | no      |
 | `zstd-compression`   | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).                                               | `zstd` 0.9.0                        | no      |
 | `snappy-compression` | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/)                                              | `snap` 1.0.5                        | no      |
-| `openssl-tls`        | Switch TLS connection handling to use ['openssl'](https://docs.rs/openssl/0.10.38/).                                                  | `openssl` 0.10.38                       | no      |
+| `openssl-tls`        | Switch TLS connection handling to use ['openssl'](https://docs.rs/openssl/0.10.38/).                                                  | `openssl` 0.10.38                   | no      |
 
 ## Example Usage
 Below are simple examples of using the driver. For more specific examples and the API reference, see the driver's [docs.rs page](https://docs.rs/mongodb/latest).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MongoDB Rust Driver
 [![Crates.io](https://img.shields.io/crates/v/mongodb.svg)](https://crates.io/crates/mongodb) [![docs.rs](https://docs.rs/mongodb/badge.svg)](https://docs.rs/mongodb) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-This repository contains the officially supported MongoDB Rust driver, a client side library that can be used to interact with MongoDB deployments in Rust applications. It uses the [`bson`](https://docs.rs/bson/latest) crate for BSON support. The driver contains a fully async API that supports either [`tokio`](https://crates.io/crates/tokio) (default) or [`async-std`](https://crates.io/crates/async-std), depending on the feature flags set. The driver also has a sync API that may be enabled via feature flag.
+This repository contains the officially supported MongoDB Rust driver, a client side library that can be used to interact with MongoDB deployments in Rust applications. It uses the [`bson`](https://docs.rs/bson/latest) crate for BSON support. The driver contains a fully async API that supports either [`tokio`](https://crates.io/crates/tokio) (default) or [`async-std`](https://crates.io/crates/async-std), depending on the feature flags set. The driver also has a sync API that may be enabled via feature flags.
 
 For more detailed documentation, see [the manual](https://mongodb.github.io/mongo-rust-driver/manual/).
 


### PR DESCRIPTION
# Summary

This PR includes improvements to README.md. This PR proposes removing version numbers from the `All Feature Flags` table.

Fixes are included in separate commits to help review.

# Background & Rationale

Removing version numbers was motivated by observing out-dated versions. Example: the README lists `tokio` 1.0. Cargo.toml specifies `1.17.0`.

Attempting to use an older incompatible `tokio` version results in a build error. Example:

```
[dependencies.mongodb]
version = "2.6.0"
features = ["tokio-runtime"]

[dependencies]
tokio = { version = ">=1.0.0,<1.17.0", features = ["full"] }
```

Results in a build error:
```
% cargo build
    Updating crates.io index
error: failed to select a version for `tokio`.
    ... required by package `follow-readme v0.1.0 (/Users/q/code/rust-bootstrap/use-rust-driver/follow-readme-async)`
versions that meet the requirements `>=1.0.0, <1.17.0` are: 1.16.1, 1.15.0, 1.14.1, 1.14.0, 1.13.1, 1.13.0, 1.12.0, 1.11.0, 1.10.1, 1.10.0, 1.9.0, 1.8.5, 1.8.4, 1.8.3, 1.8.2, 1.8.1, 1.8.0, 1.7.3, 1.7.2, 1.7.1, 1.7.0, 1.6.4, 1.6.3, 1.6.2, 1.6.1, 1.5.1, 1.5.0, 1.4.0, 1.3.0, 1.2.0, 1.1.1, 1.1.0, 1.0.3, 1.0.2, 1.0.1
```

Rather than update the versions, this PR proposes removing the versions from the README. Readers can refer to Cargo.toml to see the required versions.