### PR TITLE
Replace `async_once` with `tokio::sync::OnceCell`

### DIFF
--- a/.evergreen/MSRV-Cargo.lock
+++ b/.evergreen/MSRV-Cargo.lock
@@ -244,12 +244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async_once"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
-
-[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,11 +1130,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
- "cfg-if",
  "value-bag",
 ]
 
@@ -1257,7 +1250,6 @@ dependencies = [
  "async-std",
  "async-std-resolver",
  "async-trait",
- "async_once",
  "backtrace",
  "base64",
  "bitflags",
@@ -2193,6 +2185,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -2499,14 +2492,10 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
-
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+ 
 [[package]]
 name = "vcpkg"
 version = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,6 @@ features = ["v4"]
 [dev-dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 approx = "0.5.1"
-async_once = "0.2.6"
 backtrace = { version = "0.3.68" }
 ctrlc = "3.2.2"
 function_name = "0.2.1"
@@ -194,7 +193,7 @@ serde = { version = ">= 0.0.0", features = ["rc"] }
 serde_json = "1.0.64"
 semver = "1.0.0"
 time = "0.3.9"
-tokio = { version = ">= 0.0.0", features = ["fs"] }
+tokio = { version = ">= 0.0.0", features = ["fs", "parking_lot"] }
 tracing-subscriber = "0.3.16"
 regex = "1.6.0"
 serde-hex = "0.1.0"

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -14,13 +14,13 @@ use crate::{
     sdam::ServerInfo,
     selection_criteria::SelectionCriteria,
     test::{
+        get_client_options,
         log_uncaptured,
         Event,
         EventClient,
         EventHandler,
         SdamEvent,
         TestClient,
-        CLIENT_OPTIONS,
     },
     Client,
     Collection,
@@ -307,7 +307,7 @@ async fn cluster_time_in_commands() {
     }
 
     let handler = Arc::new(EventHandler::new());
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.heartbeat_freq = Some(Duration::from_secs(1000));
     options.command_event_handler = Some(handler.clone());
     options.sdam_event_handler = Some(handler.clone());

--- a/src/cmap/test.rs
+++ b/src/cmap/test.rs
@@ -27,12 +27,12 @@ use crate::{
     test::{
         assert_matches,
         eq_matches,
+        get_client_options,
         log_uncaptured,
         run_spec_test,
         EventClient,
         MatchErrExt,
         Matchable,
-        CLIENT_OPTIONS,
     },
 };
 use bson::doc;
@@ -157,9 +157,9 @@ impl Executor {
         let (updater, mut receiver) = TopologyUpdater::channel();
 
         let pool = ConnectionPool::new(
-            CLIENT_OPTIONS.get().await.hosts[0].clone(),
+            get_client_options().await.hosts[0].clone(),
             ConnectionEstablisher::new(EstablisherOptions::from_client_options(
-                CLIENT_OPTIONS.get().await,
+                get_client_options().await,
             ))
             .unwrap(),
             updater,
@@ -433,7 +433,7 @@ async fn cmap_spec_tests() {
             return;
         }
 
-        let mut options = CLIENT_OPTIONS.get().await.clone();
+        let mut options = get_client_options().await.clone();
         if options.load_balanced.unwrap_or(false) {
             log_uncaptured(format!(
                 "skipping {:?} due to load balanced topology",

--- a/src/compression/test.rs
+++ b/src/compression/test.rs
@@ -9,7 +9,7 @@ use bson::{doc, Bson};
 use crate::{
     client::options::ClientOptions,
     compression::{Compressor, CompressorId, Decoder},
-    test::{TestClient, CLIENT_OPTIONS},
+    test::{get_client_options, TestClient},
 };
 
 #[cfg(feature = "zlib-compression")]
@@ -67,7 +67,7 @@ fn test_snappy_compressor() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[cfg(feature = "zlib-compression")]
 async fn ping_server_with_zlib_compression() {
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.compressors = Some(vec![Compressor::Zlib { level: Some(4) }]);
     send_ping_with_compression(client_options).await;
 }
@@ -76,7 +76,7 @@ async fn ping_server_with_zlib_compression() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[cfg(feature = "zstd-compression")]
 async fn ping_server_with_zstd_compression() {
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.compressors = Some(vec![Compressor::Zstd { level: None }]);
     send_ping_with_compression(client_options).await;
 }
@@ -85,7 +85,7 @@ async fn ping_server_with_zstd_compression() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[cfg(feature = "snappy-compression")]
 async fn ping_server_with_snappy_compression() {
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.compressors = Some(vec![Compressor::Snappy]);
     send_ping_with_compression(client_options).await;
 }
@@ -98,7 +98,7 @@ async fn ping_server_with_snappy_compression() {
     feature = "snappy-compression"
 ))]
 async fn ping_server_with_all_compressors() {
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.compressors = Some(vec![
         Compressor::Zlib { level: None },
         Compressor::Snappy,

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     selection_criteria::TagSet,
     test::{
+        get_client_options,
         log_uncaptured,
         run_spec_test,
         Event,
@@ -34,7 +35,6 @@ use crate::{
         FailPointMode,
         SdamEvent,
         TestClient,
-        CLIENT_OPTIONS,
     },
 };
 
@@ -638,7 +638,7 @@ async fn topology_closed_event_last() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn heartbeat_events() {
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.hosts.drain(1..);
     options.heartbeat_freq = Some(Duration::from_millis(50));
     options.app_name = "heartbeat_events".to_string().into();
@@ -721,7 +721,7 @@ async fn direct_connection() {
         .await
         .expect("failed to select secondary");
 
-    let mut secondary_options = CLIENT_OPTIONS.get().await.clone();
+    let mut secondary_options = get_client_options().await.clone();
     secondary_options.hosts = vec![secondary_address];
 
     let mut direct_false_options = secondary_options.clone();

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -8,7 +8,7 @@ use crate::{
     options::{ClientOptions, ServerAddress},
     runtime,
     sdam::Topology,
-    test::{log_uncaptured, CLIENT_OPTIONS},
+    test::{get_client_options, log_uncaptured},
 };
 
 fn localhost_test_build_10gen(port: u16) -> ServerAddress {
@@ -131,7 +131,7 @@ async fn no_results() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn load_balanced_no_srv_polling() {
-    if CLIENT_OPTIONS.get().await.load_balanced != Some(true) {
+    if get_client_options().await.load_balanced != Some(true) {
         log_uncaptured("skipping load_balanced_no_srv_polling due to not load balanced topology");
         return;
     }

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -15,6 +15,7 @@ use crate::{
     hello::{LEGACY_HELLO_COMMAND_NAME, LEGACY_HELLO_COMMAND_NAME_LOWERCASE},
     sdam::{ServerDescription, Topology},
     test::{
+        get_client_options,
         log_uncaptured,
         Event,
         EventClient,
@@ -24,7 +25,6 @@ use crate::{
         FailPointMode,
         SdamEvent,
         TestClient,
-        CLIENT_OPTIONS,
     },
     Client,
 };
@@ -32,7 +32,7 @@ use crate::{
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn min_heartbeat_frequency() {
-    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut setup_client_options = get_client_options().await.clone();
     if setup_client_options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping min_heartbeat_frequency test due to load-balanced topology");
         return;
@@ -93,7 +93,7 @@ async fn min_heartbeat_frequency() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn sdam_pool_management() {
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     if options.load_balanced.unwrap_or(false) {
         log_uncaptured("skipping sdam_pool_management test due to load-balanced topology");
         return;
@@ -175,7 +175,7 @@ async fn sdam_pool_management() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn hello_ok_true() {
-    let mut setup_client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut setup_client_options = get_client_options().await.clone();
     setup_client_options.hosts.drain(1..);
 
     if setup_client_options.server_api.is_some() {
@@ -245,7 +245,7 @@ async fn repl_set_name_mismatch() -> crate::error::Result<()> {
         return Ok(());
     }
 
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.hosts.drain(1..);
     options.direct_connection = Some(true);
     options.repl_set_name = Some("invalid".to_string());

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -38,7 +38,7 @@ fn init_db_and_typed_coll<T>(client: &Client, db_name: &str, coll_name: &str) ->
 
 lazy_static! {
     static ref CLIENT_OPTIONS: ClientOptions =
-        runtime::block_on(async { crate::test::CLIENT_OPTIONS.get().await.clone() });
+        runtime::block_on(async { crate::test::get_client_options().await.clone() });
 }
 
 #[test]

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -17,7 +17,7 @@ use crate::{
     Collection,
 };
 
-use super::{log_uncaptured, EventClient, TestClient, CLIENT_OPTIONS};
+use super::{get_client_options, log_uncaptured, EventClient, TestClient};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -41,7 +41,7 @@ async fn init_stream(
         return Ok(None);
     }
 
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     // Direct connection is needed for reliable behavior with fail points.
     if direct_connection && init_client.is_sharded() {
         options.direct_connection = Some(true);

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -30,9 +30,9 @@ use crate::{
     results::DeleteResult,
     runtime,
     test::{
+        get_client_options,
         log_uncaptured,
         util::{drop_collection, EventClient, TestClient},
-        CLIENT_OPTIONS,
     },
     Collection,
     IndexModel,
@@ -912,7 +912,7 @@ async fn typed_returns() {
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 #[function_name::named]
 async fn count_documents_with_wc() {
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.write_concern = WriteConcern::builder()
         .w(Acknowledgment::Majority)
         .journal(true)

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -60,13 +60,13 @@ use crate::{
 };
 
 use super::{
+    get_client_options,
     log_uncaptured,
     EventClient,
     FailCommandOptions,
     FailPoint,
     FailPointMode,
     TestClient,
-    CLIENT_OPTIONS,
 };
 
 type Result<T> = anyhow::Result<T>;
@@ -272,7 +272,7 @@ async fn data_key_double_encryption() -> Result<()> {
         },
     )];
     let client_encrypted = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         KMS_PROVIDERS.clone(),
     )?
@@ -455,7 +455,7 @@ async fn external_key_vault() -> Result<()> {
 
         // Setup: test options.
         let kv_client = if with_external_key_vault {
-            let mut opts = CLIENT_OPTIONS.get().await.clone();
+            let mut opts = get_client_options().await.clone();
             opts.credential = Some(
                 Credential::builder()
                     .username("fake-user".to_string())
@@ -469,7 +469,7 @@ async fn external_key_vault() -> Result<()> {
 
         // Setup: encrypted client.
         let client_encrypted = Client::encrypted_builder(
-            CLIENT_OPTIONS.get().await.clone(),
+            get_client_options().await.clone(),
             KV_NAMESPACE.clone(),
             LOCAL_KMS.clone(),
         )?
@@ -565,7 +565,7 @@ async fn bson_size_limits() -> Result<()> {
         .await?;
 
     // Setup: encrypted client.
-    let mut opts = CLIENT_OPTIONS.get().await.clone();
+    let mut opts = get_client_options().await.clone();
     let handler = Arc::new(EventHandler::new());
     let mut events = handler.subscribe();
     opts.command_event_handler = Some(handler.clone());
@@ -692,7 +692,7 @@ async fn views_prohibited() -> Result<()> {
 
     // Setup: encrypted client.
     let client_encrypted = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -793,7 +793,7 @@ async fn run_corpus_test(local_schema: bool) -> Result<()> {
     // Setup: encrypted client and manual encryption.
     let client_encrypted = {
         let mut enc_builder = Client::encrypted_builder(
-            CLIENT_OPTIONS.get().await.clone(),
+            get_client_options().await.clone(),
             KV_NAMESPACE.clone(),
             KMS_PROVIDERS.clone(),
         )?
@@ -1321,7 +1321,7 @@ async fn bypass_mongocryptd_via_shared_library() -> Result<()> {
 
     // Setup: encrypted client.
     let client_encrypted = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -1367,7 +1367,7 @@ async fn bypass_mongocryptd_via_bypass_spawn() -> Result<()> {
         "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],
     };
     let client_encrypted = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -1400,7 +1400,7 @@ async fn bypass_mongocryptd_unencrypted_insert(bypass: Bypass) -> Result<()> {
         "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],
     };
     let builder = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -1571,7 +1571,7 @@ impl DeadlockTestCase {
         // Setup
         let client_test = TestClient::new().await;
         let client_keyvault = EventClient::with_options({
-            let mut opts = CLIENT_OPTIONS.get().await.clone();
+            let mut opts = get_client_options().await.clone();
             opts.max_pool_size = Some(1);
             opts
         })
@@ -1625,7 +1625,7 @@ impl DeadlockTestCase {
         // Run test case
         let event_handler = Arc::new(EventHandler::new());
         let mut encrypted_events = event_handler.subscribe();
-        let mut opts = CLIENT_OPTIONS.get().await.clone();
+        let mut opts = get_client_options().await.clone();
         opts.max_pool_size = Some(self.max_pool_size);
         opts.command_event_handler = Some(event_handler.clone());
         opts.sdam_event_handler = Some(event_handler.clone());
@@ -2373,7 +2373,7 @@ async fn explicit_encryption_setup() -> Result<Option<ExplicitEncryptionTestData
         LOCAL_KMS.clone(),
     )?;
     let encrypted_client = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -2699,7 +2699,7 @@ impl DecryptionEventsTestdata {
         *last = last.wrapping_add(1);
 
         let ev_handler = DecryptionEventsHandler::new();
-        let mut opts = CLIENT_OPTIONS.get().await.clone();
+        let mut opts = get_client_options().await.clone();
         opts.retry_reads = Some(false);
         opts.command_event_handler = Some(ev_handler.clone());
         let encrypted_client =
@@ -2979,7 +2979,7 @@ async fn bypass_mongocryptd_client() -> Result<()> {
     };
 
     let client_encrypted = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -3278,7 +3278,7 @@ async fn range_explicit_encryption_test(
     )?;
 
     let encrypted_client = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?
@@ -3583,7 +3583,7 @@ async fn fle2_example() -> Result<()> {
 
     // Create an FLE 2 collection.
     let encrypted_client = Client::encrypted_builder(
-        CLIENT_OPTIONS.get().await.clone(),
+        get_client_options().await.clone(),
         KV_NAMESPACE.clone(),
         LOCAL_KMS.clone(),
     )?

--- a/src/test/lambda_examples/auth.rs
+++ b/src/test/lambda_examples/auth.rs
@@ -1,40 +1,40 @@
 use crate as mongodb;
 
 // begin lambda connection example 2
-use async_once::AsyncOnce;
 use lambda_runtime::{service_fn, LambdaEvent};
-use lazy_static::lazy_static;
 use mongodb::{
     bson::doc,
     options::{AuthMechanism, ClientOptions, Credential},
     Client,
 };
 use serde_json::Value;
+use tokio::sync::OnceCell;
 
 // Initialize a global static MongoDB Client with AWS authentication. The following environment
 // variables should also be set: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and, optionally,
 // AWS_SESSION_TOKEN.
-//
-// The client can be accessed as follows:
-// let client = MONGODB_CLIENT.get().await;
-lazy_static! {
-    static ref MONGODB_CLIENT: AsyncOnce<Client> = AsyncOnce::new(async {
-        let uri = std::env::var("MONGODB_URI")
-            .expect("MONGODB_URI must be set to the URI of the MongoDB deployment");
-        let mut options = ClientOptions::parse(uri)
-            .await
-            .expect("Failed to parse options from URI");
-        let credential = Credential::builder()
-            .mechanism(AuthMechanism::MongoDbAws)
-            .build();
-        options.credential = Some(credential);
-        Client::with_options(options).expect("Failed to create MongoDB Client")
-    });
+static MONGODB_CLIENT: OnceCell<Client> = OnceCell::const_new();
+
+async fn get_mongodb_client() -> &'static Client {
+    MONGODB_CLIENT
+        .get_or_init(|| async {
+            let uri = std::env::var("MONGODB_URI")
+                .expect("MONGODB_URI must be set to the URI of the MongoDB deployment");
+            let mut options = ClientOptions::parse(uri)
+                .await
+                .expect("Failed to parse options from URI");
+            let credential = Credential::builder()
+                .mechanism(AuthMechanism::MongoDbAws)
+                .build();
+            options.credential = Some(credential);
+            Client::with_options(options).expect("Failed to create MongoDB Client")
+        })
+        .await
 }
 
 // Runs a ping operation on the "db" database and returns the response.
 async fn handler(_: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Error> {
-    let client = MONGODB_CLIENT.get().await;
+    let client = get_mongodb_client().await;
     let response = client
         .database("db")
         .run_command(doc! { "ping": 1 }, None)

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -15,7 +15,7 @@ use crate::{
         WriteConcern,
     },
     runtime,
-    test::{log_uncaptured, util::EventClient, CLIENT_OPTIONS},
+    test::{get_client_options, log_uncaptured, util::EventClient},
     Collection,
     Database,
 };
@@ -25,7 +25,7 @@ async fn run_test<F: Future>(
     test: impl Fn(EventClient, Database, Collection<Document>) -> F,
 ) {
     let options = ClientOptions::builder()
-        .hosts(CLIENT_OPTIONS.get().await.hosts.clone())
+        .hosts(get_client_options().await.hosts.clone())
         .retry_writes(false)
         .build();
     let client = EventClient::with_additional_options(Some(options), None, None, None).await;

--- a/src/test/spec/gridfs.rs
+++ b/src/test/spec/gridfs.rs
@@ -9,12 +9,12 @@ use crate::{
     options::{GridFsBucketOptions, GridFsUploadOptions},
     runtime,
     test::{
+        get_client_options,
         spec::unified_runner::run_unified_tests,
         FailCommandOptions,
         FailPoint,
         FailPointMode,
         TestClient,
-        CLIENT_OPTIONS,
     },
 };
 
@@ -186,7 +186,7 @@ async fn upload_stream_multiple_buffers() {
 async fn upload_stream_errors() {
     let client = TestClient::new().await;
     let client = if client.is_sharded() {
-        let mut options = CLIENT_OPTIONS.get().await.clone();
+        let mut options = get_client_options().await.clone();
         options.hosts.drain(1..);
         TestClient::with_options(options).await
     } else {

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -7,7 +7,7 @@ use crate::{
     client::Client,
     options::{ClientOptions, ResolverConfig},
     runtime,
-    test::{log_uncaptured, run_spec_test, TestClient, CLIENT_OPTIONS},
+    test::{get_client_options, log_uncaptured, run_spec_test, TestClient},
 };
 
 #[derive(Debug, Deserialize)]
@@ -135,7 +135,7 @@ async fn run_test(mut test_file: TestFile) {
     } else {
         let mut options_with_tls = options.clone();
         if requires_tls {
-            options_with_tls.tls = CLIENT_OPTIONS.get().await.tls.clone();
+            options_with_tls.tls = get_client_options().await.tls.clone();
         }
 
         let client = Client::with_options(options_with_tls).unwrap();

--- a/src/test/spec/ocsp.rs
+++ b/src/test/spec/ocsp.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bson::doc;
 
 use crate::{
-    test::{log_uncaptured, CLIENT_OPTIONS},
+    test::{get_client_options, log_uncaptured},
     Client,
 };
 
@@ -19,7 +19,7 @@ async fn run() {
         .unwrap()
         .to_lowercase();
 
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     let mut tls_options = options.tls_options().unwrap();
     options.server_selection_timeout = Duration::from_millis(200).into();
 

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -11,6 +11,7 @@ use crate::{
     runtime,
     runtime::AsyncJoinHandle,
     test::{
+        get_client_options,
         log_uncaptured,
         spec::{unified_runner::run_unified_tests, v2_runner::run_v2_tests},
         Event,
@@ -19,7 +20,6 @@ use crate::{
         FailPoint,
         FailPointMode,
         TestClient,
-        CLIENT_OPTIONS,
     },
     Client,
 };
@@ -41,7 +41,7 @@ async fn run_unified() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn retry_releases_connection() {
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.hosts.drain(1..);
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
@@ -75,7 +75,7 @@ async fn retry_releases_connection() {
 async fn retry_read_pool_cleared() {
     let handler = Arc::new(EventHandler::new());
 
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
     client_options.cmap_event_handler = Some(handler.clone() as Arc<dyn CmapEventHandler>);
@@ -165,7 +165,7 @@ async fn retry_read_pool_cleared() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn retry_read_different_mongos() {
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     if client_options.repl_set_name.is_some() || client_options.hosts.len() < 2 {
         log_uncaptured(
             "skipping retry_read_different_mongos: requires sharded cluster with at least two \
@@ -237,7 +237,7 @@ async fn retry_read_same_mongos() {
         return;
     }
 
-    let mut client_options = CLIENT_OPTIONS.get().await.clone();
+    let mut client_options = get_client_options().await.clone();
     client_options.hosts.drain(1..);
     client_options.retry_reads = Some(true);
     let fp_guard = {

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -6,6 +6,7 @@ use crate::{
     hello::LEGACY_HELLO_COMMAND_NAME,
     runtime,
     test::{
+        get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
         Event,
@@ -15,7 +16,6 @@ use crate::{
         FailPointMode,
         SdamEvent,
         TestClient,
-        CLIENT_OPTIONS,
     },
     Client,
 };
@@ -55,7 +55,7 @@ async fn streaming_min_heartbeat_frequency() {
     }
 
     let handler = Arc::new(EventHandler::new());
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.heartbeat_freq = Some(Duration::from_millis(500));
     options.sdam_event_handler = Some(handler.clone());
 
@@ -106,7 +106,7 @@ async fn heartbeat_frequency_is_respected() {
     }
 
     let handler = Arc::new(EventHandler::new());
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.heartbeat_freq = Some(Duration::from_millis(1000));
     options.sdam_event_handler = Some(handler.clone());
 
@@ -171,7 +171,7 @@ async fn rtt_is_updated() {
     let app_name = "streamingRttTest";
 
     let handler = Arc::new(EventHandler::new());
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     options.heartbeat_freq = Some(Duration::from_millis(500));
     options.app_name = Some(app_name.to_string());
     options.sdam_event_handler = Some(handler.clone());

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -14,12 +14,12 @@ use crate::{
     options::SessionOptions,
     runtime::process::Process,
     test::{
+        get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
         util::Event,
         EventClient,
         TestClient,
-        CLIENT_OPTIONS,
     },
     Client,
 };
@@ -109,7 +109,7 @@ async fn implicit_session_after_connection() {
     let mut max_lsids = 0usize;
     for _ in 0..5 {
         let client = {
-            let mut options = CLIENT_OPTIONS.get().await.clone();
+            let mut options = get_client_options().await.clone();
             options.max_pool_size = Some(1);
             options.retry_writes = Some(true);
             options.hosts.drain(1..);

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -22,10 +22,10 @@ use crate::{
         SelectionCriteria,
     },
     test::{
+        get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
         TestClient,
-        CLIENT_OPTIONS,
         DEFAULT_GLOBAL_TRACING_HANDLER,
         SERVER_API,
     },
@@ -121,7 +121,7 @@ async fn command_logging_truncation_default_limit() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn command_logging_truncation_explicit_limit() {
-    let mut client_opts = CLIENT_OPTIONS.get().await.clone();
+    let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(5);
     let client = TestClient::with_options(Some(client_opts)).await;
 
@@ -158,7 +158,7 @@ async fn command_logging_truncation_explicit_limit() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test)]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn command_logging_truncation_mid_codepoint() {
-    let mut client_opts = CLIENT_OPTIONS.get().await.clone();
+    let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(215);
     let client = TestClient::with_options(Some(client_opts)).await;
     // On non-standalone topologies the command includes a clusterTime and so gets truncated

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -7,13 +7,13 @@ use crate::{
     bson::{doc, Document},
     error::{Error, Result, TRANSIENT_TRANSACTION_ERROR, UNKNOWN_TRANSACTION_COMMIT_RESULT},
     test::{
+        get_client_options,
         log_uncaptured,
         spec::{unified_runner::run_unified_tests, v2_runner::run_v2_tests},
         FailCommandOptions,
         FailPoint,
         FailPointMode,
         TestClient,
-        CLIENT_OPTIONS,
     },
     Client,
     Collection,
@@ -201,7 +201,7 @@ async fn convenient_api_retry_timeout_callback() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn convenient_api_retry_timeout_commit_unknown() {
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     if Client::test_builder().build().await.is_sharded() {
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
@@ -256,7 +256,7 @@ async fn convenient_api_retry_timeout_commit_unknown() {
 #[cfg_attr(feature = "tokio-runtime", tokio::test(flavor = "multi_thread"))]
 #[cfg_attr(feature = "async-std-runtime", async_std::test)]
 async fn convenient_api_retry_timeout_commit_transient() {
-    let mut options = CLIENT_OPTIONS.get().await.clone();
+    let mut options = get_client_options().await.clone();
     if Client::test_builder().build().await.is_sharded() {
         options.direct_connection = Some(true);
         options.hosts.drain(1..);

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -20,6 +20,7 @@ use crate::{
     runtime,
     sdam::{TopologyDescription, MIN_HEARTBEAT_FREQUENCY},
     test::{
+        get_client_options,
         log_uncaptured,
         spec::unified_runner::{
             entity::EventList,
@@ -30,7 +31,6 @@ use crate::{
         util::FailPointGuard,
         EventHandler,
         TestClient,
-        CLIENT_OPTIONS,
         DEFAULT_URI,
         LOAD_BALANCED_MULTIPLE_URI,
         LOAD_BALANCED_SINGLE_URI,
@@ -431,7 +431,7 @@ impl TestRunner {
                         client.observe_sensitive_commands.unwrap_or(false);
                     let server_api = client.server_api.clone().or_else(|| SERVER_API.clone());
 
-                    let given_uri = if CLIENT_OPTIONS.get().await.load_balanced.unwrap_or(false) {
+                    let given_uri = if get_client_options().await.load_balanced.unwrap_or(false) {
                         // for serverless testing, ignore use_multiple_mongoses.
                         if client.use_multiple_mongoses() && !*SERVERLESS {
                             LOAD_BALANCED_MULTIPLE_URI.as_ref().expect(

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -19,12 +19,12 @@ use crate::{
     selection_criteria::SelectionCriteria,
     test::{
         file_level_log,
+        get_client_options,
         log_uncaptured,
         spec::deserialize_spec_tests,
         util::{get_default_name, FailPointGuard},
         EventClient,
         TestClient,
-        CLIENT_OPTIONS,
         SERVERLESS,
     },
     Client,
@@ -194,7 +194,7 @@ impl TestContext {
         let mut additional_options = match &test.client_options {
             Some(opts) => ClientOptions::parse_uri(&opts.uri, None).await.unwrap(),
             None => ClientOptions::builder()
-                .hosts(CLIENT_OPTIONS.get().await.hosts.clone())
+                .hosts(get_client_options().await.hosts.clone())
                 .build(),
         };
         if additional_options.heartbeat_freq.is_none() {

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -34,7 +34,7 @@ use bson::Document;
 use semver::{Version, VersionReq};
 use serde::{de::DeserializeOwned, Serialize};
 
-use super::CLIENT_OPTIONS;
+use super::get_client_options;
 use crate::{
     error::{CommandError, ErrorKind, Result},
     options::{AuthMechanism, ClientOptions, CollectionOptions, CreateCollectionOptions},
@@ -137,7 +137,7 @@ impl TestClientBuilder {
     pub(crate) async fn build(self) -> TestClient {
         let mut options = match self.options {
             Some(options) => options,
-            None => CLIENT_OPTIONS.get().await.clone(),
+            None => get_client_options().await.clone(),
         };
 
         if let Some(handler) = self.handler {
@@ -463,7 +463,7 @@ impl TestClient {
         let is_load_balanced = options
             .as_ref()
             .and_then(|o| o.load_balanced)
-            .or(CLIENT_OPTIONS.get().await.load_balanced)
+            .or(get_client_options().await.load_balanced)
             .unwrap_or(false);
         let default_options = if is_load_balanced {
             // for serverless testing, ignore use_multiple_mongoses.
@@ -480,7 +480,7 @@ impl TestClient {
             update_options_for_testing(&mut o);
             o
         } else {
-            CLIENT_OPTIONS.get().await.clone()
+            get_client_options().await.clone()
         };
         let mut options = match options {
             Some(mut options) => {


### PR DESCRIPTION
`async_once` is unmaintained and [has been reported unsound](https://github.com/hjiayz/async_once/issues/5).

`tokio`'s `parking_lot` feature has been added in order to have access to `OnceCell::const_new()`. This is only necessary in older `tokio` versions.