### PR TITLE
minor: set test-threads in default nextest profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,6 @@
 [profile.default]
 retries = 1
+test-threads = 1
 
 [profile.ci]
 failure-output = "final"


### PR DESCRIPTION
This removes the need to include it on the command line for local runs.