### PR TITLE
RUST-1873 Transaction API fluency

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -24,7 +24,7 @@ mod run_command;
 mod search_index;
 mod session;
 mod shutdown;
-mod transaction;
+pub(crate) mod transaction;
 mod update;
 mod watch;
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -52,7 +52,7 @@ pub use run_command::{RunCommand, RunCursorCommand};
 pub use search_index::{CreateSearchIndex, DropSearchIndex, ListSearchIndexes, UpdateSearchIndex};
 pub use session::StartSession;
 pub use shutdown::Shutdown;
-pub use transaction::{CommitTransaction, StartTransaction};
+pub use transaction::{AbortTransaction, CommitTransaction, StartTransaction};
 pub use update::Update;
 pub use watch::Watch;
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -24,6 +24,7 @@ mod run_command;
 mod search_index;
 mod session;
 mod shutdown;
+mod transaction;
 mod update;
 mod watch;
 
@@ -51,6 +52,7 @@ pub use run_command::{RunCommand, RunCursorCommand};
 pub use search_index::{CreateSearchIndex, DropSearchIndex, ListSearchIndexes, UpdateSearchIndex};
 pub use session::StartSession;
 pub use shutdown::Shutdown;
+pub use transaction::StartTransaction;
 pub use update::Update;
 pub use watch::Watch;
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -52,7 +52,7 @@ pub use run_command::{RunCommand, RunCursorCommand};
 pub use search_index::{CreateSearchIndex, DropSearchIndex, ListSearchIndexes, UpdateSearchIndex};
 pub use session::StartSession;
 pub use shutdown::Shutdown;
-pub use transaction::StartTransaction;
+pub use transaction::{CommitTransaction, StartTransaction};
 pub use update::Update;
 pub use watch::Watch;
 

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -134,7 +134,7 @@ impl<'a> Aggregate<'a, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<Document>)]
+#[action_impl(sync = crate::sync::Cursor<Document>)]
 impl<'a> Action for Aggregate<'a, ImplicitSession> {
     type Future = AggregateFuture;
 
@@ -155,7 +155,7 @@ impl<'a> Action for Aggregate<'a, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::SessionCursor::<Document>)]
+#[action_impl(sync = crate::sync::SessionCursor<Document>)]
 impl<'a> Action for Aggregate<'a, ExplicitSession<'a>> {
     type Future = AggregateSessionFuture;
 

--- a/src/action/count.rs
+++ b/src/action/count.rs
@@ -100,15 +100,14 @@ impl<'a> EstimatedDocumentCount<'a> {
     );
 }
 
-action_impl! {
-    impl<'a> Action for EstimatedDocumentCount<'a> {
-        type Future = EstimatedDocumentCountFuture;
+#[action_impl]
+impl<'a> Action for EstimatedDocumentCount<'a> {
+    type Future = EstimatedDocumentCountFuture;
 
-        async fn execute(mut self) -> Result<u64> {
-            resolve_options!(self.cr, self.options, [read_concern, selection_criteria]);
-            let op = crate::operation::count::Count::new(self.cr.namespace(), self.options);
-            self.cr.client().execute_operation(op, None).await
-        }
+    async fn execute(mut self) -> Result<u64> {
+        resolve_options!(self.cr, self.options, [read_concern, selection_criteria]);
+        let op = crate::operation::count::Count::new(self.cr.namespace(), self.options);
+        self.cr.client().execute_operation(op, None).await
     }
 }
 
@@ -140,16 +139,19 @@ impl<'a> CountDocuments<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for CountDocuments<'a> {
-        type Future = CountDocumentsFuture;
+#[action_impl]
+impl<'a> Action for CountDocuments<'a> {
+    type Future = CountDocumentsFuture;
 
-        async fn execute(mut self) -> Result<u64> {
-            resolve_read_concern_with_session!(self.cr, self.options, self.session.as_ref())?;
-            resolve_selection_criteria_with_session!(self.cr, self.options, self.session.as_ref())?;
+    async fn execute(mut self) -> Result<u64> {
+        resolve_read_concern_with_session!(self.cr, self.options, self.session.as_ref())?;
+        resolve_selection_criteria_with_session!(self.cr, self.options, self.session.as_ref())?;
 
-            let op = crate::operation::count_documents::CountDocuments::new(self.cr.namespace(), self.filter, self.options)?;
-            self.cr.client().execute_operation(op, self.session).await
-        }
+        let op = crate::operation::count_documents::CountDocuments::new(
+            self.cr.namespace(),
+            self.filter,
+            self.options,
+        )?;
+        self.cr.client().execute_operation(op, self.session).await
     }
 }

--- a/src/action/create_index.rs
+++ b/src/action/create_index.rs
@@ -102,33 +102,31 @@ impl<'a, M> CreateIndex<'a, M> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for CreateIndex<'a, Single> {
-        type Future = CreateIndexFuture;
+#[action_impl]
+impl<'a> Action for CreateIndex<'a, Single> {
+    type Future = CreateIndexFuture;
 
-        async fn execute(self) -> Result<CreateIndexResult> {
-            let inner: CreateIndex<'a, Multiple> = CreateIndex {
-                coll: self.coll,
-                indexes: self.indexes,
-                options: self.options,
-                session: self.session,
-                _mode: PhantomData,
-            };
-            let response = inner.await?;
-            Ok(response.into_create_index_result())
-        }
+    async fn execute(self) -> Result<CreateIndexResult> {
+        let inner: CreateIndex<'a, Multiple> = CreateIndex {
+            coll: self.coll,
+            indexes: self.indexes,
+            options: self.options,
+            session: self.session,
+            _mode: PhantomData,
+        };
+        let response = inner.await?;
+        Ok(response.into_create_index_result())
     }
 }
 
-action_impl! {
-    impl<'a> Action for CreateIndex<'a, Multiple> {
-        type Future = CreateIndexesFuture;
+#[action_impl]
+impl<'a> Action for CreateIndex<'a, Multiple> {
+    type Future = CreateIndexesFuture;
 
-        async fn execute(mut self) -> Result<CreateIndexesResult> {
-            resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+    async fn execute(mut self) -> Result<CreateIndexesResult> {
+        resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
 
-            let op = Op::new(self.coll.namespace(), self.indexes, self.options);
-            self.coll.client().execute_operation(op, self.session).await
-        }
+        let op = Op::new(self.coll.namespace(), self.indexes, self.options);
+        self.coll.client().execute_operation(op, self.session).await
     }
 }

--- a/src/action/csfle/create_encrypted_collection.rs
+++ b/src/action/csfle/create_encrypted_collection.rs
@@ -68,48 +68,57 @@ impl<'a> CreateEncryptedCollection<'a> {
     );
 }
 
-action_impl! {
-    impl<'a> Action for CreateEncryptedCollection<'a> {
-        type Future = CreateEncryptedCollectionFuture;
+#[action_impl]
+impl<'a> Action for CreateEncryptedCollection<'a> {
+    type Future = CreateEncryptedCollectionFuture;
 
-        async fn execute(self) -> (Document, Result<()>) {
-            let ef = match self.options.as_ref().and_then(|o| o.encrypted_fields.as_ref()) {
-                Some(ef) => ef,
-                None => {
-                    return (
-                        doc! {},
-                        Err(Error::invalid_argument(
-                            "no encrypted_fields defined for collection",
-                        )),
-                    );
-                }
-            };
-            let mut ef_prime = ef.clone();
-            if let Ok(fields) = ef_prime.get_array_mut("fields") {
-                for f in fields {
-                    let f_doc = if let Some(d) = f.as_document_mut() {
-                        d
-                    } else {
-                        continue;
+    async fn execute(self) -> (Document, Result<()>) {
+        let ef = match self
+            .options
+            .as_ref()
+            .and_then(|o| o.encrypted_fields.as_ref())
+        {
+            Some(ef) => ef,
+            None => {
+                return (
+                    doc! {},
+                    Err(Error::invalid_argument(
+                        "no encrypted_fields defined for collection",
+                    )),
+                );
+            }
+        };
+        let mut ef_prime = ef.clone();
+        if let Ok(fields) = ef_prime.get_array_mut("fields") {
+            for f in fields {
+                let f_doc = if let Some(d) = f.as_document_mut() {
+                    d
+                } else {
+                    continue;
+                };
+                if f_doc.get("keyId") == Some(&Bson::Null) {
+                    let d = match self
+                        .client_enc
+                        .create_data_key(self.master_key.clone())
+                        .await
+                    {
+                        Ok(v) => v,
+                        Err(e) => return (ef_prime, Err(e)),
                     };
-                    if f_doc.get("keyId") == Some(&Bson::Null) {
-                        let d = match self.client_enc.create_data_key(self.master_key.clone()).await {
-                            Ok(v) => v,
-                            Err(e) => return (ef_prime, Err(e)),
-                        };
-                        f_doc.insert("keyId", d);
-                    }
+                    f_doc.insert("keyId", d);
                 }
             }
-            // Unwrap safety: the check for `encrypted_fields` at the top won't succeed if `self.options` is `None`.
-            let mut opts_prime = self.options.unwrap();
-            opts_prime.encrypted_fields = Some(ef_prime.clone());
-            (
-                ef_prime,
-                self.db.create_collection(self.name)
-                    .with_options(opts_prime)
-                    .await,
-            )
         }
+        // Unwrap safety: the check for `encrypted_fields` at the top won't succeed if
+        // `self.options` is `None`.
+        let mut opts_prime = self.options.unwrap();
+        opts_prime.encrypted_fields = Some(ef_prime.clone());
+        (
+            ef_prime,
+            self.db
+                .create_collection(self.name)
+                .with_options(opts_prime)
+                .await,
+        )
     }
 }

--- a/src/action/delete.rs
+++ b/src/action/delete.rs
@@ -105,15 +105,14 @@ impl<'a> Delete<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for Delete<'a> {
-        type Future = DeleteFuture;
+#[action_impl]
+impl<'a> Action for Delete<'a> {
+    type Future = DeleteFuture;
 
-        async fn execute(mut self) -> Result<DeleteResult> {
-            resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+    async fn execute(mut self) -> Result<DeleteResult> {
+        resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
 
-            let op = Op::new(self.coll.namespace(), self.query, self.limit, self.options);
-            self.coll.client().execute_operation(op, self.session).await
-        }
+        let op = Op::new(self.coll.namespace(), self.query, self.limit, self.options);
+        self.coll.client().execute_operation(op, self.session).await
     }
 }

--- a/src/action/distinct.rs
+++ b/src/action/distinct.rs
@@ -74,21 +74,20 @@ impl<'a> Distinct<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for Distinct<'a> {
-        type Future = DistinctFuture;
+#[action_impl]
+impl<'a> Action for Distinct<'a> {
+    type Future = DistinctFuture;
 
-        async fn execute(mut self) -> Result<Vec<Bson>> {
-            resolve_read_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
-            resolve_selection_criteria_with_session!(self.coll, self.options, self.session.as_ref())?;
+    async fn execute(mut self) -> Result<Vec<Bson>> {
+        resolve_read_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+        resolve_selection_criteria_with_session!(self.coll, self.options, self.session.as_ref())?;
 
-            let op = Op::new(
-                self.coll.namespace(),
-                self.field_name,
-                self.filter,
-                self.options,
-            );
-            self.coll.client().execute_operation(op, self.session).await
-        }
+        let op = Op::new(
+            self.coll.namespace(),
+            self.field_name,
+            self.filter,
+            self.options,
+        );
+        self.coll.client().execute_operation(op, self.session).await
     }
 }

--- a/src/action/drop.rs
+++ b/src/action/drop.rs
@@ -57,17 +57,14 @@ impl<'a> DropDatabase<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for DropDatabase<'a> {
-        type Future = DropDatabaseFuture;
+#[action_impl]
+impl<'a> Action for DropDatabase<'a> {
+    type Future = DropDatabaseFuture;
 
-        async fn execute(mut self) -> Result<()> {
-            resolve_options!(self.db, self.options, [write_concern]);
-            let op = drop_database::DropDatabase::new(self.db.name().to_string(), self.options);
-            self.db.client()
-                .execute_operation(op, self.session)
-                .await
-        }
+    async fn execute(mut self) -> Result<()> {
+        resolve_options!(self.db, self.options, [write_concern]);
+        let op = drop_database::DropDatabase::new(self.db.name().to_string(), self.options);
+        self.db.client().execute_operation(op, self.session).await
     }
 }
 

--- a/src/action/drop_index.rs
+++ b/src/action/drop_index.rs
@@ -89,26 +89,25 @@ impl<'a> DropIndex<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for DropIndex<'a> {
-        type Future = DropIndexFuture;
+#[action_impl]
+impl<'a> Action for DropIndex<'a> {
+    type Future = DropIndexFuture;
 
-        async fn execute(mut self) -> Result<()> {
-            if matches!(self.name.as_deref(), Some("*")) {
-                return Err(ErrorKind::InvalidArgument {
-                    message: "Cannot pass name \"*\" to drop_index since more than one index would be \
-                              dropped."
-                        .to_string(),
-                }
-                .into());
+    async fn execute(mut self) -> Result<()> {
+        if matches!(self.name.as_deref(), Some("*")) {
+            return Err(ErrorKind::InvalidArgument {
+                message: "Cannot pass name \"*\" to drop_index since more than one index would be \
+                          dropped."
+                    .to_string(),
             }
-            resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
-
-            // If there is no provided name, that means we should drop all indexes.
-            let index_name = self.name.unwrap_or_else(|| "*".to_string());
-
-            let op = Op::new(self.coll.namespace(), index_name, self.options);
-            self.coll.client().execute_operation(op, self.session).await
+            .into());
         }
+        resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+
+        // If there is no provided name, that means we should drop all indexes.
+        let index_name = self.name.unwrap_or_else(|| "*".to_string());
+
+        let op = Op::new(self.coll.namespace(), index_name, self.options);
+        self.coll.client().execute_operation(op, self.session).await
     }
 }

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -122,38 +122,35 @@ impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     }
 }
 
-action_impl! {
-    impl<'a, T: Send + Sync> Action for Find<'a, T, ImplicitSession> {
-        type Future = FindFuture;
+#[action_impl(sync = crate::sync::Cursor::<T>)]
+impl<'a, T: Send + Sync> Action for Find<'a, T, ImplicitSession> {
+    type Future = FindFuture;
 
-        async fn execute(mut self) -> Result<Cursor<T>> {
-            resolve_options!(self.coll, self.options, [read_concern, selection_criteria]);
+    async fn execute(mut self) -> Result<Cursor<T>> {
+        resolve_options!(self.coll, self.options, [read_concern, selection_criteria]);
 
-            let find = Op::new(self.coll.namespace(), self.filter, self.options);
-            self.coll.client().execute_cursor_operation(find).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::Cursor<T>> {
-            out.map(crate::sync::Cursor::new)
-        }
+        let find = Op::new(self.coll.namespace(), self.filter, self.options);
+        self.coll.client().execute_cursor_operation(find).await
     }
 }
 
-action_impl! {
-    impl<'a, T: Send + Sync> Action for Find<'a, T, ExplicitSession<'a>> {
-        type Future = FindSessionFuture;
+#[action_impl(sync = crate::sync::SessionCursor::<T>)]
+impl<'a, T: Send + Sync> Action for Find<'a, T, ExplicitSession<'a>> {
+    type Future = FindSessionFuture;
 
-        async fn execute(mut self) -> Result<SessionCursor<T>> {
-            resolve_read_concern_with_session!(self.coll, self.options, Some(&mut *self.session.0))?;
-            resolve_selection_criteria_with_session!(self.coll, self.options, Some(&mut *self.session.0))?;
+    async fn execute(mut self) -> Result<SessionCursor<T>> {
+        resolve_read_concern_with_session!(self.coll, self.options, Some(&mut *self.session.0))?;
+        resolve_selection_criteria_with_session!(
+            self.coll,
+            self.options,
+            Some(&mut *self.session.0)
+        )?;
 
-            let find = Op::new(self.coll.namespace(), self.filter, self.options);
-            self.coll.client().execute_session_cursor_operation(find, self.session.0).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::SessionCursor<T>> {
-            out.map(crate::sync::SessionCursor::new)
-        }
+        let find = Op::new(self.coll.namespace(), self.filter, self.options);
+        self.coll
+            .client()
+            .execute_session_cursor_operation(find, self.session.0)
+            .await
     }
 }
 
@@ -195,24 +192,22 @@ impl<'a, T: Send + Sync> FindOne<'a, T> {
     }
 }
 
-action_impl! {
-    impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOne<'a, T>
-    {
-        type Future = FindOneFuture;
+#[action_impl]
+impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOne<'a, T> {
+    type Future = FindOneFuture;
 
-        async fn execute(self) -> Result<Option<T>> {
-            use futures_util::stream::StreamExt;
-            let mut options: FindOptions = self.options.unwrap_or_default().into();
-            options.limit = Some(-1);
-            let find = self.coll.find(self.filter).with_options(options);
-            if let Some(session) = self.session {
-                let mut cursor = find.session(&mut *session).await?;
-                let mut stream = cursor.stream(session);
-                stream.next().await.transpose()
-            } else {
-                let mut cursor = find.await?;
-                cursor.next().await.transpose()
-            }
+    async fn execute(self) -> Result<Option<T>> {
+        use futures_util::stream::StreamExt;
+        let mut options: FindOptions = self.options.unwrap_or_default().into();
+        options.limit = Some(-1);
+        let find = self.coll.find(self.filter).with_options(options);
+        if let Some(session) = self.session {
+            let mut cursor = find.session(&mut *session).await?;
+            let mut stream = cursor.stream(session);
+            stream.next().await.transpose()
+        } else {
+            let mut cursor = find.await?;
+            cursor.next().await.transpose()
         }
     }
 }

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -122,7 +122,7 @@ impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<T>)]
+#[action_impl(sync = crate::sync::Cursor<T>)]
 impl<'a, T: Send + Sync> Action for Find<'a, T, ImplicitSession> {
     type Future = FindFuture;
 
@@ -134,7 +134,7 @@ impl<'a, T: Send + Sync> Action for Find<'a, T, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::SessionCursor::<T>)]
+#[action_impl(sync = crate::sync::SessionCursor<T>)]
 impl<'a, T: Send + Sync> Action for Find<'a, T, ExplicitSession<'a>> {
     type Future = FindSessionFuture;
 

--- a/src/action/find_and_modify.rs
+++ b/src/action/find_and_modify.rs
@@ -202,18 +202,19 @@ impl<'a, T: Send + Sync> FindOneAndDelete<'a, T> {
     }
 }
 
-action_impl! {
-    impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOneAndDelete<'a, T> {
-        type Future = FindOneAndDeleteFuture;
+#[action_impl]
+impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOneAndDelete<'a, T> {
+    type Future = FindOneAndDeleteFuture;
 
-        async fn execute(self) -> Result<Option<T>> {
-            self.coll.find_and_modify(
+    async fn execute(self) -> Result<Option<T>> {
+        self.coll
+            .find_and_modify(
                 self.filter,
                 Modification::Delete,
                 self.options.map(FindAndModifyOptions::from),
                 self.session,
-            ).await
-        }
+            )
+            .await
     }
 }
 
@@ -251,18 +252,19 @@ impl<'a, T: Send + Sync> FindOneAndUpdate<'a, T> {
     }
 }
 
-action_impl! {
-    impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOneAndUpdate<'a, T> {
-        type Future = FindOneAndUpdateFuture;
+#[action_impl]
+impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOneAndUpdate<'a, T> {
+    type Future = FindOneAndUpdateFuture;
 
-        async fn execute(self) -> Result<Option<T>> {
-            self.coll.find_and_modify(
+    async fn execute(self) -> Result<Option<T>> {
+        self.coll
+            .find_and_modify(
                 self.filter,
                 Modification::Update(self.update.into()),
                 self.options.map(FindAndModifyOptions::from),
                 self.session,
-            ).await
-        }
+            )
+            .await
     }
 }
 
@@ -299,17 +301,18 @@ impl<'a, T: Send + Sync> FindOneAndReplace<'a, T> {
     }
 }
 
-action_impl! {
-    impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOneAndReplace<'a, T> {
-        type Future = FindOneAndReplaceFuture;
+#[action_impl]
+impl<'a, T: DeserializeOwned + Send + Sync> Action for FindOneAndReplace<'a, T> {
+    type Future = FindOneAndReplaceFuture;
 
-        async fn execute(self) -> Result<Option<T>> {
-            self.coll.find_and_modify(
+    async fn execute(self) -> Result<Option<T>> {
+        self.coll
+            .find_and_modify(
                 self.filter,
                 Modification::Update(UpdateOrReplace::Replacement(self.replacement?)),
                 self.options.map(FindAndModifyOptions::from),
                 self.session,
-            ).await
-        }
+            )
+            .await
     }
 }

--- a/src/action/gridfs/download.rs
+++ b/src/action/gridfs/download.rs
@@ -128,18 +128,13 @@ pub struct OpenDownloadStream<'a> {
     id: Bson,
 }
 
-action_impl! {
-    impl<'a> Action for OpenDownloadStream<'a> {
-        type Future = OpenDownloadStreamFuture;
+#[action_impl(sync = crate::sync::gridfs::GridFsDownloadStream)]
+impl<'a> Action for OpenDownloadStream<'a> {
+    type Future = OpenDownloadStreamFuture;
 
-        async fn execute(self) -> Result<GridFsDownloadStream> {
-            let file = self.bucket.find_file_by_id(&self.id).await?;
-            GridFsDownloadStream::new(file, self.bucket.chunks()).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::gridfs::GridFsDownloadStream> {
-            out.map(crate::sync::gridfs::GridFsDownloadStream::new)
-        }
+    async fn execute(self) -> Result<GridFsDownloadStream> {
+        let file = self.bucket.find_file_by_id(&self.id).await?;
+        GridFsDownloadStream::new(file, self.bucket.chunks()).await
     }
 }
 
@@ -159,20 +154,15 @@ impl<'a> OpenDownloadStreamByName<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for OpenDownloadStreamByName<'a> {
-        type Future = OpenDownloadStreamByNameFuture;
+#[action_impl(sync = crate::sync::gridfs::GridFsDownloadStream)]
+impl<'a> Action for OpenDownloadStreamByName<'a> {
+    type Future = OpenDownloadStreamByNameFuture;
 
-        async fn execute(self) -> Result<GridFsDownloadStream> {
-            let file = self
-                .bucket
-                .find_file_by_name(&self.filename, self.options)
-                .await?;
-            GridFsDownloadStream::new(file, self.bucket.chunks()).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::gridfs::GridFsDownloadStream> {
-            out.map(crate::sync::gridfs::GridFsDownloadStream::new)
-        }
+    async fn execute(self) -> Result<GridFsDownloadStream> {
+        let file = self
+            .bucket
+            .find_file_by_name(&self.filename, self.options)
+            .await?;
+        GridFsDownloadStream::new(file, self.bucket.chunks()).await
     }
 }

--- a/src/action/gridfs/drop.rs
+++ b/src/action/gridfs/drop.rs
@@ -26,15 +26,14 @@ pub struct Drop<'a> {
     bucket: &'a GridFsBucket,
 }
 
-action_impl! {
-    impl<'a> Action for Drop<'a> {
-        type Future = DropFuture;
+#[action_impl]
+impl<'a> Action for Drop<'a> {
+    type Future = DropFuture;
 
-        async fn execute(self) -> Result<()> {
-            self.bucket.files().drop().await?;
-            self.bucket.chunks().drop().await?;
+    async fn execute(self) -> Result<()> {
+        self.bucket.files().drop().await?;
+        self.bucket.chunks().drop().await?;
 
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/src/action/gridfs/find.rs
+++ b/src/action/gridfs/find.rs
@@ -80,7 +80,7 @@ impl<'a> Find<'a> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<FilesCollectionDocument>)]
+#[action_impl(sync = crate::sync::Cursor<FilesCollectionDocument>)]
 impl<'a> Action for Find<'a> {
     type Future = FindFuture;
 

--- a/src/action/gridfs/find.rs
+++ b/src/action/gridfs/find.rs
@@ -80,18 +80,17 @@ impl<'a> Find<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for Find<'a> {
-        type Future = FindFuture;
+#[action_impl(sync = crate::sync::Cursor::<FilesCollectionDocument>)]
+impl<'a> Action for Find<'a> {
+    type Future = FindFuture;
 
-        async fn execute(self) -> Result<Cursor<FilesCollectionDocument>> {
-            let find_options = self.options.map(FindOptions::from);
-            self.bucket.files().find(self.filter).with_options(find_options).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::Cursor<FilesCollectionDocument>> {
-            out.map(crate::sync::Cursor::new)
-        }
+    async fn execute(self) -> Result<Cursor<FilesCollectionDocument>> {
+        let find_options = self.options.map(FindOptions::from);
+        self.bucket
+            .files()
+            .find(self.filter)
+            .with_options(find_options)
+            .await
     }
 }
 
@@ -112,17 +111,16 @@ impl<'a> FindOne<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for FindOne<'a> {
-        type Future = FindOneFuture;
+#[action_impl]
+impl<'a> Action for FindOne<'a> {
+    type Future = FindOneFuture;
 
-        async fn execute(self) -> Result<Option<FilesCollectionDocument>> {
-            let find_options = self.options.map(FindOneOptions::from);
-            self.bucket
-                .files()
-                .find_one(self.filter)
-                .with_options(find_options)
-                .await
-        }
+    async fn execute(self) -> Result<Option<FilesCollectionDocument>> {
+        let find_options = self.options.map(FindOneOptions::from);
+        self.bucket
+            .files()
+            .find_one(self.filter)
+            .with_options(find_options)
+            .await
     }
 }

--- a/src/action/gridfs/rename.rs
+++ b/src/action/gridfs/rename.rs
@@ -35,20 +35,19 @@ pub struct Rename<'a> {
     new_filename: String,
 }
 
-action_impl! {
-    impl<'a> Action for Rename<'a> {
-        type Future = RenameFuture;
+#[action_impl]
+impl<'a> Action for Rename<'a> {
+    type Future = RenameFuture;
 
-        async fn execute(self) -> Result<()> {
-            self.bucket
-                .files()
-                .update_one(
-                    doc! { "_id": self.id },
-                    doc! { "$set": { "filename": self.new_filename } },
-                )
-                .await?;
+    async fn execute(self) -> Result<()> {
+        self.bucket
+            .files()
+            .update_one(
+                doc! { "_id": self.id },
+                doc! { "$set": { "filename": self.new_filename } },
+            )
+            .await?;
 
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/src/action/gridfs/upload.rs
+++ b/src/action/gridfs/upload.rs
@@ -63,29 +63,25 @@ impl<'a> OpenUploadStream<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for OpenUploadStream<'a> {
-        type Future = OpenUploadStreamFuture;
+#[action_impl(sync = crate::sync::gridfs::GridFsUploadStream)]
+impl<'a> Action for OpenUploadStream<'a> {
+    type Future = OpenUploadStreamFuture;
 
-        async fn execute(self) -> Result<GridFsUploadStream> {
-            let id = self.id.unwrap_or_else(|| ObjectId::new().into());
-            let chunk_size_bytes = self.options
-                .as_ref()
-                .and_then(|opts| opts.chunk_size_bytes)
-                .unwrap_or_else(|| self.bucket.chunk_size_bytes());
-            let metadata = self.options.and_then(|opts| opts.metadata);
-            Ok(GridFsUploadStream::new(
-                self.bucket.clone(),
-                id,
-                self.filename,
-                chunk_size_bytes,
-                metadata,
-                self.bucket.client().register_async_drop(),
-            ))
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::gridfs::GridFsUploadStream> {
-            out.map(crate::sync::gridfs::GridFsUploadStream::new)
-        }
+    async fn execute(self) -> Result<GridFsUploadStream> {
+        let id = self.id.unwrap_or_else(|| ObjectId::new().into());
+        let chunk_size_bytes = self
+            .options
+            .as_ref()
+            .and_then(|opts| opts.chunk_size_bytes)
+            .unwrap_or_else(|| self.bucket.chunk_size_bytes());
+        let metadata = self.options.and_then(|opts| opts.metadata);
+        Ok(GridFsUploadStream::new(
+            self.bucket.clone(),
+            id,
+            self.filename,
+            chunk_size_bytes,
+            metadata,
+            self.bucket.client().register_async_drop(),
+        ))
     }
 }

--- a/src/action/insert_one.rs
+++ b/src/action/insert_one.rs
@@ -84,31 +84,31 @@ impl<'a> InsertOne<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for InsertOne<'a> {
-        type Future = InsertOneFuture;
+#[action_impl]
+impl<'a> Action for InsertOne<'a> {
+    type Future = InsertOneFuture;
 
-        async fn execute(mut self) -> Result<InsertOneResult> {
-            resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+    async fn execute(mut self) -> Result<InsertOneResult> {
+        resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
 
-            #[cfg(feature = "in-use-encryption-unstable")]
-            let encrypted = self.coll.client().auto_encryption_opts().await.is_some();
-            #[cfg(not(feature = "in-use-encryption-unstable"))]
-            let encrypted = false;
+        #[cfg(feature = "in-use-encryption-unstable")]
+        let encrypted = self.coll.client().auto_encryption_opts().await.is_some();
+        #[cfg(not(feature = "in-use-encryption-unstable"))]
+        let encrypted = false;
 
-            let doc = self.doc?;
+        let doc = self.doc?;
 
-            let insert = Op::new(
-                self.coll.namespace(),
-                vec![doc.deref()],
-                self.options.map(InsertManyOptions::from_insert_one_options),
-                encrypted,
-            );
-            self.coll.client()
-                .execute_operation(insert, self.session)
-                .await
-                .map(InsertOneResult::from_insert_many_result)
-                .map_err(convert_bulk_errors)
-        }
+        let insert = Op::new(
+            self.coll.namespace(),
+            vec![doc.deref()],
+            self.options.map(InsertManyOptions::from_insert_one_options),
+            encrypted,
+        );
+        self.coll
+            .client()
+            .execute_operation(insert, self.session)
+            .await
+            .map(InsertOneResult::from_insert_many_result)
+            .map_err(convert_bulk_errors)
     }
 }

--- a/src/action/list_collections.rs
+++ b/src/action/list_collections.rs
@@ -106,7 +106,7 @@ impl<'a, M> ListCollections<'a, M, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<CollectionSpecification>)]
+#[action_impl(sync = crate::sync::Cursor<CollectionSpecification>)]
 impl<'a> Action for ListCollections<'a, ListSpecifications, ImplicitSession> {
     type Future = ListCollectionsFuture;
 
@@ -120,7 +120,7 @@ impl<'a> Action for ListCollections<'a, ListSpecifications, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::SessionCursor::<CollectionSpecification>)]
+#[action_impl(sync = crate::sync::SessionCursor<CollectionSpecification>)]
 impl<'a> Action for ListCollections<'a, ListSpecifications, ExplicitSession<'a>> {
     type Future = ListCollectionsSessionFuture;
 

--- a/src/action/list_collections.rs
+++ b/src/action/list_collections.rs
@@ -106,45 +106,31 @@ impl<'a, M> ListCollections<'a, M, ImplicitSession> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListCollections<'a, ListSpecifications, ImplicitSession> {
-        type Future = ListCollectionsFuture;
+#[action_impl(sync = crate::sync::Cursor::<CollectionSpecification>)]
+impl<'a> Action for ListCollections<'a, ListSpecifications, ImplicitSession> {
+    type Future = ListCollectionsFuture;
 
-        async fn execute(self) -> Result<Cursor<CollectionSpecification>> {
-            let list_collections = op::ListCollections::new(
-                self.db.name().to_string(),
-                false,
-                self.options,
-            );
-            self.db.client()
-                .execute_cursor_operation(list_collections)
-                .await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::Cursor<CollectionSpecification>> {
-            out.map(crate::sync::Cursor::new)
-        }
+    async fn execute(self) -> Result<Cursor<CollectionSpecification>> {
+        let list_collections =
+            op::ListCollections::new(self.db.name().to_string(), false, self.options);
+        self.db
+            .client()
+            .execute_cursor_operation(list_collections)
+            .await
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListCollections<'a, ListSpecifications, ExplicitSession<'a>> {
-        type Future = ListCollectionsSessionFuture;
+#[action_impl(sync = crate::sync::SessionCursor::<CollectionSpecification>)]
+impl<'a> Action for ListCollections<'a, ListSpecifications, ExplicitSession<'a>> {
+    type Future = ListCollectionsSessionFuture;
 
-        async fn execute(self) -> Result<SessionCursor<CollectionSpecification>> {
-            let list_collections = op::ListCollections::new(
-                self.db.name().to_string(),
-                false,
-                self.options,
-            );
-            self.db.client()
-                .execute_session_cursor_operation(list_collections, self.session.0)
-                .await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::SessionCursor<CollectionSpecification>> {
-            out.map(crate::sync::SessionCursor::new)
-        }
+    async fn execute(self) -> Result<SessionCursor<CollectionSpecification>> {
+        let list_collections =
+            op::ListCollections::new(self.db.name().to_string(), false, self.options);
+        self.db
+            .client()
+            .execute_session_cursor_operation(list_collections, self.session.0)
+            .await
     }
 }
 
@@ -166,41 +152,35 @@ async fn list_collection_names_common(
         .await
 }
 
-action_impl! {
-    impl<'a> Action for ListCollections<'a, ListNames, ImplicitSession> {
-        type Future = ListCollectionNamesFuture;
+#[action_impl]
+impl<'a> Action for ListCollections<'a, ListNames, ImplicitSession> {
+    type Future = ListCollectionNamesFuture;
 
-        async fn execute(self) -> Result<Vec<String>> {
-            let list_collections = op::ListCollections::new(
-                self.db.name().to_string(),
-                true,
-                self.options,
-            );
-            let cursor: Cursor<Document> = self.db.client()
-                .execute_cursor_operation(list_collections)
-                .await?;
-            return list_collection_names_common(cursor).await;
-        }
+    async fn execute(self) -> Result<Vec<String>> {
+        let list_collections =
+            op::ListCollections::new(self.db.name().to_string(), true, self.options);
+        let cursor: Cursor<Document> = self
+            .db
+            .client()
+            .execute_cursor_operation(list_collections)
+            .await?;
+        return list_collection_names_common(cursor).await;
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListCollections<'a, ListNames, ExplicitSession<'a>> {
-        type Future = ListCollectionNamesSessionFuture;
+#[action_impl]
+impl<'a> Action for ListCollections<'a, ListNames, ExplicitSession<'a>> {
+    type Future = ListCollectionNamesSessionFuture;
 
-        async fn execute(self) -> Result<Vec<String>> {
-            let list_collections = op::ListCollections::new(
-                self.db.name().to_string(),
-                true,
-                self.options,
-            );
-            let mut cursor: SessionCursor<Document> = self
-                .db.client()
-                .execute_session_cursor_operation(list_collections, &mut *self.session.0)
-                .await?;
+    async fn execute(self) -> Result<Vec<String>> {
+        let list_collections =
+            op::ListCollections::new(self.db.name().to_string(), true, self.options);
+        let mut cursor: SessionCursor<Document> = self
+            .db
+            .client()
+            .execute_session_cursor_operation(list_collections, &mut *self.session.0)
+            .await?;
 
-            list_collection_names_common(cursor.stream(self.session.0))
-                .await
-        }
+        list_collection_names_common(cursor.stream(self.session.0)).await
     }
 }

--- a/src/action/list_databases.rs
+++ b/src/action/list_databases.rs
@@ -86,48 +86,46 @@ impl<'a, M> ListDatabases<'a, M> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListDatabases<'a, ListSpecifications> {
-        type Future = ListDatabasesFuture;
+#[action_impl]
+impl<'a> Action for ListDatabases<'a, ListSpecifications> {
+    type Future = ListDatabasesFuture;
 
-        async fn execute(self) -> Result<Vec<DatabaseSpecification>> {
-            let op = op::ListDatabases::new(false, self.options);
-                self.client
-                    .execute_operation(op, self.session)
-                    .await
-                    .and_then(|dbs| {
-                        dbs.into_iter()
-                            .map(|db_spec| {
-                                bson::from_slice(db_spec.as_bytes()).map_err(crate::error::Error::from)
-                            })
-                            .collect()
+    async fn execute(self) -> Result<Vec<DatabaseSpecification>> {
+        let op = op::ListDatabases::new(false, self.options);
+        self.client
+            .execute_operation(op, self.session)
+            .await
+            .and_then(|dbs| {
+                dbs.into_iter()
+                    .map(|db_spec| {
+                        bson::from_slice(db_spec.as_bytes()).map_err(crate::error::Error::from)
                     })
-        }
+                    .collect()
+            })
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListDatabases<'a, ListNames> {
-        type Future = ListDatabaseNamesFuture;
+#[action_impl]
+impl<'a> Action for ListDatabases<'a, ListNames> {
+    type Future = ListDatabaseNamesFuture;
 
-        async fn execute(self) -> Result<Vec<String>> {
-            let op = op::ListDatabases::new(true, self.options);
-            match self.client.execute_operation(op, self.session).await {
-                Ok(databases) => databases
-                    .into_iter()
-                    .map(|doc| {
-                        let name = doc
-                            .get_str("name")
-                            .map_err(|_| ErrorKind::InvalidResponse {
-                                message: "Expected \"name\" field in server response, but it was \
-                                            not found"
-                                    .to_string(),
-                            })?;
-                        Ok(name.to_string())
-                    })
-                    .collect(),
-                Err(e) => Err(e),
-            }
+    async fn execute(self) -> Result<Vec<String>> {
+        let op = op::ListDatabases::new(true, self.options);
+        match self.client.execute_operation(op, self.session).await {
+            Ok(databases) => databases
+                .into_iter()
+                .map(|doc| {
+                    let name = doc
+                        .get_str("name")
+                        .map_err(|_| ErrorKind::InvalidResponse {
+                            message: "Expected \"name\" field in server response, but it was not \
+                                      found"
+                                .to_string(),
+                        })?;
+                    Ok(name.to_string())
+                })
+                .collect(),
+            Err(e) => Err(e),
         }
     }
 }

--- a/src/action/list_indexes.rs
+++ b/src/action/list_indexes.rs
@@ -113,74 +113,65 @@ impl<'a, Mode> ListIndexes<'a, Mode, ImplicitSession> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListIndexes<'a, ListSpecifications, ImplicitSession> {
-        type Future = ListIndexesFuture;
+#[action_impl(sync = crate::sync::Cursor::<IndexModel>)]
+impl<'a> Action for ListIndexes<'a, ListSpecifications, ImplicitSession> {
+    type Future = ListIndexesFuture;
 
-        async fn execute(self) -> Result<Cursor<IndexModel>> {
-            let op = Op::new(self.coll.namespace(), self.options);
-            self.coll.client().execute_cursor_operation(op).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::Cursor<IndexModel>> {
-            out.map(crate::sync::Cursor::new)
-        }
+    async fn execute(self) -> Result<Cursor<IndexModel>> {
+        let op = Op::new(self.coll.namespace(), self.options);
+        self.coll.client().execute_cursor_operation(op).await
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListIndexes<'a, ListSpecifications, ExplicitSession<'a>> {
-        type Future = ListIndexesSessionFuture;
+#[action_impl(sync = crate::sync::SessionCursor::<IndexModel>)]
+impl<'a> Action for ListIndexes<'a, ListSpecifications, ExplicitSession<'a>> {
+    type Future = ListIndexesSessionFuture;
 
-        async fn execute(self) -> Result<SessionCursor<IndexModel>> {
-            let op = Op::new(self.coll.namespace(), self.options);
-            self.coll.client().execute_session_cursor_operation(op, self.session.0).await
-        }
-
-        fn sync_wrap(out) -> Result<crate::sync::SessionCursor<IndexModel>> {
-            out.map(crate::sync::SessionCursor::new)
-        }
+    async fn execute(self) -> Result<SessionCursor<IndexModel>> {
+        let op = Op::new(self.coll.namespace(), self.options);
+        self.coll
+            .client()
+            .execute_session_cursor_operation(op, self.session.0)
+            .await
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListIndexes<'a, ListNames, ImplicitSession> {
-        type Future = ListIndexNamesFuture;
+#[action_impl]
+impl<'a> Action for ListIndexes<'a, ListNames, ImplicitSession> {
+    type Future = ListIndexNamesFuture;
 
-        async fn execute(self) -> Result<Vec<String>> {
-            let inner = ListIndexes {
-                coll: self.coll,
-                options: self.options,
-                session: self.session,
-                _mode: PhantomData::<ListSpecifications>,
-            };
-            let cursor = inner.await?;
-            cursor
-                .try_filter_map(|index| futures_util::future::ok(index.get_name()))
-                .try_collect()
-                .await
-        }
+    async fn execute(self) -> Result<Vec<String>> {
+        let inner = ListIndexes {
+            coll: self.coll,
+            options: self.options,
+            session: self.session,
+            _mode: PhantomData::<ListSpecifications>,
+        };
+        let cursor = inner.await?;
+        cursor
+            .try_filter_map(|index| futures_util::future::ok(index.get_name()))
+            .try_collect()
+            .await
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListIndexes<'a, ListNames, ExplicitSession<'a>> {
-        type Future = ListIndexNamesSessionFuture;
+#[action_impl]
+impl<'a> Action for ListIndexes<'a, ListNames, ExplicitSession<'a>> {
+    type Future = ListIndexNamesSessionFuture;
 
-        async fn execute(self) -> Result<Vec<String>> {
-            let session = self.session.0;
-            let inner = ListIndexes {
-                coll: self.coll,
-                options: self.options,
-                session: ExplicitSession(&mut *session),
-                _mode: PhantomData::<ListSpecifications>,
-            };
-            let mut cursor = inner.await?;
-            let stream = cursor.stream(session);
-            stream
-                .try_filter_map(|index| futures_util::future::ok(index.get_name()))
-                .try_collect()
-                .await
-        }
+    async fn execute(self) -> Result<Vec<String>> {
+        let session = self.session.0;
+        let inner = ListIndexes {
+            coll: self.coll,
+            options: self.options,
+            session: ExplicitSession(&mut *session),
+            _mode: PhantomData::<ListSpecifications>,
+        };
+        let mut cursor = inner.await?;
+        let stream = cursor.stream(session);
+        stream
+            .try_filter_map(|index| futures_util::future::ok(index.get_name()))
+            .try_collect()
+            .await
     }
 }

--- a/src/action/list_indexes.rs
+++ b/src/action/list_indexes.rs
@@ -113,7 +113,7 @@ impl<'a, Mode> ListIndexes<'a, Mode, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<IndexModel>)]
+#[action_impl(sync = crate::sync::Cursor<IndexModel>)]
 impl<'a> Action for ListIndexes<'a, ListSpecifications, ImplicitSession> {
     type Future = ListIndexesFuture;
 
@@ -123,7 +123,7 @@ impl<'a> Action for ListIndexes<'a, ListSpecifications, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::SessionCursor::<IndexModel>)]
+#[action_impl(sync = crate::sync::SessionCursor<IndexModel>)]
 impl<'a> Action for ListIndexes<'a, ListSpecifications, ExplicitSession<'a>> {
     type Future = ListIndexesSessionFuture;
 

--- a/src/action/replace_one.rs
+++ b/src/action/replace_one.rs
@@ -85,21 +85,23 @@ impl<'a> ReplaceOne<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for ReplaceOne<'a> {
-        type Future = ReplaceOneFuture;
+#[action_impl]
+impl<'a> Action for ReplaceOne<'a> {
+    type Future = ReplaceOneFuture;
 
-        async fn execute(mut self) -> Result<UpdateResult> {
-            resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+    async fn execute(mut self) -> Result<UpdateResult> {
+        resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
 
-            let update = Op::with_replace_raw(
-                self.coll.namespace(),
-                self.query,
-                self.replacement?,
-                false,
-                self.options.map(UpdateOptions::from_replace_options),
-            )?;
-            self.coll.client().execute_operation(update, self.session).await
-        }
+        let update = Op::with_replace_raw(
+            self.coll.namespace(),
+            self.query,
+            self.replacement?,
+            false,
+            self.options.map(UpdateOptions::from_replace_options),
+        )?;
+        self.coll
+            .client()
+            .execute_operation(update, self.session)
+            .await
     }
 }

--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -174,7 +174,7 @@ impl<'a> RunCursorCommand<'a, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<Document>)]
+#[action_impl(sync = crate::sync::Cursor<Document>)]
 impl<'a> Action for RunCursorCommand<'a, ImplicitSession> {
     type Future = RunCursorCommandFuture;
 
@@ -195,7 +195,7 @@ impl<'a> Action for RunCursorCommand<'a, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::SessionCursor::<Document>)]
+#[action_impl(sync = crate::sync::SessionCursor<Document>)]
 impl<'a> Action for RunCursorCommand<'a, ExplicitSession<'a>> {
     type Future = RunCursorCommandSessionFuture;
 

--- a/src/action/search_index.rs
+++ b/src/action/search_index.rs
@@ -263,7 +263,7 @@ impl<'a> ListSearchIndexes<'a> {
     }
 }
 
-#[action_impl(sync = crate::sync::Cursor::<Document>)]
+#[action_impl(sync = crate::sync::Cursor<Document>)]
 impl<'a> Action for ListSearchIndexes<'a> {
     type Future = ListSearchIndexesFuture;
 

--- a/src/action/search_index.rs
+++ b/src/action/search_index.rs
@@ -164,29 +164,29 @@ impl<'a, Mode> CreateSearchIndex<'a, Mode> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for CreateSearchIndex<'a, Multiple> {
-        type Future = CreateSearchIndexesFuture;
+#[action_impl]
+impl<'a> Action for CreateSearchIndex<'a, Multiple> {
+    type Future = CreateSearchIndexesFuture;
 
-        async fn execute(self) -> Result<Vec<String>> {
-            let op = operation::CreateSearchIndexes::new(self.coll.namespace(), self.models);
-            self.coll.client().execute_operation(op, None).await
-        }
+    async fn execute(self) -> Result<Vec<String>> {
+        let op = operation::CreateSearchIndexes::new(self.coll.namespace(), self.models);
+        self.coll.client().execute_operation(op, None).await
     }
 }
 
-action_impl! {
-    impl<'a> Action for CreateSearchIndex<'a, Single> {
-        type Future = CreateSearchIndexFuture;
+#[action_impl]
+impl<'a> Action for CreateSearchIndex<'a, Single> {
+    type Future = CreateSearchIndexFuture;
 
-        async fn execute(self) -> Result<String> {
-            let mut names = self.coll
-                .create_search_indexes(self.models)
-                .with_options(self.options).await?;
-            match names.len() {
-                1 => Ok(names.pop().unwrap()),
-                n => Err(Error::internal(format!("expected 1 index name, got {}", n))),
-            }
+    async fn execute(self) -> Result<String> {
+        let mut names = self
+            .coll
+            .create_search_indexes(self.models)
+            .with_options(self.options)
+            .await?;
+        match names.len() {
+            1 => Ok(names.pop().unwrap()),
+            n => Err(Error::internal(format!("expected 1 index name, got {}", n))),
         }
     }
 }
@@ -205,18 +205,14 @@ impl<'a> UpdateSearchIndex<'a> {
     option_setters! { options: UpdateSearchIndexOptions; }
 }
 
-action_impl! {
-    impl<'a> Action for UpdateSearchIndex<'a> {
-        type Future = UpdateSearchIndexFuture;
+#[action_impl]
+impl<'a> Action for UpdateSearchIndex<'a> {
+    type Future = UpdateSearchIndexFuture;
 
-        async fn execute(self) -> Result<()> {
-            let op = operation::UpdateSearchIndex::new(
-                self.coll.namespace(),
-                self.name,
-                self.definition,
-            );
-            self.coll.client().execute_operation(op, None).await
-        }
+    async fn execute(self) -> Result<()> {
+        let op =
+            operation::UpdateSearchIndex::new(self.coll.namespace(), self.name, self.definition);
+        self.coll.client().execute_operation(op, None).await
     }
 }
 
@@ -232,17 +228,13 @@ impl<'a> DropSearchIndex<'a> {
     option_setters! { options: DropSearchIndexOptions; }
 }
 
-action_impl! {
-    impl<'a> Action for DropSearchIndex<'a> {
-        type Future = DropSearchIndexFuture;
+#[action_impl]
+impl<'a> Action for DropSearchIndex<'a> {
+    type Future = DropSearchIndexFuture;
 
-        async fn execute(self) -> Result<()> {
-            let op = operation::DropSearchIndex::new(
-                self.coll.namespace(),
-                self.name,
-            );
-            self.coll.client().execute_operation(op, None).await
-        }
+    async fn execute(self) -> Result<()> {
+        let op = operation::DropSearchIndex::new(self.coll.namespace(), self.name);
+        self.coll.client().execute_operation(op, None).await
     }
 }
 
@@ -271,26 +263,21 @@ impl<'a> ListSearchIndexes<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for ListSearchIndexes<'a> {
-        type Future = ListSearchIndexesFuture;
+#[action_impl(sync = crate::sync::Cursor::<Document>)]
+impl<'a> Action for ListSearchIndexes<'a> {
+    type Future = ListSearchIndexesFuture;
 
-        async fn execute(self) -> Result<Cursor<Document>> {
-            let mut inner = doc! {};
-            if let Some(name) = self.name {
-                inner.insert("name", name);
-            }
-            self.coll
-                .clone_unconcerned()
-                .aggregate(vec![doc! {
-                    "$listSearchIndexes": inner,
-                }])
-                .with_options(self.agg_options)
-                .await
+    async fn execute(self) -> Result<Cursor<Document>> {
+        let mut inner = doc! {};
+        if let Some(name) = self.name {
+            inner.insert("name", name);
         }
-
-        fn sync_wrap(out) -> Result<crate::sync::Cursor<Document>> {
-            out.map(crate::sync::Cursor::new)
-        }
+        self.coll
+            .clone_unconcerned()
+            .aggregate(vec![doc! {
+                "$listSearchIndexes": inner,
+            }])
+            .with_options(self.agg_options)
+            .await
     }
 }

--- a/src/action/session.rs
+++ b/src/action/session.rs
@@ -46,19 +46,14 @@ impl<'a> StartSession<'a> {
     );
 }
 
-action_impl! {
-    impl<'a> Action for StartSession<'a> {
-        type Future = StartSessionFuture;
+#[action_impl(sync = crate::sync::ClientSession)]
+impl<'a> Action for StartSession<'a> {
+    type Future = StartSessionFuture;
 
-        async fn execute(self) -> Result<ClientSession> {
-            if let Some(options) = &self.options {
-                options.validate()?;
-            }
-            Ok(ClientSession::new(self.client.clone(), self.options, false).await)
+    async fn execute(self) -> Result<ClientSession> {
+        if let Some(options) = &self.options {
+            options.validate()?;
         }
-
-        fn sync_wrap(out) -> Result<crate::sync::ClientSession> {
-            out.map(Into::into)
-        }
+        Ok(ClientSession::new(self.client.clone(), self.options, false).await)
     }
 }

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -29,7 +29,7 @@ impl ClientSession {
     /// # let client = Client::with_uri_str("mongodb://example.com").await?;
     /// # let coll = client.database("foo").collection::<Document>("bar");
     /// # let mut session = client.start_session().await?;
-    /// session.start_transaction(None).await?;
+    /// session.start_transaction().await?;
     /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).await?;
     /// session.commit_transaction().await?;
     /// # Ok(())
@@ -60,7 +60,7 @@ impl ClientSession {
     /// # let client = Client::with_uri_str("mongodb://example.com").await?;
     /// # let coll = client.database("foo").collection::<Document>("bar");
     /// # let mut session = client.start_session().await?;
-    /// session.start_transaction(None).await?;
+    /// session.start_transaction().await?;
     /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).await?;
     /// session.commit_transaction().await?;
     /// # Ok(())
@@ -87,7 +87,7 @@ impl ClientSession {
     /// # let client = Client::with_uri_str("mongodb://example.com").await?;
     /// # let coll = client.database("foo").collection::<Document>("bar");
     /// # let mut session = client.start_session().await?;
-    /// session.start_transaction(None).await?;
+    /// session.start_transaction().await?;
     /// match execute_transaction(&coll, &mut session).await {
     ///     Ok(_) => session.commit_transaction().await?,
     ///     Err(_) => session.abort_transaction().await?,
@@ -127,9 +127,9 @@ impl crate::sync::ClientSession {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;
     /// # let coll = client.database("foo").collection::<Document>("bar");
     /// # let mut session = client.start_session().run()?;
-    /// session.start_transaction(None)?;
+    /// session.start_transaction().run()?;
     /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).run()?;
-    /// session.commit_transaction()?;
+    /// session.commit_transaction().run()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -151,9 +151,9 @@ impl crate::sync::ClientSession {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;
     /// # let coll = client.database("foo").collection::<Document>("bar");
     /// # let mut session = client.start_session().run()?;
-    /// session.start_transaction(None)?;
+    /// session.start_transaction().run()?;
     /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).run()?;
-    /// session.commit_transaction()?;
+    /// session.commit_transaction().run()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -178,10 +178,10 @@ impl crate::sync::ClientSession {
     /// # let client = Client::with_uri_str("mongodb://example.com")?;
     /// # let coll = client.database("foo").collection::<Document>("bar");
     /// # let mut session = client.start_session().run()?;
-    /// session.start_transaction(None)?;
+    /// session.start_transaction().run()?;
     /// match execute_transaction(coll, &mut session) {
-    ///     Ok(_) => session.commit_transaction()?,
-    ///     Err(_) => session.abort_transaction()?,
+    ///     Ok(_) => session.commit_transaction().run()?,
+    ///     Err(_) => session.abort_transaction().run()?,
     /// }
     /// # Ok(())
     /// # }

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -76,6 +76,41 @@ impl ClientSession {
     pub fn commit_transaction(&mut self) -> CommitTransaction {
         CommitTransaction { session: self }
     }
+
+    /// Aborts the transaction that is currently active on this session. Any open transaction will
+    /// be aborted automatically in the `Drop` implementation of `ClientSession`.
+    ///
+    /// ```rust
+    /// # use mongodb::{bson::{doc, Document}, error::Result, Client, ClientSession, Collection};
+    /// #
+    /// # async fn do_stuff() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com").await?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let mut session = client.start_session().await?;
+    /// session.start_transaction(None).await?;
+    /// match execute_transaction(&coll, &mut session).await {
+    ///     Ok(_) => session.commit_transaction().await?,
+    ///     Err(_) => session.abort_transaction().await?,
+    /// }
+    /// # Ok(())
+    /// # }
+    ///
+    /// async fn execute_transaction(coll: &Collection<Document>, session: &mut ClientSession) -> Result<()> {
+    ///     coll.insert_one(doc! { "x": 1 }).session(&mut *session).await?;
+    ///     coll.delete_one(doc! { "y": 2 }).session(&mut *session).await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// This operation will retry once upon failure if the connection and encountered error support
+    /// retryability. See the documentation
+    /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
+    /// retryable writes.
+    ///
+    /// `await` will return [`Result<()>`].
+    pub fn abort_transaction_2(&mut self) -> AbortTransaction {
+        AbortTransaction { session: self }
+    }
 }
 
 #[cfg(feature = "sync")]
@@ -129,6 +164,41 @@ impl crate::sync::ClientSession {
     pub fn commit_transaction(&mut self) -> CommitTransaction {
         self.async_client_session.commit_transaction()
     }
+
+    /// Aborts the transaction that is currently active on this session. Any open transaction will
+    /// be aborted automatically in the `Drop` implementation of `ClientSession`.
+    ///
+    /// ```rust
+    /// # use mongodb::{bson::{doc, Document}, error::Result, sync::{Client, ClientSession, Collection}};
+    /// #
+    /// # async fn do_stuff() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com")?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let mut session = client.start_session().run()?;
+    /// session.start_transaction(None)?;
+    /// match execute_transaction(coll, &mut session) {
+    ///     Ok(_) => session.commit_transaction()?,
+    ///     Err(_) => session.abort_transaction()?,
+    /// }
+    /// # Ok(())
+    /// # }
+    ///
+    /// fn execute_transaction(coll: Collection<Document>, session: &mut ClientSession) -> Result<()> {
+    ///     coll.insert_one(doc! { "x": 1 }).session(&mut *session).run()?;
+    ///     coll.delete_one(doc! { "y": 2 }).session(&mut *session).run()?;
+    ///     Ok(())   
+    /// }
+    /// ```
+    ///
+    /// This operation will retry once upon failure if the connection and encountered error support
+    /// retryability. See the documentation
+    /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
+    /// retryable writes.
+    ///
+    /// [`run`](AbortTransaction::run) will return [`Result<()>`].
+    pub fn abort_transaction_2(&mut self) -> AbortTransaction {
+        self.async_client_session.abort_transaction_2()
+    }
 }
 
 /// Start a new transaction.  Construct with [`ClientSession::start_transaction`].
@@ -150,6 +220,13 @@ impl<'a> StartTransaction<'a> {
 /// Commits a currently-active transaction.  Construct with [`ClientSession::commit_transaction`].
 #[must_use]
 pub struct CommitTransaction<'a> {
+    pub(crate) session: &'a mut ClientSession,
+}
+
+/// Abort the currently active transaction on a session.  Construct with
+/// [`ClientSession::abort_transaction`].
+#[must_use]
+pub struct AbortTransaction<'a> {
     pub(crate) session: &'a mut ClientSession,
 }
 

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -37,7 +37,7 @@ impl ClientSession {
     /// ```
     ///
     /// `await` will return [`Result<()>`].
-    pub fn start_transaction_2(&mut self) -> StartTransaction {
+    pub fn start_transaction(&mut self) -> StartTransaction {
         StartTransaction {
             session: self,
             options: None,
@@ -67,8 +67,8 @@ impl crate::sync::ClientSession {
     /// ```
     ///
     /// [`run`](StartTransaction::run) will return [`Result<()>`].
-    pub fn start_transaction_2(&mut self) -> StartTransaction {
-        self.async_client_session.start_transaction_2()
+    pub fn start_transaction(&mut self) -> StartTransaction {
+        self.async_client_session.start_transaction()
     }
 }
 

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -46,7 +46,6 @@ impl ClientSession {
 
     /// Commits the transaction that is currently active on this session.
     ///
-    ///
     /// This method may return an error with a [`crate::error::UNKNOWN_TRANSACTION_COMMIT_RESULT`]
     /// label. This label indicates that it is unknown whether the commit has satisfied the write
     /// concern associated with the transaction. If an error with this label is returned, it is

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -43,6 +43,39 @@ impl ClientSession {
             options: None,
         }
     }
+
+    /// Commits the transaction that is currently active on this session.
+    ///
+    ///
+    /// This method may return an error with a [`crate::error::UNKNOWN_TRANSACTION_COMMIT_RESULT`]
+    /// label. This label indicates that it is unknown whether the commit has satisfied the write
+    /// concern associated with the transaction. If an error with this label is returned, it is
+    /// safe to retry the commit until the write concern is satisfied or an error without the label
+    /// is returned.
+    ///
+    /// ```rust
+    /// # use mongodb::{bson::{doc, Document}, error::Result, Client, ClientSession};
+    /// #
+    /// # async fn do_stuff() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com").await?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let mut session = client.start_session().await?;
+    /// session.start_transaction(None).await?;
+    /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).await?;
+    /// session.commit_transaction().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This operation will retry once upon failure if the connection and encountered error support
+    /// retryability. See the documentation
+    /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
+    /// retryable writes.
+    ///
+    /// `await` will return [`Result<()>`].
+    pub fn commit_transaction_2(&mut self) -> CommitTransaction {
+        CommitTransaction { session: self }
+    }
 }
 
 #[cfg(feature = "sync")]
@@ -70,6 +103,32 @@ impl crate::sync::ClientSession {
     pub fn start_transaction(&mut self) -> StartTransaction {
         self.async_client_session.start_transaction()
     }
+
+    /// Commits the transaction that is currently active on this session.
+    ///
+    /// ```rust
+    /// # use mongodb::{bson::{doc, Document}, error::Result, sync::{Client, ClientSession}};
+    /// #
+    /// # async fn do_stuff() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com")?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let mut session = client.start_session().run()?;
+    /// session.start_transaction(None)?;
+    /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).run()?;
+    /// session.commit_transaction()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This operation will retry once upon failure if the connection and encountered error support
+    /// retryability. See the documentation
+    /// [here](https://www.mongodb.com/docs/manual/core/retryable-writes/) for more information on
+    /// retryable writes.
+    ///
+    /// [`run`](CommitTransaction::run) will return [`Result<()>`].
+    pub fn commit_transaction_2(&mut self) -> CommitTransaction {
+        self.async_client_session.commit_transaction_2()
+    }
 }
 
 /// Start a new transaction.  Construct with [`ClientSession::start_transaction`].
@@ -88,4 +147,10 @@ impl<'a> StartTransaction<'a> {
     }
 }
 
-// Action impl at src/client/session/action.rs
+/// Commits a currently-active transaction.  Construct with [`ClientSession::commit_transaction`].
+#[must_use]
+pub struct CommitTransaction<'a> {
+    pub(crate) session: &'a mut ClientSession,
+}
+
+// Action impls at src/client/session/action.rs

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -73,7 +73,7 @@ impl ClientSession {
     /// retryable writes.
     ///
     /// `await` will return [`Result<()>`].
-    pub fn commit_transaction_2(&mut self) -> CommitTransaction {
+    pub fn commit_transaction(&mut self) -> CommitTransaction {
         CommitTransaction { session: self }
     }
 }
@@ -126,8 +126,8 @@ impl crate::sync::ClientSession {
     /// retryable writes.
     ///
     /// [`run`](CommitTransaction::run) will return [`Result<()>`].
-    pub fn commit_transaction_2(&mut self) -> CommitTransaction {
-        self.async_client_session.commit_transaction_2()
+    pub fn commit_transaction(&mut self) -> CommitTransaction {
+        self.async_client_session.commit_transaction()
     }
 }
 

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -1,0 +1,91 @@
+use std::time::Duration;
+
+use crate::{
+    client::options::TransactionOptions,
+    options::{ReadConcern, WriteConcern},
+    selection_criteria::SelectionCriteria,
+    ClientSession,
+};
+
+use super::option_setters;
+
+impl ClientSession {
+    /// Starts a new transaction on this session. If no options are set, the session's
+    /// `defaultTransactionOptions` will be used. This session must be passed into each operation
+    /// within the transaction; otherwise, the operation will be executed outside of the
+    /// transaction.
+    ///
+    /// Errors returned from operations executed within a transaction may include a
+    /// [`crate::error::TRANSIENT_TRANSACTION_ERROR`] label. This label indicates that the entire
+    /// transaction can be retried with a reasonable expectation that it will succeed.
+    ///
+    /// Transactions are supported on MongoDB 4.0+. The Rust driver currently only supports
+    /// transactions on replica sets.
+    ///
+    /// ```rust
+    /// # use mongodb::{bson::{doc, Document}, error::Result, Client, ClientSession};
+    /// #
+    /// # async fn do_stuff() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com").await?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let mut session = client.start_session().await?;
+    /// session.start_transaction(None).await?;
+    /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).await?;
+    /// session.commit_transaction().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// `await` will return [`Result<()>`].
+    pub fn start_transaction_2(&mut self) -> StartTransaction {
+        StartTransaction {
+            session: self,
+            options: None,
+        }
+    }
+}
+
+#[cfg(feature = "sync")]
+impl crate::sync::ClientSession {
+    /// Starts a new transaction on this session with the given `TransactionOptions`. If no options
+    /// are provided, the session's `defaultTransactionOptions` will be used. This session must
+    /// be passed into each operation within the transaction; otherwise, the operation will be
+    /// executed outside of the transaction.
+    ///
+    /// ```rust
+    /// # use mongodb::{bson::{doc, Document}, error::Result, sync::{Client, ClientSession}};
+    /// #
+    /// # async fn do_stuff() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com")?;
+    /// # let coll = client.database("foo").collection::<Document>("bar");
+    /// # let mut session = client.start_session().run()?;
+    /// session.start_transaction(None)?;
+    /// let result = coll.insert_one(doc! { "x": 1 }).session(&mut session).run()?;
+    /// session.commit_transaction()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`run`](StartTransaction::run) will return [`Result<()>`].
+    pub fn start_transaction_2(&mut self) -> StartTransaction {
+        self.async_client_session.start_transaction_2()
+    }
+}
+
+/// Start a new transaction.  Construct with [`ClientSession::start_transaction`].
+#[must_use]
+pub struct StartTransaction<'a> {
+    pub(crate) session: &'a mut ClientSession,
+    pub(crate) options: Option<TransactionOptions>,
+}
+
+impl<'a> StartTransaction<'a> {
+    option_setters! { options: TransactionOptions;
+        read_concern: ReadConcern,
+        write_concern: WriteConcern,
+        selection_criteria: SelectionCriteria,
+        max_commit_time: Duration,
+    }
+}
+
+// Action impl at src/client/session/action.rs

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -37,9 +37,9 @@ impl ClientSession {
     /// ```
     ///
     /// `await` will return [`Result<()>`].
-    pub fn start_transaction(&mut self) -> StartTransaction<AsyncSession> {
+    pub fn start_transaction(&mut self) -> StartTransaction<&mut Self> {
         StartTransaction {
-            session: AsyncSession(self),
+            session: self,
             options: None,
         }
     }
@@ -134,9 +134,9 @@ impl crate::sync::ClientSession {
     /// ```
     ///
     /// [`run`](StartTransaction::run) will return [`Result<()>`].
-    pub fn start_transaction(&mut self) -> StartTransaction<SyncSession> {
+    pub fn start_transaction(&mut self) -> StartTransaction<&mut Self> {
         StartTransaction {
-            session: SyncSession(self),
+            session: self,
             options: None,
         }
     }
@@ -209,10 +209,6 @@ pub struct StartTransaction<S> {
     pub(crate) session: S,
     pub(crate) options: Option<TransactionOptions>,
 }
-
-pub struct AsyncSession<'a>(pub(crate) &'a mut ClientSession);
-#[cfg(feature = "sync")]
-pub struct SyncSession<'a>(pub(crate) &'a mut crate::sync::ClientSession);
 
 impl<S> StartTransaction<S> {
     option_setters! { options: TransactionOptions;

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -108,7 +108,7 @@ impl ClientSession {
     /// retryable writes.
     ///
     /// `await` will return [`Result<()>`].
-    pub fn abort_transaction_2(&mut self) -> AbortTransaction {
+    pub fn abort_transaction(&mut self) -> AbortTransaction {
         AbortTransaction { session: self }
     }
 }
@@ -196,8 +196,8 @@ impl crate::sync::ClientSession {
     /// retryable writes.
     ///
     /// [`run`](AbortTransaction::run) will return [`Result<()>`].
-    pub fn abort_transaction_2(&mut self) -> AbortTransaction {
-        self.async_client_session.abort_transaction_2()
+    pub fn abort_transaction(&mut self) -> AbortTransaction {
+        self.async_client_session.abort_transaction()
     }
 }
 

--- a/src/action/transaction.rs
+++ b/src/action/transaction.rs
@@ -19,8 +19,8 @@ impl ClientSession {
     /// [`crate::error::TRANSIENT_TRANSACTION_ERROR`] label. This label indicates that the entire
     /// transaction can be retried with a reasonable expectation that it will succeed.
     ///
-    /// Transactions are supported on MongoDB 4.0+. The Rust driver currently only supports
-    /// transactions on replica sets.
+    /// Transactions on replica sets are supported on MongoDB 4.0+. Transactions on sharded
+    /// clusters are supported on MongoDB 4.2+.
     ///
     /// ```rust
     /// # use mongodb::{bson::{doc, Document}, error::Result, Client, ClientSession};

--- a/src/action/update.rs
+++ b/src/action/update.rs
@@ -131,24 +131,23 @@ impl<'a> Update<'a> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for Update<'a> {
-        type Future = UpdateFuture;
+#[action_impl]
+impl<'a> Action for Update<'a> {
+    type Future = UpdateFuture;
 
-        async fn execute(mut self) -> Result<UpdateResult> {
-            if let UpdateModifications::Document(d) = &self.update {
-                crate::bson_util::update_document_check(d)?;
-            }
-            resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
-
-            let op = Op::with_update(
-                self.coll.namespace(),
-                self.query,
-                self.update,
-                self.multi,
-                self.options,
-            );
-            self.coll.client().execute_operation(op, self.session).await
+    async fn execute(mut self) -> Result<UpdateResult> {
+        if let UpdateModifications::Document(d) = &self.update {
+            crate::bson_util::update_document_check(d)?;
         }
+        resolve_write_concern_with_session!(self.coll, self.options, self.session.as_ref())?;
+
+        let op = Op::with_update(
+            self.coll.namespace(),
+            self.query,
+            self.update,
+            self.multi,
+            self.options,
+        );
+        self.coll.client().execute_operation(op, self.session).await
     }
 }

--- a/src/action/watch.rs
+++ b/src/action/watch.rs
@@ -252,7 +252,7 @@ impl<'a> Watch<'a, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::ChangeStream::<ChangeStreamEvent<Document>>)]
+#[action_impl(sync = crate::sync::ChangeStream<ChangeStreamEvent<Document>>)]
 impl<'a> Action for Watch<'a, ImplicitSession> {
     type Future = WatchFuture;
 
@@ -273,7 +273,7 @@ impl<'a> Action for Watch<'a, ImplicitSession> {
     }
 }
 
-#[action_impl(sync = crate::sync::SessionChangeStream::<ChangeStreamEvent<Document>>)]
+#[action_impl(sync = crate::sync::SessionChangeStream<ChangeStreamEvent<Document>>)]
 impl<'a> Action for Watch<'a, ExplicitSession<'a>> {
     type Future = WatchSessionFuture;
 

--- a/src/action/watch.rs
+++ b/src/action/watch.rs
@@ -252,65 +252,51 @@ impl<'a> Watch<'a, ImplicitSession> {
     }
 }
 
-action_impl! {
-    impl<'a> Action for Watch<'a, ImplicitSession> {
-        type Future = WatchFuture;
+#[action_impl(sync = crate::sync::ChangeStream::<ChangeStreamEvent<Document>>)]
+impl<'a> Action for Watch<'a, ImplicitSession> {
+    type Future = WatchFuture;
 
-        async fn execute(mut self) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
-            resolve_options!(
-                self.client,
-                self.options,
-                [read_concern, selection_criteria]
-            );
-            if self.cluster {
-                self.options
-                    .get_or_insert_with(Default::default)
-                    .all_changes_for_cluster = Some(true);
-            }
-            self.client
-                .execute_watch(self.pipeline, self.options, self.target, None)
-                .await
+    async fn execute(mut self) -> Result<ChangeStream<ChangeStreamEvent<Document>>> {
+        resolve_options!(
+            self.client,
+            self.options,
+            [read_concern, selection_criteria]
+        );
+        if self.cluster {
+            self.options
+                .get_or_insert_with(Default::default)
+                .all_changes_for_cluster = Some(true);
         }
-
-        fn sync_wrap(out) -> Result<crate::sync::ChangeStream<ChangeStreamEvent<Document>>> {
-            out.map(crate::sync::ChangeStream::new)
-        }
+        self.client
+            .execute_watch(self.pipeline, self.options, self.target, None)
+            .await
     }
 }
 
-action_impl! {
-    impl<'a> Action for Watch<'a, ExplicitSession<'a>> {
-        type Future = WatchSessionFuture;
+#[action_impl(sync = crate::sync::SessionChangeStream::<ChangeStreamEvent<Document>>)]
+impl<'a> Action for Watch<'a, ExplicitSession<'a>> {
+    type Future = WatchSessionFuture;
 
-        async fn execute(mut self) -> Result<SessionChangeStream<ChangeStreamEvent<Document>>> {
-            resolve_read_concern_with_session!(
-                self.client,
-                self.options,
-                Some(&mut *self.session.0)
-            )?;
-            resolve_selection_criteria_with_session!(
-                self.client,
-                self.options,
-                Some(&mut *self.session.0)
-            )?;
-            if self.cluster {
-                self.options
-                    .get_or_insert_with(Default::default)
-                    .all_changes_for_cluster = Some(true);
-            }
-            self.client
-                .execute_watch_with_session(
-                    self.pipeline,
-                    self.options,
-                    self.target,
-                    None,
-                    self.session.0,
-                )
-                .await
+    async fn execute(mut self) -> Result<SessionChangeStream<ChangeStreamEvent<Document>>> {
+        resolve_read_concern_with_session!(self.client, self.options, Some(&mut *self.session.0))?;
+        resolve_selection_criteria_with_session!(
+            self.client,
+            self.options,
+            Some(&mut *self.session.0)
+        )?;
+        if self.cluster {
+            self.options
+                .get_or_insert_with(Default::default)
+                .all_changes_for_cluster = Some(true);
         }
-
-        fn sync_wrap(out) -> Result<crate::sync::SessionChangeStream<ChangeStreamEvent<Document>>> {
-            out.map(crate::sync::SessionChangeStream::new)
-        }
+        self.client
+            .execute_watch_with_session(
+                self.pipeline,
+                self.options,
+                self.target,
+                None,
+                self.session.0,
+            )
+            .await
     }
 }

--- a/src/client/action/perf.rs
+++ b/src/client/action/perf.rs
@@ -1,21 +1,20 @@
 use crate::action::action_impl;
 
-action_impl! {
-    impl<'a> Action for crate::action::WarmConnectionPool<'a> {
-        type Future = WarmConnectionPoolFuture;
+#[action_impl]
+impl<'a> Action for crate::action::WarmConnectionPool<'a> {
+    type Future = WarmConnectionPoolFuture;
 
-        async fn execute(self) -> () {
-            if !self
-                .client
-                .inner
-                .options
-                .min_pool_size
-                .map_or(false, |s| s > 0)
-            {
-                // No-op when min_pool_size is zero.
-                return;
-            }
-            self.client.inner.topology.warm_pool().await;
+    async fn execute(self) -> () {
+        if !self
+            .client
+            .inner
+            .options
+            .min_pool_size
+            .map_or(false, |s| s > 0)
+        {
+            // No-op when min_pool_size is zero.
+            return;
         }
+        self.client.inner.topology.warm_pool().await;
     }
 }

--- a/src/client/action/shutdown.rs
+++ b/src/client/action/shutdown.rs
@@ -4,32 +4,31 @@ use futures_util::future::join_all;
 
 use crate::action::action_impl;
 
-action_impl! {
-    impl Action for crate::action::Shutdown {
-        type Future = ShutdownFuture;
+#[action_impl]
+impl Action for crate::action::Shutdown {
+    type Future = ShutdownFuture;
 
-        async fn execute(self) -> () {
-            if !self.immediate {
-                // Subtle bug: if this is inlined into the `join_all(..)` call, Rust will extend the
-                // lifetime of the temporary unnamed `MutexLock` until the end of the *statement*,
-                // causing the lock to be held for the duration of the join, which deadlocks.
-                let pending = self
-                    .client
-                    .inner
-                    .shutdown
-                    .pending_drops
-                    .lock()
-                    .unwrap()
-                    .extract();
-                join_all(pending).await;
-            }
-            self.client.inner.topology.shutdown().await;
-            // This has to happen last to allow pending cleanup to execute commands.
-            self.client
+    async fn execute(self) -> () {
+        if !self.immediate {
+            // Subtle bug: if this is inlined into the `join_all(..)` call, Rust will extend the
+            // lifetime of the temporary unnamed `MutexLock` until the end of the *statement*,
+            // causing the lock to be held for the duration of the join, which deadlocks.
+            let pending = self
+                .client
                 .inner
                 .shutdown
-                .executed
-                .store(true, Ordering::SeqCst);
+                .pending_drops
+                .lock()
+                .unwrap()
+                .extract();
+            join_all(pending).await;
         }
+        self.client.inner.topology.shutdown().await;
+        // This has to happen last to allow pending cleanup to execute commands.
+        self.client
+            .inner
+            .shutdown
+            .executed
+            .store(true, Ordering::SeqCst);
     }
 }

--- a/src/client/csfle/client_encryption/create_data_key.rs
+++ b/src/client/csfle/client_encryption/create_data_key.rs
@@ -11,25 +11,26 @@ use crate::{
 
 use super::{ClientEncryption, MasterKey};
 
-action_impl! {
-    impl<'a> Action for CreateDataKey<'a> {
-        type Future = CreateDataKeyFuture;
+#[action_impl]
+impl<'a> Action for CreateDataKey<'a> {
+    type Future = CreateDataKeyFuture;
 
-        async fn execute(self) -> Result<Binary> {
-            #[allow(unused_mut)]
-            let mut provider = self.master_key.provider();
-            #[cfg(test)]
-            if let Some(tp) = self.test_kms_provider {
-                provider = tp;
-            }
-            let ctx = self.client_enc.create_data_key_ctx(provider, self.master_key, self.options)?;
-            let data_key = self.client_enc.exec.run_ctx(ctx, None).await?;
-            self.client_enc.key_vault.insert_one(&data_key).await?;
-            let bin_ref = data_key
-                .get_binary("_id")
-                .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
-            Ok(bin_ref.to_binary())
+    async fn execute(self) -> Result<Binary> {
+        #[allow(unused_mut)]
+        let mut provider = self.master_key.provider();
+        #[cfg(test)]
+        if let Some(tp) = self.test_kms_provider {
+            provider = tp;
         }
+        let ctx = self
+            .client_enc
+            .create_data_key_ctx(provider, self.master_key, self.options)?;
+        let data_key = self.client_enc.exec.run_ctx(ctx, None).await?;
+        self.client_enc.key_vault.insert_one(&data_key).await?;
+        let bin_ref = data_key
+            .get_binary("_id")
+            .map_err(|e| Error::internal(format!("invalid data key id: {}", e)))?;
+        Ok(bin_ref.to_binary())
     }
 }
 

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -11,43 +11,41 @@ use crate::{
 
 use super::ClientEncryption;
 
-action_impl! {
-    impl<'a> Action for Encrypt<'a, Value> {
-        type Future = EncryptFuture;
+#[action_impl]
+impl<'a> Action for Encrypt<'a, Value> {
+    type Future = EncryptFuture;
 
-        async fn execute(self) -> Result<Binary> {
-            let ctx = self
-                .client_enc
-                .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?
-                .build_explicit_encrypt(self.mode.value)?;
-            let result = self.client_enc.exec.run_ctx(ctx, None).await?;
-            let bin_ref = result
-                .get_binary("v")
-                .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
-            Ok(bin_ref.to_binary())
-        }
+    async fn execute(self) -> Result<Binary> {
+        let ctx = self
+            .client_enc
+            .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?
+            .build_explicit_encrypt(self.mode.value)?;
+        let result = self.client_enc.exec.run_ctx(ctx, None).await?;
+        let bin_ref = result
+            .get_binary("v")
+            .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
+        Ok(bin_ref.to_binary())
     }
 }
 
-action_impl! {
-    impl<'a> Action for Encrypt<'a, Expression> {
-        type Future = EncryptExpressionFuture;
+#[action_impl]
+impl<'a> Action for Encrypt<'a, Expression> {
+    type Future = EncryptExpressionFuture;
 
-        async fn execute(self) -> Result<Document> {
-            let ctx = self
-                .client_enc
-                .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?
-                .build_explicit_encrypt_expression(self.mode.value)?;
-            let result = self.client_enc.exec.run_ctx(ctx, None).await?;
-            let doc_ref = result
-                .get_document("v")
-                .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
-            let doc = doc_ref
-                .to_owned()
-                .to_document()
-                .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
-            Ok(doc)
-        }
+    async fn execute(self) -> Result<Document> {
+        let ctx = self
+            .client_enc
+            .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?
+            .build_explicit_encrypt_expression(self.mode.value)?;
+        let result = self.client_enc.exec.run_ctx(ctx, None).await?;
+        let doc_ref = result
+            .get_document("v")
+            .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
+        let doc = doc_ref
+            .to_owned()
+            .to_document()
+            .map_err(|e| Error::internal(format!("invalid encryption result: {}", e)))?;
+        Ok(doc)
     }
 }
 

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -1,3 +1,4 @@
+mod action;
 mod cluster_time;
 mod pool;
 #[cfg(test)]

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -63,11 +63,11 @@ pub(crate) static SESSIONS_UNSUPPORTED_COMMANDS: Lazy<HashSet<&'static str>> = L
 /// # let client = Client::with_uri_str("mongodb://example.com").await?;
 /// # let coll: Collection<Document> = client.database("foo").collection("bar");
 /// let mut session = client.start_session().await?;
-/// let options = TransactionOptions::builder()
+/// session
+///     .start_transaction()
 ///     .read_concern(ReadConcern::majority())
-///     .write_concern(WriteConcern::builder().w(Acknowledgment::Majority).build())
-///     .build();
-/// session.start_transaction(options).await?;
+///     .write_concern(WriteConcern::majority())
+///     .await?;
 /// // A "TransientTransactionError" label indicates that the entire transaction can be retried
 /// // with a reasonable expectation that it will succeed.
 /// while let Err(error) = execute_transaction(&coll, &mut session).await {

--- a/src/client/session/action.rs
+++ b/src/client/session/action.rs
@@ -1,0 +1,90 @@
+use crate::{
+    action::{action_impl, StartTransaction},
+    error::{ErrorKind, Result},
+    sdam::TransactionSupportStatus,
+};
+
+use super::TransactionState;
+
+action_impl! {
+    impl<'a> Action for StartTransaction<'a> {
+        type Future = StartTransactionFuture;
+
+        async fn execute(self) -> Result<()> {
+            if self
+                .session
+                .options
+                .as_ref()
+                .and_then(|o| o.snapshot)
+                .unwrap_or(false)
+            {
+                return Err(ErrorKind::Transaction {
+                    message: "Transactions are not supported in snapshot sessions".into(),
+                }
+                .into());
+            }
+            match self.session.transaction.state {
+                TransactionState::Starting | TransactionState::InProgress => {
+                    return Err(ErrorKind::Transaction {
+                        message: "transaction already in progress".into(),
+                    }
+                    .into());
+                }
+                TransactionState::Committed { .. } => {
+                    self.session.unpin(); // Unpin session if previous transaction is committed.
+                }
+                _ => {}
+            }
+            match self.session.client.transaction_support_status().await? {
+                TransactionSupportStatus::Supported => {
+                    let mut options = match self.options {
+                        Some(mut options) => {
+                            if let Some(defaults) = self.session.default_transaction_options() {
+                                merge_options!(
+                                    defaults,
+                                    options,
+                                    [
+                                        read_concern,
+                                        write_concern,
+                                        selection_criteria,
+                                        max_commit_time
+                                    ]
+                                );
+                            }
+                            Some(options)
+                        }
+                        None => self.session.default_transaction_options().cloned(),
+                    };
+                    resolve_options!(
+                        self.session.client,
+                        options,
+                        [read_concern, write_concern, selection_criteria]
+                    );
+
+                    if let Some(ref options) = options {
+                        if !options
+                            .write_concern
+                            .as_ref()
+                            .map(|wc| wc.is_acknowledged())
+                            .unwrap_or(true)
+                        {
+                            return Err(ErrorKind::Transaction {
+                                message: "transactions do not support unacknowledged write concerns"
+                                    .into(),
+                            }
+                            .into());
+                        }
+                    }
+
+                    self.session.increment_txn_number();
+                    self.session.transaction.start(options);
+                    Ok(())
+                }
+                _ => Err(ErrorKind::Transaction {
+                    message: "Transactions are not supported by this deployment".into(),
+                }
+                .into()),
+            }
+        }
+    }
+}

--- a/src/client/session/action.rs
+++ b/src/client/session/action.rs
@@ -1,8 +1,12 @@
+use std::time::{Duration, Instant};
+
 use crate::{
     action::{action_impl, AbortTransaction, CommitTransaction, StartTransaction},
     error::{ErrorKind, Result},
     operation::{self, Operation},
     sdam::TransactionSupportStatus,
+    BoxFuture,
+    ClientSession,
 };
 
 use super::TransactionState;
@@ -85,6 +89,188 @@ impl<'a> Action for StartTransaction<'a> {
                 message: "Transactions are not supported by this deployment".into(),
             }
             .into()),
+        }
+    }
+}
+
+impl<'a> StartTransaction<'a> {
+    /// Starts a transaction, runs the given callback, and commits or aborts the transaction.
+    /// Transient transaction errors will cause the callback or the commit to be retried;
+    /// other errors will cause the transaction to be aborted and the error returned to the
+    /// caller.  If the callback needs to provide its own error information, the
+    /// [`Error::custom`](crate::error::Error::custom) method can accept an arbitrary payload that
+    /// can be retrieved via [`Error::get_custom`](crate::error::Error::get_custom).
+    ///
+    /// If a command inside the callback fails, it may cause the transaction on the server to be
+    /// aborted. This situation is normally handled transparently by the driver. However, if the
+    /// application does not return that error from the callback, the driver will not be able to
+    /// determine whether the transaction was aborted or not. The driver will then retry the
+    /// callback indefinitely. To avoid this situation, the application MUST NOT silently handle
+    /// errors within the callback. If the application needs to handle errors within the
+    /// callback, it MUST return them after doing so.
+    ///
+    /// Because the callback can be repeatedly executed and because it returns a future, the rust
+    /// closure borrowing rules for captured values can be overly restrictive.  As a
+    /// convenience, `with_transaction` accepts a context argument that will be passed to the
+    /// callback along with the session:
+    ///
+    /// ```no_run
+    /// # use mongodb::{bson::{doc, Document}, error::Result, Client};
+    /// # use futures::FutureExt;
+    /// # async fn wrapper() -> Result<()> {
+    /// # let client = Client::with_uri_str("mongodb://example.com").await?;
+    /// # let mut session = client.start_session().await?;
+    /// let coll = client.database("mydb").collection::<Document>("mycoll");
+    /// let my_data = "my data".to_string();
+    /// // This works:
+    /// session.start_transaction().and_run(
+    ///     (&coll, &my_data),
+    ///     |session, (coll, my_data)| async move {
+    ///         coll.insert_one(doc! { "data": *my_data }).session(session).await
+    ///     }.boxed()
+    /// ).await?;
+    /// /* This will not compile with a "variable moved due to use in generator" error:
+    /// session.start_transaction().and_run(
+    ///     (),
+    ///     |session, _| async move {
+    ///         coll.insert_one(doc! { "data": my_data }).session(session).await
+    ///     }.boxed()
+    /// ).await?;
+    /// */
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn and_run<R, C, F>(self, mut context: C, mut callback: F) -> Result<R>
+    where
+        F: for<'b> FnMut(&'b mut ClientSession, &'b mut C) -> BoxFuture<'b, Result<R>>,
+    {
+        let timeout = Duration::from_secs(120);
+        #[cfg(test)]
+        let timeout = self
+            .session
+            .convenient_transaction_timeout
+            .unwrap_or(timeout);
+        let start = Instant::now();
+
+        use crate::error::{TRANSIENT_TRANSACTION_ERROR, UNKNOWN_TRANSACTION_COMMIT_RESULT};
+
+        'transaction: loop {
+            self.session
+                .start_transaction()
+                .with_options(self.options.clone())
+                .await?;
+            let ret = match callback(self.session, &mut context).await {
+                Ok(v) => v,
+                Err(e) => {
+                    if matches!(
+                        self.session.transaction.state,
+                        TransactionState::Starting | TransactionState::InProgress
+                    ) {
+                        self.session.abort_transaction().await?;
+                    }
+                    if e.contains_label(TRANSIENT_TRANSACTION_ERROR) && start.elapsed() < timeout {
+                        continue 'transaction;
+                    }
+                    return Err(e);
+                }
+            };
+            if matches!(
+                self.session.transaction.state,
+                TransactionState::None
+                    | TransactionState::Aborted
+                    | TransactionState::Committed { .. }
+            ) {
+                return Ok(ret);
+            }
+            'commit: loop {
+                match self.session.commit_transaction().await {
+                    Ok(()) => return Ok(ret),
+                    Err(e) => {
+                        if e.is_max_time_ms_expired_error() || start.elapsed() >= timeout {
+                            return Err(e);
+                        }
+                        if e.contains_label(UNKNOWN_TRANSACTION_COMMIT_RESULT) {
+                            continue 'commit;
+                        }
+                        if e.contains_label(TRANSIENT_TRANSACTION_ERROR) {
+                            continue 'transaction;
+                        }
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Starts a transaction, runs the given callback, and commits or aborts the transaction.
+    /// Transient transaction errors will cause the callback or the commit to be retried;
+    /// other errors will cause the transaction to be aborted and the error returned to the
+    /// caller.  If the callback needs to provide its own error information, the
+    /// [`Error::custom`](crate::error::Error::custom) method can accept an arbitrary payload that
+    /// can be retrieved via [`Error::get_custom`](crate::error::Error::get_custom).
+    ///
+    /// If a command inside the callback fails, it may cause the transaction on the server to be
+    /// aborted. This situation is normally handled transparently by the driver. However, if the
+    /// application does not return that error from the callback, the driver will not be able to
+    /// determine whether the transaction was aborted or not. The driver will then retry the
+    /// callback indefinitely. To avoid this situation, the application MUST NOT silently handle
+    /// errors within the callback. If the application needs to handle errors within the
+    /// callback, it MUST return them after doing so.
+    #[cfg(feature = "sync")]
+    pub fn and_run_sync<R, F>(self, mut callback: F) -> Result<R>
+    where
+        F: for<'b> FnMut(&'b mut ClientSession) -> Result<R>,
+    {
+        let timeout = std::time::Duration::from_secs(120);
+        let start = std::time::Instant::now();
+
+        use crate::error::{TRANSIENT_TRANSACTION_ERROR, UNKNOWN_TRANSACTION_COMMIT_RESULT};
+
+        'transaction: loop {
+            self.session
+                .start_transaction()
+                .with_options(self.options.clone())
+                .run()?;
+            let ret = match callback(self.session) {
+                Ok(v) => v,
+                Err(e) => {
+                    if matches!(
+                        self.session.transaction.state,
+                        TransactionState::Starting | TransactionState::InProgress
+                    ) {
+                        self.session.abort_transaction().run()?;
+                    }
+                    if e.contains_label(TRANSIENT_TRANSACTION_ERROR) && start.elapsed() < timeout {
+                        continue 'transaction;
+                    }
+                    return Err(e);
+                }
+            };
+            if matches!(
+                self.session.transaction.state,
+                TransactionState::None
+                    | TransactionState::Aborted
+                    | TransactionState::Committed { .. }
+            ) {
+                return Ok(ret);
+            }
+            'commit: loop {
+                match self.session.commit_transaction().run() {
+                    Ok(()) => return Ok(ret),
+                    Err(e) => {
+                        if e.is_max_time_ms_expired_error() || start.elapsed() >= timeout {
+                            return Err(e);
+                        }
+                        if e.contains_label(UNKNOWN_TRANSACTION_COMMIT_RESULT) {
+                            continue 'commit;
+                        }
+                        if e.contains_label(TRANSIENT_TRANSACTION_ERROR) {
+                            continue 'transaction;
+                        }
+                        return Err(e);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/client/session/action.rs
+++ b/src/client/session/action.rs
@@ -7,181 +7,178 @@ use crate::{
 
 use super::TransactionState;
 
-action_impl! {
-    impl<'a> Action for StartTransaction<'a> {
-        type Future = StartTransactionFuture;
+#[action_impl]
+impl<'a> Action for StartTransaction<'a> {
+    type Future = StartTransactionFuture;
 
-        async fn execute(self) -> Result<()> {
-            if self
-                .session
-                .options
-                .as_ref()
-                .and_then(|o| o.snapshot)
-                .unwrap_or(false)
-            {
+    async fn execute(self) -> Result<()> {
+        if self
+            .session
+            .options
+            .as_ref()
+            .and_then(|o| o.snapshot)
+            .unwrap_or(false)
+        {
+            return Err(ErrorKind::Transaction {
+                message: "Transactions are not supported in snapshot sessions".into(),
+            }
+            .into());
+        }
+        match self.session.transaction.state {
+            TransactionState::Starting | TransactionState::InProgress => {
                 return Err(ErrorKind::Transaction {
-                    message: "Transactions are not supported in snapshot sessions".into(),
+                    message: "transaction already in progress".into(),
                 }
                 .into());
             }
-            match self.session.transaction.state {
-                TransactionState::Starting | TransactionState::InProgress => {
-                    return Err(ErrorKind::Transaction {
-                        message: "transaction already in progress".into(),
-                    }
-                    .into());
-                }
-                TransactionState::Committed { .. } => {
-                    self.session.unpin(); // Unpin session if previous transaction is committed.
-                }
-                _ => {}
+            TransactionState::Committed { .. } => {
+                self.session.unpin(); // Unpin session if previous transaction is committed.
             }
-            match self.session.client.transaction_support_status().await? {
-                TransactionSupportStatus::Supported => {
-                    let mut options = match self.options {
-                        Some(mut options) => {
-                            if let Some(defaults) = self.session.default_transaction_options() {
-                                merge_options!(
-                                    defaults,
-                                    options,
-                                    [
-                                        read_concern,
-                                        write_concern,
-                                        selection_criteria,
-                                        max_commit_time
-                                    ]
-                                );
-                            }
-                            Some(options)
-                        }
-                        None => self.session.default_transaction_options().cloned(),
-                    };
-                    resolve_options!(
-                        self.session.client,
-                        options,
-                        [read_concern, write_concern, selection_criteria]
-                    );
-
-                    if let Some(ref options) = options {
-                        if !options
-                            .write_concern
-                            .as_ref()
-                            .map(|wc| wc.is_acknowledged())
-                            .unwrap_or(true)
-                        {
-                            return Err(ErrorKind::Transaction {
-                                message: "transactions do not support unacknowledged write concerns"
-                                    .into(),
-                            }
-                            .into());
-                        }
-                    }
-
-                    self.session.increment_txn_number();
-                    self.session.transaction.start(options);
-                    Ok(())
-                }
-                _ => Err(ErrorKind::Transaction {
-                    message: "Transactions are not supported by this deployment".into(),
-                }
-                .into()),
-            }
+            _ => {}
         }
-    }
-}
+        match self.session.client.transaction_support_status().await? {
+            TransactionSupportStatus::Supported => {
+                let mut options = match self.options {
+                    Some(mut options) => {
+                        if let Some(defaults) = self.session.default_transaction_options() {
+                            merge_options!(
+                                defaults,
+                                options,
+                                [
+                                    read_concern,
+                                    write_concern,
+                                    selection_criteria,
+                                    max_commit_time
+                                ]
+                            );
+                        }
+                        Some(options)
+                    }
+                    None => self.session.default_transaction_options().cloned(),
+                };
+                resolve_options!(
+                    self.session.client,
+                    options,
+                    [read_concern, write_concern, selection_criteria]
+                );
 
-action_impl! {
-    impl<'a> Action for CommitTransaction<'a> {
-        type Future = CommitTransactionFuture;
-
-        async fn execute(self) -> Result<()> {
-            match &mut self.session.transaction.state {
-                TransactionState::None => Err(ErrorKind::Transaction {
-                    message: "no transaction started".into(),
-                }
-                .into()),
-                TransactionState::Aborted => Err(ErrorKind::Transaction {
-                    message: "Cannot call commitTransaction after calling abortTransaction".into(),
-                }
-                .into()),
-                TransactionState::Starting => {
-                    self.session.transaction.commit(false);
-                    Ok(())
-                }
-                TransactionState::InProgress => {
-                    let commit_transaction =
-                        operation::CommitTransaction::new(self.session.transaction.options.clone());
-                    self.session.transaction.commit(true);
-                    self.session
-                        .client
-                        .clone()
-                        .execute_operation(commit_transaction, self.session)
-                        .await
-                }
-                TransactionState::Committed {
-                    data_committed: true,
-                } => {
-                    let mut commit_transaction =
-                        operation::CommitTransaction::new(self.session.transaction.options.clone());
-                    commit_transaction.update_for_retry();
-                    self.session
-                        .client
-                        .clone()
-                        .execute_operation(commit_transaction, self.session)
-                        .await
-                }
-                TransactionState::Committed {
-                    data_committed: false,
-                } => Ok(()),
-            }
-        }
-    }
-}
-
-action_impl! {
-    impl<'a> Action for AbortTransaction<'a> {
-        type Future = AbortTransactionFuture;
-
-        async fn execute(self) -> Result<()> {
-            match self.session.transaction.state {
-                TransactionState::None => Err(ErrorKind::Transaction {
-                    message: "no transaction started".into(),
-                }
-                .into()),
-                TransactionState::Committed { .. } => Err(ErrorKind::Transaction {
-                    message: "Cannot call abortTransaction after calling commitTransaction".into(),
-                }
-                .into()),
-                TransactionState::Aborted => Err(ErrorKind::Transaction {
-                    message: "cannot call abortTransaction twice".into(),
-                }
-                .into()),
-                TransactionState::Starting => {
-                    self.session.transaction.abort();
-                    Ok(())
-                }
-                TransactionState::InProgress => {
-                    let write_concern = self
-                        .session
-                        .transaction
-                        .options
+                if let Some(ref options) = options {
+                    if !options
+                        .write_concern
                         .as_ref()
-                        .and_then(|options| options.write_concern.as_ref())
-                        .cloned();
-                    let abort_transaction = operation::AbortTransaction::new(
-                        write_concern,
-                        self.session.transaction.pinned.take(),
-                    );
-                    self.session.transaction.abort();
-                    // Errors returned from running an abortTransaction command should be ignored.
-                    let _result = self
-                        .session
-                        .client
-                        .clone()
-                        .execute_operation(abort_transaction, &mut *self.session)
-                        .await;
-                    Ok(())
+                        .map(|wc| wc.is_acknowledged())
+                        .unwrap_or(true)
+                    {
+                        return Err(ErrorKind::Transaction {
+                            message: "transactions do not support unacknowledged write concerns"
+                                .into(),
+                        }
+                        .into());
+                    }
                 }
+
+                self.session.increment_txn_number();
+                self.session.transaction.start(options);
+                Ok(())
+            }
+            _ => Err(ErrorKind::Transaction {
+                message: "Transactions are not supported by this deployment".into(),
+            }
+            .into()),
+        }
+    }
+}
+
+#[action_impl]
+impl<'a> Action for CommitTransaction<'a> {
+    type Future = CommitTransactionFuture;
+
+    async fn execute(self) -> Result<()> {
+        match &mut self.session.transaction.state {
+            TransactionState::None => Err(ErrorKind::Transaction {
+                message: "no transaction started".into(),
+            }
+            .into()),
+            TransactionState::Aborted => Err(ErrorKind::Transaction {
+                message: "Cannot call commitTransaction after calling abortTransaction".into(),
+            }
+            .into()),
+            TransactionState::Starting => {
+                self.session.transaction.commit(false);
+                Ok(())
+            }
+            TransactionState::InProgress => {
+                let commit_transaction =
+                    operation::CommitTransaction::new(self.session.transaction.options.clone());
+                self.session.transaction.commit(true);
+                self.session
+                    .client
+                    .clone()
+                    .execute_operation(commit_transaction, self.session)
+                    .await
+            }
+            TransactionState::Committed {
+                data_committed: true,
+            } => {
+                let mut commit_transaction =
+                    operation::CommitTransaction::new(self.session.transaction.options.clone());
+                commit_transaction.update_for_retry();
+                self.session
+                    .client
+                    .clone()
+                    .execute_operation(commit_transaction, self.session)
+                    .await
+            }
+            TransactionState::Committed {
+                data_committed: false,
+            } => Ok(()),
+        }
+    }
+}
+
+#[action_impl]
+impl<'a> Action for AbortTransaction<'a> {
+    type Future = AbortTransactionFuture;
+
+    async fn execute(self) -> Result<()> {
+        match self.session.transaction.state {
+            TransactionState::None => Err(ErrorKind::Transaction {
+                message: "no transaction started".into(),
+            }
+            .into()),
+            TransactionState::Committed { .. } => Err(ErrorKind::Transaction {
+                message: "Cannot call abortTransaction after calling commitTransaction".into(),
+            }
+            .into()),
+            TransactionState::Aborted => Err(ErrorKind::Transaction {
+                message: "cannot call abortTransaction twice".into(),
+            }
+            .into()),
+            TransactionState::Starting => {
+                self.session.transaction.abort();
+                Ok(())
+            }
+            TransactionState::InProgress => {
+                let write_concern = self
+                    .session
+                    .transaction
+                    .options
+                    .as_ref()
+                    .and_then(|options| options.write_concern.as_ref())
+                    .cloned();
+                let abort_transaction = operation::AbortTransaction::new(
+                    write_concern,
+                    self.session.transaction.pinned.take(),
+                );
+                self.session.transaction.abort();
+                // Errors returned from running an abortTransaction command should be ignored.
+                let _result = self
+                    .session
+                    .client
+                    .clone()
+                    .execute_operation(abort_transaction, &mut *self.session)
+                    .await;
+                Ok(())
             }
         }
     }

--- a/src/coll/action/drop.rs
+++ b/src/coll/action/drop.rs
@@ -4,22 +4,23 @@ use crate::{
     operation::drop_collection as op,
 };
 
-action_impl! {
-    impl<'a> Action for DropCollection<'a> {
-        type Future = DropCollectionFuture;
+#[action_impl]
+impl<'a> Action for DropCollection<'a> {
+    type Future = DropCollectionFuture;
 
-        async fn execute(mut self) -> Result<()> {
-            resolve_options!(self.cr, self.options, [write_concern]);
+    async fn execute(mut self) -> Result<()> {
+        resolve_options!(self.cr, self.options, [write_concern]);
 
-            #[cfg(feature = "in-use-encryption-unstable")]
-            self.cr.drop_aux_collections(self.options.as_ref(), self.session.as_deref_mut())
-                .await?;
+        #[cfg(feature = "in-use-encryption-unstable")]
+        self.cr
+            .drop_aux_collections(self.options.as_ref(), self.session.as_deref_mut())
+            .await?;
 
-            let drop = op::DropCollection::new(self.cr.namespace(), self.options);
-            self.cr.client()
-                .execute_operation(drop, self.session.as_deref_mut())
-                .await
-        }
+        let drop = op::DropCollection::new(self.cr.namespace(), self.options);
+        self.cr
+            .client()
+            .execute_operation(drop, self.session.as_deref_mut())
+            .await
     }
 }
 

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -5,7 +5,7 @@ use crate::test::EventClient;
 use crate::{
     bson::{doc, Bson, Document},
     error::ErrorKind,
-    options::{Acknowledgment, ReadConcern, TransactionOptions, WriteConcern},
+    options::{Acknowledgment, ReadConcern, WriteConcern},
     test::TestClient,
     Client,
     Collection,
@@ -146,10 +146,11 @@ async fn snapshot_read_concern() {
 
     if client.supports_transactions() {
         let mut session = client.start_session().await.unwrap();
-        let options = TransactionOptions::builder()
+        session
+            .start_transaction()
             .read_concern(ReadConcern::snapshot())
-            .build();
-        session.start_transaction(options).await.unwrap();
+            .await
+            .unwrap();
         let result = coll.find_one(doc! {}).session(&mut session).await;
         assert!(result.is_ok());
         assert_event_contains_read_concern(&client).await;

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,7 @@ pub struct Error {
 
 impl Error {
     /// Create a new `Error` wrapping an arbitrary value.  Can be used to abort transactions in
-    /// callbacks for [`ClientSession::with_transaction`](crate::ClientSession::with_transaction).
+    /// callbacks for [`StartTransaction::and_run`](crate::action::StartTransaction::and_run).
     pub fn custom(e: impl Any + Send + Sync) -> Self {
         Self::new(ErrorKind::Custom(Arc::new(e)), None::<Option<String>>)
     }

--- a/src/sync/client/session.rs
+++ b/src/sync/client/session.rs
@@ -1,11 +1,5 @@
 use super::Client;
-use crate::{
-    bson::Document,
-    client::session::ClusterTime,
-    error::Result,
-    options::TransactionOptions,
-    ClientSession as AsyncClientSession,
-};
+use crate::{bson::Document, client::session::ClusterTime, ClientSession as AsyncClientSession};
 
 /// A MongoDB client session. This struct represents a logical session used for ordering sequential
 /// operations. To create a `ClientSession`, call `start_session` on a
@@ -58,83 +52,5 @@ impl ClientSession {
     /// cluster time or if this session's cluster time is `None`.
     pub fn advance_cluster_time(&mut self, to: &ClusterTime) {
         self.async_client_session.advance_cluster_time(to)
-    }
-
-    /// Starts a transaction, runs the given callback, and commits or aborts the transaction.
-    /// Transient transaction errors will cause the callback or the commit to be retried;
-    /// other errors will cause the transaction to be aborted and the error returned to the
-    /// caller.  If the callback needs to provide its own error information, the
-    /// [`Error::custom`](crate::error::Error::custom) method can accept an arbitrary payload that
-    /// can be retrieved via [`Error::get_custom`](crate::error::Error::get_custom).
-    ///
-    /// If a command inside the callback fails, it may cause the transaction on the server to be
-    /// aborted. This situation is normally handled transparently by the driver. However, if the
-    /// application does not return that error from the callback, the driver will not be able to
-    /// determine whether the transaction was aborted or not. The driver will then retry the
-    /// callback indefinitely. To avoid this situation, the application MUST NOT silently handle
-    /// errors within the callback. If the application needs to handle errors within the
-    /// callback, it MUST return them after doing so.
-    pub fn with_transaction<R, F>(
-        &mut self,
-        mut callback: F,
-        options: impl Into<Option<TransactionOptions>>,
-    ) -> Result<R>
-    where
-        F: for<'a> FnMut(&'a mut ClientSession) -> Result<R>,
-    {
-        let options = options.into();
-        let timeout = std::time::Duration::from_secs(120);
-        let start = std::time::Instant::now();
-
-        use crate::{
-            client::session::TransactionState,
-            error::{TRANSIENT_TRANSACTION_ERROR, UNKNOWN_TRANSACTION_COMMIT_RESULT},
-        };
-
-        'transaction: loop {
-            self.start_transaction()
-                .with_options(options.clone())
-                .run()?;
-            let ret = match callback(self) {
-                Ok(v) => v,
-                Err(e) => {
-                    if matches!(
-                        self.async_client_session.transaction.state,
-                        TransactionState::Starting | TransactionState::InProgress
-                    ) {
-                        self.abort_transaction().run()?;
-                    }
-                    if e.contains_label(TRANSIENT_TRANSACTION_ERROR) && start.elapsed() < timeout {
-                        continue 'transaction;
-                    }
-                    return Err(e);
-                }
-            };
-            if matches!(
-                self.async_client_session.transaction.state,
-                TransactionState::None
-                    | TransactionState::Aborted
-                    | TransactionState::Committed { .. }
-            ) {
-                return Ok(ret);
-            }
-            'commit: loop {
-                match self.commit_transaction().run() {
-                    Ok(()) => return Ok(ret),
-                    Err(e) => {
-                        if e.is_max_time_ms_expired_error() || start.elapsed() >= timeout {
-                            return Err(e);
-                        }
-                        if e.contains_label(UNKNOWN_TRANSACTION_COMMIT_RESULT) {
-                            continue 'commit;
-                        }
-                        if e.contains_label(TRANSIENT_TRANSACTION_ERROR) {
-                            continue 'transaction;
-                        }
-                        return Err(e);
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/sync/client/session.rs
+++ b/src/sync/client/session.rs
@@ -32,6 +32,12 @@ impl<'a> From<&'a mut ClientSession> for &'a mut AsyncClientSession {
 }
 
 impl ClientSession {
+    pub(crate) fn new(async_client_session: AsyncClientSession) -> Self {
+        Self {
+            async_client_session,
+        }
+    }
+
     /// The client used to create this session.
     pub fn client(&self) -> Client {
         self.async_client_session.client().into()

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -275,7 +275,8 @@ fn transactions() {
         .expect("create collection should succeed");
 
     session
-        .start_transaction(None)
+        .start_transaction()
+        .run()
         .expect("start transaction should succeed");
 
     run_transaction_with_retry(&mut session, |s| {
@@ -300,7 +301,8 @@ fn transactions() {
     }
 
     session
-        .start_transaction(None)
+        .start_transaction()
+        .run()
         .expect("start transaction should succeed");
     run_transaction_with_retry(&mut session, |s| {
         coll.insert_one(doc! { "x": 1 }).session(s).run()?;

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -252,7 +252,7 @@ fn transactions() {
                     if error.contains_label(TRANSIENT_TRANSACTION_ERROR) {
                         continue;
                     } else {
-                        session.abort_transaction()?;
+                        session.abort_transaction().run()?;
                         return Err(error);
                     }
                 }
@@ -311,6 +311,7 @@ fn transactions() {
     .unwrap();
     session
         .abort_transaction()
+        .run()
         .expect("abort transaction should succeed");
 }
 

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -286,7 +286,7 @@ fn transactions() {
     .unwrap();
 
     loop {
-        match session.commit_transaction() {
+        match session.commit_transaction().run() {
             Ok(()) => {
                 break;
             }

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -694,7 +694,7 @@ async fn retry_commit_txn_check_out() {
     let client = Client::with_options(options).unwrap();
 
     let mut session = client.start_session().await.unwrap();
-    session.start_transaction(None).await.unwrap();
+    session.start_transaction().await.unwrap();
     // transition transaction to "in progress" so that the commit
     // actually executes an operation.
     client
@@ -819,7 +819,7 @@ async fn manual_shutdown_with_resources() {
         let _cursor = coll.find(doc! {}).batch_size(1).await.unwrap();
         // Similarly, sessions need an in-progress transaction to have cleanup.
         let mut session = client.start_session().await.unwrap();
-        if session.start_transaction(None).await.is_err() {
+        if session.start_transaction().await.is_err() {
             // Transaction start can transiently fail; if so, just bail out of the test.
             log_uncaptured("Skipping manual_shutdown_with_resources: transaction start failed");
             return;
@@ -881,7 +881,7 @@ async fn manual_shutdown_immediate_with_resources() {
     let _cursor = coll.find(doc! {}).batch_size(1).await.unwrap();
     // Similarly, sessions need an in-progress transaction to have cleanup.
     let mut session = client.start_session().await.unwrap();
-    session.start_transaction(None).await.unwrap();
+    session.start_transaction().await.unwrap();
     coll.insert_one(doc! {})
         .session(&mut session)
         .await

--- a/src/test/documentation_examples.rs
+++ b/src/test/documentation_examples.rs
@@ -1726,10 +1726,11 @@ async fn convenient_transaction_examples() -> Result<()> {
     // Step 2: Start a client session.
     let mut session = client.start_session().await?;
 
-    // Step 3: Use with_transaction to start a transaction, execute the callback, and commit (or
+    // Step 3: Use and_run to start a transaction, execute the callback, and commit (or
     // abort on error).
     session
-        .with_transaction((), |session, _| callback(session).boxed(), None)
+        .start_transaction()
+        .and_run((), |session, _| callback(session).boxed())
         .await?;
 
     // End Transactions withTxn API Example 1

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -84,7 +84,7 @@ async fn deserialize_recovery_token() {
     let coll: Collection<B> = client
         .database(function_name!())
         .collection(function_name!());
-    session.start_transaction(None).await.unwrap();
+    session.start_transaction().await.unwrap();
     assert!(session.transaction.recovery_token.is_none());
     let result = coll.find_one(doc! {}).session(&mut session).await;
     assert!(result.is_err()); // Assert that the deserialization failed.

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -108,17 +108,14 @@ async fn convenient_api_custom_error() {
 
     struct MyErr;
     let result: Result<()> = session
-        .with_transaction(
-            coll,
-            |session, coll| {
-                async move {
-                    coll.find_one(doc! {}).session(session).await?;
-                    Err(Error::custom(MyErr))
-                }
-                .boxed()
-            },
-            None,
-        )
+        .start_transaction()
+        .and_run(coll, |session, coll| {
+            async move {
+                coll.find_one(doc! {}).session(session).await?;
+                Err(Error::custom(MyErr))
+            }
+            .boxed()
+        })
         .await;
 
     assert!(result.is_err());
@@ -143,17 +140,14 @@ async fn convenient_api_returned_value() {
         .collection::<Document>("test_convenient");
 
     let value = session
-        .with_transaction(
-            coll,
-            |session, coll| {
-                async move {
-                    coll.find_one(doc! {}).session(session).await?;
-                    Ok(42)
-                }
-                .boxed()
-            },
-            None,
-        )
+        .start_transaction()
+        .and_run(coll, |session, coll| {
+            async move {
+                coll.find_one(doc! {}).session(session).await?;
+                Ok(42)
+            }
+            .boxed()
+        })
         .await
         .unwrap();
 
@@ -175,19 +169,16 @@ async fn convenient_api_retry_timeout_callback() {
         .collection::<Document>("test_convenient");
 
     let result: Result<()> = session
-        .with_transaction(
-            coll,
-            |session, coll| {
-                async move {
-                    coll.find_one(doc! {}).session(session).await?;
-                    let mut err = Error::custom(42);
-                    err.add_label(TRANSIENT_TRANSACTION_ERROR);
-                    Err(err)
-                }
-                .boxed()
-            },
-            None,
-        )
+        .start_transaction()
+        .and_run(coll, |session, coll| {
+            async move {
+                coll.find_one(doc! {}).session(session).await?;
+                let mut err = Error::custom(42);
+                err.add_label(TRANSIENT_TRANSACTION_ERROR);
+                Err(err)
+            }
+            .boxed()
+        })
         .await;
 
     let err = result.unwrap_err();
@@ -233,17 +224,14 @@ async fn convenient_api_retry_timeout_commit_unknown() {
     .unwrap();
 
     let result = session
-        .with_transaction(
-            coll,
-            |session, coll| {
-                async move {
-                    coll.find_one(doc! {}).session(session).await?;
-                    Ok(())
-                }
-                .boxed()
-            },
-            None,
-        )
+        .start_transaction()
+        .and_run(coll, |session, coll| {
+            async move {
+                coll.find_one(doc! {}).session(session).await?;
+                Ok(())
+            }
+            .boxed()
+        })
         .await;
 
     let err = result.unwrap_err();
@@ -288,17 +276,14 @@ async fn convenient_api_retry_timeout_commit_transient() {
     .unwrap();
 
     let result = session
-        .with_transaction(
-            coll,
-            |session, coll| {
-                async move {
-                    coll.find_one(doc! {}).session(session).await?;
-                    Ok(())
-                }
-                .boxed()
-            },
-            None,
-        )
+        .start_transaction()
+        .and_run(coll, |session, coll| {
+            async move {
+                coll.find_one(doc! {}).session(session).await?;
+                Ok(())
+            }
+            .boxed()
+        })
         .await;
 
     let err = result.unwrap_err();

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -1867,7 +1867,7 @@ impl TestOperation for StartTransaction {
     ) -> BoxFuture<'a, Result<Option<Entity>>> {
         async move {
             with_mut_session!(test_runner, id, |session| {
-                async move { session.start_transaction(None).await }
+                async move { session.start_transaction().await }
             })
             .await?;
             Ok(None)

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1409,7 +1409,9 @@ impl TestOperation for WithTransaction {
         async move {
             let session = sessions.session0.unwrap();
             session
-                .with_transaction(
+                .start_transaction()
+                .with_options(self.options.clone())
+                .and_run(
                     (runner, &self.callback.operations, sessions.session1),
                     |session, (runner, operations, session1)| {
                         async move {
@@ -1433,7 +1435,6 @@ impl TestOperation for WithTransaction {
                         }
                         .boxed()
                     },
-                    self.options.clone(),
                 )
                 .await?;
             Ok(None)

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -1001,7 +1001,8 @@ impl TestOperation for StartTransaction {
     ) -> BoxFuture<'a, Result<Option<Bson>>> {
         async move {
             session
-                .start_transaction(self.options.clone())
+                .start_transaction()
+                .with_options(self.options.clone())
                 .await
                 .map(|_| None)
         }


### PR DESCRIPTION
RUST-1873

This conversion PR has a couple of wrinkles.  First up, I converted `action_impl` from a regular macro to an attribute macro.  Regular macros can take as input any arbitrary string of tokens, which means that rustfmt will ignore their contents; attribute macros have to take input in the shape of normal Rust toplevel items, so rustfmt will happily process them, and that's a strong positive for the action impls.

The other is that I changed the convenient transaction API to chain off of `start_transaction` rather than being its own toplevel thing.  My motivation here was that this flows nicely especially when options are present:
```
session
    .start_transaction()
    .some_option(value)
    .and_run(...)
    .await
```
That reads well IMO and puts the options before the body of the transaction, which makes more sense to me than putting the options after as they would be if `with_transaction` were its own action.