### PR TITLE
RUST-1829 Update csfle fluent API to be consistent with the rest of the driver

### DIFF
--- a/manual/src/encryption.md
+++ b/manual/src/encryption.md
@@ -159,7 +159,6 @@ async fn main() -> Result<()> {
     let data_key_id = client_encryption
         .create_data_key(MasterKey::Local)
         .key_alt_names(["encryption_example_1".to_string()])
-        .run()
         .await?;
     let schema = doc! {
         "properties": {
@@ -264,7 +263,6 @@ async fn main() -> Result<()> {
     let data_key_id = client_encryption
         .create_data_key(MasterKey::Local)
         .key_alt_names(["encryption_example_2".to_string()])
-        .run()
         .await?;
     let schema = doc! {
         "properties": {
@@ -367,12 +365,10 @@ async fn main() -> Result<()> {
     let key1_id = client_encryption
         .create_data_key(MasterKey::Local)
         .key_alt_names(["firstName".to_string()])
-        .run()
         .await?;
     let key2_id = client_encryption
         .create_data_key(MasterKey::Local)
         .key_alt_names(["lastName".to_string()])
-        .run()
         .await?;
 
     let encrypted_fields_map = vec![(
@@ -483,11 +479,9 @@ async fn main() -> Result<()> {
     // Create a new data key for the encryptedField.
     let indexed_key_id = client_encryption
         .create_data_key(MasterKey::Local)
-        .run()
         .await?;
     let unindexed_key_id = client_encryption
         .create_data_key(MasterKey::Local)
-        .run()
         .await?;
 
     let encrypted_fields = doc! {
@@ -535,11 +529,9 @@ async fn main() -> Result<()> {
     let insert_payload_indexed = client_encryption
         .encrypt(val, indexed_key_id.clone(), Algorithm::Indexed)
         .contention_factor(1)
-        .run()
         .await?;
     let insert_payload_unindexed = client_encryption
         .encrypt(unindexed_val, unindexed_key_id, Algorithm::Unindexed)
-        .run()
         .await?;
 
     // Insert the payloads.
@@ -559,7 +551,6 @@ async fn main() -> Result<()> {
         .encrypt(val, indexed_key_id, Algorithm::Indexed)
         .query_type("equality")
         .contention_factor(1)
-        .run()
         .await?;
 
     // Find the document we inserted using the encrypted payload.
@@ -633,7 +624,6 @@ async fn main() -> Result<()> {
     let data_key_id = client_encryption
         .create_data_key(MasterKey::Local)
         .key_alt_names(["encryption_example_3".to_string()])
-        .run()
         .await?;
 
     // Explicitly encrypt a field:
@@ -643,7 +633,6 @@ async fn main() -> Result<()> {
             data_key_id,
             Algorithm::AeadAes256CbcHmacSha512Deterministic,
         )
-        .run()
         .await?;
     coll.insert_one(doc! { "encryptedField": encrypted_field }, None)
         .await?;
@@ -736,7 +725,6 @@ async fn main() -> Result<()> {
     let data_key_id = client_encryption
         .create_data_key(MasterKey::Local)
         .key_alt_names(["encryption_example_4".to_string()])
-        .run()
         .await?;
 
     // Explicitly encrypt a field:
@@ -746,7 +734,6 @@ async fn main() -> Result<()> {
             data_key_id,
             Algorithm::AeadAes256CbcHmacSha512Deterministic,
         )
-        .run()
         .await?;
     coll.insert_one(doc! { "encryptedField": encrypted_field }, None)
         .await?;

--- a/src/action.rs
+++ b/src/action.rs
@@ -4,6 +4,8 @@ mod aggregate;
 mod count;
 mod create_collection;
 mod create_index;
+#[cfg(feature = "in-use-encryption-unstable")]
+mod csfle;
 mod delete;
 mod distinct;
 mod drop;
@@ -25,6 +27,8 @@ use bson::Document;
 pub use count::{CountDocuments, EstimatedDocumentCount};
 pub use create_collection::CreateCollection;
 pub use create_index::CreateIndex;
+#[cfg(feature = "in-use-encryption-unstable")]
+pub use csfle::*;
 pub use delete::Delete;
 pub use distinct::Distinct;
 pub use drop::{DropCollection, DropDatabase};
@@ -60,7 +64,7 @@ macro_rules! option_setters {
         $(
             $(#[$($attrss:tt)*])*
             $opt_name:ident: $opt_ty:ty,
-        )+
+        )*
     ) => {
         fn options(&mut self) -> &mut $opt_field_ty {
             self.$opt_field.get_or_insert_with(<$opt_field_ty>::default)
@@ -79,7 +83,7 @@ macro_rules! option_setters {
                 self.options().$opt_name = Some(value);
                 self
             }
-        )+
+        )*
     };
 }
 use option_setters;

--- a/src/action.rs
+++ b/src/action.rs
@@ -5,7 +5,7 @@ mod count;
 mod create_collection;
 mod create_index;
 #[cfg(feature = "in-use-encryption-unstable")]
-pub(crate) mod csfle;
+pub mod csfle;
 mod delete;
 mod distinct;
 mod drop;
@@ -27,8 +27,6 @@ use bson::Document;
 pub use count::{CountDocuments, EstimatedDocumentCount};
 pub use create_collection::CreateCollection;
 pub use create_index::CreateIndex;
-#[cfg(feature = "in-use-encryption-unstable")]
-pub use csfle::*;
 pub use delete::Delete;
 pub use distinct::Distinct;
 pub use drop::{DropCollection, DropDatabase};

--- a/src/action.rs
+++ b/src/action.rs
@@ -5,7 +5,7 @@ mod count;
 mod create_collection;
 mod create_index;
 #[cfg(feature = "in-use-encryption-unstable")]
-mod csfle;
+pub(crate) mod csfle;
 mod delete;
 mod distinct;
 mod drop;

--- a/src/action/csfle.rs
+++ b/src/action/csfle.rs
@@ -1,7 +1,9 @@
 //! Action builders for in-use encryption.
 
 mod create_data_key;
+mod create_encrypted_collection;
 pub(crate) mod encrypt;
 
 pub use create_data_key::{CreateDataKey, DataKeyOptions};
+pub use create_encrypted_collection::CreateEncryptedCollection;
 pub use encrypt::{Encrypt, EncryptOptions};

--- a/src/action/csfle.rs
+++ b/src/action/csfle.rs
@@ -1,3 +1,5 @@
+//! Action builders for in-use encryption.
+
 mod create_data_key;
 pub(crate) mod encrypt;
 

--- a/src/action/csfle.rs
+++ b/src/action/csfle.rs
@@ -1,3 +1,5 @@
 mod create_data_key;
+pub(crate) mod encrypt;
 
 pub use create_data_key::{CreateDataKey, DataKeyOptions};
+pub use encrypt::{Encrypt, EncryptOptions};

--- a/src/action/csfle.rs
+++ b/src/action/csfle.rs
@@ -1,0 +1,3 @@
+mod create_data_key;
+
+pub use create_data_key::{CreateDataKey, DataKeyOptions};

--- a/src/action/csfle/create_data_key.rs
+++ b/src/action/csfle/create_data_key.rs
@@ -1,0 +1,66 @@
+use crate::client_encryption::{ClientEncryption, MasterKey};
+
+use super::super::option_setters;
+
+impl ClientEncryption {
+    /// Creates a new key document and inserts into the key vault collection.
+    ///
+    /// `await` will return `Result<Binary>` (subtype 0x04) with the _id of the created
+    /// document as a UUID.
+    pub fn create_data_key(&self, master_key: MasterKey) -> CreateDataKey {
+        CreateDataKey {
+            client_enc: self,
+            master_key,
+            options: None,
+            #[cfg(test)]
+            test_kms_provider: None,
+        }
+    }
+}
+
+/// Create a new key document and insert it into the key vault collection.  Construct via
+/// [`ClientEncryption::create_data_key`].
+#[must_use]
+pub struct CreateDataKey<'a> {
+    pub(crate) client_enc: &'a ClientEncryption,
+    pub(crate) master_key: MasterKey,
+    pub(crate) options: Option<DataKeyOptions>,
+    #[cfg(test)]
+    pub(crate) test_kms_provider: Option<mongocrypt::ctx::KmsProvider>,
+}
+
+/// Options for creating a data key.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct DataKeyOptions {
+    /// An optional list of alternate names that can be used to reference the key.
+    pub key_alt_names: Option<Vec<String>>,
+    /// A buffer of 96 bytes to use as custom key material for the data key being
+    /// created.  If unset, key material for the new data key is generated from a cryptographically
+    /// secure random device.
+    pub key_material: Option<Vec<u8>>,
+}
+
+impl<'a> CreateDataKey<'a> {
+    option_setters! { options: DataKeyOptions; }
+
+    /// Set the [`DataKeyOptions::key_alt_names`] option.
+    pub fn key_alt_names(mut self, value: impl IntoIterator<Item = String>) -> Self {
+        self.options().key_alt_names = Some(value.into_iter().collect());
+        self
+    }
+
+    /// Set the [`DataKeyOptions::key_material`] option.
+    pub fn key_material(mut self, value: impl IntoIterator<Item = u8>) -> Self {
+        self.options().key_material = Some(value.into_iter().collect());
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_kms_provider(mut self, value: mongocrypt::ctx::KmsProvider) -> Self {
+        self.test_kms_provider = Some(value);
+        self
+    }
+}
+
+// Action impl in src/client/csfle/client_encryption/create_data_key.rs

--- a/src/action/csfle/create_data_key.rs
+++ b/src/action/csfle/create_data_key.rs
@@ -8,6 +8,7 @@ impl ClientEncryption {
     /// `await` will return `Result<Binary>` (subtype 0x04) with the _id of the created
     /// document as a UUID.
     pub fn create_data_key(&self, master_key: MasterKey) -> CreateDataKey {
+        dbg!("construct");
         CreateDataKey {
             client_enc: self,
             master_key,

--- a/src/action/csfle/create_data_key.rs
+++ b/src/action/csfle/create_data_key.rs
@@ -8,7 +8,6 @@ impl ClientEncryption {
     /// `await` will return `Result<Binary>` (subtype 0x04) with the _id of the created
     /// document as a UUID.
     pub fn create_data_key(&self, master_key: MasterKey) -> CreateDataKey {
-        dbg!("construct");
         CreateDataKey {
             client_enc: self,
             master_key,

--- a/src/action/csfle/create_encrypted_collection.rs
+++ b/src/action/csfle/create_encrypted_collection.rs
@@ -1,0 +1,115 @@
+use bson::{doc, Bson, Document};
+
+use super::super::{action_impl, option_setters};
+use crate::{
+    client_encryption::{ClientEncryption, MasterKey},
+    db::options::CreateCollectionOptions,
+    error::{Error, Result},
+    Database,
+};
+
+impl ClientEncryption {
+    /// Creates a new collection with encrypted fields, automatically creating new data encryption
+    /// keys when needed based on the configured [`CreateCollectionOptions::encrypted_fields`].
+    ///
+    /// `await` will return `(Document, Result<()>)` containing the potentially updated
+    /// `encrypted_fields` along with the collection creation status, as keys may have been created
+    /// even when a failure occurs.
+    ///
+    /// Does not affect any auto encryption settings on existing MongoClients that are already
+    /// configured with auto encryption.
+    pub fn create_encrypted_collection<'a>(
+        &'a self,
+        db: &'a Database,
+        name: &'a str,
+        master_key: MasterKey,
+    ) -> CreateEncryptedCollection {
+        CreateEncryptedCollection {
+            client_enc: self,
+            db,
+            name,
+            master_key,
+            options: None,
+        }
+    }
+}
+
+/// Create a new collection with encrypted fields.  Construct with
+/// [`ClientEncryption::create_encrypted_collection`].
+#[must_use]
+pub struct CreateEncryptedCollection<'a> {
+    client_enc: &'a ClientEncryption,
+    db: &'a Database,
+    name: &'a str,
+    master_key: MasterKey,
+    options: Option<CreateCollectionOptions>,
+}
+
+impl<'a> CreateEncryptedCollection<'a> {
+    option_setters!(options: CreateCollectionOptions;
+        capped: bool,
+        size: u64,
+        max: u64,
+        storage_engine: Document,
+        validator: Document,
+        validation_level: crate::db::options::ValidationLevel,
+        validation_action: crate::db::options::ValidationAction,
+        view_on: String,
+        pipeline: Vec<Document>,
+        collation: crate::collation::Collation,
+        write_concern: crate::options::WriteConcern,
+        index_option_defaults: crate::db::options::IndexOptionDefaults,
+        timeseries: crate::db::options::TimeseriesOptions,
+        expire_after_seconds: std::time::Duration,
+        change_stream_pre_and_post_images: crate::db::options::ChangeStreamPreAndPostImages,
+        clustered_index: crate::db::options::ClusteredIndex,
+        comment: bson::Bson,
+        encrypted_fields: Document,
+    );
+}
+
+action_impl! {
+    impl<'a> Action for CreateEncryptedCollection<'a> {
+        type Future = CreateEncryptedCollectionFuture;
+
+        async fn execute(self) -> (Document, Result<()>) {
+            let ef = match self.options.as_ref().and_then(|o| o.encrypted_fields.as_ref()) {
+                Some(ef) => ef,
+                None => {
+                    return (
+                        doc! {},
+                        Err(Error::invalid_argument(
+                            "no encrypted_fields defined for collection",
+                        )),
+                    );
+                }
+            };
+            let mut ef_prime = ef.clone();
+            if let Ok(fields) = ef_prime.get_array_mut("fields") {
+                for f in fields {
+                    let f_doc = if let Some(d) = f.as_document_mut() {
+                        d
+                    } else {
+                        continue;
+                    };
+                    if f_doc.get("keyId") == Some(&Bson::Null) {
+                        let d = match self.client_enc.create_data_key(self.master_key.clone()).await {
+                            Ok(v) => v,
+                            Err(e) => return (ef_prime, Err(e)),
+                        };
+                        f_doc.insert("keyId", d);
+                    }
+                }
+            }
+            // Unwrap safety: the check for `encrypted_fields` at the top won't succeed if `self.options` is `None`.
+            let mut opts_prime = self.options.unwrap();
+            opts_prime.encrypted_fields = Some(ef_prime.clone());
+            (
+                ef_prime,
+                self.db.create_collection(self.name)
+                    .with_options(opts_prime)
+                    .await,
+            )
+        }
+    }
+}

--- a/src/action/csfle/encrypt.rs
+++ b/src/action/csfle/encrypt.rs
@@ -50,7 +50,10 @@ impl ClientEncryption {
             mode: Expression { value: expression },
             key: key.into(),
             algorithm: Algorithm::RangePreview,
-            options: None,
+            options: Some(EncryptOptions {
+                query_type: Some("rangePreview".into()),
+                ..Default::default()
+            }),
         }
     }
 }

--- a/src/action/csfle/encrypt.rs
+++ b/src/action/csfle/encrypt.rs
@@ -1,0 +1,108 @@
+use bson::RawDocumentBuf;
+use mongocrypt::ctx::Algorithm;
+
+use crate::client_encryption::{ClientEncryption, EncryptKey, RangeOptions};
+use super::super::option_setters;
+
+impl ClientEncryption {
+    /// Encrypts a BsonValue with a given key and algorithm.
+    ///
+    /// To insert or query with an "Indexed" encrypted payload, use a `Client` configured with
+    /// `AutoEncryptionOptions`. `AutoEncryptionOptions.bypass_query_analysis` may be true.
+    /// `AutoEncryptionOptions.bypass_auto_encryption` must be false.
+    ///
+    /// `await` will return a `Result<Binary>` (subtype 6) containing the encrypted value.
+    pub fn encrypt_2(
+        &self,
+        value: impl Into<bson::RawBson>,
+        key: impl Into<EncryptKey>,
+        algorithm: Algorithm,
+    ) -> Encrypt {
+        Encrypt {
+            client_enc: self,
+            mode: Value { value: value.into() },
+            key: key.into(),
+            algorithm,
+            options: None,
+        }
+    }
+
+    /// NOTE: This method is experimental only. It is not intended for public use.
+    ///
+    /// Encrypts a match or aggregate expression with the given key.
+    ///
+    /// The expression will be encrypted using the [`Algorithm::RangePreview`] algorithm and the
+    /// "rangePreview" query type.
+    ///
+    /// `await` returns a `Result<Document>` containing the encrypted expression.
+    pub fn encrypt_expression_2(
+        &self,
+        expression: RawDocumentBuf,
+        key: impl Into<EncryptKey>,
+    ) -> Encrypt<'_, Expression> {
+        Encrypt {
+            client_enc: self,
+            mode: Expression { value: expression },
+            key: key.into(),
+            algorithm: Algorithm::RangePreview,
+            options: None,
+        }
+    }
+}
+
+/// Encrypt a value.  Construct with [`ClientEncryption::encrypt`].
+#[must_use]
+pub struct Encrypt<'a, Mode = Value> {
+    pub(crate) client_enc: &'a ClientEncryption,
+    pub(crate) mode: Mode,
+    pub(crate) key: EncryptKey,
+    pub(crate) algorithm: Algorithm,
+    pub(crate) options: Option<EncryptOptions>,
+}
+
+pub struct Value {
+    pub(crate) value: bson::RawBson,
+}
+
+pub struct Expression {
+    pub(crate) value: RawDocumentBuf,
+}
+
+/// Options for encrypting a value.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct EncryptOptions {
+    /// The contention factor.
+    pub contention_factor: Option<i64>,
+    /// The query type.
+    pub query_type: Option<String>,
+    /// NOTE: This method is experimental and not intended for public use.
+    ///
+    /// Set the range options. This method should only be called when the algorithm is
+    /// [`Algorithm::RangePreview`].
+    pub range_options: Option<RangeOptions>,
+}
+
+impl<'a, Mode> Encrypt<'a, Mode> {
+    option_setters!(options: EncryptOptions;
+        contention_factor: i64,
+    );
+}
+
+impl<'a> Encrypt<'a, Value> {
+    /// Set the [`EncryptOptions::query_type`] option.
+    pub fn query_type(mut self, value: impl Into<String>) -> Self {
+        self.options().query_type = Some(value.into());
+        self
+    }
+}
+
+impl<'a> Encrypt<'a, Expression> {
+    /// Set the [`EncryptOptions::range_options`] option.
+    pub fn range_options(mut self, value: RangeOptions) -> Self {
+        self.options().range_options = Some(value);
+        self
+    }
+}
+
+// Action impl in src/client/csfle/client_encryption/encrypt.rs

--- a/src/action/csfle/encrypt.rs
+++ b/src/action/csfle/encrypt.rs
@@ -1,8 +1,8 @@
 use bson::RawDocumentBuf;
 use mongocrypt::ctx::Algorithm;
 
-use crate::client_encryption::{ClientEncryption, EncryptKey, RangeOptions};
 use super::super::option_setters;
+use crate::client_encryption::{ClientEncryption, EncryptKey, RangeOptions};
 
 impl ClientEncryption {
     /// Encrypts a BsonValue with a given key and algorithm.
@@ -20,7 +20,9 @@ impl ClientEncryption {
     ) -> Encrypt {
         Encrypt {
             client_enc: self,
-            mode: Value { value: value.into() },
+            mode: Value {
+                value: value.into(),
+            },
             key: key.into(),
             algorithm,
             options: None,

--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -1,6 +1,7 @@
 //! Support for explicit encryption.
 
 mod create_data_key;
+mod encrypt;
 
 use mongocrypt::{
     ctx::{Algorithm, CtxBuilder, KmsProvider},

--- a/src/client/csfle/client_encryption/create_data_key.rs
+++ b/src/client/csfle/client_encryption/create_data_key.rs
@@ -2,7 +2,10 @@ use bson::{doc, Binary};
 use mongocrypt::ctx::{Ctx, KmsProvider};
 
 use crate::{
-    action::{action_impl, CreateDataKey, DataKeyOptions},
+    action::{
+        action_impl,
+        csfle::{CreateDataKey, DataKeyOptions},
+    },
     error::{Error, Result},
 };
 

--- a/src/client/csfle/client_encryption/create_data_key.rs
+++ b/src/client/csfle/client_encryption/create_data_key.rs
@@ -16,18 +16,23 @@ action_impl! {
         type Future = CreateDataKeyFuture;
 
         async fn execute(self) -> Result<Binary> {
+            dbg!("execute start");
             #[allow(unused_mut)]
             let mut provider = self.master_key.provider();
             #[cfg(test)]
             if let Some(tp) = self.test_kms_provider {
                 provider = tp;
             }
+            dbg!("create ctx");
             let ctx = self.client_enc.create_data_key_ctx(provider, self.master_key, self.options)?;
+            dbg!("run ctx");
             let data_key = self.client_enc.exec.run_ctx(ctx, None).await?;
+            dbg!("insert");
             self.client_enc.key_vault.insert_one(&data_key, None).await?;
             let bin_ref = data_key
                 .get_binary("_id")
                 .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
+            dbg!("execute end");
             Ok(bin_ref.to_binary())
         }
     }
@@ -42,11 +47,11 @@ impl ClientEncryption {
     ) -> Result<Ctx> {
         let mut builder = self.crypt.ctx_builder();
         let mut key_doc = doc! { "provider": kms_provider.name() };
+        if !matches!(master_key, MasterKey::Local) {
+            let master_doc = bson::to_document(&master_key)?;
+            key_doc.extend(master_doc);
+        }
         if let Some(opts) = opts {
-            if !matches!(master_key, MasterKey::Local) {
-                let master_doc = bson::to_document(&master_key)?;
-                key_doc.extend(master_doc);
-            }
             if let Some(alt_names) = &opts.key_alt_names {
                 for name in alt_names {
                     builder = builder.key_alt_name(name)?;
@@ -56,6 +61,7 @@ impl ClientEncryption {
                 builder = builder.key_material(material)?;
             }
         }
+        dbg!(&key_doc);
         builder = builder.key_encryption_key(&key_doc)?;
         Ok(builder.build_datakey()?)
     }

--- a/src/client/csfle/client_encryption/create_data_key.rs
+++ b/src/client/csfle/client_encryption/create_data_key.rs
@@ -16,23 +16,18 @@ action_impl! {
         type Future = CreateDataKeyFuture;
 
         async fn execute(self) -> Result<Binary> {
-            dbg!("execute start");
             #[allow(unused_mut)]
             let mut provider = self.master_key.provider();
             #[cfg(test)]
             if let Some(tp) = self.test_kms_provider {
                 provider = tp;
             }
-            dbg!("create ctx");
             let ctx = self.client_enc.create_data_key_ctx(provider, self.master_key, self.options)?;
-            dbg!("run ctx");
             let data_key = self.client_enc.exec.run_ctx(ctx, None).await?;
-            dbg!("insert");
             self.client_enc.key_vault.insert_one(&data_key, None).await?;
             let bin_ref = data_key
                 .get_binary("_id")
                 .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
-            dbg!("execute end");
             Ok(bin_ref.to_binary())
         }
     }
@@ -61,7 +56,6 @@ impl ClientEncryption {
                 builder = builder.key_material(material)?;
             }
         }
-        dbg!(&key_doc);
         builder = builder.key_encryption_key(&key_doc)?;
         Ok(builder.build_datakey()?)
     }

--- a/src/client/csfle/client_encryption/create_data_key.rs
+++ b/src/client/csfle/client_encryption/create_data_key.rs
@@ -1,0 +1,59 @@
+use bson::{doc, Binary};
+use mongocrypt::ctx::{Ctx, KmsProvider};
+
+use crate::{
+    action::{action_impl, CreateDataKey, DataKeyOptions},
+    error::{Error, Result},
+};
+
+use super::{ClientEncryption, MasterKey};
+
+action_impl! {
+    impl<'a> Action for CreateDataKey<'a> {
+        type Future = CreateDataKeyFuture;
+
+        async fn execute(self) -> Result<Binary> {
+            #[allow(unused_mut)]
+            let mut provider = self.master_key.provider();
+            #[cfg(test)]
+            if let Some(tp) = self.test_kms_provider {
+                provider = tp;
+            }
+            let ctx = self.client_enc.create_data_key_ctx(provider, self.master_key, self.options)?;
+            let data_key = self.client_enc.exec.run_ctx(ctx, None).await?;
+            self.client_enc.key_vault.insert_one(&data_key, None).await?;
+            let bin_ref = data_key
+                .get_binary("_id")
+                .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
+            Ok(bin_ref.to_binary())
+        }
+    }
+}
+
+impl ClientEncryption {
+    fn create_data_key_ctx(
+        &self,
+        kms_provider: KmsProvider,
+        master_key: MasterKey,
+        opts: Option<DataKeyOptions>,
+    ) -> Result<Ctx> {
+        let mut builder = self.crypt.ctx_builder();
+        let mut key_doc = doc! { "provider": kms_provider.name() };
+        if let Some(opts) = opts {
+            if !matches!(master_key, MasterKey::Local) {
+                let master_doc = bson::to_document(&master_key)?;
+                key_doc.extend(master_doc);
+            }
+            if let Some(alt_names) = &opts.key_alt_names {
+                for name in alt_names {
+                    builder = builder.key_alt_name(name)?;
+                }
+            }
+            if let Some(material) = &opts.key_material {
+                builder = builder.key_material(material)?;
+            }
+        }
+        builder = builder.key_encryption_key(&key_doc)?;
+        Ok(builder.build_datakey()?)
+    }
+}

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -4,21 +4,19 @@ use mongocrypt::ctx::{Algorithm, CtxBuilder};
 use crate::{
     action::{
         action_impl,
-        csfle::encrypt::{Expression, Value},
-        Encrypt,
-        EncryptOptions,
+        csfle::encrypt::{Encrypt, EncryptKey, EncryptOptions, Expression, Value},
     },
     error::{Error, Result},
 };
 
-use super::{ClientEncryption, EncryptKey};
+use super::ClientEncryption;
 
 action_impl! {
     impl<'a> Action for Encrypt<'a, Value> {
         type Future = EncryptFuture;
 
         async fn execute(self) -> Result<Binary> {
-            let builder = self.client_enc.get_ctx_builder_2(self.key, self.algorithm, self.options.unwrap_or_default())?;
+            let builder = self.client_enc.get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?;
             let ctx = builder.build_explicit_encrypt(self.mode.value)?;
             let result = self.client_enc.exec.run_ctx(ctx, None).await?;
             let bin_ref = result
@@ -34,7 +32,7 @@ action_impl! {
         type Future = EncryptExpressionFuture;
 
         async fn execute(self) -> Result<Document> {
-            let builder = self.client_enc.get_ctx_builder_2(self.key, self.algorithm, self.options.unwrap_or_default())?;
+            let builder = self.client_enc.get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?;
             let ctx = builder.build_explicit_encrypt_expression(self.mode.value)?;
             let result = self.client_enc.exec.run_ctx(ctx, None).await?;
             let doc_ref = result
@@ -50,7 +48,7 @@ action_impl! {
 }
 
 impl ClientEncryption {
-    fn get_ctx_builder_2(
+    fn get_ctx_builder(
         &self,
         key: EncryptKey,
         algorithm: Algorithm,

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -34,8 +34,10 @@ action_impl! {
         type Future = EncryptExpressionFuture;
 
         async fn execute(self) -> Result<Document> {
-            let builder = self.client_enc.get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?;
-            let ctx = builder.build_explicit_encrypt_expression(self.mode.value)?;
+            let ctx = self
+                .client_enc
+                .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?
+                .build_explicit_encrypt_expression(self.mode.value)?;
             let result = self.client_enc.exec.run_ctx(ctx, None).await?;
             let doc_ref = result
                 .get_document("v")

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -1,9 +1,15 @@
 use bson::{Binary, Document};
 use mongocrypt::ctx::{Algorithm, CtxBuilder};
 
-use crate::action::{action_impl, Encrypt, EncryptOptions};
-use crate::action::csfle::encrypt::{Expression, Value};
-use crate::error::{Error, Result};
+use crate::{
+    action::{
+        action_impl,
+        csfle::encrypt::{Expression, Value},
+        Encrypt,
+        EncryptOptions,
+    },
+    error::{Error, Result},
+};
 
 use super::{ClientEncryption, EncryptKey};
 
@@ -38,7 +44,7 @@ action_impl! {
                 .to_owned()
                 .to_document()
                 .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
-            Ok(doc)    
+            Ok(doc)
         }
     }
 }

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -1,0 +1,75 @@
+use bson::{Binary, Document};
+use mongocrypt::ctx::{Algorithm, CtxBuilder};
+
+use crate::action::{action_impl, Encrypt, EncryptOptions};
+use crate::action::csfle::encrypt::{Expression, Value};
+use crate::error::{Error, Result};
+
+use super::{ClientEncryption, EncryptKey};
+
+action_impl! {
+    impl<'a> Action for Encrypt<'a, Value> {
+        type Future = EncryptFuture;
+
+        async fn execute(self) -> Result<Binary> {
+            let builder = self.client_enc.get_ctx_builder_2(self.key, self.algorithm, self.options.unwrap_or_default())?;
+            let ctx = builder.build_explicit_encrypt(self.mode.value)?;
+            let result = self.client_enc.exec.run_ctx(ctx, None).await?;
+            let bin_ref = result
+                .get_binary("v")
+                .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
+            Ok(bin_ref.to_binary())
+        }
+    }
+}
+
+action_impl! {
+    impl<'a> Action for Encrypt<'a, Expression> {
+        type Future = EncryptExpressionFuture;
+
+        async fn execute(self) -> Result<Document> {
+            let builder = self.client_enc.get_ctx_builder_2(self.key, self.algorithm, self.options.unwrap_or_default())?;
+            let ctx = builder.build_explicit_encrypt_expression(self.mode.value)?;
+            let result = self.client_enc.exec.run_ctx(ctx, None).await?;
+            let doc_ref = result
+                .get_document("v")
+                .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
+            let doc = doc_ref
+                .to_owned()
+                .to_document()
+                .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
+            Ok(doc)    
+        }
+    }
+}
+
+impl ClientEncryption {
+    fn get_ctx_builder_2(
+        &self,
+        key: EncryptKey,
+        algorithm: Algorithm,
+        opts: EncryptOptions,
+    ) -> Result<CtxBuilder> {
+        let mut builder = self.crypt.ctx_builder();
+        match key {
+            EncryptKey::Id(id) => {
+                builder = builder.key_id(&id.bytes)?;
+            }
+            EncryptKey::AltName(name) => {
+                builder = builder.key_alt_name(&name)?;
+            }
+        }
+        builder = builder.algorithm(algorithm)?;
+        if let Some(factor) = opts.contention_factor {
+            builder = builder.contention_factor(factor)?;
+        }
+        if let Some(qtype) = &opts.query_type {
+            builder = builder.query_type(qtype)?;
+        }
+        if let Some(range_options) = &opts.range_options {
+            let options_doc = bson::to_document(range_options)?;
+            builder = builder.range_options(options_doc)?;
+        }
+        Ok(builder)
+    }
+}

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -16,8 +16,10 @@ action_impl! {
         type Future = EncryptFuture;
 
         async fn execute(self) -> Result<Binary> {
-            let builder = self.client_enc.get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?;
-            let ctx = builder.build_explicit_encrypt(self.mode.value)?;
+            let ctx = self
+                .client_enc
+                .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?
+                .build_explicit_encrypt(self.mode.value)?;
             let result = self.client_enc.exec.run_ctx(ctx, None).await?;
             let bin_ref = result
                 .get_binary("v")

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2697,7 +2697,6 @@ async fn on_demand_aws_failure() -> Result<()> {
                 .to_string(),
             endpoint: None,
         })
-        .run()
         .await;
     assert!(result.is_err(), "Expected error, got {:?}", result);
 
@@ -2724,7 +2723,6 @@ async fn on_demand_aws_success() -> Result<()> {
             .to_string(),
         endpoint: None,
     })
-    .run()
     .await?;
 
     Ok(())
@@ -2753,7 +2751,6 @@ async fn on_demand_gcp_credentials() -> Result<()> {
             key_version: None,
             endpoint: None,
         })
-        .run()
         .await;
 
     if std::env::var("ON_DEMAND_GCP_CREDS_SHOULD_SUCCEED").is_ok() {
@@ -2865,7 +2862,6 @@ async fn azure_imds_integration_failure() -> Result<()> {
             key_name: "KEY-NAME".to_string(),
             key_version: None,
         })
-        .run()
         .await;
 
     assert!(result.is_err(), "expected error, got {:?}", result);

--- a/src/test/spec/unified_runner/operation/csfle.rs
+++ b/src/test/spec/unified_runner/operation/csfle.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use super::{Entity, TestOperation, TestRunner};
 
 use crate::{
-    action::DataKeyOptions,
+    action::csfle::DataKeyOptions,
     bson::{doc, Bson},
     client_encryption::MasterKey,
     error::Result,

--- a/src/test/spec/unified_runner/operation/csfle.rs
+++ b/src/test/spec/unified_runner/operation/csfle.rs
@@ -6,8 +6,9 @@ use serde::Deserialize;
 use super::{Entity, TestOperation, TestRunner};
 
 use crate::{
+    action::DataKeyOptions,
     bson::{doc, Bson},
-    client_encryption::{DataKeyOptions, MasterKey},
+    client_encryption::MasterKey,
     error::Result,
 };
 
@@ -108,32 +109,46 @@ impl TestOperation for AddKeyAltName {
     }
 }
 
-impl<'de> Deserialize<'de> for DataKeyOptions {
+#[derive(Debug)]
+pub(super) struct CreateDataKey {
+    kms_provider: mongocrypt::ctx::KmsProvider,
+    master_key: MasterKey,
+    opts: Option<DataKeyOptions>,
+}
+
+impl<'de> Deserialize<'de> for CreateDataKey {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
         #[serde(rename_all = "camelCase")]
-        struct Helper {
+        struct TestOptions {
             master_key: Option<MasterKey>,
             key_alt_names: Option<Vec<String>>,
             key_material: Option<bson::Binary>,
         }
-        let h = Helper::deserialize(deserializer)?;
-        Ok(DataKeyOptions {
-            master_key: h.master_key.unwrap_or(MasterKey::Local),
-            key_alt_names: h.key_alt_names,
-            key_material: h.key_material.map(|bin| bin.bytes),
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct TestOp {
+            kms_provider: mongocrypt::ctx::KmsProvider,
+            opts: Option<TestOptions>,
+        }
+        let t_op = TestOp::deserialize(deserializer)?;
+        Ok(CreateDataKey {
+            kms_provider: t_op.kms_provider,
+            master_key: t_op
+                .opts
+                .as_ref()
+                .and_then(|o| o.master_key.as_ref())
+                .cloned()
+                .unwrap_or(MasterKey::Local),
+            opts: t_op.opts.map(|to| DataKeyOptions {
+                key_alt_names: to.key_alt_names,
+                key_material: to.key_material.map(|bin| bin.bytes),
+            }),
         })
     }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct CreateDataKey {
-    kms_provider: mongocrypt::ctx::KmsProvider,
-    opts: Option<DataKeyOptions>,
 }
 
 impl TestOperation for CreateDataKey {
@@ -145,7 +160,9 @@ impl TestOperation for CreateDataKey {
         async move {
             let ce = test_runner.get_client_encryption(id).await;
             let key = ce
-                .create_data_key_final(&self.kms_provider, self.opts.clone())
+                .create_data_key(self.master_key.clone())
+                .with_options(self.opts.clone())
+                .test_kms_provider(self.kms_provider.clone())
                 .await?;
             Ok(Some(Entity::Bson(Bson::Binary(key))))
         }


### PR DESCRIPTION
RUST-1829

The CSFLE API already used a fluent pattern, but it wasn't using the common machinery we built for the rest of the client.  There's lots of bits shuffling around here but no functional changes.