### PR TITLE
RUST-1831 Use secret manager for serverless tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -324,7 +324,7 @@ buildvariants:
       - test-plain-auth
 
   - name: serverless-passthrough
-    patchable: false
+    #patchable: false
     display_name: "Serverless (Passthrough)"
     run_on:
       - rhel80-small
@@ -338,7 +338,7 @@ buildvariants:
 
 
   - name: serverless-terminating
-    patchable: false
+    #patchable: false
     display_name: "Serverless (Terminating)"
     run_on:
       - rhel80-small
@@ -435,17 +435,12 @@ task_groups:
           shell: "bash"
           script: |
             ${PREPARE_SHELL}
-            set +o xtrace
             if [ "terminating" = "${SERVERLESS_PROXY_TYPE}" ]; then
-              SERVERLESS_GROUP=${TERMINATING_PROXY_SERVERLESS_DRIVERS_GROUP}
+              bash ${DRIVERS_TOOLS}/.evergreen/serverless/setup-secrets.sh serverless_next
             else
-              SERVERLESS_GROUP=${SERVERLESS_DRIVERS_GROUP}
+              bash ${DRIVERS_TOOLS}/.evergreen/serverless/setup-secrets.sh
             fi
-            SERVERLESS_DRIVERS_GROUP=$SERVERLESS_GROUP \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-            LOADBALANCED=ON \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
+            bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
       - command: expansions.update
         params:
           file: serverless-expansion.yml
@@ -454,17 +449,7 @@ task_groups:
         params:
           script: |
             ${PREPARE_SHELL}
-            set +o xtrace
-            if [ "terminating" = "${SERVERLESS_PROXY_TYPE}" ]; then
-              SERVERLESS_GROUP=${TERMINATING_PROXY_SERVERLESS_DRIVERS_GROUP}
-            else
-              SERVERLESS_GROUP=${SERVERLESS_DRIVERS_GROUP}
-            fi
-            SERVERLESS_DRIVERS_GROUP=$SERVERLESS_GROUP \
-            SERVERLESS_API_PUBLIC_KEY=${SERVERLESS_API_PUBLIC_KEY} \
-            SERVERLESS_API_PRIVATE_KEY=${SERVERLESS_API_PRIVATE_KEY} \
-            SERVERLESS_INSTANCE_NAME=${SERVERLESS_INSTANCE_NAME} \
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
+            bash ${DRIVERS_TOOLS}/.evergreen/serverless/delete-instance.sh
       - func: "upload test results"
       - func: "upload-mo-artifacts"
       - func: "cleanup"


### PR DESCRIPTION
This updates the serverless tests to use the aws secret manager (which includes `SERVERLESS_REGION`).