### PR TITLE
fixing the find or delete serde inconsistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,7 @@ time = "0.3.9"
 tokio = { version = ">= 0.0.0", features = ["fs"] }
 tracing-subscriber = "0.3.16"
 regex = "1.6.0"
+serde-hex = "0.1.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/operation/find_and_modify.rs
+++ b/src/operation/find_and_modify.rs
@@ -146,20 +146,26 @@ impl<'a, R: Serialize, T: DeserializeOwned> OperationWithDefaults for FindAndMod
         response: RawCommandResponse,
         _description: &StreamDescription,
     ) -> Result<Self::O> {
-        let response: Response = response.body()?;
-
-        match response.value {
-            Bson::Document(doc) => Ok(Some(from_document(doc)?)),
-            Bson::Null => Ok(None),
-            other => Err(ErrorKind::InvalidResponse {
-                message: format!(
-                    "expected document for value field of findAndModify response, but instead got \
-                     {:?}",
-                    other
-                ),
-            }
-            .into()),
+        #[derive(Debug, Deserialize)]
+        pub(crate) struct Response<T> {
+            value: Option<T>,
         }
+
+        response.body().map(|r: Response<T>| r.value)
+        // let response: Response = response.body()?;
+
+        // match response.value {
+        //     Bson::Document(doc) => Ok(Some(from_document(doc)?)),
+        //     Bson::Null => Ok(None),
+        //     other => Err(ErrorKind::InvalidResponse {
+        //         message: format!(
+        //             "expected document for value field of findAndModify response, but instead got
+        // \              {:?}",
+        //             other
+        //         ),
+        //     }
+        //     .into()),
+        // }
     }
 
     fn write_concern(&self) -> Option<&WriteConcern> {

--- a/src/operation/find_and_modify.rs
+++ b/src/operation/find_and_modify.rs
@@ -152,20 +152,6 @@ impl<'a, R: Serialize, T: DeserializeOwned> OperationWithDefaults for FindAndMod
         }
 
         response.body().map(|r: Response<T>| r.value)
-        // let response: Response = response.body()?;
-
-        // match response.value {
-        //     Bson::Document(doc) => Ok(Some(from_document(doc)?)),
-        //     Bson::Null => Ok(None),
-        //     other => Err(ErrorKind::InvalidResponse {
-        //         message: format!(
-        //             "expected document for value field of findAndModify response, but instead got
-        // \              {:?}",
-        //             other
-        //         ),
-        //     }
-        //     .into()),
-        // }
     }
 
     fn write_concern(&self) -> Option<&WriteConcern> {
@@ -175,9 +161,4 @@ impl<'a, R: Serialize, T: DeserializeOwned> OperationWithDefaults for FindAndMod
     fn retryability(&self) -> Retryability {
         Retryability::Write
     }
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct Response {
-    value: Bson,
 }

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, collections::HashMap, sync::Arc, time::Duration};
 
 use bson::Document;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     bson::{doc, Bson},
@@ -938,6 +938,39 @@ async fn manual_shutdown_immediate_with_resources() {
         .get_command_started_events(&["abortTransaction"])
         .is_empty());
     assert!(events.get_command_started_events(&["delete"]).is_empty());
+}
+
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn find_one_and_delete_serde_consistency() {
+    let client = Client::test_builder().build().await;
+
+    let coll = client
+        .database("find_one_and_delete_serde_consistency")
+        .collection("test");
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Foo {
+        #[serde(with = "serde_hex::SerHexSeq::<serde_hex::StrictPfx>")]
+        problematic: Vec<u8>,
+    }
+
+    let doc = Foo {
+        problematic: vec![0, 1, 2, 3, 4, 5, 6, 7],
+    };
+
+    coll.insert_one(&doc, None).await.unwrap();
+    let rec: Foo = coll.find_one(doc! {}, None).await.unwrap().unwrap();
+    assert_eq!(doc.problematic, rec.problematic);
+    let rec: Foo = coll
+        .find_one_and_delete(doc! {}, None)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(doc.problematic, rec.problematic);
+
+    let nothing = coll.find_one_and_delete(doc! {}, None).await.unwrap();
+    assert!(nothing.is_none());
 }
 
 // Verifies that `Client::warm_connection_pool` succeeds.


### PR DESCRIPTION
Hello,

I found an inconsistency in the way mongo documents are deserialized when using `serde(with)`  and `find_one_and_delete`. My fix might nor be ideal because it breaks
```
< operation::find_and_modify::test::handle_no_value_delete                                                                                                                                                                                    
< operation::find_and_modify::test::handle_no_value_replace                      
< operation::find_and_modify::test::handle_no_value_update
```
The tests no longer return `Err(_)` but just `Ok(None)`. I am not sure how I can assert that Field is present but can be null, when deserializing `Option<T>` and could not find anything either.

I added a tests to verify my changes fix the issue (see changes)