### PR TITLE
RUST-1749 Update log_uncaptured to bypass cargo nextest

### DIFF
--- a/.evergreen/cargo-test.sh
+++ b/.evergreen/cargo-test.sh
@@ -24,7 +24,12 @@ cargo_test_options() {
 }
 
 cargo_test() {
-  RUST_BACKTRACE=1 cargo nextest run --profile ci $(cargo_test_options $1)
+  LOG_PATH=$(mktemp)
+  tail -f ${LOG_PATH} &
+  TAIL_PID=$!
+  LOG_UNCAPTURED=${LOG_PATH} RUST_BACKTRACE=1 cargo nextest run --profile ci $(cargo_test_options $1)
   ((CARGO_RESULT = ${CARGO_RESULT} || $?))
   mv target/nextest/ci/junit.xml $2
+  kill ${TAIL_PID}
+  rm ${LOG_PATH}
 }


### PR DESCRIPTION
RUST-1749

This is a little complex because I had to use two tricks here:
* When running attached to a terminal (i.e. local testing), writing directly to `/dev/tty` will bypass the indirection.
* However, there's no attached terminal when running on Evergreen, so in that case it creates a temporary file and runs a background task tailing that file before running the tests.