### PR TITLE
RUST-1885 Fix FLE tests broken on -latest

### DIFF
--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -2986,7 +2986,7 @@ async fn range_explicit_encryption() -> Result<()> {
         return Ok(());
     }
     let client = TestClient::new().await;
-    if client.server_version_lt(6, 2) || client.is_standalone() {
+    if client.server_version_lt(6, 2) || client.server_version_gte(8, 0) || client.is_standalone() {
         log_uncaptured("Skipping range_explicit_encryption due to unsupported topology");
         return Ok(());
     }

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Date-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Aggregate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Correctness.yml
@@ -8,6 +8,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Delete.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-InsertFind.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Decimal-Update.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DecimalPrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Double-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-DoublePrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Int-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Delete.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Update.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-Long-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-WrongType.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-WrongType.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-WrongType.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Range-WrongType.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
RUST-1885

This syncs the spec tests and updates the prose test to avoid running the broken behavior on servers >= 8.0.