### PR TITLE
RUST-1743 Fix gridfs numeric type serialization

### DIFF
--- a/src/gridfs.rs
+++ b/src/gridfs.rs
@@ -31,9 +31,17 @@ pub(crate) struct Chunk<'a> {
     #[serde(rename = "_id")]
     id: ObjectId,
     files_id: Bson,
+    #[serde(serialize_with = "u32_as_i32")]
     n: u32,
     #[serde(borrow)]
     data: RawBinaryRef<'a>,
+}
+
+fn u32_as_i32<S>(value: &u32, ser: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    ser.serialize_i32((*value).try_into().map_err(serde::ser::Error::custom)?)
 }
 
 /// A model for the documents stored in a GridFS bucket's files
@@ -51,7 +59,7 @@ pub struct FilesCollectionDocument {
     pub length: u64,
 
     /// The size of the file's chunks in bytes.
-    #[serde(rename = "chunkSize")]
+    #[serde(rename = "chunkSize", serialize_with = "u32_as_i32")]
     pub chunk_size_bytes: u32,
 
     /// The time at which the file was uploaded.

--- a/src/gridfs.rs
+++ b/src/gridfs.rs
@@ -31,17 +31,10 @@ pub(crate) struct Chunk<'a> {
     #[serde(rename = "_id")]
     id: ObjectId,
     files_id: Bson,
-    #[serde(serialize_with = "u32_as_i32")]
+    #[serde(serialize_with = "bson::serde_helpers::serialize_u32_as_i32")]
     n: u32,
     #[serde(borrow)]
     data: RawBinaryRef<'a>,
-}
-
-fn u32_as_i32<S>(value: &u32, ser: S) -> std::result::Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    ser.serialize_i32((*value).try_into().map_err(serde::ser::Error::custom)?)
 }
 
 /// A model for the documents stored in a GridFS bucket's files
@@ -59,7 +52,10 @@ pub struct FilesCollectionDocument {
     pub length: u64,
 
     /// The size of the file's chunks in bytes.
-    #[serde(rename = "chunkSize", serialize_with = "u32_as_i32")]
+    #[serde(
+        rename = "chunkSize",
+        serialize_with = "bson::serde_helpers::serialize_u32_as_i32"
+    )]
     pub chunk_size_bytes: u32,
 
     /// The time at which the file was uploaded.


### PR DESCRIPTION
RUST-1743

This fixes the ``Chunk.n`` and ``FilesCollectionDocument.chunk_size_bytes`` to serialize as ``i32`` rather than ``i64``.  Happily, deserialization will accept either, so this is backwards-compatible.