### PR TITLE
RUST-1856 expose Database::client

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -90,7 +90,7 @@ impl Database {
     }
 
     /// Get the `Client` that this collection descended from.
-    pub(crate) fn client(&self) -> &Client {
+    pub fn client(&self) -> &Client {
         &self.inner.client
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/RUST-1856

Expose existing `Database::client` method as `pub`.