### PR TITLE
RUST-1841 Allow double-valued connectionIds

### DIFF
--- a/src/hello.rs
+++ b/src/hello.rs
@@ -179,7 +179,29 @@ pub(crate) struct HelloCommandResponse {
 
     /// The server-generated ID for the connection the "hello" command was run on.
     /// Present on server versions 4.2+.
+    #[serde(deserialize_with = "deserialize_connection_id", default = "none")]
     pub connection_id: Option<i64>,
+}
+
+fn none<T>() -> Option<T> {
+    None
+}
+
+fn deserialize_connection_id<'de, D: serde::Deserializer<'de>>(
+    de: D,
+) -> std::result::Result<Option<i64>, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Helper {
+        Int32(i32),
+        Int64(i64),
+        Double(f64),
+    }
+    Ok(Some(match Helper::deserialize(de)? {
+        Helper::Int32(v) => v as i64,
+        Helper::Int64(v) => v,
+        Helper::Double(v) => v as i64,
+    }))
 }
 
 impl HelloCommandResponse {

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -179,12 +179,8 @@ pub(crate) struct HelloCommandResponse {
 
     /// The server-generated ID for the connection the "hello" command was run on.
     /// Present on server versions 4.2+.
-    #[serde(deserialize_with = "deserialize_connection_id", default = "none")]
+    #[serde(deserialize_with = "deserialize_connection_id", default)]
     pub connection_id: Option<i64>,
-}
-
-fn none<T>() -> Option<T> {
-    None
 }
 
 fn deserialize_connection_id<'de, D: serde::Deserializer<'de>>(

--- a/src/test.rs
+++ b/src/test.rs
@@ -12,6 +12,7 @@ mod cursor;
 mod db;
 #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
 mod documentation_examples;
+mod hello;
 mod index_management;
 #[cfg(all(not(feature = "sync"), not(feature = "tokio-sync")))]
 mod lambda_examples;

--- a/src/test/hello.rs
+++ b/src/test/hello.rs
@@ -1,0 +1,37 @@
+use bson::{doc, Bson};
+
+use crate::hello::HelloCommandResponse;
+
+#[test]
+fn parse_connection_id() {
+    let mut parsed: HelloCommandResponse = bson::from_document(doc! {
+        "connectionId": Bson::Int32(42),
+        "maxBsonObjectSize": 0,
+        "maxMessageSizeBytes": 0,
+    })
+    .unwrap();
+    assert_eq!(parsed.connection_id, Some(42));
+
+    parsed = bson::from_document(doc! {
+        "connectionId": Bson::Int64(13),
+        "maxBsonObjectSize": 0,
+        "maxMessageSizeBytes": 0,
+    })
+    .unwrap();
+    assert_eq!(parsed.connection_id, Some(13));
+
+    parsed = bson::from_document(doc! {
+        "connectionId": Bson::Double(1066.0),
+        "maxBsonObjectSize": 0,
+        "maxMessageSizeBytes": 0,
+    })
+    .unwrap();
+    assert_eq!(parsed.connection_id, Some(1066));
+
+    parsed = bson::from_document(doc! {
+        "maxBsonObjectSize": 0,
+        "maxMessageSizeBytes": 0,
+    })
+    .unwrap();
+    assert_eq!(parsed.connection_id, None);
+}


### PR DESCRIPTION
RUST-1841

It turns out that when we implemented RUST-1571 we missed that the value could be a double as well as an int64.

I'll cherry-pick this to `main` as well.