### PR TITLE
RUST-1757 Fix final cursor batch handling

### DIFF
--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -135,12 +135,14 @@ where
         let result = self.provider.execute(spec, client, pin).await;
         self.handle_get_more_result(result)?;
 
-        if self.is_exhausted() {
-            Ok(AdvanceResult::Exhausted)
-        } else {
-            match self.state_mut().buffer.advance() {
-                true => Ok(AdvanceResult::Advanced),
-                false => Ok(AdvanceResult::Waiting),
+        match self.state_mut().buffer.advance() {
+            true => Ok(AdvanceResult::Advanced),
+            false => {
+                if self.is_exhausted() {
+                    Ok(AdvanceResult::Exhausted)
+                } else {
+                    Ok(AdvanceResult::Waiting)
+                }
             }
         }
     }


### PR DESCRIPTION
RUST-1757

Looks like this broke as part of a refactor a few weeks ago, so the only release it's live in is 2.7.0-beta :)