### PR TITLE
RUST-1512 Better links for action return types

### DIFF
--- a/action_macro/Cargo.toml
+++ b/action_macro/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
-syn = { version = "2.0.52", features = ["full", "parsing", "proc-macro"] }
+syn = { version = "2.0.52", features = ["full", "parsing", "proc-macro", "extra-traits"] }
 
 [lib]
 proc-macro = true

--- a/action_macro/src/lib.rs
+++ b/action_macro/src/lib.rs
@@ -1,18 +1,22 @@
 extern crate proc_macro;
 
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{
     braced,
+    ext::IdentExt,
     parenthesized,
     parse::{Parse, ParseStream},
     parse_macro_input,
     parse_quote,
     parse_quote_spanned,
+    punctuated::Punctuated,
     spanned::Spanned,
+    Attribute,
     Block,
     Error,
     Generics,
     Ident,
+    ImplItemFn,
     Lifetime,
     Token,
     Type,
@@ -217,4 +221,128 @@ fn parse_name(input: ParseStream, name: &str) -> syn::Result<()> {
         ));
     }
     Ok(())
+}
+
+/// #[action_return_doc(return_type [, session = type] [, run = path])]
+///
+/// Generates linked documentation for the return value of an action.
+#[proc_macro_attribute]
+pub fn action_return_doc(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let ActionReturnArgs {
+        ret_type,
+        session_type,
+        run,
+    } = parse_macro_input!(attr as ActionReturnArgs);
+    let mut impl_fn = parse_macro_input!(item as ImplItemFn);
+
+    let call = if let Some(r) = run {
+        format!("<code>{}</code>", r.doc_link())
+    } else {
+        "`await`".to_string()
+    };
+    let session = if let Some(t) = session_type {
+        format!(
+            " or <code>{}</code> if a [`ClientSession`] is provided",
+            t.doc_link()
+        )
+    } else {
+        String::new()
+    };
+    let s = format!(
+        "\n\n{} will return <code>{}</code>{}.",
+        call,
+        ret_type.doc_link(),
+        session,
+    );
+    let attr: Attribute = parse_quote! { #[doc = #s] };
+    impl_fn.attrs.push(attr);
+    impl_fn.into_token_stream().into()
+}
+
+// return type [, session = type] [, run = path]
+struct ActionReturnArgs {
+    ret_type: SimplePath,
+    session_type: Option<SimplePath>,
+    run: Option<SimplePath>,
+}
+
+impl Parse for ActionReturnArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ret_type = input.parse()?;
+
+        let mut session_type = None;
+        let mut run = None;
+        for _ in 0..2 {
+            if input.parse::<Option<Token![,]>>()?.is_none() {
+                break;
+            }
+            let ident = input.parse::<Ident>()?;
+            match ident.to_string().as_str() {
+                "session" => {
+                    input.parse::<Token![=]>()?;
+                    session_type = Some(input.parse()?);
+                }
+                "run" => {
+                    input.parse::<Token![=]>()?;
+                    run = Some(input.parse()?);
+                }
+                _ => {
+                    return Err(Error::new(
+                        ident.span(),
+                        format!("expected 'session' or 'run', got '{}'", ident),
+                    ))
+                }
+            }
+        }
+
+        Ok(Self {
+            ret_type,
+            session_type,
+            run,
+        })
+    }
+}
+
+struct SimplePath {
+    segments: Punctuated<Ident, Token![::]>,
+    args: Option<Punctuated<SimplePath, Token![,]>>,
+}
+
+impl Parse for SimplePath {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let segments = input
+            .call(|input| Punctuated::parse_separated_nonempty_with(input, Ident::parse_any))?;
+        let args = if input.peek(Token![<]) {
+            input.parse::<Token![<]>()?;
+            let val = input.call(Punctuated::parse_separated_nonempty)?;
+            input.parse::<Token![>]>()?;
+            Some(val)
+        } else {
+            None
+        };
+        Ok(Self { segments, args })
+    }
+}
+
+impl SimplePath {
+    fn doc_link(&self) -> String {
+        let mut out = format!(
+            "[{}]({})",
+            self.segments.last().unwrap().to_token_stream(),
+            self.segments
+                .to_token_stream()
+                .to_string()
+                .split_ascii_whitespace()
+                .collect::<String>(),
+        );
+        if let Some(args) = &self.args {
+            let arg_strs: Vec<_> = args.into_iter().map(|p| p.doc_link()).collect();
+            out += &format!("&lt;{}&gt;", arg_strs.join(","));
+        }
+
+        out
+    }
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -143,7 +143,7 @@ pub trait Action: private::Sealed + IntoFuture {
     }
 }
 
-pub(crate) use action_macro::action_impl;
+pub(crate) use action_macro::{action_impl, deeplink};
 
 use crate::Collection;
 

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -23,9 +23,7 @@ impl Database {
     ///
     /// See the documentation [here](https://www.mongodb.com/docs/manual/aggregation/) for more
     /// information on aggregations.
-    ///
-    /// `await` will return `Result<`[`Cursor`]`<Document>>` or `Result<SessionCursor<Document>>` if
-    /// a `ClientSession` is provided.
+    #[action_macro::action_return_doc(Result<Cursor<Document>>, session = Result<SessionCursor<Document>>)]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         Aggregate {
             target: AggregateTargetRef::Database(self),
@@ -66,6 +64,7 @@ impl crate::sync::Database {
     ///
     /// [`run`](Aggregate::run) will return `Result<`[`Cursor`]`<Document>>` or
     /// `Result<SessionCursor<Document>>` if a `ClientSession` is provided.
+    #[action_macro::action_return_doc(Result<crate::sync::Cursor<Document>>, session = Result<crate::sync::SessionCursor<Document>>, run = Aggregate::run)]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         self.async_database.aggregate(pipeline)
     }

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -16,14 +16,17 @@ use crate::{
     SessionCursor,
 };
 
-use super::{action_impl, option_setters, CollRef, ExplicitSession, ImplicitSession};
+use super::{action_impl, deeplink, option_setters, CollRef, ExplicitSession, ImplicitSession};
 
 impl Database {
     /// Runs an aggregation operation.
     ///
     /// See the documentation [here](https://www.mongodb.com/docs/manual/aggregation/) for more
     /// information on aggregations.
-    #[action_macro::action_return_doc(Result<Cursor<Document>>, session = Result<SessionCursor<Document>>)]
+    ///
+    /// `await` will return d[`Result<Cursor<Document>>`] or d[`Result<SessionCursor<Document>>`] if
+    /// a `ClientSession` is provided.
+    #[deeplink]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         Aggregate {
             target: AggregateTargetRef::Database(self),
@@ -62,9 +65,9 @@ impl crate::sync::Database {
     /// See the documentation [here](https://www.mongodb.com/docs/manual/aggregation/) for more
     /// information on aggregations.
     ///
-    /// [`run`](Aggregate::run) will return `Result<`[`Cursor`]`<Document>>` or
-    /// `Result<SessionCursor<Document>>` if a `ClientSession` is provided.
-    #[action_macro::action_return_doc(Result<crate::sync::Cursor<Document>>, session = Result<crate::sync::SessionCursor<Document>>, run = Aggregate::run)]
+    /// [`run`](Aggregate::run) will return d[`Result<crate::sync::Cursor<Document>>`] or
+    /// d[`Result<crate::sync::SessionCursor<Document>>`] if a [`ClientSession`] is provided.
+    #[action_macro::deeplink]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         self.async_database.aggregate(pipeline)
     }

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -46,8 +46,9 @@ where
     /// See the documentation [here](https://www.mongodb.com/docs/manual/aggregation/) for more
     /// information on aggregations.
     ///
-    /// `await` will return `Result<Cursor<Document>>` or `Result<SessionCursor<Document>>` if
-    /// a `ClientSession` is provided.
+    /// `await` will return d[`Result<Cursor<Document>>`] or d[`Result<SessionCursor<Document>>`] if
+    /// a [`ClientSession`] is provided.
+    #[deeplink]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         Aggregate {
             target: AggregateTargetRef::Collection(CollRef::new(self)),
@@ -67,7 +68,7 @@ impl crate::sync::Database {
     ///
     /// [`run`](Aggregate::run) will return d[`Result<crate::sync::Cursor<Document>>`] or
     /// d[`Result<crate::sync::SessionCursor<Document>>`] if a [`ClientSession`] is provided.
-    #[action_macro::deeplink]
+    #[deeplink]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         self.async_database.aggregate(pipeline)
     }
@@ -83,14 +84,15 @@ where
     /// See the documentation [here](https://www.mongodb.com/docs/manual/aggregation/) for more
     /// information on aggregations.
     ///
-    /// [`run`](Aggregate::run) will return `Result<Cursor<Document>>` or
-    /// `Result<SessionCursor<Document>>` if a `ClientSession` is provided.
+    /// [`run`](Aggregate::run) will return d[`Result<crate::sync::Cursor<Document>>`] or
+    /// d[`Result<crate::sync::SessionCursor<Document>>`] if a `ClientSession` is provided.
+    #[deeplink]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         self.async_collection.aggregate(pipeline)
     }
 }
 
-/// Run an aggregation operation.  Create by calling [`Database::aggregate`] or
+/// Run an aggregation operation.  Construct with [`Database::aggregate`] or
 /// [`Collection::aggregate`].
 #[must_use]
 pub struct Aggregate<'a, Session = ImplicitSession> {

--- a/src/action/count.rs
+++ b/src/action/count.rs
@@ -7,7 +7,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T> Collection<T>
 where
@@ -25,7 +25,8 @@ where
     /// For more information on the behavior of the `count` server command, see
     /// [Count: Behavior](https://www.mongodb.com/docs/manual/reference/command/count/#behavior).
     ///
-    /// `await` will return `Result<u64>`.
+    /// `await` will return d[`Result<u64>`].
+    #[deeplink]
     pub fn estimated_document_count(&self) -> EstimatedDocumentCount {
         EstimatedDocumentCount {
             cr: CollRef::new(self),
@@ -37,7 +38,8 @@ where
     ///
     /// Note that this method returns an accurate count.
     ///
-    /// `await` will return `Result<u64>`.
+    /// `await` will return d[`Result<u64>`].
+    #[deeplink]
     pub fn count_documents(&self, filter: Document) -> CountDocuments {
         CountDocuments {
             cr: CollRef::new(self),
@@ -65,7 +67,8 @@ where
     /// For more information on the behavior of the `count` server command, see
     /// [Count: Behavior](https://www.mongodb.com/docs/manual/reference/command/count/#behavior).
     ///
-    /// [`run`](EstimatedDocumentCount::run) will return `Result<u64>`.
+    /// [`run`](EstimatedDocumentCount::run) will return d[`Result<u64>`].
+    #[deeplink]
     pub fn estimated_document_count(&self) -> EstimatedDocumentCount {
         self.async_collection.estimated_document_count()
     }
@@ -74,13 +77,14 @@ where
     ///
     /// Note that this method returns an accurate count.
     ///
-    /// [`run`](CountDocuments::run) will return `Result<u64>`.
+    /// [`run`](CountDocuments::run) will return d[`Result<u64>`].
+    #[deeplink]
     pub fn count_documents(&self, filter: Document) -> CountDocuments {
         self.async_collection.count_documents(filter)
     }
 }
 
-/// Gather an estimated document count.  Create by calling [`Collection::estimated_document_count`].
+/// Gather an estimated document count.  Construct with [`Collection::estimated_document_count`].
 #[must_use]
 pub struct EstimatedDocumentCount<'a> {
     cr: CollRef<'a>,
@@ -108,7 +112,7 @@ action_impl! {
     }
 }
 
-/// Get an accurate count of documents.  Create by calling [`Collection::count_documents`].
+/// Get an accurate count of documents.  Construct with [`Collection::count_documents`].
 #[must_use]
 pub struct CountDocuments<'a> {
     cr: CollRef<'a>,

--- a/src/action/create_collection.rs
+++ b/src/action/create_collection.rs
@@ -2,7 +2,7 @@ use bson::Document;
 
 use crate::{options::CreateCollectionOptions, ClientSession, Database};
 
-use crate::action::option_setters;
+use crate::action::{deeplink, option_setters};
 
 impl Database {
     /// Creates a new collection in the database with the given `name`.
@@ -10,8 +10,8 @@ impl Database {
     /// Note that MongoDB creates collections implicitly when data is inserted, so this method is
     /// not needed if no special options are required.
     ///
-    /// `await` will return `Result<()>`.
-    #[action_macro::action_return_doc(Result<()>)]
+    /// `await` will return d[`Result<()>`].
+    #[deeplink]
     pub fn create_collection(&self, name: impl AsRef<str>) -> CreateCollection {
         CreateCollection {
             db: self,

--- a/src/action/create_collection.rs
+++ b/src/action/create_collection.rs
@@ -29,13 +29,14 @@ impl crate::sync::Database {
     /// Note that MongoDB creates collections implicitly when data is inserted, so this method is
     /// not needed if no special options are required.
     ///
-    /// [`run`](CreateCollection::run) will return `Result<()>`.
+    /// [`run`](CreateCollection::run) will return d[`Result<()>`].
+    #[deeplink]
     pub fn create_collection(&self, name: impl AsRef<str>) -> CreateCollection {
         self.async_database.create_collection(name)
     }
 }
 
-/// Creates a new collection.  Create by calling [`Database::create_collection`].
+/// Creates a new collection.  Construct with [`Database::create_collection`].
 #[must_use]
 pub struct CreateCollection<'a> {
     pub(crate) db: &'a Database,

--- a/src/action/create_collection.rs
+++ b/src/action/create_collection.rs
@@ -11,6 +11,7 @@ impl Database {
     /// not needed if no special options are required.
     ///
     /// `await` will return `Result<()>`.
+    #[action_macro::action_return_doc(Result<()>)]
     pub fn create_collection(&self, name: impl AsRef<str>) -> CreateCollection {
         CreateCollection {
             db: self,

--- a/src/action/create_index.rs
+++ b/src/action/create_index.rs
@@ -13,7 +13,7 @@ use crate::{
     IndexModel,
 };
 
-use super::{action_impl, option_setters, CollRef, Multiple, Single};
+use super::{action_impl, deeplink, option_setters, CollRef, Multiple, Single};
 
 impl<T> Collection<T>
 where
@@ -21,7 +21,8 @@ where
 {
     /// Creates the given index on this collection.
     ///
-    /// `await` will return `Result<CreateIndexResult>`.
+    /// `await` will return d[`Result<CreateIndexResult>`].
+    #[deeplink]
     pub fn create_index(&self, index: IndexModel) -> CreateIndex {
         CreateIndex {
             coll: CollRef::new(self),
@@ -34,7 +35,8 @@ where
 
     /// Creates the given indexes on this collection.
     ///
-    /// `await` will return `Result<CreateIndexesResult>`.
+    /// `await` will return d[`Result<CreateIndexesResult>`].
+    #[deeplink]
     pub fn create_indexes(
         &self,
         indexes: impl IntoIterator<Item = IndexModel>,
@@ -56,14 +58,16 @@ where
 {
     /// Creates the given index on this collection.
     ///
-    /// [`run`](CreateIndex::run) will return `Result<CreateIndexResult>`.
+    /// [`run`](CreateIndex::run) will return d[`Result<CreateIndexResult>`].
+    #[deeplink]
     pub fn create_index(&self, index: IndexModel) -> CreateIndex {
         self.async_collection.create_index(index)
     }
 
     /// Creates the given indexes on this collection.
     ///
-    /// [`run`](CreateIndex::run) will return `Result<CreateIndexesResult>`.
+    /// [`run`](CreateIndex::run) will return d[`Result<CreateIndexesResult>`].
+    #[deeplink]
     pub fn create_indexes(
         &self,
         indexes: impl IntoIterator<Item = IndexModel>,

--- a/src/action/csfle/create_data_key.rs
+++ b/src/action/csfle/create_data_key.rs
@@ -1,12 +1,13 @@
 use crate::client_encryption::{ClientEncryption, MasterKey};
 
-use super::super::option_setters;
+use super::super::{deeplink, option_setters};
 
 impl ClientEncryption {
     /// Creates a new key document and inserts into the key vault collection.
     ///
-    /// `await` will return `Result<Binary>` (subtype 0x04) with the _id of the created
+    /// `await` will return d[`Result<Binary>`] (subtype 0x04) with the _id of the created
     /// document as a UUID.
+    #[deeplink]
     pub fn create_data_key(&self, master_key: MasterKey) -> CreateDataKey {
         CreateDataKey {
             client_enc: self,

--- a/src/action/csfle/encrypt.rs
+++ b/src/action/csfle/encrypt.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
 
-use super::super::option_setters;
+use super::super::{deeplink, option_setters};
 use crate::client_encryption::ClientEncryption;
 
 impl ClientEncryption {
@@ -14,7 +14,8 @@ impl ClientEncryption {
     /// `AutoEncryptionOptions`. `AutoEncryptionOptions.bypass_query_analysis` may be true.
     /// `AutoEncryptionOptions.bypass_auto_encryption` must be false.
     ///
-    /// `await` will return a `Result<Binary>` (subtype 6) containing the encrypted value.
+    /// `await` will return a d[`Result<Binary>`] (subtype 6) containing the encrypted value.
+    #[deeplink]
     pub fn encrypt(
         &self,
         value: impl Into<bson::RawBson>,
@@ -39,7 +40,8 @@ impl ClientEncryption {
     /// The expression will be encrypted using the [`Algorithm::RangePreview`] algorithm and the
     /// "rangePreview" query type.
     ///
-    /// `await` returns a `Result<Document>` containing the encrypted expression.
+    /// `await` will return a d[`Result<Document>`] containing the encrypted expression.
+    #[deeplink]
     pub fn encrypt_expression(
         &self,
         expression: RawDocumentBuf,

--- a/src/action/delete.rs
+++ b/src/action/delete.rs
@@ -11,7 +11,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T> Collection<T>
 where
@@ -24,7 +24,8 @@ where
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<DeleteResult>`.
+    /// `await` will return d[`Result<DeleteResult>`].
+    #[deeplink]
     pub fn delete_one(&self, query: Document) -> Delete {
         Delete {
             coll: CollRef::new(self),
@@ -37,7 +38,8 @@ where
 
     /// Deletes all documents stored in the collection matching `query`.
     ///
-    /// `await` will return `Result<DeleteResult>`.
+    /// `await` will return d[`Result<DeleteResult>`].
+    #[deeplink]
     pub fn delete_many(&self, query: Document) -> Delete {
         Delete {
             coll: CollRef::new(self),
@@ -61,14 +63,16 @@ where
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](Delete::run) will return `Result<DeleteResult>`.
+    /// [`run`](Delete::run) will return d[`Result<DeleteResult>`].
+    #[deeplink]
     pub fn delete_one(&self, query: Document) -> Delete {
         self.async_collection.delete_one(query)
     }
 
     /// Deletes all documents stored in the collection matching `query`.
     ///
-    /// [`run`](Delete::run) will return `Result<DeleteResult>`.
+    /// [`run`](Delete::run) will return d[`Result<DeleteResult>`].
+    #[deeplink]
     pub fn delete_many(&self, query: Document) -> Delete {
         self.async_collection.delete_many(query)
     }

--- a/src/action/distinct.rs
+++ b/src/action/distinct.rs
@@ -13,7 +13,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T> Collection<T>
 where
@@ -21,7 +21,8 @@ where
 {
     /// Finds the distinct values of the field specified by `field_name` across the collection.
     ///
-    /// `await` will return `Result<Vec<Bson>>`.
+    /// `await` will return d[`Result<Vec<Bson>>`].
+    #[deeplink]
     pub fn distinct(&self, field_name: impl AsRef<str>, filter: Document) -> Distinct {
         Distinct {
             coll: CollRef::new(self),
@@ -40,7 +41,8 @@ where
 {
     /// Finds the distinct values of the field specified by `field_name` across the collection.
     ///
-    /// [`run`](Distinct::run) will return `Result<Vec<Bson>>`.
+    /// [`run`](Distinct::run) will return d[`Result<Vec<Bson>>`].
+    #[deeplink]
     pub fn distinct(&self, field_name: impl AsRef<str>, filter: Document) -> Distinct {
         self.async_collection.distinct(field_name, filter)
     }

--- a/src/action/drop.rs
+++ b/src/action/drop.rs
@@ -9,12 +9,13 @@ use crate::{
     Database,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl Database {
     /// Drops the database, deleting all data, collections, and indexes stored in it.
     ///
-    /// `await` will return `Result<()>`.
+    /// `await` will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop(&self) -> DropDatabase {
         DropDatabase {
             db: self,
@@ -28,13 +29,14 @@ impl Database {
 impl crate::sync::Database {
     /// Drops the database, deleting all data, collections, and indexes stored in it.
     ///
-    /// [`run`](DropDatabase::run) will return `Result<()>`.
+    /// [`run`](DropDatabase::run) will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop(&self) -> DropDatabase {
         self.async_database.drop()
     }
 }
 
-/// Drops the database, deleting all data, collections, and indexes stored in it.  Create by calling
+/// Drops the database, deleting all data, collections, and indexes stored in it.  Construct with
 /// [`Database::drop`].
 #[must_use]
 pub struct DropDatabase<'a> {
@@ -75,7 +77,8 @@ where
 {
     /// Drops the collection, deleting all data and indexes stored in it.
     ///
-    /// `await` will return `Result<()>`.
+    /// `await` will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop(&self) -> DropCollection {
         DropCollection {
             cr: CollRef::new(self),
@@ -92,13 +95,14 @@ where
 {
     /// Drops the collection, deleting all data and indexes stored in it.
     ///
-    /// [`run`](DropCollection::run) will return `Result<()>`.
+    /// [`run`](DropCollection::run) will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop(&self) -> DropCollection {
         self.async_collection.drop()
     }
 }
 
-/// Drops the collection, deleting all data and indexes stored in it.  Create by calling
+/// Drops the collection, deleting all data and indexes stored in it.  Construct with
 /// [`Collection::drop`].
 #[must_use]
 pub struct DropCollection<'a> {

--- a/src/action/drop_index.rs
+++ b/src/action/drop_index.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use bson::Bson;
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 use crate::{
     coll::options::DropIndexOptions,
     error::{ErrorKind, Result},
@@ -18,7 +18,8 @@ where
 {
     /// Drops the index specified by `name` from this collection.
     ///
-    /// `await` will return `Result<()>`.
+    /// `await` will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop_index(&self, name: impl AsRef<str>) -> DropIndex {
         DropIndex {
             coll: CollRef::new(self),
@@ -30,7 +31,8 @@ where
 
     /// Drops all indexes associated with this collection.
     ///
-    /// `await` will return `Result<()>`.
+    /// `await` will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop_indexes(&self) -> DropIndex {
         DropIndex {
             coll: CollRef::new(self),
@@ -48,14 +50,16 @@ where
 {
     /// Drops the index specified by `name` from this collection.
     ///
-    /// [`run`](DropIndex::run) will return `Result<()>`.
+    /// [`run`](DropIndex::run) will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop_index(&self, name: impl AsRef<str>) -> DropIndex {
         self.async_collection.drop_index(name)
     }
 
     /// Drops all indexes associated with this collection.
     ///
-    /// [`run`](DropIndex::run) will return `Result<()>`.
+    /// [`run`](DropIndex::run) will return d[`Result<()>`].
+    #[deeplink]
     pub fn drop_indexes(&self) -> DropIndex {
         self.async_collection.drop_indexes()
     }

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -16,13 +16,14 @@ use crate::{
     SessionCursor,
 };
 
-use super::{action_impl, option_setters, ExplicitSession, ImplicitSession};
+use super::{action_impl, deeplink, option_setters, ExplicitSession, ImplicitSession};
 
 impl<T: Send + Sync> Collection<T> {
     /// Finds the documents in the collection matching `filter`.
     ///
-    /// `await` will return `Result<Cursor<T>>` (or `Result<SessionCursor<T>>` if a session is
+    /// `await` will return d[`Result<Cursor<T>>`] (or d[`Result<SessionCursor<T>>`] if a session is
     /// provided).
+    #[deeplink]
     pub fn find(&self, filter: Document) -> Find<'_, T> {
         Find {
             coll: self,
@@ -36,7 +37,8 @@ impl<T: Send + Sync> Collection<T> {
 impl<T: DeserializeOwned + Send + Sync> Collection<T> {
     /// Finds a single document in the collection matching `filter`.
     ///
-    /// `await` will return `Result<Option<T>>`.
+    /// `await` will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one(&self, filter: Document) -> FindOne<'_, T> {
         FindOne {
             coll: self,
@@ -51,8 +53,9 @@ impl<T: DeserializeOwned + Send + Sync> Collection<T> {
 impl<T: Send + Sync> crate::sync::Collection<T> {
     /// Finds the documents in the collection matching `filter`.
     ///
-    /// [`run`](Find::run) will return `Result<Cursor<T>>` (or `Result<SessionCursor<T>>` if a
-    /// session is provided).
+    /// [`run`](Find::run) will return d[`Result<crate::sync::Cursor<T>>`] (or
+    /// d[`Result<crate::sync::SessionCursor<T>>`] if a session is provided).
+    #[deeplink]
     pub fn find(&self, filter: Document) -> Find<'_, T> {
         self.async_collection.find(filter)
     }
@@ -62,7 +65,8 @@ impl<T: Send + Sync> crate::sync::Collection<T> {
 impl<T: DeserializeOwned + Send + Sync> crate::sync::Collection<T> {
     /// Finds a single document in the collection matching `filter`.
     ///
-    /// [`run`](Find::run) will return `Result<Option<T>>`.
+    /// [`run`](Find::run) will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one(&self, filter: Document) -> FindOne<'_, T> {
         self.async_collection.find_one(filter)
     }

--- a/src/action/find_and_modify.rs
+++ b/src/action/find_and_modify.rs
@@ -25,7 +25,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters};
+use super::{action_impl, deeplink, option_setters};
 
 impl<T: DeserializeOwned + Send + Sync> Collection<T> {
     async fn find_and_modify<'a>(
@@ -48,7 +48,8 @@ impl<T: DeserializeOwned + Send + Sync> Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<Option<T>>`.
+    /// `await` will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one_and_delete(&self, filter: Document) -> FindOneAndDelete<'_, T> {
         FindOneAndDelete {
             coll: self,
@@ -68,7 +69,8 @@ impl<T: DeserializeOwned + Send + Sync> Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<Option<T>>`.
+    /// `await` will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one_and_update(
         &self,
         filter: Document,
@@ -92,6 +94,9 @@ impl<T: Serialize + DeserializeOwned + Send + Sync> Collection<T> {
     /// retryability. See the documentation
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
+    ///
+    /// `await` will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one_and_replace(
         &self,
         filter: Document,
@@ -119,7 +124,8 @@ impl<T: DeserializeOwned + Send + Sync> crate::sync::Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](FindOneAndDelete::run) will return `Result<Option<T>>`.
+    /// [`run`](FindOneAndDelete::run) will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one_and_delete(&self, filter: Document) -> FindOneAndDelete<'_, T> {
         self.async_collection.find_one_and_delete(filter)
     }
@@ -134,7 +140,8 @@ impl<T: DeserializeOwned + Send + Sync> crate::sync::Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](FindOneAndDelete::run) will return `Result<Option<T>>`.
+    /// [`run`](FindOneAndDelete::run) will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one_and_update(
         &self,
         filter: Document,
@@ -154,7 +161,8 @@ impl<T: Serialize + DeserializeOwned + Send + Sync> crate::sync::Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](FindOneAndReplace::run) will return `Result<Option<T>>`.
+    /// [`run`](FindOneAndReplace::run) will return d[`Result<Option<T>>`].
+    #[deeplink]
     pub fn find_one_and_replace(
         &self,
         filter: Document,

--- a/src/action/insert_many.rs
+++ b/src/action/insert_many.rs
@@ -14,7 +14,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T: Serialize + Send + Sync> Collection<T> {
     /// Inserts the data in `docs` into the collection.
@@ -27,7 +27,8 @@ impl<T: Serialize + Send + Sync> Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<InsertManyResult>`.
+    /// `await` will return d[`Result<InsertManyResult>`].
+    #[deeplink]
     pub fn insert_many(&self, docs: impl IntoIterator<Item = impl Borrow<T>>) -> InsertMany {
         let human_readable = self.human_readable_serialization();
         InsertMany {
@@ -54,7 +55,8 @@ impl<T: Serialize + Send + Sync> crate::sync::Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](InsertMany::run) will return `Result<InsertManyResult>`.
+    /// [`run`](InsertMany::run) will return d[`Result<InsertManyResult>`].
+    #[deeplink]
     pub fn insert_many(&self, docs: impl IntoIterator<Item = impl Borrow<T>>) -> InsertMany {
         self.async_collection.insert_many(docs)
     }

--- a/src/action/insert_one.rs
+++ b/src/action/insert_one.rs
@@ -14,7 +14,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T: Serialize + Send + Sync> Collection<T> {
     /// Inserts `doc` into the collection.
@@ -27,7 +27,8 @@ impl<T: Serialize + Send + Sync> Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<InsertOneResult>`.
+    /// `await` will return d[`Result<InsertOneResult>`].
+    #[deeplink]
     pub fn insert_one(&self, doc: impl Borrow<T>) -> InsertOne {
         InsertOne {
             coll: CollRef::new(self),
@@ -53,7 +54,8 @@ impl<T: Serialize + Send + Sync> crate::sync::Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](InsertOne::run) will return `Result<InsertOneResult>`.
+    /// [`run`](InsertOne::run) will return d[`Result<InsertOneResult>`].
+    #[deeplink]
     pub fn insert_one(&self, doc: impl Borrow<T>) -> InsertOne {
         self.async_collection.insert_one(doc)
     }

--- a/src/action/list_collections.rs
+++ b/src/action/list_collections.rs
@@ -16,6 +16,7 @@ use crate::{
 
 use super::{
     action_impl,
+    deeplink,
     option_setters,
     ExplicitSession,
     ImplicitSession,
@@ -26,7 +27,8 @@ use super::{
 impl Database {
     /// Gets information about each of the collections in the database.
     ///
-    /// `await` will return `Result<`[`Cursor`]`<`[`CollectionSpecification`]`>>`.
+    /// `await` will return d[`Result<Cursor<CollectionSpecification>>`].
+    #[deeplink]
     pub fn list_collections(&self) -> ListCollections {
         ListCollections {
             db: self,
@@ -38,7 +40,8 @@ impl Database {
 
     /// Gets the names of the collections in the database.
     ///
-    /// `await` will return `Result<Vec<String>>`.
+    /// `await` will return d[`Result<Vec<String>>`].
+    #[deeplink]
     pub fn list_collection_names(&self) -> ListCollections<'_, ListNames> {
         ListCollections {
             db: self,
@@ -54,14 +57,16 @@ impl crate::sync::Database {
     /// Gets information about each of the collections in the database.
     ///
     /// [`run`](ListCollections::run) will return
-    /// `Result<`[`Cursor`]`<`[`CollectionSpecification`]`>>`.
+    /// d[`Result<Cursor<CollectionSpecification>>`].
+    #[deeplink]
     pub fn list_collections(&self) -> ListCollections {
         self.async_database.list_collections()
     }
 
     /// Gets the names of the collections in the database.
     ///
-    /// [`run`](ListCollections::run) will return `Result<Vec<String>>`.
+    /// [`run`](ListCollections::run) will return d[`Result<Vec<String>>`].
+    #[deeplink]
     pub fn list_collection_names(&self) -> ListCollections<'_, ListNames> {
         self.async_database.list_collection_names()
     }

--- a/src/action/list_databases.rs
+++ b/src/action/list_databases.rs
@@ -13,12 +13,13 @@ use crate::{
     ClientSession,
 };
 
-use super::{action_impl, option_setters, ListNames, ListSpecifications};
+use super::{action_impl, deeplink, option_setters, ListNames, ListSpecifications};
 
 impl Client {
     /// Gets information about each database present in the cluster the Client is connected to.
     ///
-    /// `await` will return `Result<Vec<`[`DatabaseSpecification`]`>>`.
+    /// `await` will return d[`Result<Vec<DatabaseSpecification>>`].
+    #[deeplink]
     pub fn list_databases(&self) -> ListDatabases {
         ListDatabases {
             client: self,
@@ -30,7 +31,8 @@ impl Client {
 
     /// Gets the names of the databases present in the cluster the Client is connected to.
     ///
-    /// `await` will return `Result<Vec<String>>`.
+    /// `await` will return d[`Result<Vec<String>>`].
+    #[deeplink]
     pub fn list_database_names(&self) -> ListDatabases<'_, ListNames> {
         ListDatabases {
             client: self,
@@ -45,14 +47,16 @@ impl Client {
 impl SyncClient {
     /// Gets information about each database present in the cluster the Client is connected to.
     ///
-    /// [run](ListDatabases::run) will return `Result<Vec<`[`DatabaseSpecification`]`>>`.
+    /// [run](ListDatabases::run) will return d[`Result<Vec<DatabaseSpecification>>`].
+    #[deeplink]
     pub fn list_databases(&self) -> ListDatabases {
         self.async_client.list_databases()
     }
 
     /// Gets the names of the databases present in the cluster the Client is connected to.
     ///
-    /// [run](ListDatabases::run) will return `Result<Vec<String>>`.
+    /// [run](ListDatabases::run) will return d[`Result<Vec<String>>`].
+    #[deeplink]
     pub fn list_database_names(&self) -> ListDatabases<'_, ListNames> {
         self.async_client.list_database_names()
     }

--- a/src/action/list_indexes.rs
+++ b/src/action/list_indexes.rs
@@ -16,6 +16,7 @@ use crate::{
 
 use super::{
     action_impl,
+    deeplink,
     option_setters,
     CollRef,
     ExplicitSession,
@@ -30,8 +31,9 @@ where
 {
     /// Lists all indexes on this collection.
     ///
-    /// `await` will return `Result<Cursor<IndexModel>>` (or `Result<SessionCursor<IndexModel>>` if
-    /// a `ClientSession` is provided).
+    /// `await` will return d[`Result<Cursor<IndexModel>>`] (or
+    /// d[`Result<SessionCursor<IndexModel>>`] if a `ClientSession` is provided).
+    #[deeplink]
     pub fn list_indexes(&self) -> ListIndexes {
         ListIndexes {
             coll: CollRef::new(self),
@@ -43,7 +45,8 @@ where
 
     /// Gets the names of all indexes on the collection.
     ///
-    /// `await` will return `Result<Vec<String>>`.
+    /// `await` will return d[`Result<Vec<String>>`].
+    #[deeplink]
     pub fn list_index_names(&self) -> ListIndexes<ListNames> {
         ListIndexes {
             coll: CollRef::new(self),
@@ -61,15 +64,17 @@ where
 {
     /// Lists all indexes on this collection.
     ///
-    /// [`run`](ListIndexes::run) will return `Result<Cursor<IndexModel>>` (or
-    /// `Result<SessionCursor<IndexModel>>` if a `ClientSession` is provided).
+    /// [`run`](ListIndexes::run) will return d[`Result<crate::sync::Cursor<IndexModel>>`] (or
+    /// d[`Result<crate::sync::SessionCursor<IndexModel>>`] if a `ClientSession` is provided).
+    #[deeplink]
     pub fn list_indexes(&self) -> ListIndexes {
         self.async_collection.list_indexes()
     }
 
     /// Gets the names of all indexes on the collection.
     ///
-    /// [`run`](ListIndexes::run) will return `Result<Vec<String>>`.
+    /// [`run`](ListIndexes::run) will return d[`Result<Vec<String>>`].
+    #[deeplink]
     pub fn list_index_names(&self) -> ListIndexes<ListNames> {
         self.async_collection.list_index_names()
     }

--- a/src/action/perf.rs
+++ b/src/action/perf.rs
@@ -37,7 +37,7 @@ impl crate::sync::Client {
     }
 }
 
-/// Add connections to the connection pool up to `min_pool_size`.  Create by calling
+/// Add connections to the connection pool up to `min_pool_size`.  Construct with
 /// [`Client::warm_connection_pool`].
 #[must_use]
 pub struct WarmConnectionPool<'a> {

--- a/src/action/replace_one.rs
+++ b/src/action/replace_one.rs
@@ -15,7 +15,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T: Serialize + Send + Sync> Collection<T> {
     /// Replaces up to one document matching `query` in the collection with `replacement`.
@@ -25,7 +25,8 @@ impl<T: Serialize + Send + Sync> Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<UpdateResult>`.
+    /// `await` will return d[`Result<UpdateResult>`].
+    #[deeplink]
     pub fn replace_one(&self, query: Document, replacement: impl Borrow<T>) -> ReplaceOne {
         ReplaceOne {
             coll: CollRef::new(self),
@@ -49,7 +50,8 @@ impl<T: Serialize + Send + Sync> crate::sync::Collection<T> {
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](ReplaceOne::run) will return `Result<UpdateResult>`.
+    /// [`run`](ReplaceOne::run) will return d[`Result<UpdateResult>`].
+    #[deeplink]
     pub fn replace_one(&self, query: Document, replacement: impl Borrow<T>) -> ReplaceOne {
         self.async_collection.replace_one(query, replacement)
     }

--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -12,7 +12,7 @@ use crate::{
     SessionCursor,
 };
 
-use super::{action_impl, option_setters, ExplicitSession, ImplicitSession};
+use super::{action_impl, deeplink, option_setters, ExplicitSession, ImplicitSession};
 
 impl Database {
     /// Runs a database-level command.
@@ -23,7 +23,8 @@ impl Database {
     /// Please note that run_command doesn't validate WriteConcerns passed into the body of the
     /// command document.
     ///
-    /// `await` will return `Result<Document>`.
+    /// `await` will return d[`Result<Document>`].
+    #[deeplink]
     pub fn run_command(&self, command: Document) -> RunCommand {
         RunCommand {
             db: self,
@@ -35,8 +36,9 @@ impl Database {
 
     /// Runs a database-level command and returns a cursor to the response.
     ///
-    /// `await` will return `Result<`[`Cursor`]`<Document>>` or a
-    /// `Result<`[`SessionCursor`]`<Document>>` if a [`ClientSession`] is provided.
+    /// `await` will return d[`Result<Cursor<Document>>`] or a
+    /// d[`Result<SessionCursor<Document>>`] if a [`ClientSession`] is provided.
+    #[deeplink]
     pub fn run_cursor_command(&self, command: Document) -> RunCursorCommand {
         RunCursorCommand {
             db: self,
@@ -57,15 +59,17 @@ impl crate::sync::Database {
     /// Please note that run_command doesn't validate WriteConcerns passed into the body of the
     /// command document.
     ///
-    /// [`run`](RunCommand::run) will return `Result<Document>`.
+    /// [`run`](RunCommand::run) will return d[`Result<Document>`].
+    #[deeplink]
     pub fn run_command(&self, command: Document) -> RunCommand {
         self.async_database.run_command(command)
     }
 
     /// Runs a database-level command and returns a cursor to the response.
     ///
-    /// [`run`](RunCursorCommand::run) will return `Result<`[`Cursor`]`<Document>>` or a
-    /// `Result<`[`SessionCursor`]`<Document>>` if a [`ClientSession`] is provided.
+    /// [`run`](RunCursorCommand::run) will return d[`Result<crate::sync::Cursor<Document>>`] or a
+    /// d[`Result<crate::sync::SessionCursor<Document>>`] if a [`ClientSession`] is provided.
+    #[deeplink]
     pub fn run_cursor_command(&self, command: Document) -> RunCursorCommand {
         self.async_database.run_cursor_command(command)
     }

--- a/src/action/session.rs
+++ b/src/action/session.rs
@@ -5,12 +5,13 @@ use crate::{
     ClientSession,
 };
 
-use super::{action_impl, option_setters};
+use super::{action_impl, deeplink, option_setters};
 
 impl Client {
     /// Starts a new [`ClientSession`].
     ///
-    /// `await` will return `Result<`[`ClientSession`]`>`.
+    /// `await` will return d[`Result<ClientSession>`].
+    #[deeplink]
     pub fn start_session(&self) -> StartSession {
         StartSession {
             client: self,
@@ -23,13 +24,14 @@ impl Client {
 impl crate::sync::Client {
     /// Starts a new [`ClientSession`].
     ///
-    /// [run](StartSession::run) will return `Result<`[`ClientSession`]`>`.
+    /// [run](StartSession::run) will return d[`Result<crate::sync::ClientSession>`].
+    #[deeplink]
     pub fn start_session(&self) -> StartSession {
         self.async_client.start_session()
     }
 }
 
-/// Starts a new [`ClientSession`].  Create by calling [`Client::start_session`].
+/// Starts a new [`ClientSession`].  Construct with [`Client::start_session`].
 #[must_use]
 pub struct StartSession<'a> {
     client: &'a Client,

--- a/src/action/update.rs
+++ b/src/action/update.rs
@@ -11,7 +11,7 @@ use crate::{
     Collection,
 };
 
-use super::{action_impl, option_setters, CollRef};
+use super::{action_impl, deeplink, option_setters, CollRef};
 
 impl<T> Collection<T>
 where
@@ -24,7 +24,8 @@ where
     /// in MongoDB 4.2+. See the official MongoDB
     /// [documentation](https://www.mongodb.com/docs/manual/reference/command/update/#behavior) for more information on specifying updates.
     ///
-    /// `await` will return `Result<UpdateResult>`.
+    /// `await` will return d[`Result<UpdateResult>`].
+    #[deeplink]
     pub fn update_many(&self, query: Document, update: impl Into<UpdateModifications>) -> Update {
         Update {
             coll: CollRef::new(self),
@@ -48,7 +49,8 @@ where
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// `await` will return `Result<UpdateResult>`.
+    /// `await` will return d[`Result<UpdateResult>`].
+    #[deeplink]
     pub fn update_one(&self, query: Document, update: impl Into<UpdateModifications>) -> Update {
         Update {
             coll: CollRef::new(self),
@@ -73,7 +75,8 @@ where
     /// in MongoDB 4.2+. See the official MongoDB
     /// [documentation](https://www.mongodb.com/docs/manual/reference/command/update/#behavior) for more information on specifying updates.
     ///
-    /// [`run`](Update::run) will return `Result<UpdateResult>`.
+    /// [`run`](Update::run) will return d[`Result<UpdateResult>`].
+    #[deeplink]
     pub fn update_many(&self, query: Document, update: impl Into<UpdateModifications>) -> Update {
         self.async_collection.update_many(query, update)
     }
@@ -90,7 +93,8 @@ where
     /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
     /// retryable writes.
     ///
-    /// [`run`](Update::run) will return `Result<UpdateResult>`.
+    /// [`run`](Update::run) will return d[`Result<UpdateResult>`].
+    #[deeplink]
     pub fn update_one(&self, query: Document, update: impl Into<UpdateModifications>) -> Update {
         self.async_collection.update_one(query, update)
     }

--- a/src/action/watch.rs
+++ b/src/action/watch.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use bson::{Bson, Document, Timestamp};
 
-use super::{action_impl, option_setters, ExplicitSession, ImplicitSession};
+use super::{action_impl, deeplink, option_setters, ExplicitSession, ImplicitSession};
 use crate::{
     change_stream::{
         event::{ChangeStreamEvent, ResumeToken},
@@ -41,9 +41,10 @@ impl Client {
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
     ///
-    /// `await` will return `Result<`[`ChangeStream`]`<`[`ChangeStreamEvent`]`<Document>>>` or
-    /// `Result<`[`SessionChangeStream`]`<`[`ChangeStreamEvent`]`<Document>>>` if a
+    /// `await` will return d[`Result<ChangeStream<ChangeStreamEvent<Document>>>`] or
+    /// d[`Result<SessionChangeStream<ChangeStreamEvent<Document>>>`] if a
     /// [`ClientSession`] has been provided.
+    #[deeplink]
     pub fn watch(&self) -> Watch {
         Watch::new_cluster(self)
     }
@@ -68,9 +69,10 @@ impl Database {
     /// If the pipeline alters the structure of the returned events, the parsed type will need to be
     /// changed via [`ChangeStream::with_type`].
     ///
-    /// `await` will return `Result<`[`ChangeStream`]`<`[`ChangeStreamEvent`]`<Document>>>` or
-    /// `Result<`[`SessionChangeStream`]`<`[`ChangeStreamEvent`]`<Document>>>` if a
+    /// `await` will return d[`Result<ChangeStream<ChangeStreamEvent<Document>>>`] or
+    /// d[`Result<SessionChangeStream<ChangeStreamEvent<Document>>>`] if a
     /// [`ClientSession`] has been provided.
+    #[deeplink]
     pub fn watch(&self) -> Watch {
         Watch::new(
             self.client(),
@@ -94,9 +96,10 @@ where
     /// Change streams require either a "majority" read concern or no read concern. Anything else
     /// will cause a server error.
     ///
-    /// `await` will return `Result<`[`ChangeStream`]`<`[`ChangeStreamEvent`]`<Document>>>` or
-    /// `Result<`[`SessionChangeStream`]`<`[`ChangeStreamEvent`]`<Document>>>` if a
+    /// `await` will return d[`Result<ChangeStream<ChangeStreamEvent<Document>>>`] or
+    /// d[`Result<SessionChangeStream<ChangeStreamEvent<Document>>>`] if a
     /// [`ClientSession`] has been provided.
+    #[deeplink]
     pub fn watch(&self) -> Watch {
         Watch::new(self.client(), self.namespace().into())
     }


### PR DESCRIPTION
RUST-1512

For return types in code that include generic parameters, rustdoc will generate output that links to both the generic type and the parameter types; however, when using bracketed comment links, the generic parameters are ignored.  This means that the action documentation for what `await` or `run` returns is less useful than previously, especially in cases of deeply nested types like `Result<ChangeStream<ChangeStreamEvent<Document>>>`.  For particularly gnarly cases I attempted to manually link components but this is fiddly, error-prone, and easy to forget.

This PR addresses that by introducing a helper `#[deeplink]` attr macro that will look for docstring links of the form `d[...]` and render them with all component types individually linked.  The core trick is that `/// stuff` comments are actually syntactic sugar for `#[doc = "stuff"]` attributes, which the attr macro can then update. 