### PR TITLE
RUST-1881 Check integer conversions

### DIFF
--- a/src/bson_util.rs
+++ b/src/bson_util.rs
@@ -5,12 +5,14 @@ use std::{
 
 use crate::{
     bson::{Bson, Document, RawArrayBuf, RawBson, RawBsonRef, RawDocumentBuf},
+    checked::Checked,
     error::{ErrorKind, Result},
     runtime::SyncLittleEndianRead,
 };
 
 /// Coerce numeric types into an `i64` if it would be lossless to do so. If this Bson is not numeric
 /// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn get_int(val: &Bson) -> Option<i64> {
     match *val {
         Bson::Int32(i) => Some(i64::from(i)),
@@ -33,6 +35,7 @@ pub(crate) fn get_int_raw(val: RawBsonRef<'_>) -> Option<i64> {
 
 /// Coerce numeric types into an `u64` if it would be lossless to do so. If this Bson is not numeric
 /// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
     match *val {
         Bson::Int32(i) => u64::try_from(i).ok(),
@@ -89,18 +92,18 @@ pub(crate) fn update_document_check(update: &Document) -> Result<()> {
 }
 
 /// The size in bytes of the provided document's entry in a BSON array at the given index.
-pub(crate) fn array_entry_size_bytes(index: usize, doc_len: usize) -> u64 {
+pub(crate) fn array_entry_size_bytes(index: usize, doc_len: usize) -> Result<usize> {
     //   * type (1 byte)
     //   * number of decimal digits in key
     //   * null terminator for the key (1 byte)
     //   * size of value
 
-    1 + num_decimal_digits(index) + 1 + doc_len as u64
+    (Checked::new(1) + num_decimal_digits(index) + 1 + doc_len).get()
 }
 
 /// The number of digits in `n` in base 10.
 /// Useful for calculating the size of an array entry in BSON.
-fn num_decimal_digits(mut n: usize) -> u64 {
+fn num_decimal_digits(mut n: usize) -> usize {
     let mut digits = 0;
 
     loop {

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -1,0 +1,510 @@
+// Modified from https://github.com/zeta12ti/Checked/blob/master/src/num.rs
+// Original license:
+// MIT License
+//
+// Copyright (c) 2017 zeta12ti
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use std::{cmp::Ordering, convert::TryFrom, fmt, ops::*};
+
+/// The Checked type. See the [module level documentation for more.](index.html)
+#[derive(PartialEq, Eq, Clone, Copy, Hash)]
+pub struct Checked<T>(pub Option<T>);
+
+impl<T> Checked<T> {
+    /// Creates a new Checked instance from some sort of integer.
+    /// # Examples
+    /// ```
+    /// use checked::Checked;
+    ///
+    /// let x = Checked::new(1_000_u32);
+    /// let y = Checked::new(1_000_000_u32);
+    /// assert_eq!(x * x, y);
+    /// ```
+    #[inline]
+    pub fn new(x: T) -> Checked<T> {
+        Checked(Some(x))
+    }
+
+    pub fn try_from<F>(value: F) -> crate::error::Result<Self>
+    where
+        T: TryFrom<F>,
+        T::Error: std::fmt::Display,
+    {
+        value
+            .try_into()
+            .map(|v| Self(Some(v)))
+            .map_err(|e| crate::error::Error::invalid_argument(format! {"{}", e}))
+    }
+
+    pub fn get(self) -> crate::error::Result<T> {
+        self.0
+            .ok_or_else(|| crate::error::Error::invalid_argument("checked arithmetic failure"))
+    }
+
+    pub fn try_into<F>(self) -> crate::error::Result<F>
+    where
+        T: TryInto<F>,
+        T::Error: std::fmt::Display,
+    {
+        self.get().and_then(|v| {
+            v.try_into()
+                .map_err(|e| crate::error::Error::invalid_argument(format!("{}", e)))
+        })
+    }
+}
+
+// The derived Default only works if T has Default
+// Even though this is what it would be anyway
+// May change this to T's default (if it has one)
+impl<T> Default for Checked<T> {
+    #[inline]
+    fn default() -> Checked<T> {
+        Checked(None)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Checked<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match **self {
+            Some(ref x) => x.fmt(f),
+            None => "overflow".fmt(f),
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Checked<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match **self {
+            Some(ref x) => x.fmt(f),
+            None => "overflow".fmt(f),
+        }
+    }
+}
+
+// I'd like to do
+// `impl<T, U> From<U> where T: From<U> for Checked<T>``
+// in the obvious way, but that "conflicts" with the default `impl From<T> for T`.
+// This would subsume both the below Froms since Option has the right From impl.
+impl<T> From<T> for Checked<T> {
+    #[inline]
+    fn from(x: T) -> Checked<T> {
+        Checked(Some(x))
+    }
+}
+
+impl<T> From<Option<T>> for Checked<T> {
+    #[inline]
+    fn from(x: Option<T>) -> Checked<T> {
+        Checked(x)
+    }
+}
+
+impl<T> Deref for Checked<T> {
+    type Target = Option<T>;
+
+    #[inline]
+    fn deref(&self) -> &Option<T> {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Checked<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<T> {
+        &mut self.0
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for Checked<T> {
+    fn partial_cmp(&self, other: &Checked<T>) -> Option<Ordering> {
+        // I'm not really sure why we can't match **self etc. here.
+        // Even with refs everywhere it complains
+        // Note what happens in this implementation:
+        // we take the reference self, and call deref (the method) on it
+        // By Deref coercion, self gets derefed to a Checked<T>
+        // Now Checked<T>'s deref gets called, returning a &Option<T>
+        // That's what gets matched
+        match (self.deref(), other.deref()) {
+            (Some(x), Some(y)) => PartialOrd::partial_cmp(x, y),
+            _ => None,
+        }
+    }
+}
+
+// implements the unary operator `op &T`
+// based on `op T` where `T` is expected to be `Copy`able
+macro_rules! forward_ref_unop {
+    (impl $imp:ident, $method:ident for $t:ty {}) => {
+        impl<'a> $imp for &'a $t {
+            type Output = <$t as $imp>::Output;
+
+            #[inline]
+            fn $method(self) -> <$t as $imp>::Output {
+                $imp::$method(*self)
+            }
+        }
+    };
+}
+
+// implements binary operators "&T op U", "T op &U", "&T op &U"
+// based on "T op U" where T and U are expected to be `Copy`able
+macro_rules! forward_ref_binop {
+    (impl $imp:ident, $method:ident for $t:ty, $u:ty {}) => {
+        impl<'a> $imp<$u> for &'a $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, other)
+            }
+        }
+
+        impl<'a> $imp<&'a $u> for $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(self, *other)
+            }
+        }
+
+        impl<'a, 'b> $imp<&'a $u> for &'b $t {
+            type Output = <$t as $imp<$u>>::Output;
+
+            #[inline]
+            fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
+                $imp::$method(*self, *other)
+            }
+        }
+    };
+}
+
+macro_rules! impl_sh {
+    ($t:ident, $f:ident) => {
+        impl Shl<Checked<$f>> for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn shl(self, other: Checked<$f>) -> Checked<$t> {
+                match (*self, *other) {
+                    (Some(x), Some(y)) => Checked(x.checked_shl(y)),
+                    _ => Checked(None),
+                }
+            }
+        }
+
+        impl Shl<$f> for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn shl(self, other: $f) -> Checked<$t> {
+                match *self {
+                    Some(x) => Checked(x.checked_shl(other)),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_binop! { impl Shl, shl for Checked<$t>, Checked<$f> {} }
+        forward_ref_binop! { impl Shl, shl for Checked<$t>, $f {} }
+
+        impl ShlAssign<$f> for Checked<$t> {
+            #[inline]
+            fn shl_assign(&mut self, other: $f) {
+                *self = *self << other;
+            }
+        }
+
+        impl ShlAssign<Checked<$f>> for Checked<$t> {
+            #[inline]
+            fn shl_assign(&mut self, other: Checked<$f>) {
+                *self = *self << other;
+            }
+        }
+
+        impl Shr<Checked<$f>> for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn shr(self, other: Checked<$f>) -> Checked<$t> {
+                match (*self, *other) {
+                    (Some(x), Some(y)) => Checked(x.checked_shr(y)),
+                    _ => Checked(None),
+                }
+            }
+        }
+
+        impl Shr<$f> for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn shr(self, other: $f) -> Checked<$t> {
+                match *self {
+                    Some(x) => Checked(x.checked_shr(other)),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_binop! { impl Shr, shr for Checked<$t>, Checked<$f> {} }
+        forward_ref_binop! { impl Shr, shr for Checked<$t>, $f {} }
+
+        impl ShrAssign<$f> for Checked<$t> {
+            #[inline]
+            fn shr_assign(&mut self, other: $f) {
+                *self = *self >> other;
+            }
+        }
+
+        impl ShrAssign<Checked<$f>> for Checked<$t> {
+            #[inline]
+            fn shr_assign(&mut self, other: Checked<$f>) {
+                *self = *self >> other;
+            }
+        }
+    };
+}
+
+macro_rules! impl_sh_reverse {
+    ($t:ident, $f:ident) => {
+        impl Shl<Checked<$t>> for $f {
+            type Output = Checked<$f>;
+
+            fn shl(self, other: Checked<$t>) -> Checked<$f> {
+                match *other {
+                    Some(x) => Checked(self.checked_shl(x)),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_binop! { impl Shl, shl for $f, Checked<$t> {} }
+
+        impl Shr<Checked<$t>> for $f {
+            type Output = Checked<$f>;
+
+            fn shr(self, other: Checked<$t>) -> Checked<$f> {
+                match *other {
+                    Some(x) => Checked(self.checked_shr(x)),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_binop! { impl Shr, shr for $f, Checked<$t> {} }
+    };
+}
+
+macro_rules! impl_sh_all {
+    ($($t:ident)*) => ($(
+        // When checked_shX is added for other shift sizes, uncomment some of these.
+        // impl_sh! { $t, u8 }
+        // impl_sh! { $t, u16 }
+        impl_sh! { $t, u32 }
+        //impl_sh! { $t, u64 }
+        //impl_sh! { $t, usize }
+
+        //impl_sh! { $t, i8 }
+        //impl_sh! { $t, i16 }
+        //impl_sh! { $t, i32 }
+        //impl_sh! { $t, i64 }
+        //impl_sh! { $t, isize }
+
+        // impl_sh_reverse! { u8, $t }
+        // impl_sh_reverse! { u16, $t }
+        impl_sh_reverse! { u32, $t }
+        //impl_sh_reverse! { u64, $t }
+        //impl_sh_reverse! { usize, $t }
+
+        //impl_sh_reverse! { i8, $t }
+        //impl_sh_reverse! { i16, $t }
+        //impl_sh_reverse! { i32, $t }
+        //impl_sh_reverse! { i64, $t }
+        //impl_sh_reverse! { isize, $t }
+    )*)
+}
+
+impl_sh_all! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }
+
+// implements unary operators for checked types
+macro_rules! impl_unop {
+    (impl $imp:ident, $method:ident, $checked_method:ident for $t:ty {}) => {
+        impl $imp for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn $method(self) -> Checked<$t> {
+                match *self {
+                    Some(x) => Checked(x.$checked_method()),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_unop! { impl $imp, $method for Checked<$t> {} }
+    };
+}
+
+// implements unary operators for checked types (with no checked method)
+macro_rules! impl_unop_unchecked {
+    (impl $imp:ident, $method:ident for $t:ty {$op:tt}) => {
+        impl $imp for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn $method(self) -> Checked<$t> {
+                match *self {
+                    Some(x) => Checked(Some($op x)),
+                    None => Checked(None)
+                }
+            }
+        }
+
+        forward_ref_unop! { impl $imp, $method for Checked<$t> {} }
+    }
+}
+
+// implements binary operators for checked types
+macro_rules! impl_binop {
+    (impl $imp:ident, $method:ident, $checked_method:ident for $t:ty {}) => {
+        impl $imp for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn $method(self, other: Checked<$t>) -> Checked<$t> {
+                match (*self, *other) {
+                    (Some(x), Some(y)) => Checked(x.$checked_method(y)),
+                    _ => Checked(None),
+                }
+            }
+        }
+
+        impl $imp<$t> for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn $method(self, other: $t) -> Checked<$t> {
+                match *self {
+                    Some(x) => Checked(x.$checked_method(other)),
+                    _ => Checked(None),
+                }
+            }
+        }
+
+        impl $imp<Checked<$t>> for $t {
+            type Output = Checked<$t>;
+
+            fn $method(self, other: Checked<$t>) -> Checked<$t> {
+                match *other {
+                    Some(x) => Checked(self.$checked_method(x)),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_binop! { impl $imp, $method for Checked<$t>, Checked<$t> {} }
+        forward_ref_binop! { impl $imp, $method for Checked<$t>, $t {} }
+        forward_ref_binop! { impl $imp, $method for $t, Checked<$t> {} }
+    };
+}
+
+// implements binary operators for checked types (no checked method)
+macro_rules! impl_binop_unchecked {
+    (impl $imp:ident, $method:ident for $t:ty {$op:tt}) => {
+        impl $imp for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn $method(self, other: Checked<$t>) -> Checked<$t> {
+                match (*self, *other) {
+                    (Some(x), Some(y)) => Checked(Some(x $op y)),
+                    _ => Checked(None),
+                }
+            }
+        }
+
+        impl $imp<$t> for Checked<$t> {
+            type Output = Checked<$t>;
+
+            fn $method(self, other: $t) -> Checked<$t> {
+                match *self {
+                    Some(x) => Checked(Some(x $op other)),
+                    _ => Checked(None),
+                }
+            }
+        }
+
+        impl $imp<Checked<$t>> for $t {
+            type Output = Checked<$t>;
+
+            fn $method(self, other: Checked<$t>) -> Checked<$t> {
+                match *other {
+                    Some(x) => Checked(Some(self $op x)),
+                    None => Checked(None),
+                }
+            }
+        }
+
+        forward_ref_binop! { impl $imp, $method for Checked<$t>, Checked<$t> {} }
+        forward_ref_binop! { impl $imp, $method for Checked<$t>, $t {} }
+        forward_ref_binop! { impl $imp, $method for $t, Checked<$t> {} }
+    }
+}
+
+// implements assignment operators for checked types
+macro_rules! impl_binop_assign {
+    (impl $imp:ident, $method:ident for $t:ty {$op:tt}) => {
+        impl $imp for Checked<$t> {
+            #[inline]
+            fn $method(&mut self, other: Checked<$t>) {
+                *self = *self $op other;
+            }
+        }
+
+        impl $imp<$t> for Checked<$t> {
+            #[inline]
+            fn $method(&mut self, other: $t) {
+                *self = *self $op other;
+            }
+        }
+    };
+}
+
+macro_rules! checked_impl {
+    ($($t:ty)*) => {
+        $(
+            impl_binop! { impl Add, add, checked_add for $t {} }
+            impl_binop_assign! { impl AddAssign, add_assign for $t {+} }
+            impl_binop! { impl Sub, sub, checked_sub for $t {} }
+            impl_binop_assign! { impl SubAssign, sub_assign for $t {-} }
+            impl_binop! { impl Mul, mul, checked_mul for $t {} }
+            impl_binop_assign! { impl MulAssign, mul_assign for $t {*} }
+            impl_binop! { impl Div, div, checked_div for $t {} }
+            impl_binop_assign! { impl DivAssign, div_assign for $t {/} }
+            impl_binop! { impl Rem, rem, checked_rem for $t {} }
+            impl_binop_assign! { impl RemAssign, rem_assign for $t {%} }
+            impl_unop_unchecked! { impl Not, not for $t {!} }
+            impl_binop_unchecked! { impl BitXor, bitxor for $t {^} }
+            impl_binop_assign! { impl BitXorAssign, bitxor_assign for $t {^} }
+            impl_binop_unchecked! { impl BitOr, bitor for $t {|} }
+            impl_binop_assign! { impl BitOrAssign, bitor_assign for $t {|} }
+            impl_binop_unchecked! { impl BitAnd, bitand for $t {&} }
+            impl_binop_assign! { impl BitAndAssign, bitand_assign for $t {&} }
+            impl_unop! { impl Neg, neg, checked_neg for $t {} }
+
+        )*
+    };
+}
+
+checked_impl! { u8 u16 u32 u64 usize i8 i16 i32 i64 isize }

--- a/src/checked.rs
+++ b/src/checked.rs
@@ -30,14 +30,6 @@ pub struct Checked<T>(pub Option<T>);
 
 impl<T> Checked<T> {
     /// Creates a new Checked instance from some sort of integer.
-    /// # Examples
-    /// ```
-    /// use checked::Checked;
-    ///
-    /// let x = Checked::new(1_000_u32);
-    /// let y = Checked::new(1_000_000_u32);
-    /// assert_eq!(x * x, y);
-    /// ```
     #[inline]
     pub fn new(x: T) -> Checked<T> {
         Checked(Some(x))

--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -740,7 +740,11 @@ impl Serialize for ClientOptions {
             writeconcern: &self.write_concern,
             loadbalanced: &self.load_balanced,
             zlibcompressionlevel: &None,
-            srvmaxhosts: self.srv_max_hosts.map(|v| v as i32),
+            srvmaxhosts: self
+                .srv_max_hosts
+                .map(|v| v.try_into())
+                .transpose()
+                .map_err(serde::ser::Error::custom)?,
         };
 
         client_options.serialize(serializer)

--- a/src/cmap/conn/wire/message.rs
+++ b/src/cmap/conn/wire/message.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::{
     bson::RawDocumentBuf,
     bson_util,
+    checked::Checked,
     cmap::{conn::wire::util::SyncCountReader, Command},
     compression::{Compressor, Decoder},
     error::{Error, ErrorKind, Result},
@@ -121,21 +122,22 @@ impl Message {
         mut reader: T,
         header: &Header,
     ) -> Result<Self> {
-        // TODO: RUST-616 ensure length is < maxMessageSizeBytes
-        let length_remaining = header.length - Header::LENGTH as i32;
-        let mut buf = vec![0u8; length_remaining as usize];
+        let length = Checked::<usize>::try_from(header.length)?;
+        let length_remaining = length - Header::LENGTH;
+        let mut buf = vec![0u8; length_remaining.get()?];
         reader.read_exact(&mut buf).await?;
         let reader = buf.as_slice();
 
-        Self::read_op_common(reader, length_remaining, header)
+        Self::read_op_common(reader, length_remaining.get()?, header)
     }
 
     async fn read_from_op_compressed<T: AsyncRead + Unpin + Send>(
         mut reader: T,
         header: &Header,
     ) -> Result<Self> {
-        let length_remaining = header.length - Header::LENGTH as i32;
-        let mut buf = vec![0u8; length_remaining as usize];
+        let length = Checked::<usize>::try_from(header.length)?;
+        let length_remaining = length - Header::LENGTH;
+        let mut buf = vec![0u8; length_remaining.get()?];
         reader.read_exact(&mut buf).await?;
         let mut reader = buf.as_slice();
 
@@ -153,7 +155,7 @@ impl Message {
         }
 
         // Read uncompressed size
-        let uncompressed_size = reader.read_i32_sync()?;
+        let uncompressed_size = Checked::<usize>::try_from(reader.read_i32_sync()?)?;
 
         // Read compressor id
         let compressor_id: u8 = reader.read_u8_sync()?;
@@ -165,7 +167,7 @@ impl Message {
         let decoded_message = decoder.decode(reader)?;
 
         // Check that claimed length matches original length
-        if decoded_message.len() as i32 != uncompressed_size {
+        if decoded_message.len() != uncompressed_size.get()? {
             return Err(ErrorKind::InvalidResponse {
                 message: format!(
                     "The server's message claims that the uncompressed length is {}, but was \
@@ -181,21 +183,18 @@ impl Message {
         let reader = decoded_message.as_slice();
         let length_remaining = decoded_message.len();
 
-        Self::read_op_common(reader, length_remaining as i32, header)
+        Self::read_op_common(reader, length_remaining, header)
     }
 
-    fn read_op_common(
-        mut reader: &[u8],
-        mut length_remaining: i32,
-        header: &Header,
-    ) -> Result<Self> {
+    fn read_op_common(mut reader: &[u8], length_remaining: usize, header: &Header) -> Result<Self> {
+        let mut length_remaining = Checked::new(length_remaining);
         let flags = MessageFlags::from_bits_truncate(reader.read_u32_sync()?);
-        length_remaining -= std::mem::size_of::<u32>() as i32;
+        length_remaining -= std::mem::size_of::<u32>();
 
         let mut count_reader = SyncCountReader::new(&mut reader);
         let mut document_payload = None;
         let mut document_sequences = Vec::new();
-        while length_remaining - count_reader.bytes_read() as i32 > 4 {
+        while (length_remaining - count_reader.bytes_read()).get()? > 4 {
             let next_section = MessageSection::read(&mut count_reader)?;
             match next_section {
                 MessageSection::Document(document) => {
@@ -216,22 +215,19 @@ impl Message {
             }
         }
 
-        length_remaining -= count_reader.bytes_read() as i32;
+        length_remaining -= count_reader.bytes_read();
 
         let mut checksum = None;
 
-        if length_remaining == 4 && flags.contains(MessageFlags::CHECKSUM_PRESENT) {
+        if length_remaining.get()? == 4 && flags.contains(MessageFlags::CHECKSUM_PRESENT) {
             checksum = Some(reader.read_u32_sync()?);
-        } else if length_remaining != 0 {
-            return Err(ErrorKind::InvalidResponse {
-                message: format!(
-                    "The server indicated that the reply would be {} bytes long, but it instead \
-                     was {}",
-                    header.length,
-                    header.length - length_remaining + count_reader.bytes_read() as i32,
-                ),
-            }
-            .into());
+        } else if length_remaining.get()? != 0 {
+            let header_len = Checked::<usize>::try_from(header.length)?;
+            return Err(Error::invalid_response(format!(
+                "The server indicated that the reply would be {} bytes long, but it instead was {}",
+                header.length,
+                header_len - length_remaining + count_reader.bytes_read(),
+            )));
         }
 
         Ok(Self {
@@ -249,9 +245,9 @@ impl Message {
 
     /// Serializes the Message to bytes and writes them to `writer`.
     pub(crate) async fn write_to<T: AsyncWrite + Send + Unpin>(&self, mut writer: T) -> Result<()> {
-        let sections = self.get_sections_bytes();
+        let sections = self.get_sections_bytes()?;
 
-        let total_length = Header::LENGTH
+        let total_length = Checked::new(Header::LENGTH)
             + std::mem::size_of::<u32>()
             + sections.len()
             + self
@@ -261,7 +257,7 @@ impl Message {
                 .unwrap_or(0);
 
         let header = Header {
-            length: total_length as i32,
+            length: total_length.try_into()?,
             request_id: self.request_id.unwrap_or_else(next_request_id),
             response_to: self.response_to,
             op_code: OpCode::Message,
@@ -289,24 +285,24 @@ impl Message {
         let mut encoder = compressor.to_encoder()?;
         let compressor_id = compressor.id() as u8;
 
-        let sections = self.get_sections_bytes();
+        let sections = self.get_sections_bytes()?;
 
         let flag_bytes = &self.flags.bits().to_le_bytes();
-        let uncompressed_len = sections.len() + flag_bytes.len();
+        let uncompressed_len = Checked::new(sections.len()) + flag_bytes.len();
         // Compress the flags and sections.  Depending on the handshake
         // this could use zlib, zstd or snappy
         encoder.write_all(flag_bytes)?;
         encoder.write_all(sections.as_slice())?;
         let compressed_bytes = encoder.finish()?;
 
-        let total_length = Header::LENGTH
+        let total_length = Checked::new(Header::LENGTH)
             + std::mem::size_of::<i32>()
             + std::mem::size_of::<i32>()
             + std::mem::size_of::<u8>()
             + compressed_bytes.len();
 
         let header = Header {
-            length: total_length as i32,
+            length: total_length.try_into()?,
             request_id: self.request_id.unwrap_or_else(next_request_id),
             response_to: self.response_to,
             op_code: OpCode::Compressed,
@@ -317,7 +313,7 @@ impl Message {
         // Write original (pre-compressed) opcode (always OP_MSG)
         writer.write_i32_le(OpCode::Message as i32).await?;
         // Write uncompressed size
-        writer.write_i32_le(uncompressed_len as i32).await?;
+        writer.write_i32_le(uncompressed_len.try_into()?).await?;
         // Write compressor id
         writer.write_u8(compressor_id).await?;
         // Write compressed message
@@ -328,7 +324,7 @@ impl Message {
         Ok(())
     }
 
-    fn get_sections_bytes(&self) -> Vec<u8> {
+    fn get_sections_bytes(&self) -> Result<Vec<u8>> {
         let mut sections = Vec::new();
 
         // Payload type 0
@@ -349,8 +345,8 @@ impl Message {
                 });
 
             // Size bytes + identifier bytes + null-terminator byte + document bytes
-            let size = 4 + identifier_bytes.len() + 1 + documents_size;
-            sections.extend((size as i32).to_le_bytes());
+            let size = Checked::new(4) + identifier_bytes.len() + 1 + documents_size;
+            sections.extend(size.try_into::<i32>()?.to_le_bytes());
 
             sections.extend(identifier_bytes);
             sections.push(0);
@@ -360,7 +356,7 @@ impl Message {
             }
         }
 
-        sections
+        Ok(sections)
     }
 }
 
@@ -393,28 +389,28 @@ impl MessageSection {
             return Ok(MessageSection::Document(document));
         }
 
-        let size = reader.read_i32_sync()?;
-        let mut length_remaining = size - std::mem::size_of::<i32>() as i32;
+        let size = Checked::<usize>::try_from(reader.read_i32_sync()?)?;
+        let mut length_remaining = size - std::mem::size_of::<i32>();
 
         let mut identifier = String::new();
-        length_remaining -= reader.read_to_string(&mut identifier)? as i32;
+        length_remaining -= reader.read_to_string(&mut identifier)?;
 
         let mut documents = Vec::new();
         let mut count_reader = SyncCountReader::new(reader);
 
-        while length_remaining > count_reader.bytes_read() as i32 {
+        while length_remaining.get()? > count_reader.bytes_read() {
             let bytes = bson_util::read_document_bytes(&mut count_reader)?;
             let document = RawDocumentBuf::from_bytes(bytes)?;
             documents.push(document);
         }
 
-        if length_remaining != count_reader.bytes_read() as i32 {
+        if length_remaining.get()? != count_reader.bytes_read() {
             return Err(ErrorKind::InvalidResponse {
                 message: format!(
                     "The server indicated that the reply would be {} bytes long, but it instead \
                      was {}",
                     size,
-                    length_remaining + count_reader.bytes_read() as i32,
+                    length_remaining + count_reader.bytes_read(),
                 ),
             }
             .into());

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -128,7 +128,7 @@ impl Serialize for CollationStrength {
         S: serde::Serializer,
     {
         let level = u32::from(*self);
-        serializer.serialize_i32(level as i32)
+        serializer.serialize_i32(level.try_into().map_err(serde::ser::Error::custom)?)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,6 +124,13 @@ impl Error {
         .into()
     }
 
+    pub(crate) fn invalid_response(message: impl Into<String>) -> Error {
+        ErrorKind::InvalidResponse {
+            message: message.into(),
+        }
+        .into()
+    }
+
     /// Construct a generic network timeout error.
     pub(crate) fn network_timeout() -> Error {
         ErrorKind::Io(Arc::new(std::io::ErrorKind::TimedOut.into())).into()

--- a/src/gridfs.rs
+++ b/src/gridfs.rs
@@ -11,6 +11,7 @@ use serde_with::skip_serializing_none;
 
 use crate::{
     bson::{doc, oid::ObjectId, Bson, DateTime, Document, RawBinaryRef},
+    checked::Checked,
     cursor::Cursor,
     error::{Error, ErrorKind, GridFsErrorKind, GridFsFileIdentifier, Result},
     options::{
@@ -83,8 +84,8 @@ impl FilesCollectionDocument {
 
     fn n_from_vals(length: u64, chunk_size_bytes: u32) -> u32 {
         let chunk_size_bytes = chunk_size_bytes as u64;
-        let n = length / chunk_size_bytes + u64::from(length % chunk_size_bytes != 0);
-        n as u32
+        let n = Checked::new(length) / chunk_size_bytes + u64::from(length % chunk_size_bytes != 0);
+        n.try_into().unwrap()
     }
 
     /// Returns the expected length of a chunk given its index.
@@ -95,7 +96,7 @@ impl FilesCollectionDocument {
     fn expected_chunk_length_from_vals(length: u64, chunk_size_bytes: u32, n: u32) -> u32 {
         let remainder = length % (chunk_size_bytes as u64);
         if n == Self::n_from_vals(length, chunk_size_bytes) - 1 && remainder != 0 {
-            remainder as u32
+            Checked::new(remainder).try_into().unwrap()
         } else {
             chunk_size_bytes
         }

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -54,7 +54,13 @@ pub(crate) fn hello_command(
 
     if let Some(opts) = awaitable_options {
         command.insert("topologyVersion", opts.topology_version);
-        command.insert("maxAwaitTimeMS", opts.max_await_time.as_millis() as i64);
+        command.insert(
+            "maxAwaitTimeMS",
+            opts.max_await_time
+                .as_millis()
+                .try_into()
+                .unwrap_or(i64::MAX),
+        );
     }
 
     let mut command = Command::new(command_name, "admin", command);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,8 @@
 
 #![warn(missing_docs)]
 #![warn(rustdoc::missing_crate_level_docs)]
+#![warn(clippy::cast_possible_truncation)]
+#![warn(clippy::cast_possible_wrap)]
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(
@@ -296,6 +298,7 @@ pub use ::mongocrypt;
 pub mod action;
 mod bson_util;
 pub mod change_stream;
+pub(crate) mod checked;
 mod client;
 mod cmap;
 mod coll;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -71,9 +71,9 @@ const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
 const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
 // The maximum number of bytes that may be included in a write payload when auto-encryption is
 // enabled.
-const MAX_ENCRYPTED_WRITE_SIZE: u64 = 2_097_152;
+const MAX_ENCRYPTED_WRITE_SIZE: usize = 2_097_152;
 // The amount of overhead bytes to account for when building a document sequence.
-const COMMAND_OVERHEAD_SIZE: u64 = 16_000;
+const COMMAND_OVERHEAD_SIZE: usize = 16_000;
 
 /// A trait modeling the behavior of a server side operation.
 ///

--- a/src/operation/get_more.rs
+++ b/src/operation/get_more.rs
@@ -70,7 +70,10 @@ impl<'conn> OperationWithDefaults for GetMore<'conn> {
         }
 
         if let Some(ref max_time) = self.max_time {
-            body.insert("maxTimeMS", max_time.as_millis() as i32);
+            body.insert(
+                "maxTimeMS",
+                max_time.as_millis().try_into().unwrap_or(i32::MAX),
+            );
         }
 
         if let Some(ref comment) = self.comment {

--- a/src/sdam/description/topology/server_selection.rs
+++ b/src/sdam/description/topology/server_selection.rs
@@ -291,7 +291,7 @@ impl TopologyDescription {
         primary: &ServerDescription,
         max_staleness: Duration,
     ) {
-        let max_staleness_ms = max_staleness.as_millis() as i64;
+        let max_staleness_ms = max_staleness.as_millis().try_into().unwrap_or(i64::MAX);
 
         servers.retain(|server| {
             let server_staleness = self.calculate_secondary_staleness_with_primary(server, primary);
@@ -307,7 +307,7 @@ impl TopologyDescription {
         servers: &mut Vec<&ServerDescription>,
         max_staleness: Duration,
     ) {
-        let max_staleness = max_staleness.as_millis() as i64;
+        let max_staleness = max_staleness.as_millis().try_into().unwrap_or(i64::MAX);
         let max_write_date = self
             .servers
             .values()
@@ -347,7 +347,11 @@ impl TopologyDescription {
         let secondary_last_update = secondary.last_update_time?.timestamp_millis();
         let secondary_last_write = secondary.last_write_date().ok()??.timestamp_millis();
 
-        let heartbeat_frequency = self.heartbeat_frequency().as_millis() as i64;
+        let heartbeat_frequency = self
+            .heartbeat_frequency()
+            .as_millis()
+            .try_into()
+            .unwrap_or(i64::MAX);
 
         let staleness = (secondary_last_update - secondary_last_write)
             - (primary_last_update - primary_last_write)
@@ -362,7 +366,11 @@ impl TopologyDescription {
         max_last_write_date: i64,
     ) -> Option<i64> {
         let secondary_last_write = secondary.last_write_date().ok()??.timestamp_millis();
-        let heartbeat_frequency = self.heartbeat_frequency().as_millis() as i64;
+        let heartbeat_frequency = self
+            .heartbeat_frequency()
+            .as_millis()
+            .try_into()
+            .unwrap_or(i64::MAX);
 
         let staleness = max_last_write_date - secondary_last_write + heartbeat_frequency;
         Some(staleness)

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -198,18 +198,21 @@ async fn load_balancing_test() {
         counts.sort();
 
         let share_of_selections = (*counts[0] as f64) / ((*counts[0] + *counts[1]) as f64);
-        assert!(
-            share_of_selections <= max_share,
-            "expected no more than {}% of selections, instead got {}%",
-            (max_share * 100.0) as u32,
-            (share_of_selections * 100.0) as u32
-        );
-        assert!(
-            share_of_selections >= min_share,
-            "expected at least {}% of selections, instead got {}%",
-            (min_share * 100.0) as u32,
-            (share_of_selections * 100.0) as u32
-        );
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            assert!(
+                share_of_selections <= max_share,
+                "expected no more than {}% of selections, instead got {}%",
+                (max_share * 100.0) as u32,
+                (share_of_selections * 100.0) as u32
+            );
+            assert!(
+                share_of_selections >= min_share,
+                "expected at least {}% of selections, instead got {}%",
+                (min_share * 100.0) as u32,
+                (share_of_selections * 100.0) as u32
+            );
+        }
     }
 
     let mut handler = EventHandler::new();

--- a/src/sdam/description/topology/test.rs
+++ b/src/sdam/description/topology/test.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 pub use event::TestSdamEvent;
 
+#[allow(clippy::cast_possible_truncation)]
 pub(crate) fn f64_ms_as_duration(f: f64) -> Duration {
     Duration::from_micros((f * 1000.0) as u64)
 }

--- a/src/serde_util.rs
+++ b/src/serde_util.rs
@@ -18,9 +18,13 @@ pub(crate) mod duration_option_as_int_seconds {
         serializer: S,
     ) -> std::result::Result<S::Ok, S::Error> {
         match val {
-            Some(duration) if duration.as_secs() > i32::MAX as u64 => {
-                serializer.serialize_i64(duration.as_secs() as i64)
-            }
+            Some(duration) if duration.as_secs() > i32::MAX as u64 => serializer.serialize_i64(
+                duration
+                    .as_secs()
+                    .try_into()
+                    .map_err(serde::ser::Error::custom)?,
+            ),
+            #[allow(clippy::cast_possible_truncation)]
             Some(duration) => serializer.serialize_i32(duration.as_secs() as i32),
             None => serializer.serialize_none(),
         }
@@ -42,9 +46,13 @@ pub(crate) fn serialize_duration_option_as_int_millis<S: Serializer>(
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {
     match val {
-        Some(duration) if duration.as_millis() > i32::MAX as u128 => {
-            serializer.serialize_i64(duration.as_millis() as i64)
-        }
+        Some(duration) if duration.as_millis() > i32::MAX as u128 => serializer.serialize_i64(
+            duration
+                .as_millis()
+                .try_into()
+                .map_err(serde::ser::Error::custom)?,
+        ),
+        #[allow(clippy::cast_possible_truncation)]
         Some(duration) => serializer.serialize_i32(duration.as_millis() as i32),
         None => serializer.serialize_none(),
     }
@@ -77,6 +85,7 @@ pub(crate) fn serialize_u32_option_as_batch_size<S: Serializer>(
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {
     match val {
+        #[allow(clippy::cast_possible_wrap)]
         Some(val) if *val <= std::i32::MAX as u32 => (doc! {
             "batchSize": (*val as i32)
         })

--- a/src/serde_util.rs
+++ b/src/serde_util.rs
@@ -150,6 +150,7 @@ where
     }
 
     let date_time = match AwsDateTime::deserialize(deserializer)? {
+        #[allow(clippy::cast_possible_truncation)]
         AwsDateTime::Double(seconds) => {
             let millis = seconds * 1000.0;
             bson::DateTime::from_millis(millis as i64)

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+
 mod atlas_connectivity;
 mod atlas_planned_maintenance_testing;
 #[cfg(feature = "aws-auth")]


### PR DESCRIPTION
RUST-1881

This vendors the `Checked` type from https://github.com/zeta12ti/Checked, minus the `num_traits` support, plus a few conveniences for our specific error type, and uses it to check both integer conversions and integer arithmetic for particularly sensitive values like buffer sizes.  The guidelines I used for this:
* at function boundaries, sizes should be represented as `usize`
* within a function, sizes should be `Checked<usize>` starting at the earliest possible point (ideally, initialization from a constant or single value), and persisting as late as possible so that all arithmetic is also checked.
* deadlines (number of seconds/millis) can saturate in conversion
* where context doesn't provide an easy way to propagate a `Result`, `unwrap` is used on the grounds that a crash is better than silent bad behavior

I added a lint for risky `as` conversions to the toplevel `lib.rs` so future uses will get caught :)

(Once this goes in I will, of course, cherry-pick this into 2.8.x.)