### PR TITLE
RUST-1763 deprecate CollectionOptions::human_readable_serialization (#957)

### DIFF
--- a/src/coll.rs
+++ b/src/coll.rs
@@ -158,6 +158,7 @@ impl<T> Collection<T> {
         let write_concern = options
             .write_concern
             .or_else(|| db.write_concern().cloned());
+        #[allow(deprecated)]
         let human_readable_serialization = options.human_readable_serialization.unwrap_or_default();
 
         Self {

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -13,27 +13,41 @@ use crate::{
     serde_util,
 };
 
-/// These are the valid options for creating a [`Collection`](../struct.Collection.html) with
-/// [`Database::collection_with_options`](../struct.Database.html#method.collection_with_options).
-#[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
-#[builder(field_defaults(default, setter(into)))]
-#[serde(rename_all = "camelCase")]
-#[non_exhaustive]
-pub struct CollectionOptions {
-    /// The default read preference for operations.
-    pub selection_criteria: Option<SelectionCriteria>,
+// Generated code for `Deserialize` or `TypedBuilder` causes a deprecation warning; annotating the
+// field or struct doesn't fix it because that annotation isn't propagated by the code generator.
+// This works around that by defining it in a non-pub module and immediately re-exporting that
+// module's contents.
+#[allow(deprecated)]
+mod suppress_warning {
+    use super::*;
 
-    /// The default read concern for operations.
-    pub read_concern: Option<ReadConcern>,
+    /// These are the valid options for creating a [`Collection`](../struct.Collection.html) with
+    /// [`Database::collection_with_options`](../struct.Database.html#method.
+    /// collection_with_options).
+    #[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
+    #[builder(field_defaults(default, setter(into)))]
+    #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
+    pub struct CollectionOptions {
+        /// The default read preference for operations.
+        pub selection_criteria: Option<SelectionCriteria>,
 
-    /// The default write concern for operations.
-    pub write_concern: Option<WriteConcern>,
+        /// The default read concern for operations.
+        pub read_concern: Option<ReadConcern>,
 
-    /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`] serializer.
-    /// The default value is `false`.
-    /// Note: Specifying `true` for this value will decrease the performance of insert operations.
-    pub human_readable_serialization: Option<bool>,
+        /// The default write concern for operations.
+        pub write_concern: Option<WriteConcern>,
+
+        /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`]
+        /// serializer. The default value is `false`.
+        /// Note: Specifying `true` for this value will decrease the performance of insert
+        /// operations.
+        #[deprecated = "This is a workaround for a potential bug related to RUST-1687, and should \
+                        not be used in new code."]
+        pub human_readable_serialization: Option<bool>,
+    }
 }
+pub use suppress_warning::*;
 
 /// Specifies whether a
 /// [`Collection::find_one_and_replace`](../struct.Collection.html#method.find_one_and_replace) and


### PR DESCRIPTION
Cherry-pick from https://github.com/mongodb/mongo-rust-driver/pull/957.