### PR TITLE
RUST-1698 Fix reading gridfs chunks from async-std file stream

### DIFF
--- a/src/gridfs/upload.rs
+++ b/src/gridfs/upload.rs
@@ -231,6 +231,9 @@ where
             n => n,
         };
         total_bytes_read += bytes_read;
+        if total_bytes_read == buf.len() {
+            break;
+        }
     }
 
     Ok(total_bytes_read)


### PR DESCRIPTION
This works around https://github.com/async-rs/async-std/issues/1066; tokio doesn't have this issue but the workaround works either way.