### PR TITLE
RUST-1806 Fix in use encryption tests

### DIFF
--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -22,7 +22,9 @@ if [ "$OS" = "Windows_NT" ]; then
   export SSL_CERT_DIR=$(cygpath /etc/ssl/certs --windows)
 fi
 
-. ${DRIVERS_TOOLS}/.evergreen/csfle/activate_venv.sh
+pushd ${DRIVERS_TOOLS}/.evergreen/csfle
+. ./activate-kmstlsvenv.sh
+popd
 export PYTHON=python  # use the venv-provided python
 export AWS_DEFAULT_REGION=us-east-1
 . ${DRIVERS_TOOLS}/.evergreen/csfle/set-temp-creds.sh


### PR DESCRIPTION
RUST-1806

We hadn't implemented this bit of the tests yet when the ticket to convert to the new shell scripts was done, so I guess this is the moral equivalent of a race condition use after free?