### PR TITLE
chore: bump `socket2` to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ serde_with = "1.3.1"
 sha-1 = "0.10.0"
 sha2 = "0.10.2"
 snap = { version = "1.0.5", optional = true }
-socket2 = "0.4.0"
+socket2 = "0.5.5"
 stringprep = "0.1.2"
 strsim = "0.10.0"
 take_mut = "0.2.2"

--- a/src/operation/update.rs
+++ b/src/operation/update.rs
@@ -196,7 +196,7 @@ impl<'a, T: Serialize> OperationWithDefaults for Update<'a, T> {
             .as_ref()
             .and_then(|v| v.first())
             .and_then(|doc| doc.get("_id"))
-            .map(Clone::clone);
+            .cloned();
 
         let matched_count = if upserted_id.is_some() { 0 } else { response.n };
 

--- a/src/sdam/description/topology.rs
+++ b/src/sdam/description/topology.rs
@@ -220,9 +220,8 @@ impl TopologyDescription {
             }
             (TopologyType::Single, ServerType::Standalone) => {}
             (TopologyType::Single, _) => {
-                let specified_read_pref = criteria
-                    .and_then(SelectionCriteria::as_read_pref)
-                    .map(Clone::clone);
+                let specified_read_pref =
+                    criteria.and_then(SelectionCriteria::as_read_pref).cloned();
 
                 let resolved_read_pref = match specified_read_pref {
                     Some(ReadPreference::Primary) | None => ReadPreference::PrimaryPreferred {


### PR DESCRIPTION
AFAIK, socket2's

```
 rust-version  = "1.63" 
```

matchs the driver's 1.64+