### PR TITLE
RUST-1707 Add durations to connection pool events

### DIFF
--- a/src/cmap.rs
+++ b/src/cmap.rs
@@ -9,6 +9,8 @@ pub(crate) mod options;
 mod status;
 mod worker;
 
+use std::time::Instant;
+
 use derivative::Derivative;
 
 pub use self::conn::ConnectionInfo;
@@ -119,6 +121,7 @@ impl ConnectionPool {
     /// front of the wait queue, and then will block again if no available connections are in the
     /// pool and the total number of connections is not less than the max pool size.
     pub(crate) async fn check_out(&self) -> Result<Connection> {
+        let time_started = Instant::now();
         self.event_emitter.emit_event(|| {
             ConnectionCheckoutStartedEvent {
                 address: self.address.clone(),
@@ -142,25 +145,17 @@ impl ConnectionPool {
         match conn {
             Ok(ref conn) => {
                 self.event_emitter
-                    .emit_event(|| conn.checked_out_event().into());
+                    .emit_event(|| conn.checked_out_event(time_started).into());
             }
-            #[cfg(feature = "tracing-unstable")]
-            Err(ref err) => {
+            
+            Err(ref _err) => {
                 self.event_emitter.emit_event(|| {
                     ConnectionCheckoutFailedEvent {
                         address: self.address.clone(),
                         reason: ConnectionCheckoutFailedReason::ConnectionError,
-                        error: Some(err.clone()),
-                    }
-                    .into()
-                });
-            }
-            #[cfg(not(feature = "tracing-unstable"))]
-            Err(_) => {
-                self.event_emitter.emit_event(|| {
-                    ConnectionCheckoutFailedEvent {
-                        address: self.address.clone(),
-                        reason: ConnectionCheckoutFailedReason::ConnectionError,
+                        #[cfg(feature = "tracing-unstable")]
+                        error: Some(_err.clone()),
+                        duration: Instant::now() - time_started,
                     }
                     .into()
                 });

--- a/src/cmap.rs
+++ b/src/cmap.rs
@@ -147,7 +147,7 @@ impl ConnectionPool {
                 self.event_emitter
                     .emit_event(|| conn.checked_out_event(time_started).into());
             }
-            
+
             Err(ref _err) => {
                 self.event_emitter.emit_event(|| {
                     ConnectionCheckoutFailedEvent {

--- a/src/cmap/conn.rs
+++ b/src/cmap/conn.rs
@@ -172,7 +172,13 @@ impl Connection {
     /// Create a connection intended for monitoring purposes.
     /// TODO: RUST-1454 Rename this to just `new`, drop the pooling-specific data.
     pub(crate) fn new_monitoring(address: ServerAddress, stream: AsyncStream, id: u32) -> Self {
-        Self::new(address, stream, id, ConnectionGeneration::Monitoring, Instant::now())
+        Self::new(
+            address,
+            stream,
+            id,
+            ConnectionGeneration::Monitoring,
+            Instant::now(),
+        )
     }
 
     pub(crate) fn info(&self) -> ConnectionInfo {

--- a/src/cmap/test/event.rs
+++ b/src/cmap/test/event.rs
@@ -1,4 +1,7 @@
-use std::{sync::{Arc, RwLock}, time::Duration};
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
 use serde::{de::Unexpected, Deserialize, Deserializer, Serialize};
 

--- a/src/cmap/test/event.rs
+++ b/src/cmap/test/event.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::{sync::{Arc, RwLock}, time::Duration};
 
 use serde::{de::Unexpected, Deserialize, Deserializer, Serialize};
 
@@ -268,5 +268,6 @@ where
         reason,
         #[cfg(feature = "tracing-unstable")]
         error: None,
+        duration: Duration::ZERO,
     })
 }

--- a/src/cmap/worker.rs
+++ b/src/cmap/worker.rs
@@ -38,7 +38,7 @@ use crate::{
 
 use std::{
     collections::{HashMap, VecDeque},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 const DEFAULT_MAX_CONNECTING: u32 = 2;
@@ -468,6 +468,7 @@ impl ConnectionPoolWorker {
             address: self.address.clone(),
             generation: self.generation.clone(),
             event_emitter: self.event_emitter.clone(),
+            time_created: Instant::now(),
         };
         self.next_connection_id += 1;
         self.event_emitter

--- a/src/event/cmap.rs
+++ b/src/event/cmap.rs
@@ -135,6 +135,9 @@ pub struct ConnectionReadyEvent {
     /// to identify other events related to this connection.
     #[serde(default = "default_connection_id")]
     pub connection_id: u32,
+
+    /// The time it took to establish the connection.
+    pub duration: Duration,
 }
 
 /// Event emitted when a connection is closed.
@@ -216,6 +219,9 @@ pub struct ConnectionCheckoutFailedEvent {
     #[serde(skip)]
     #[derivative(PartialEq = "ignore")]
     pub(crate) error: Option<crate::error::Error>,
+
+    /// See [ConnectionCheckedOutEvent::duration].
+    pub duration: Duration,
 }
 
 /// The reasons a connection may not be able to be checked out.
@@ -245,6 +251,9 @@ pub struct ConnectionCheckedOutEvent {
     /// to identify other events related to this connection.
     #[serde(default = "default_connection_id")]
     pub connection_id: u32,
+
+    /// The time it took to check out the connection.
+    pub duration: Duration,
 }
 
 /// Event emitted when a connection is checked back into a connection pool.

--- a/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-logging.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-logging.json
@@ -140,6 +140,13 @@
                     "int",
                     "long"
                   ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
                 }
               }
             },
@@ -159,6 +166,13 @@
                 },
                 "serverPort": {
                   "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]
@@ -424,6 +438,13 @@
                 "reason": "An error occurred while trying to establish a new connection",
                 "error": {
                   "$$exists": true
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
                 }
               }
             }

--- a/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-logging.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-logging.yml
@@ -66,7 +66,8 @@ tests:
               driverConnectionId: { $$type: [int, long] }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
-          
+              durationMS: { $$type: [double, int, long] }
+
           - level: debug
             component: connection
             data:
@@ -74,6 +75,7 @@ tests:
               driverConnectionId: { $$type: [int, long] }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
 
           - level: debug
             component: connection
@@ -194,3 +196,4 @@ tests:
               serverPort: { $$type: [int, long] }
               reason: "An error occurred while trying to establish a new connection"
               error: { $$exists: true }
+              durationMS: { $$type: [double, int, long] }

--- a/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-pool-options.json
+++ b/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-pool-options.json
@@ -1,5 +1,5 @@
 {
-  "description": "connection-logging",
+  "description": "connection-pool-options",
   "schemaVersion": "1.13",
   "runOnRequirements": [
     {
@@ -125,6 +125,13 @@
                 },
                 "serverPort": {
                   "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]

--- a/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-pool-options.yml
+++ b/src/test/spec/json/connection-monitoring-and-pooling/logging/connection-pool-options.yml
@@ -1,4 +1,4 @@
-description: "connection-logging"
+description: "connection-pool-options"
 
 schemaVersion: "1.13"
 
@@ -71,6 +71,7 @@ tests:
               driverConnectionId: { $$type: [int, long] }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
 
   # Drivers who have not done DRIVERS-1943 will need to skip this test.
   - description: "maxConnecting should be included in connection pool created message when specified"

--- a/src/trace/connection.rs
+++ b/src/trace/connection.rs
@@ -95,6 +95,7 @@ impl CmapEventHandler for ConnectionTracingEventEmitter {
             serverHost = event.address.host().as_ref(),
             serverPort = event.address.port_tracing_representation(),
             driverConnectionId = event.connection_id,
+            durationMS = event.duration.as_millis(),
             "Connection ready",
         );
     }
@@ -130,6 +131,7 @@ impl CmapEventHandler for ConnectionTracingEventEmitter {
             serverPort = event.address.port_tracing_representation(),
             reason = event.reason.tracing_representation(),
             error = event.error.map(|e| e.tracing_representation()),
+            durationMS = event.duration.as_millis(),
             "Connection checkout failed",
         );
     }
@@ -141,6 +143,7 @@ impl CmapEventHandler for ConnectionTracingEventEmitter {
             serverHost = event.address.host().as_ref(),
             serverPort = event.address.port_tracing_representation(),
             driverConnectionId = event.connection_id,
+            durationMS = event.duration.as_millis(),
             "Connection checked out",
         );
     }


### PR DESCRIPTION
RUST-1707

Just a bit of data plumbing.  This also includes RUST-1742, which just updated the spec for the details of how the duration is measured.