### PR TITLE
RUST-935 direct retries to different mongos

### DIFF
--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -77,10 +77,14 @@ async fn run_test(test_file: TestFile) {
     .into();
 
     for _ in 0..test_file.iterations {
-        let selection =
-            server_selection::attempt_to_select_server(&read_pref, &topology_description, &servers)
-                .expect("selection should not fail")
-                .expect("a server should have been selected");
+        let selection = server_selection::attempt_to_select_server(
+            &read_pref,
+            &topology_description,
+            &servers,
+            None,
+        )
+        .expect("selection should not fail")
+        .expect("a server should have been selected");
         *tallies.entry(selection.address.clone()).or_insert(0) += 1;
     }
 

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -173,11 +173,15 @@ async fn retry_read_different_mongos() {
     client_options.hosts.drain(2..);
 
     let mut guards = vec![];
-    for ix in 0..=1 {
+    for ix in [0, 1] {
         let mut opts = client_options.clone();
         opts.hosts.remove(ix);
         opts.direct_connection = Some(true);
         let client = Client::test_builder().options(opts).build().await;
+        if !client.supports_fail_command() {
+            log_uncaptured("skipping retry_read_different_mongos: requires failCommand");
+            return;
+        }
         let fail_opts = FailCommandOptions::builder()
             .error_code(6)
             .close_connection(true)

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -176,6 +176,7 @@ async fn retry_read_different_mongos() {
     for ix in 0..=1 {
         let mut opts = client_options.clone();
         opts.hosts.remove(ix);
+        opts.direct_connection = Some(true);
         let client = Client::test_builder().options(opts).build().await;
         let fail_opts = FailCommandOptions::builder()
             .error_code(6)

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -171,6 +171,7 @@ async fn retry_read_different_mongos() {
         return;
     }
     client_options.hosts.drain(2..);
+    client_options.retry_reads = Some(true);
 
     let mut guards = vec![];
     for ix in [0, 1] {
@@ -190,7 +191,7 @@ async fn retry_read_different_mongos() {
         guards.push(client.enable_failpoint(fp, None).await.unwrap());
     }
 
-    let client = Client::test_builder().options(client_options.clone()).event_client().build().await;
+    let client = Client::test_builder().options(client_options).event_client().build().await;
     let result = client.database("test").collection::<bson::Document>("retry_read_different_mongos").find(doc! { }, None).await;
     assert!(result.is_err());
     let events = client.get_command_events(&["find"]);
@@ -208,4 +209,53 @@ async fn retry_read_different_mongos() {
     );
 
     drop(guards);  // enforce lifetime
+}
+
+// Retryable Reads Are Retried on the Same mongos if No Others are Available
+#[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn retry_read_same_mongos() {
+    let init_client = Client::test_builder().build().await;
+    if !init_client.supports_fail_command() {
+        log_uncaptured("skipping retry_read_same_mongos: requires failCommand");
+        return;
+    }
+    if !init_client.is_sharded() {
+        log_uncaptured("skipping retry_read_same_mongos: requires sharded cluster");
+        return;
+    }
+
+    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    client_options.hosts.drain(1..);
+    client_options.retry_reads = Some(true);
+    let fp_guard = {
+        let mut client_options = client_options.clone();
+        client_options.direct_connection = Some(true);
+        let client = Client::test_builder().options(client_options).build().await;
+        let fail_opts = FailCommandOptions::builder()
+            .error_code(6)
+            .close_connection(true)
+            .build();
+        let fp = FailPoint::fail_command(&["find"], FailPointMode::Times(1), Some(fail_opts));
+        client.enable_failpoint(fp, None).await.unwrap()
+    };
+
+    let client = Client::test_builder().options(client_options).event_client().build().await;
+    let result = client.database("test").collection::<bson::Document>("retry_read_same_mongos").find(doc! { }, None).await;
+    assert!(result.is_ok(), "{:?}", result);
+    let events = client.get_command_events(&["find"]);
+    assert!(
+        matches!(
+            &events[..],
+            &[
+                CommandEvent::Started(_),
+                CommandEvent::Failed(_),
+                CommandEvent::Started(_),
+                CommandEvent::Succeeded(_),
+            ]
+        ),
+        "unexpected events: {:#?}", events,
+    );
+
+    drop(fp_guard);  // enforce lifetime
 }

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -585,7 +585,10 @@ async fn retry_write_retryable_write_error() {
 async fn retry_write_different_mongos() {
     let mut client_options = CLIENT_OPTIONS.get().await.clone();
     if client_options.repl_set_name.is_some() || client_options.hosts.len() < 2 {
-        log_uncaptured("skipping retry_write_different_mongos: requires sharded cluster with at least two hosts");
+        log_uncaptured(
+            "skipping retry_write_different_mongos: requires sharded cluster with at least two \
+             hosts",
+        );
         return;
     }
     client_options.hosts.drain(2..);
@@ -610,8 +613,16 @@ async fn retry_write_different_mongos() {
         guards.push(client.enable_failpoint(fp, None).await.unwrap());
     }
 
-    let client = Client::test_builder().options(client_options).event_client().build().await;
-    let result = client.database("test").collection::<bson::Document>("retry_write_different_mongos").insert_one(doc! { }, None).await;
+    let client = Client::test_builder()
+        .options(client_options)
+        .event_client()
+        .build()
+        .await;
+    let result = client
+        .database("test")
+        .collection::<bson::Document>("retry_write_different_mongos")
+        .insert_one(doc! {}, None)
+        .await;
     assert!(result.is_err());
     let events = client.get_command_events(&["insert"]);
     assert!(
@@ -624,10 +635,11 @@ async fn retry_write_different_mongos() {
                 CommandEvent::Failed(_),
             ]
         ),
-        "unexpected events: {:#?}", events,
+        "unexpected events: {:#?}",
+        events,
     );
 
-    drop(guards);  // enforce lifetime
+    drop(guards); // enforce lifetime
 }
 
 // Retryable Reads Are Retried on the Same mongos if No Others are Available
@@ -660,8 +672,16 @@ async fn retry_write_same_mongos() {
         client.enable_failpoint(fp, None).await.unwrap()
     };
 
-    let client = Client::test_builder().options(client_options).event_client().build().await;
-    let result = client.database("test").collection::<bson::Document>("retry_write_same_mongos").insert_one(doc! { }, None).await;
+    let client = Client::test_builder()
+        .options(client_options)
+        .event_client()
+        .build()
+        .await;
+    let result = client
+        .database("test")
+        .collection::<bson::Document>("retry_write_same_mongos")
+        .insert_one(doc! {}, None)
+        .await;
     assert!(result.is_ok(), "{:?}", result);
     let events = client.get_command_events(&["insert"]);
     assert!(
@@ -674,8 +694,9 @@ async fn retry_write_same_mongos() {
                 CommandEvent::Succeeded(_),
             ]
         ),
-        "unexpected events: {:#?}", events,
+        "unexpected events: {:#?}",
+        events,
     );
 
-    drop(fp_guard);  // enforce lifetime
+    drop(fp_guard); // enforce lifetime
 }


### PR DESCRIPTION
RUST-935

I opted to introduce the `SelectionRetry` wrapper so that the actual details of what it is and how it's used only need to be known within `attempt_to_select_server` - callers just need to preserve it and pass it back in.  I did consider making this part of `SelectionCriteria`, but that would have been a pretty major refactoring since that would have to move from the current `enum` to a `struct` with a "kind" enum.