### PR TITLE
RUST-1588 Implement `IterateOnce` unified test runner operation

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -208,6 +208,13 @@ impl<T> Cursor<T> {
         self.wrapped_cursor.as_mut().unwrap().advance().await
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) async fn try_advance(&mut self) -> Result<()> {
+        let _ = self.wrapped_cursor.as_mut().unwrap().try_advance().await?;
+        Ok(())
+    }
+
     /// Returns a reference to the current result in the cursor.
     ///
     /// # Panics

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -209,10 +209,13 @@ impl<T> Cursor<T> {
     }
 
     #[cfg(test)]
-    #[allow(dead_code)]
     pub(crate) async fn try_advance(&mut self) -> Result<()> {
-        let _ = self.wrapped_cursor.as_mut().unwrap().try_advance().await?;
-        Ok(())
+        self.wrapped_cursor
+            .as_mut()
+            .unwrap()
+            .try_advance()
+            .await
+            .map(|_| ())
     }
 
     /// Returns a reference to the current result in the cursor.

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -528,9 +528,9 @@ impl CursorBuffer {
         // consumed yet.
         if self.fresh {
             self.fresh = false;
-            return !self.is_empty();
+        } else {
+            self.docs.pop_front();
         }
-        self.docs.pop_front();
         !self.is_empty()
     }
 

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -245,6 +245,15 @@ impl<T> SessionCursor<T> {
         self.make_stream(session).generic_cursor.advance().await
     }
 
+    #[cfg(test)]
+    pub(crate) async fn try_advance(&mut self, session: &mut ClientSession) -> Result<()> {
+        self.make_stream(session)
+            .generic_cursor
+            .try_advance()
+            .await
+            .map(|_| ())
+    }
+
     /// Returns a reference to the current result in the cursor.
     ///
     /// # Panics

--- a/src/test/spec/run_command.rs
+++ b/src/test/spec/run_command.rs
@@ -6,10 +6,8 @@ async fn run_unified() {
     let _guard = LOCK.run_exclusively().await;
     run_unified_tests(&["run-command", "unified"])
         .skip_tests(&[
-            // TODO re: RUST-1649: fix withTransaction for new test runner
+            // TODO RUST-1649: unskip when withTransaction is implemented
             "attaches transaction fields to given command",
-            // TODO fix in a follow up PR because need to add IterateOnce
-            "does not close the cursor when receiving an empty batch",
         ])
         .await;
 }

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -50,6 +50,7 @@ use super::{
     CollectionData,
     Entity,
     SessionEntity,
+    TestCursor,
     TestFileEntity,
 };
 
@@ -697,6 +698,27 @@ impl TestRunner {
             .unwrap()
             .as_client_encryption()
             .clone()
+    }
+
+    /// Removes the cursor with the given ID from the entity map. This method passes ownership of
+    /// the cursor to the caller so that a mutable reference to a ClientSession can be accessed from
+    /// the entity map simultaneously. Once the caller is finished with the cursor, it MUST be
+    /// returned to the test runner via the return_cursor method below.
+    pub(crate) async fn take_cursor(&self, id: impl AsRef<str>) -> TestCursor {
+        self.entities
+            .write()
+            .await
+            .remove(id.as_ref())
+            .unwrap()
+            .into_cursor()
+    }
+
+    /// Returns the given cursor to the entity map. This method must be called after take_cursor.
+    pub(crate) async fn return_cursor(&self, id: impl AsRef<str>, cursor: TestCursor) {
+        self.entities
+            .write()
+            .await
+            .insert(id.as_ref().into(), Entity::Cursor(cursor));
     }
 }
 


### PR DESCRIPTION
This PR implements the `IterateOnce` unified test operation and unskips the "does not close the cursor when receiving an empty batch" `run_cursor_command` test. This operation required adding a test-only `try_advance` method to `Cursor` and `SessionCursor`, which only performs one getMore rather than looping until the buffer has been refilled. I considered adding this method to the public API, but chose not to for a few reasons:

- No users have asked for this functionality.
- Depending upon what we decided the method should return, we might need to add a new type (`AdvanceResult`) to our API as well.
- The existence of `advance` and `try_advance` might be confusing to users.

If we do receive requests for this functionality we can further discuss API and consider making it public then.