### PR TITLE
RUST-933 Add support for the srvMaxHosts option

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,4 @@
 [profile.default]
-retries = 1
 test-threads = 1
 
 [profile.ci]

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -712,6 +712,8 @@ impl Serialize for ClientOptions {
             zlibcompressionlevel: &'a Option<i32>,
 
             loadbalanced: &'a Option<bool>,
+
+            srvmaxhosts: Option<i32>,
         }
 
         let client_options = ClientOptionsHelper {
@@ -736,6 +738,7 @@ impl Serialize for ClientOptions {
             writeconcern: &self.write_concern,
             loadbalanced: &self.load_balanced,
             zlibcompressionlevel: &None,
+            srvmaxhosts: self.srv_max_hosts.map(|v| v as i32),
         };
 
         client_options.serialize(serializer)

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -1262,10 +1262,14 @@ impl ClientOptions {
                 if let Some(max) = options.srv_max_hosts {
                     if max > 0 {
                         if options.repl_set_name.is_some() {
-                            return Err(Error::invalid_argument("srvMaxHosts and replicaSet cannot both be present"));
+                            return Err(Error::invalid_argument(
+                                "srvMaxHosts and replicaSet cannot both be present",
+                            ));
                         }
                         if options.load_balanced == Some(true) {
-                            return Err(Error::invalid_argument("srvMaxHosts and loadBalanced=true cannot both be present"));
+                            return Err(Error::invalid_argument(
+                                "srvMaxHosts and loadBalanced=true cannot both be present",
+                            ));
                         }
                         use rand::prelude::SliceRandom;
                         config.hosts.shuffle(&mut rand::thread_rng());
@@ -1745,14 +1749,20 @@ impl ConnectionString {
 
         if let Some(srv_max_hosts) = conn_str.srv_max_hosts {
             if !srv {
-                return Err(Error::invalid_argument("srvMaxHosts cannot be specified with a non-SRV URI"));
+                return Err(Error::invalid_argument(
+                    "srvMaxHosts cannot be specified with a non-SRV URI",
+                ));
             }
             if srv_max_hosts > 0 {
                 if conn_str.replica_set.is_some() {
-                    return Err(Error::invalid_argument("srvMaxHosts and replicaSet cannot both be present"));
+                    return Err(Error::invalid_argument(
+                        "srvMaxHosts and replicaSet cannot both be present",
+                    ));
                 }
                 if conn_str.load_balanced == Some(true) {
-                    return Err(Error::invalid_argument("srvMaxHosts and loadBalanced=true cannot both be present"));
+                    return Err(Error::invalid_argument(
+                        "srvMaxHosts and loadBalanced=true cannot both be present",
+                    ));
                 }
             }
         }

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -1274,9 +1274,9 @@ impl ClientOptions {
                                 "srvMaxHosts and loadBalanced=true cannot both be present",
                             ));
                         }
-                        use rand::prelude::SliceRandom;
-                        config.hosts.shuffle(&mut rand::thread_rng());
-                        config.hosts.truncate(max as usize);
+                        config.hosts = crate::sdam::choose_n(&config.hosts, max as usize)
+                            .cloned()
+                            .collect();
                     }
                 }
 

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -75,6 +75,8 @@ async fn run_test(test_file: TestFile) {
                 )
             // The Rust driver disallows `maxPoolSize=0`.
             || test_case.description.contains("maxPoolSize=0 does not error")
+            // TODO RUST-933 implement custom srvServiceName support
+            || test_case.description.contains("custom srvServiceName")
         {
             continue;
         }

--- a/src/sdam.rs
+++ b/src/sdam.rs
@@ -13,6 +13,7 @@ pub(crate) use self::{
     description::{
         server::{ServerDescription, TopologyVersion},
         topology::{
+            choose_n,
             server_selection::{self, SelectedServer},
             verify_max_staleness,
             TopologyDescription,

--- a/src/sdam/description/topology.rs
+++ b/src/sdam/description/topology.rs
@@ -399,7 +399,7 @@ impl TopologyDescription {
             if max > 0 && max < self.servers.len() + new.len() {
                 use rand::prelude::SliceRandom;
                 new.shuffle(&mut rand::thread_rng());
-                new.truncate(max.checked_sub(self.servers.len()).unwrap_or(0));
+                new.truncate(max.saturating_sub(self.servers.len()));
             }
         }
         self.servers.extend(new);

--- a/src/sdam/description/topology.rs
+++ b/src/sdam/description/topology.rs
@@ -397,9 +397,9 @@ impl TopologyDescription {
         if let Some(max) = self.srv_max_hosts {
             let max = max as usize;
             if max > 0 && max < self.servers.len() + new.len() {
-                use rand::prelude::SliceRandom;
-                new.shuffle(&mut rand::thread_rng());
-                new.truncate(max.saturating_sub(self.servers.len()));
+                new = choose_n(&new, max.saturating_sub(self.servers.len()))
+                    .cloned()
+                    .collect();
             }
         }
         self.servers.extend(new);
@@ -747,6 +747,11 @@ impl TopologyDescription {
             }
         }
     }
+}
+
+pub(crate) fn choose_n<T>(values: &[T], n: usize) -> impl Iterator<Item = &T> {
+    use rand::{prelude::SliceRandom, SeedableRng};
+    values.choose_multiple(&mut rand::rngs::SmallRng::from_entropy(), n)
 }
 
 /// Enum representing whether transactions are supported by the topology.

--- a/src/sdam/description/topology.rs
+++ b/src/sdam/description/topology.rs
@@ -397,11 +397,9 @@ impl TopologyDescription {
         if let Some(max) = self.srv_max_hosts {
             let max = max as usize;
             if max > 0 && max < self.servers.len() + new.len() {
-                if let Some(capacity) = (max as usize).checked_sub(self.servers.len()) {
-                    use rand::prelude::SliceRandom;
-                    new.shuffle(&mut rand::thread_rng());
-                    new.truncate(capacity);
-                }
+                use rand::prelude::SliceRandom;
+                new.shuffle(&mut rand::thread_rng());
+                new.truncate(max.checked_sub(self.servers.len()).unwrap_or(0));
             }
         }
         self.servers.extend(new);

--- a/src/sdam/description/topology/server_selection.rs
+++ b/src/sdam/description/topology/server_selection.rs
@@ -3,8 +3,6 @@ mod test;
 
 use std::{collections::HashMap, fmt, ops::Deref, sync::Arc, time::Duration};
 
-use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng};
-
 use super::TopologyDescription;
 use crate::{
     error::{ErrorKind, Result},
@@ -86,9 +84,7 @@ fn select_server_in_latency_window(in_window: Vec<&Arc<Server>>) -> Option<Arc<S
         return Some(in_window[0].clone());
     }
 
-    let mut rng = SmallRng::from_entropy();
-    in_window
-        .choose_multiple(&mut rng, 2)
+    super::choose_n(&in_window, 2)
         .min_by_key(|s| s.operation_count())
         .map(|server| (*server).clone())
 }

--- a/src/sdam/description/topology/server_selection/test.rs
+++ b/src/sdam/description/topology/server_selection/test.rs
@@ -52,6 +52,7 @@ impl TestTopologyDescription {
             local_threshold: None,
             heartbeat_freq: heartbeat_frequency,
             servers,
+            srv_max_hosts: None,
         }
     }
 }

--- a/src/sdam/srv_polling.rs
+++ b/src/sdam/srv_polling.rs
@@ -120,7 +120,9 @@ impl SrvPollingMonitor {
         }
         let initial_hostname = self.initial_hostname.clone();
         let resolver = self.get_or_create_srv_resolver().await?;
-        resolver.get_srv_hosts(initial_hostname.as_str(), crate::srv::DomainMismatch::Skip).await
+        resolver
+            .get_srv_hosts(initial_hostname.as_str(), crate::srv::DomainMismatch::Skip)
+            .await
     }
 
     async fn get_or_create_srv_resolver(&mut self) -> Result<&SrvResolver> {

--- a/src/sdam/srv_polling.rs
+++ b/src/sdam/srv_polling.rs
@@ -129,10 +129,7 @@ impl SrvPollingMonitor {
         }
 
         let resolver =
-            SrvResolver::new(
-                self.client_options.resolver_config.clone().map(|c| c.inner),
-                self.client_options.srv_max_hosts,
-            ).await?;
+            SrvResolver::new(self.client_options.resolver_config.clone().map(|c| c.inner)).await?;
 
         // Since the connection was not `Some` above, this will always insert the new connection and
         // return a reference to it.

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -60,7 +60,7 @@ async fn run_test_extra(
 
 fn make_lookup_hosts(hosts: Vec<ServerAddress>) -> Result<LookupHosts> {
     Ok(LookupHosts {
-        hosts: hosts,
+        hosts,
         min_ttl: Duration::from_secs(60),
     })
 }

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -29,12 +29,19 @@ async fn run_test(new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet
     run_test_srv(None, new_hosts, expected_hosts).await
 }
 
-async fn run_test_srv(max_hosts: Option<u32>, new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet<ServerAddress>) {
+async fn run_test_srv(
+    max_hosts: Option<u32>,
+    new_hosts: Result<Vec<ServerAddress>>,
+    expected_hosts: HashSet<ServerAddress>,
+) {
     let actual = run_test_extra(max_hosts, new_hosts).await;
     assert_eq!(expected_hosts, actual);
 }
 
-async fn run_test_extra(max_hosts: Option<u32>, new_hosts: Result<Vec<ServerAddress>>) -> HashSet<ServerAddress> {
+async fn run_test_extra(
+    max_hosts: Option<u32>,
+    new_hosts: Result<Vec<ServerAddress>>,
+) -> HashSet<ServerAddress> {
     let mut options = ClientOptions::new_srv();
     options.hosts = DEFAULT_HOSTS.clone();
     options.test_options_mut().disable_monitoring_threads = true;
@@ -161,7 +168,8 @@ async fn srv_max_hosts_zero() {
     run_test_srv(Some(0), Ok(hosts.clone()), hosts.into_iter().collect()).await;
 }
 
-// SRV polling with srvMaxHosts MongoClient option: All DNS records are selected (srvMaxHosts >= records)
+// SRV polling with srvMaxHosts MongoClient option: All DNS records are selected (srvMaxHosts >=
+// records)
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn srv_max_hosts_gt_actual() {
@@ -173,7 +181,8 @@ async fn srv_max_hosts_gt_actual() {
     run_test_srv(Some(2), Ok(hosts.clone()), hosts.into_iter().collect()).await;
 }
 
-// SRV polling with srvMaxHosts MongoClient option: New DNS records are randomly selected (srvMaxHosts > 0)
+// SRV polling with srvMaxHosts MongoClient option: New DNS records are randomly selected
+// (srvMaxHosts > 0)
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn srv_max_hosts_random() {

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -26,9 +26,19 @@ lazy_static::lazy_static! {
 }
 
 async fn run_test(new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet<ServerAddress>) {
+    run_test_srv(None, new_hosts, expected_hosts).await
+}
+
+async fn run_test_srv(max_hosts: Option<u32>, new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet<ServerAddress>) {
+    let actual = run_test_extra(max_hosts, new_hosts).await;
+    assert_eq!(expected_hosts, actual);
+}
+
+async fn run_test_extra(max_hosts: Option<u32>, new_hosts: Result<Vec<ServerAddress>>) -> HashSet<ServerAddress> {
     let mut options = ClientOptions::new_srv();
     options.hosts = DEFAULT_HOSTS.clone();
     options.test_options_mut().disable_monitoring_threads = true;
+    options.srv_max_hosts = max_hosts;
     let mut topology = Topology::new(options.clone()).unwrap();
     topology.watch().wait_until_initialized().await;
     let mut monitor =
@@ -38,12 +48,12 @@ async fn run_test(new_hosts: Result<Vec<ServerAddress>>, expected_hosts: HashSet
         .update_hosts(new_hosts.and_then(make_lookup_hosts))
         .await;
 
-    assert_eq!(expected_hosts, topology.server_addresses());
+    topology.server_addresses()
 }
 
 fn make_lookup_hosts(hosts: Vec<ServerAddress>) -> Result<LookupHosts> {
     Ok(LookupHosts {
-        hosts: hosts.into_iter().map(Result::Ok).collect(),
+        hosts: hosts,
         min_ttl: Duration::from_secs(60),
     })
 }
@@ -135,4 +145,45 @@ async fn load_balanced_no_srv_polling() {
         hosts.into_iter().collect::<HashSet<_>>(),
         topology.server_addresses()
     );
+}
+
+// SRV polling with srvMaxHosts MongoClient option: All DNS records are selected (srvMaxHosts = 0)
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn srv_max_hosts_zero() {
+    let hosts = vec![
+        localhost_test_build_10gen(27017),
+        localhost_test_build_10gen(27019),
+        localhost_test_build_10gen(27020),
+    ];
+
+    run_test_srv(None, Ok(hosts.clone()), hosts.clone().into_iter().collect()).await;
+    run_test_srv(Some(0), Ok(hosts.clone()), hosts.into_iter().collect()).await;
+}
+
+// SRV polling with srvMaxHosts MongoClient option: All DNS records are selected (srvMaxHosts >= records)
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn srv_max_hosts_gt_actual() {
+    let hosts = vec![
+        localhost_test_build_10gen(27019),
+        localhost_test_build_10gen(27020),
+    ];
+
+    run_test_srv(Some(2), Ok(hosts.clone()), hosts.into_iter().collect()).await;
+}
+
+// SRV polling with srvMaxHosts MongoClient option: New DNS records are randomly selected (srvMaxHosts > 0)
+#[cfg_attr(feature = "tokio-runtime", tokio::test)]
+#[cfg_attr(feature = "async-std-runtime", async_std::test)]
+async fn srv_max_hosts_random() {
+    let hosts = vec![
+        localhost_test_build_10gen(27017),
+        localhost_test_build_10gen(27019),
+        localhost_test_build_10gen(27020),
+    ];
+
+    let actual = run_test_extra(Some(2), Ok(hosts)).await;
+    assert_eq!(2, actual.len());
+    assert!(actual.contains(&localhost_test_build_10gen(27017)));
 }

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -480,7 +480,7 @@ impl TopologyWorker {
 
     async fn sync_hosts(&mut self, hosts: HashSet<ServerAddress>) -> bool {
         let mut new_description = self.topology_description.clone();
-        new_description.sync_hosts(&hosts);
+        new_description.sync_hosts(hosts);
         self.update_topology(new_description).await
     }
 

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -64,7 +64,11 @@ impl SrvResolver {
         Ok(config)
     }
 
-    pub(crate) async fn get_srv_hosts(&self, original_hostname: &str, dm: DomainMismatch) -> Result<LookupHosts> {
+    pub(crate) async fn get_srv_hosts(
+        &self,
+        original_hostname: &str,
+        dm: DomainMismatch,
+    ) -> Result<LookupHosts> {
         let hostname_parts: Vec<_> = original_hostname.split('.').collect();
 
         if hostname_parts.len() < 3 {
@@ -108,7 +112,8 @@ impl SrvResolver {
                 if matches!(dm, DomainMismatch::Error) {
                     return Err(ErrorKind::DnsResolve {
                         message: format!(
-                            "SRV lookup for {} returned result {}, which does not match domain name {}",
+                            "SRV lookup for {} returned result {}, which does not match domain \
+                             name {}",
                             original_hostname,
                             address,
                             domain_name.join(".")

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -11,7 +11,6 @@ use crate::{
 
 pub(crate) struct SrvResolver {
     resolver: AsyncResolver,
-    max_hosts: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -41,13 +40,10 @@ pub(crate) enum DomainMismatch {
 }
 
 impl SrvResolver {
-    pub(crate) async fn new(
-        config: Option<ResolverConfig>,
-        max_hosts: Option<u32>,
-    ) -> Result<Self> {
+    pub(crate) async fn new(config: Option<ResolverConfig>) -> Result<Self> {
         let resolver = AsyncResolver::new(config).await?;
 
-        Ok(Self { resolver, max_hosts })
+        Ok(Self { resolver })
     }
 
     pub(crate) async fn resolve_client_options(
@@ -139,14 +135,6 @@ impl SrvResolver {
                 message: format!("SRV lookup for {} returned no records", original_hostname),
             }
             .into());
-        }
-
-        if let Some(max_hosts) = self.max_hosts {
-            if max_hosts > 0 && (max_hosts as usize) < srv_addresses.len() {
-                use rand::prelude::SliceRandom;
-                srv_addresses.shuffle(&mut rand::thread_rng());
-                srv_addresses.truncate(max_hosts as usize);
-            }
         }
 
         Ok(LookupHosts {

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -64,10 +64,7 @@ struct ParsedOptions {
 async fn run_test(mut test_file: TestFile) {
     if let Some(ref options) = test_file.options {
         // TODO RUST-933: Remove this skip.
-        let skip = if options.srv_max_hosts.is_some() {
-            Some("srvMaxHosts")
-        // TODO RUST-911: Remove this skip.
-        } else if options.srv_service_name.is_some() {
+        let skip = if options.srv_service_name.is_some() {
             Some("srvServiceName")
         } else {
             None

--- a/src/test/spec/json/uri-options/srv-options.json
+++ b/src/test/spec/json/uri-options/srv-options.json
@@ -1,0 +1,116 @@
+{
+  "tests": [
+    {
+      "description": "SRV URI with custom srvServiceName",
+      "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "srvServiceName": "customname"
+      }
+    },
+    {
+      "description": "Non-SRV URI with custom srvServiceName",
+      "uri": "mongodb://example.com/?srvServiceName=customname",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "srvMaxHosts": 2
+      }
+    },
+    {
+      "description": "SRV URI with negative integer for srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with invalid type for srvMaxHosts",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-SRV URI with srvMaxHosts",
+      "uri": "mongodb://example.com/?srvMaxHosts=2",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and replicaSet",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and loadBalanced=true",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "SRV URI with positive srvMaxHosts and loadBalanced=false",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": false,
+        "srvMaxHosts": 2
+      }
+    },
+    {
+      "description": "SRV URI with srvMaxHosts=0 and replicaSet",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&replicaSet=foo",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "replicaSet": "foo",
+        "srvMaxHosts": 0
+      }
+    },
+    {
+      "description": "SRV URI with srvMaxHosts=0 and loadBalanced=true",
+      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "loadBalanced": true,
+        "srvMaxHosts": 0
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/uri-options/srv-options.yml
+++ b/src/test/spec/json/uri-options/srv-options.yml
@@ -1,0 +1,89 @@
+tests:
+    - description: "SRV URI with custom srvServiceName"
+      uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          srvServiceName: "customname"
+    - description: "Non-SRV URI with custom srvServiceName"
+      uri: "mongodb://example.com/?srvServiceName=customname"
+      valid: false
+      warning: false
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with srvMaxHosts"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          srvMaxHosts: 2
+    - description: "SRV URI with negative integer for srvMaxHosts"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1"
+      valid: true
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with invalid type for srvMaxHosts"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
+      valid: true
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "Non-SRV URI with srvMaxHosts"
+      uri: "mongodb://example.com/?srvMaxHosts=2"
+      valid: false
+      warning: false
+      hosts: ~
+      auth: ~
+      options: {}
+    # Note: Testing URI validation for srvMaxHosts conflicting with either
+    # loadBalanced=true or replicaSet specified via TXT records is covered by
+    # the Initial DNS Seedlist Discovery test suite.
+    - description: "SRV URI with positive srvMaxHosts and replicaSet"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo"
+      valid: false
+      warning: false
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with positive srvMaxHosts and loadBalanced=true"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true"
+      valid: false
+      warning: false
+      hosts: ~
+      auth: ~
+      options: {}
+    - description: "SRV URI with positive srvMaxHosts and loadBalanced=false"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=false"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          loadBalanced: false
+          srvMaxHosts: 2
+    - description: "SRV URI with srvMaxHosts=0 and replicaSet"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=0&replicaSet=foo"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          replicaSet: foo
+          srvMaxHosts: 0
+    - description: "SRV URI with srvMaxHosts=0 and loadBalanced=true"
+      uri: "mongodb+srv://test3.test.build.10gen.cc/?srvMaxHosts=0&loadBalanced=true"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          loadBalanced: true
+          srvMaxHosts: 0

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -474,6 +474,7 @@ fn topology_description_tracing_representation() {
         local_threshold: None,
         heartbeat_freq: None,
         servers,
+        srv_max_hosts: None,
     };
 
     assert_eq!(


### PR DESCRIPTION
RUST-933

Pretty straightforward.  The shuffling needs to be in two places (initial host discovery and polling), unfortunately, because the logic at those two places is a bit different.