### PR TITLE
RUST-1525 Update AWS tests to use new scripts

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -257,7 +257,7 @@ buildvariants:
 
   - name: aws-auth
     display_name: "AWS Authentication"
-    # patchable: false
+    patchable: false
     run_on:
       - ubuntu2004-small
     expansions:
@@ -1356,9 +1356,6 @@ functions:
           ECS_SRC_DIR=$AUTH_AWS_DIR/src
 
           mkdir -p $ECS_SRC_DIR/.evergreen
-
-          # fix issue with `TestData` in SERVER-46340
-          sed -i '1s+^+TestData = {};\n+' $AUTH_AWS_DIR/lib/ecs_hosted_test.js
 
           # compile mini test project
           cd $PROJECT_DIRECTORY/.evergreen/aws-ecs-test

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -79,9 +79,6 @@ buildvariants:
     run_on:
       - ubuntu2204-arm64-small
     expansions:
-      # Needed to skip installation of the legacy shell in boostrap mongo-orchestration, which is
-      # not available on Ubuntu 22.04.
-      SKIP_LEGACY_SHELL: true
       AUTH: auth
       SSL: ssl
     tasks:
@@ -119,9 +116,6 @@ buildvariants:
     run_on:
       - ubuntu2204-arm64-small
     expansions:
-      # Needed to skip installation of the legacy shell in boostrap mongo-orchestration, which is
-      # not available on Ubuntu 22.04.
-      SKIP_LEGACY_SHELL: true
       ASYNC_STD: true
       AUTH: auth
       SSL: ssl
@@ -178,9 +172,6 @@ buildvariants:
     run_on:
       - ubuntu2204-arm64-small
     expansions:
-      # Needed to skip installation of the legacy shell (which is not available on Ubuntu 22.04) in
-      # boostrap mongo-orchestration.
-      SKIP_LEGACY_SHELL: true
       OPENSSL: true
       AUTH: auth
       SSL: ssl
@@ -266,13 +257,10 @@ buildvariants:
 
   - name: aws-auth
     display_name: "AWS Authentication"
-    patchable: false
+    # patchable: false
     run_on:
-      # Use ubuntu1804. AWS tasks require legacy `mongo` shell. Legacy `mongo` shell is not available on newer distros.
-      - ubuntu1804-small
+      - ubuntu2004-small
     expansions:
-      AUTH: auth
-      SSL: ssl
       ORCHESTRATION_FILE: auth-aws.json
     tasks:
       - .aws-auth
@@ -1263,188 +1251,94 @@ functions:
         file: src/expansion.yml
 
   "add aws auth variables to file":
-    - command: shell.exec
-      type: test
+    - command: ec2.assume_role
       params:
-        working_dir: src
-        silent: true
-        script: |
-          cat <<EOF > ${DRIVERS_TOOLS}/.evergreen/auth_aws/aws_e2e_setup.json
-          {
-              "iam_auth_ecs_account": "${iam_auth_ecs_account}",
-              "iam_auth_ecs_secret_access_key": "${iam_auth_ecs_secret_access_key}",
-              "iam_auth_ecs_account_arn": "arn:aws:iam::557821124784:user/authtest_fargate_user",
-              "iam_auth_ecs_cluster": "${iam_auth_ecs_cluster}",
-              "iam_auth_ecs_task_definition": "${iam_auth_ecs_task_definition}",
-              "iam_auth_ecs_subnet_a": "${iam_auth_ecs_subnet_a}",
-              "iam_auth_ecs_subnet_b": "${iam_auth_ecs_subnet_b}",
-              "iam_auth_ecs_security_group": "${iam_auth_ecs_security_group}",
-              "iam_auth_assume_aws_account": "${iam_auth_assume_aws_account}",
-              "iam_auth_assume_aws_secret_access_key": "${iam_auth_assume_aws_secret_access_key}",
-              "iam_auth_assume_role_name": "${iam_auth_assume_role_name}",
-              "iam_auth_ec2_instance_account": "${iam_auth_ec2_instance_account}",
-              "iam_auth_ec2_instance_secret_access_key" : "${iam_auth_ec2_instance_secret_access_key}",
-              "iam_auth_ec2_instance_profile": "${iam_auth_ec2_instance_profile}",
-              "iam_auth_assume_web_role_name": "${iam_auth_assume_web_role_name}",
-              "iam_web_identity_issuer": "${iam_web_identity_issuer}",
-              "iam_web_identity_jwks_uri": "${iam_web_identity_jwks_uri}",
-              "iam_web_identity_token_file": "${iam_web_identity_token_file}",
-              "iam_web_identity_rsa_key": "${iam_web_identity_rsa_key}"
-          }
-          EOF
+        role_arn: ${aws_test_secrets_role}
+    - command: subprocess.exec
+      params:
+        binary: bash
+        working_dir: ${DRIVERS_TOOLS}/.evergreen/auth_aws
+        args:
+          - ./setup_secrets.sh
+          - drivers/aws_auth
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
 
   "run aws auth test with regular aws credentials":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-authawsvenv.sh
-          mongo aws_e2e_regular_aws.js
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        silent: true
-        script: |
-          cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias urlencode='python -c "import sys, urllib as ul; sys.stdout.write(ul.quote_plus(sys.argv[1]))"'
-            USER=$(urlencode ${iam_auth_ecs_account})
-            PASS=$(urlencode ${iam_auth_ecs_secret_access_key})
-            MONGODB_URI="mongodb://$USER:$PASS@localhost"
-          EOF
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          SKIP_CREDENTIAL_CACHING_TESTS=1 .evergreen/run-aws-tests.sh
+        binary: bash
+        working_dir: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-aws-tests.sh
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+        env:
+          AWS_AUTH_TYPE: regular
+          SKIP_CREDENTIAL_CACHING_TESTS: "true"
 
   "run aws auth test with assume role credentials":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-authawsvenv.sh
-          mongo aws_e2e_assume_role.js
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        silent: true
-        script: |
-          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-              alias urlencode='python -c "import sys, urllib as ul; sys.stdout.write(ul.quote_plus(sys.argv[1]))"'
-              alias jsonkey='python -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
-              USER=$(jsonkey AccessKeyId)
-              USER=$(urlencode $USER)
-              PASS=$(jsonkey SecretAccessKey)
-              PASS=$(urlencode $PASS)
-              SESSION_TOKEN=$(jsonkey SessionToken)
-              SESSION_TOKEN=$(urlencode $SESSION_TOKEN)
-              MONGODB_URI="mongodb://$USER:$PASS@localhost"
-          EOF
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          SKIP_CREDENTIAL_CACHING_TESTS=1 .evergreen/run-aws-tests.sh
+        binary: bash
+        working_dir: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-aws-tests.sh
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+        env:
+          AWS_AUTH_TYPE: assume-role
+          SKIP_CREDENTIAL_CACHING_TESTS: "true"
 
   "run aws auth test with aws EC2 credentials":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-authawsvenv.sh
-          mongo aws_e2e_ec2.js
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          # Write an empty prepare_mongodb_aws so no auth environment variables
-          # are set.
-          echo "" > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-          .evergreen/run-aws-tests.sh
+        binary: bash
+        working_dir: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-aws-tests.sh
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+        env:
+          AWS_AUTH_TYPE: ec2
 
   "run aws auth test with aws credentials as environment variables":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-authawsvenv.sh
-          mongo aws_e2e_regular_aws.js
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        silent: true
-        script: |
-          cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            export AWS_ACCESS_KEY_ID=${iam_auth_ecs_account}
-            export AWS_SECRET_ACCESS_KEY=${iam_auth_ecs_secret_access_key}
-          EOF
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          PROJECT_DIRECTORY=${PROJECT_DIRECTORY} \
-            SKIP_CREDENTIAL_CACHING_TESTS=1 \
-            .evergreen/run-aws-tests.sh
+        binary: bash
+        working_dir: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-aws-tests.sh
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+        env:
+          AWS_AUTH_TYPE: env-creds
+          SKIP_CREDENTIAL_CACHING_TESTS: "true"
 
   "run aws auth test with aws credentials and session token as environment variables":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-authawsvenv.sh
-          mongo aws_e2e_assume_role.js
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        silent: true
-        script: |
-          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            alias jsonkey='python -c "import json,sys;sys.stdout.write(json.load(sys.stdin)[sys.argv[1]])" < ${DRIVERS_TOOLS}/.evergreen/auth_aws/creds.json'
-            export AWS_ACCESS_KEY_ID=$(jsonkey AccessKeyId)
-            export AWS_SECRET_ACCESS_KEY=$(jsonkey SecretAccessKey)
-            export AWS_SESSION_TOKEN=$(jsonkey SessionToken)
-          EOF
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        script: |
-          ${PREPARE_SHELL}
-          SKIP_CREDENTIAL_CACHING_TESTS=1 .evergreen/run-aws-tests.sh
+        binary: bash
+        working_dir: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-aws-tests.sh
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+        env:
+          AWS_AUTH_TYPE: session-creds
+          SKIP_CREDENTIAL_CACHING_TESTS: "true"
 
   "run aws ecs auth test":
     - command: shell.exec
@@ -1476,46 +1370,22 @@ functions:
           cp $PROJECT_DIRECTORY/.evergreen/run-mongodb-aws-ecs-test.sh $ECS_SRC_DIR/.evergreen
           cp $PROJECT_DIRECTORY/.evergreen/aws-ecs-test/target/debug/aws-ecs-test $ECS_SRC_DIR
 
-          cd $AUTH_AWS_DIR
-          . ./activate-authawsvenv.sh
-          export MONGODB_BINARIES=${MONGODB_BINARIES}
           export PROJECT_DIRECTORY="$ECS_SRC_DIR"
-          python aws_tester.py ecs
+          $AUTH_AWS_DIR/aws_setup.sh ecs
 
   "run aws assume role with web identity test":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          cd ${DRIVERS_TOOLS}/.evergreen/auth_aws
-          . ./activate-authawsvenv.sh
-          mongo aws_e2e_web_identity.js
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        silent: true
-        script: |
-          # DO NOT ECHO WITH XTRACE (which PREPARE_SHELL does)
-          cat <<'EOF' > "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-            export AWS_ROLE_ARN="${iam_auth_assume_web_role_name}"
-            export AWS_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}"
-            if [ "$AWS_ROLE_SESSION_NAME" != "" ]; then
-              export AWS_ROLE_SESSION_NAME="$AWS_ROLE_SESSION_NAME"
-            fi
-          EOF
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          PROJECT_DIRECTORY=${PROJECT_DIRECTORY} \
-            ASSERT_NO_URI_CREDS=true \
-            .evergreen/run-aws-tests.sh
+        binary: bash
+        working_dir: ${PROJECT_DIRECTORY}
+        args:
+          - .evergreen/run-aws-tests.sh
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+        env:
+          AWS_AUTH_TYPE: web-identity
 
   "run x509 tests":
     - command: shell.exec

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -9,8 +9,7 @@ export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 
 . ${CARGO_HOME}/env
 
-set +u # allow undefined variable for $OS
-if [[ "$OS" == "Windows_NT" ]]; then
+if [[ "$OSTYPE" == "cygwin" ]]; then
   # Update path for DLLs
   export PATH="${MONGOCRYPT_LIB_DIR}/../bin:$PATH"
 

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -9,6 +9,7 @@ export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"
 
 . ${CARGO_HOME}/env
 
+set +u # allow undefined variable for $OS
 if [[ "$OS" == "Windows_NT" ]]; then
   # Update path for DLLs
   export PATH="${MONGOCRYPT_LIB_DIR}/../bin:$PATH"

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -3,43 +3,14 @@
 set -o xtrace
 set -o errexit # Exit the script with error if any of the commands fail
 
-############################################
-#            Main Program                  #
-############################################
-
-# Supported/used environment variables:
-#  MONGODB_URI    Set the URI, including an optional username/password to use
-#                 to connect to the server via MONGODB-AWS authentication
-#                 mechanism.
-
 echo "Running MONGODB-AWS authentication tests"
-# ensure no secrets are printed in log files
-set +x
 
-# load the script
-shopt -s expand_aliases # needed for `urlencode` alias
-[ -s "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh" ] && source "${PROJECT_DIRECTORY}/prepare_mongodb_aws.sh"
-
-MONGODB_URI=${MONGODB_URI:-"mongodb://localhost"}
-MONGODB_URI="${MONGODB_URI}/aws?authMechanism=MONGODB-AWS"
-if [[ -n ${SESSION_TOKEN} ]]; then
-  MONGODB_URI="${MONGODB_URI}&authMechanismProperties=AWS_SESSION_TOKEN:${SESSION_TOKEN}"
-fi
-
-export MONGODB_URI="$MONGODB_URI"
-
-if [ "$ASSERT_NO_URI_CREDS" = "true" ]; then
-  if echo "$MONGODB_URI" | grep -q "@"; then
-    echo "MONGODB_URI unexpectedly contains user credentials!"
-    exit 1
-  fi
-fi
-
-# show test output
-set -x
+cd $DRIVERS_TOOLS/.evergreen/auth_aws
+. aws_setup.sh $AWS_AUTH_TYPE
 
 set -o errexit
 
+cd ${PROJECT_DIRECTORY}
 source .evergreen/env.sh
 source .evergreen/cargo-test.sh
 


### PR DESCRIPTION
Removes all uses of the legacy shell by migrating to the new AWS scripts in drivers-evergreen-tools. Also completes RUST-1777 by upgrading to Ubuntu 20.04 (the new arn is no longer relevant now that we're using the secrets manager).