### PR TITLE
minor: fix deprecation warnings (#960)

### DIFF
--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -21,9 +21,8 @@ use crate::{
 mod suppress_warning {
     use super::*;
 
-    /// These are the valid options for creating a [`Collection`](../struct.Collection.html) with
-    /// [`Database::collection_with_options`](../struct.Database.html#method.
-    /// collection_with_options).
+    /// These are the valid options for creating a [`Collection`](crate::Collection) with
+    /// [`Database::collection_with_options`](crate::Database::collection_with_options).
     #[derive(Clone, Debug, Default, Deserialize, TypedBuilder)]
     #[builder(field_defaults(default, setter(into)))]
     #[serde(rename_all = "camelCase")]

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -373,6 +373,7 @@ impl CollectionOrDatabaseOptions {
         }
     }
 
+    #[allow(deprecated)]
     pub(crate) fn as_collection_options(&self) -> CollectionOptions {
         CollectionOptions {
             read_concern: self.read_concern.clone(),


### PR DESCRIPTION
Cherry-pick from https://github.com/mongodb/mongo-rust-driver/pull/960.