### PR TITLE
RUST-1631 Always use polling monitoring when running in a FaaS environment

### DIFF
--- a/.evergreen/aws-lambda-test/mongodb/src/main.rs
+++ b/.evergreen/aws-lambda-test/mongodb/src/main.rs
@@ -34,10 +34,12 @@ impl Stats {
 
     fn handle_sdam(&mut self, event: &SdamEvent) {
         match event {
-            SdamEvent::ServerHeartbeatStarted(_) => {
+            SdamEvent::ServerHeartbeatStarted(ev) => {
+                assert!(!ev.awaited);
                 self.heartbeats_started += 1;
             }
             SdamEvent::ServerHeartbeatFailed(ev) => {
+                assert!(!ev.awaited);
                 self.failed_heartbeat_durations_millis.push(ev.duration.as_millis());
             }
             _ => (),

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -732,7 +732,10 @@ impl Serialize for ClientOptions {
             replicaset: &self.repl_set_name,
             retryreads: &self.retry_reads,
             retrywrites: &self.retry_writes,
-            servermonitoringmode: self.server_monitoring_mode.as_ref().map(|m| format!("{:?}", m).to_lowercase()),
+            servermonitoringmode: self
+                .server_monitoring_mode
+                .as_ref()
+                .map(|m| format!("{:?}", m).to_lowercase()),
             selectioncriteria: &self.selection_criteria,
             serverselectiontimeoutms: &self.server_selection_timeout,
             sockettimeoutms: &self.socket_timeout,

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -690,6 +690,8 @@ impl Serialize for ClientOptions {
 
             retrywrites: &'a Option<bool>,
 
+            servermonitoringmode: Option<String>,
+
             #[serde(
                 flatten,
                 serialize_with = "SelectionCriteria::serialize_for_client_options"
@@ -730,6 +732,7 @@ impl Serialize for ClientOptions {
             replicaset: &self.repl_set_name,
             retryreads: &self.retry_reads,
             retrywrites: &self.retry_writes,
+            servermonitoringmode: self.server_monitoring_mode.as_ref().map(|m| format!("{:?}", m).to_lowercase()),
             selectioncriteria: &self.selection_criteria,
             serverselectiontimeoutms: &self.server_selection_timeout,
             sockettimeoutms: &self.socket_timeout,

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -68,6 +68,7 @@ const URI_OPTIONS: &[&str] = &[
     "replicaset",
     "retrywrites",
     "retryreads",
+    "servermonitoringmode",
     "serverselectiontimeoutms",
     "sockettimeoutms",
     "tls",
@@ -512,6 +513,12 @@ pub struct ClientOptions {
     #[builder(default)]
     pub retry_writes: Option<bool>,
 
+    /// Configures which server monitoring protocol to use.
+    ///
+    /// The default is [`Auto`](ServerMonitoringMode::Auto).
+    #[builder(default)]
+    pub server_monitoring_mode: Option<ServerMonitoringMode>,
+
     /// The handler that should process all Server Discovery and Monitoring events.
     #[derivative(Debug = "ignore", PartialEq = "ignore")]
     #[builder(default, setter(strip_option))]
@@ -843,6 +850,11 @@ pub struct ConnectionString {
     ///
     /// The default value is true.
     pub retry_writes: Option<bool>,
+
+    /// Configures which server monitoring protocol to use.
+    ///
+    /// The default is [`Auto`](ServerMonitoringMode::Auto).
+    pub server_monitoring_mode: Option<ServerMonitoringMode>,
 
     /// Specifies whether the Client should directly connect to a single host rather than
     /// autodiscover all servers in the cluster.
@@ -1340,6 +1352,7 @@ impl ClientOptions {
             connect_timeout: conn_str.connect_timeout,
             retry_reads: conn_str.retry_reads,
             retry_writes: conn_str.retry_writes,
+            server_monitoring_mode: conn_str.server_monitoring_mode,
             socket_timeout: conn_str.socket_timeout,
             direct_connection: conn_str.direct_connection,
             default_database: conn_str.default_database,
@@ -2182,6 +2195,19 @@ impl ConnectionString {
             k @ "retryreads" => {
                 self.retry_reads = Some(get_bool!(value, k));
             }
+            "servermonitoringmode" => {
+                self.server_monitoring_mode = Some(match value.to_lowercase().as_str() {
+                    "stream" => ServerMonitoringMode::Stream,
+                    "poll" => ServerMonitoringMode::Poll,
+                    "auto" => ServerMonitoringMode::Auto,
+                    other => {
+                        return Err(Error::invalid_argument(format!(
+                            "{:?} is not a valid server monitoring mode",
+                            other
+                        )));
+                    }
+                });
+            }
             k @ "serverselectiontimeoutms" => {
                 self.server_selection_timeout = Some(Duration::from_millis(get_duration!(value, k)))
             }
@@ -2874,4 +2900,18 @@ pub struct TransactionOptions {
         default
     )]
     pub max_commit_time: Option<Duration>,
+}
+
+/// Which server monitoring protocol to use.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ServerMonitoringMode {
+    /// The client will use the streaming protocol when the server supports it and fall back to the
+    /// polling protocol otherwise.
+    Stream,
+    /// The client will use the polling protocol.
+    Poll,
+    /// The client will use the polling protocol when running on a FaaS platform and behave the
+    /// same as `Stream` otherwise.
+    Auto,
 }

--- a/src/cmap.rs
+++ b/src/cmap.rs
@@ -184,3 +184,7 @@ impl ConnectionPool {
         self.manager.broadcast(msg)
     }
 }
+
+pub(crate) fn is_faas() -> bool {
+    establish::handshake::FaasEnvironmentName::new().is_some()
+}

--- a/src/cmap/establish/handshake.rs
+++ b/src/cmap/establish/handshake.rs
@@ -67,7 +67,7 @@ struct RuntimeEnvironment {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-enum FaasEnvironmentName {
+pub(crate) enum FaasEnvironmentName {
     AwsLambda,
     AzureFunc,
     GcpFunc,
@@ -221,7 +221,7 @@ fn var_set(name: &str) -> bool {
 }
 
 impl FaasEnvironmentName {
-    fn new() -> Option<Self> {
+    pub(crate) fn new() -> Option<Self> {
         use FaasEnvironmentName::*;
         let mut found: Option<Self> = None;
         let lambda_env = env::var_os("AWS_EXECUTION_ENV")

--- a/src/sdam/monitor.rs
+++ b/src/sdam/monitor.rs
@@ -16,6 +16,7 @@ use super::{
     TopologyWatcher,
 };
 use crate::{
+    client::options::ServerMonitoringMode,
     cmap::{establish::ConnectionEstablisher, Connection},
     error::{Error, Result},
     event::sdam::{
@@ -67,14 +68,6 @@ pub(crate) struct Monitor {
     request_receiver: MonitorRequestReceiver,
 }
 
-// TODO: put this in client options
-#[non_exhaustive]
-enum ServerMonitoringMode {
-    Stream,
-    Poll,
-    Auto,
-}
-
 impl Monitor {
     pub(crate) fn start(
         address: ServerAddress,
@@ -91,8 +84,11 @@ impl Monitor {
             connection_establisher.clone(),
             client_options.clone(),
         );
-        let monitoring_mode = ServerMonitoringMode::Auto; // TODO
-        let allow_streaming = match monitoring_mode {
+        let allow_streaming = match client_options
+            .server_monitoring_mode
+            .clone()
+            .unwrap_or(ServerMonitoringMode::Auto)
+        {
             ServerMonitoringMode::Stream => true,
             ServerMonitoringMode::Poll => false,
             ServerMonitoringMode::Auto => !crate::cmap::is_faas(),

--- a/src/test/spec/json/server-discovery-and-monitoring/README.rst
+++ b/src/test/spec/json/server-discovery-and-monitoring/README.rst
@@ -262,32 +262,6 @@ Run the following test(s) on MongoDB 4.4+.
              mode: "off",
          });
 
-Heartbeat Tests
-~~~~~~~~~~~~~~~
-
-1. Test that ``ServerHeartbeatStartedEvent`` is emitted before the monitoring socket was created
-
-   #. Create a mock TCP server (example shown below) that pushes a ``client connected`` event to a shared array when a client connects and a ``client hello received`` event when the server receives the client hello and then closes the connection::
-         
-        let events = [];
-        server = createServer(clientSocket => {
-          events.push('client connected');
-
-          clientSocket.on('data', () => {
-            events.push('client hello received');
-            clientSocket.destroy();
-          });
-        });
-        server.listen(9999);
-
-   #. Create a client with ``serverSelectionTimeoutMS: 500`` and listen to ``ServerHeartbeatStartedEvent`` and ``ServerHeartbeatFailedEvent``, pushing the event name to the same shared array as the mock TCP server
-    
-   #. Attempt to connect client to previously created TCP server, catching the error when the client fails to connect
-
-   #. Assert that the first four elements in the array are: ::
-
-        ['serverHeartbeatStartedEvent', 'client connected', 'client hello received', 'serverHeartbeatFailedEvent']
-
 .. Section for links.
 
 .. _Server Description Equality: /source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#server-description-equality

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/pool-cleared-error.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/pool-cleared-error.yml
@@ -200,7 +200,7 @@ tests:
           event:
             poolClearedEvent: {}
           count: 1
-      # Perform an operation to ensure the node still useable.
+      # Perform an operation to ensure the node still usable.
       - name: insertOne
         object: *collection
         arguments:

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/serverMonitoringMode.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/serverMonitoringMode.json
@@ -1,0 +1,449 @@
+{
+  "description": "serverMonitoringMode",
+  "schemaVersion": "1.17",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "single",
+        "sharded",
+        "sharded-replicaset"
+      ],
+      "serverless": "forbid"
+    }
+  ],
+  "tests": [
+    {
+      "description": "connect with serverMonitoringMode=auto >=4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "auto"
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=auto <4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "auto",
+                    "heartbeatFrequencyMS": 500
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=stream >=4.4",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "stream"
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=stream <4.4",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.2.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "stream",
+                    "heartbeatFrequencyMS": 500
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "connect with serverMonitoringMode=poll",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "poll",
+                    "heartbeatFrequencyMS": 500
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 2
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": true,
+          "events": [
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatSucceededEvent": {
+                "awaited": false
+              }
+            },
+            {
+              "serverHeartbeatStartedEvent": {
+                "awaited": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/serverMonitoringMode.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/serverMonitoringMode.yml
@@ -1,0 +1,173 @@
+description: serverMonitoringMode
+
+schemaVersion: "1.17"
+# These tests cannot run on replica sets because the order of the expected
+# SDAM events are non-deterministic when monitoring multiple servers.
+# They also cannot run on Serverless or load balanced clusters where SDAM is disabled.
+runOnRequirements:
+  - topologies: [single, sharded, sharded-replicaset]
+    serverless: forbid
+tests:
+  - description: "connect with serverMonitoringMode=auto >=4.4"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "auto"
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - &ping
+        name: runCommand
+        object: db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectResult: { ok: 1 }
+      # Wait for the second serverHeartbeatStartedEvent to ensure we start streaming.
+      - &waitForSecondHeartbeatStarted
+        name: waitForEvent
+        object: testRunner
+        arguments:
+          client: client
+          event:
+            serverHeartbeatStartedEvent: {}
+          count: 2
+    expectEvents: &streamingStartedEvents
+      - client: client
+        eventType: sdam
+        ignoreExtraEvents: true
+        events:
+          - serverHeartbeatStartedEvent:
+              awaited: False
+          - serverHeartbeatSucceededEvent:
+              awaited: False
+          - serverHeartbeatStartedEvent:
+              awaited: True
+
+  - description: "connect with serverMonitoringMode=auto <4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "auto"
+                  heartbeatFrequencyMS: 500
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: &pollingStartedEvents
+      - client: client
+        eventType: sdam
+        ignoreExtraEvents: true
+        events:
+          - serverHeartbeatStartedEvent:
+              awaited: False
+          - serverHeartbeatSucceededEvent:
+              awaited: False
+          - serverHeartbeatStartedEvent:
+              awaited: False
+
+  - description: "connect with serverMonitoringMode=stream >=4.4"
+    runOnRequirements:
+      - minServerVersion: "4.4.0"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "stream"
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we start streaming.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: *streamingStartedEvents
+
+  - description: "connect with serverMonitoringMode=stream <4.4"
+    runOnRequirements:
+      - maxServerVersion: "4.2.99"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "stream"
+                  heartbeatFrequencyMS: 500
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: *pollingStartedEvents
+
+  - description: "connect with serverMonitoringMode=poll"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "poll"
+                  heartbeatFrequencyMS: 500
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      - *ping
+      # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
+      - *waitForSecondHeartbeatStarted
+    expectEvents: *pollingStartedEvents

--- a/src/test/spec/json/uri-options/sdam-options.json
+++ b/src/test/spec/json/uri-options/sdam-options.json
@@ -1,0 +1,46 @@
+{
+  "tests": [
+    {
+      "description": "serverMonitoringMode=auto",
+      "uri": "mongodb://example.com/?serverMonitoringMode=auto",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverMonitoringMode": "auto"
+      }
+    },
+    {
+      "description": "serverMonitoringMode=stream",
+      "uri": "mongodb://example.com/?serverMonitoringMode=stream",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverMonitoringMode": "stream"
+      }
+    },
+    {
+      "description": "serverMonitoringMode=poll",
+      "uri": "mongodb://example.com/?serverMonitoringMode=poll",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverMonitoringMode": "poll"
+      }
+    },
+    {
+      "description": "invalid serverMonitoringMode",
+      "uri": "mongodb://example.com/?serverMonitoringMode=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/src/test/spec/json/uri-options/sdam-options.yml
+++ b/src/test/spec/json/uri-options/sdam-options.yml
@@ -1,0 +1,35 @@
+tests:
+    - description: "serverMonitoringMode=auto"
+      uri: "mongodb://example.com/?serverMonitoringMode=auto"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          serverMonitoringMode: "auto"
+
+    - description: "serverMonitoringMode=stream"
+      uri: "mongodb://example.com/?serverMonitoringMode=stream"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          serverMonitoringMode: "stream"
+
+    - description: "serverMonitoringMode=poll"
+      uri: "mongodb://example.com/?serverMonitoringMode=poll"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          serverMonitoringMode: "poll"
+
+    - description: "invalid serverMonitoringMode"
+      uri: "mongodb://example.com/?serverMonitoringMode=invalid"
+      valid: true
+      warning: true
+      hosts: ~
+      auth: ~
+      options: {}

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -356,10 +356,24 @@ fn sdam_events_match(actual: &SdamEvent, expected: &ExpectedSdamEvent) -> Result
             ExpectedSdamEvent::TopologyDescriptionChanged {},
         ) => Ok(()),
         (
-            SdamEvent::ServerHeartbeatSucceeded(_),
-            ExpectedSdamEvent::ServerHeartbeatSucceeded {},
-        ) => Ok(()),
-        (SdamEvent::ServerHeartbeatFailed(_), ExpectedSdamEvent::ServerHeartbeatFailed {}) => {
+            SdamEvent::ServerHeartbeatStarted(actual),
+            ExpectedSdamEvent::ServerHeartbeatStarted { awaited },
+        ) => {
+            match_opt(&actual.awaited, awaited)?;
+            Ok(())
+        }
+        (
+            SdamEvent::ServerHeartbeatSucceeded(actual),
+            ExpectedSdamEvent::ServerHeartbeatSucceeded { awaited },
+        ) => {
+            match_opt(&actual.awaited, awaited)?;
+            Ok(())
+        }
+        (
+            SdamEvent::ServerHeartbeatFailed(actual),
+            ExpectedSdamEvent::ServerHeartbeatFailed { awaited },
+        ) => {
+            match_opt(&actual.awaited, awaited)?;
             Ok(())
         }
         _ => expected_err(actual, expected),

--- a/src/test/spec/unified_runner/test_event.rs
+++ b/src/test/spec/unified_runner/test_event.rs
@@ -85,10 +85,12 @@ pub(crate) enum ExpectedSdamEvent {
     },
     #[serde(rename = "topologyDescriptionChangedEvent")]
     TopologyDescriptionChanged {},
+    #[serde(rename = "serverHeartbeatStartedEvent", rename_all = "camelCase")]
+    ServerHeartbeatStarted { awaited: Option<bool> },
     #[serde(rename = "serverHeartbeatSucceededEvent", rename_all = "camelCase")]
-    ServerHeartbeatSucceeded {},
+    ServerHeartbeatSucceeded { awaited: Option<bool> },
     #[serde(rename = "serverHeartbeatFailedEvent", rename_all = "camelCase")]
-    ServerHeartbeatFailed {},
+    ServerHeartbeatFailed { awaited: Option<bool> },
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -425,6 +425,7 @@ pub(crate) enum ExpectedEventType {
     // TODO RUST-1055 Remove this when connection usage is serialized.
     #[serde(skip)]
     CmapWithoutConnectionReady,
+    Sdam,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -75,7 +75,7 @@ const SKIPPED_OPERATIONS: &[&str] = &[
 ];
 
 static MIN_SPEC_VERSION: Version = Version::new(1, 0, 0);
-static MAX_SPEC_VERSION: Version = Version::new(1, 16, 0);
+static MAX_SPEC_VERSION: Version = Version::new(1, 17, 0);
 
 pub(crate) type EntityMap = HashMap<String, Entity>;
 

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -291,6 +291,15 @@ impl EventHandler {
                 events.retain(|ev| !matches!(ev, Event::Cmap(CmapEvent::ConnectionReady(_))));
                 events
             }
+            ExpectedEventType::Sdam => {
+                let events = self.sdam_events.read().unwrap();
+                events
+                    .iter()
+                    .cloned()
+                    .map(|(event, _)| Event::Sdam(event))
+                    .filter(filter)
+                    .collect()
+            }
         }
     }
 


### PR DESCRIPTION
RUST-1631

The core change is pretty simple - add some behavior to switch back to polling when FaaS is detected - but there's a lot of stuff around that (tests, URI config, etc.)