### PR TITLE
RUST-1839 Avoid logging secrets when running OIDC or serverless tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1566,13 +1566,11 @@ functions:
       params:
         working_dir: src
         shell: bash
+        include_expansions_in_env:
+          - SERVERLESS_ATLAS_USER
+          - SERVERLESS_ATLAS_PASSWORD
         script: |
           ${PREPARE_SHELL}
-
-          # Export without xtrace to avoid leaking credentials.
-          set +o xtrace
-          export SERVERLESS_ATLAS_USER=${SERVERLESS_ATLAS_USER}
-          export SERVERLESS_ATLAS_PASSWORD=${SERVERLESS_ATLAS_PASSWORD}
 
           export SINGLE_MONGOS_LB_URI=${SERVERLESS_URI}
           . .evergreen/generate-uri.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1726,9 +1726,6 @@ functions:
           cd ${DRIVERS_TOOLS}/.evergreen/auth_oidc
           set +o xtrace
 
-          export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-          export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-          export AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
           export OIDC_TOKEN_DIR=/tmp/tokens
 
           . ./activate-authoidcvenv.sh

--- a/.evergreen/generate-uri.sh
+++ b/.evergreen/generate-uri.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -o errexit
-set -o xtrace
 
 if [[ "$SSL" = "ssl" ]]; then
   DRIVERS_TOOLS_X509="${DRIVERS_TOOLS}/.evergreen/x509gen"


### PR DESCRIPTION
RUST-1839 / RUST-1838

Since they're not patchable, [here's](https://spruce.mongodb.com/version/65ce5ae3a4cf473f1634d93e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) a run with OIDC and [here's](https://spruce.mongodb.com/version/65ce62a8850e61402789c00b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) one with serverless.