### PR TITLE
RUST-1764 Drop human_readable options in favor of HumanReadable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,9 +68,6 @@ in-use-encryption-unstable = ["mongocrypt", "rayon", "num_cpus"]
 # TODO: pending https://github.com/tokio-rs/tracing/issues/2036 stop depending directly on log.
 tracing-unstable = ["tracing", "log"]
 
-[patch.'https://github.com/mongodb/bson-rust']
-bson = { git = "https://github.com/abr-egn/bson-rust", branch = "RUST-1764/human-readable" }
-
 [dependencies]
 action_macro = { path = "action_macro" }
 async-trait = "0.1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ in-use-encryption-unstable = ["mongocrypt", "rayon", "num_cpus"]
 # TODO: pending https://github.com/tokio-rs/tracing/issues/2036 stop depending directly on log.
 tracing-unstable = ["tracing", "log"]
 
+[patch.'https://github.com/mongodb/bson-rust']
+bson = { git = "https://github.com/abr-egn/bson-rust", branch = "RUST-1764/human-readable" }
+
 [dependencies]
 action_macro = { path = "action_macro" }
 async-trait = "0.1.42"

--- a/src/action/find_and_modify.rs
+++ b/src/action/find_and_modify.rs
@@ -20,7 +20,6 @@ use crate::{
         UpdateOrReplace,
     },
     options::WriteConcern,
-    serde_util,
     ClientSession,
     Collection,
 };
@@ -105,10 +104,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync> Collection<T> {
         FindOneAndReplace {
             coll: self,
             filter,
-            replacement: serde_util::to_raw_document_buf_with_options(
-                replacement.borrow(),
-                self.human_readable_serialization(),
-            ),
+            replacement: bson::to_raw_document_buf(replacement.borrow()).map_err(Into::into),
             options: None,
             session: None,
         }

--- a/src/action/insert_many.rs
+++ b/src/action/insert_many.rs
@@ -9,7 +9,6 @@ use crate::{
     operation::Insert as Op,
     options::WriteConcern,
     results::InsertManyResult,
-    serde_util,
     ClientSession,
     Collection,
 };
@@ -30,12 +29,11 @@ impl<T: Serialize + Send + Sync> Collection<T> {
     /// `await` will return d[`Result<InsertManyResult>`].
     #[deeplink]
     pub fn insert_many(&self, docs: impl IntoIterator<Item = impl Borrow<T>>) -> InsertMany {
-        let human_readable = self.human_readable_serialization();
         InsertMany {
             coll: CollRef::new(self),
             docs: docs
                 .into_iter()
-                .map(|v| serde_util::to_raw_document_buf_with_options(v.borrow(), human_readable))
+                .map(|v| bson::to_raw_document_buf(v.borrow()).map_err(Into::into))
                 .collect(),
             options: None,
             session: None,

--- a/src/action/insert_one.rs
+++ b/src/action/insert_one.rs
@@ -9,7 +9,6 @@ use crate::{
     operation::Insert as Op,
     options::WriteConcern,
     results::InsertOneResult,
-    serde_util,
     ClientSession,
     Collection,
 };
@@ -32,10 +31,7 @@ impl<T: Serialize + Send + Sync> Collection<T> {
     pub fn insert_one(&self, doc: impl Borrow<T>) -> InsertOne {
         InsertOne {
             coll: CollRef::new(self),
-            doc: serde_util::to_raw_document_buf_with_options(
-                doc.borrow(),
-                self.human_readable_serialization(),
-            ),
+            doc: bson::to_raw_document_buf(doc.borrow()).map_err(Into::into),
             options: None,
             session: None,
         }

--- a/src/action/replace_one.rs
+++ b/src/action/replace_one.rs
@@ -10,7 +10,6 @@ use crate::{
     operation::Update as Op,
     options::WriteConcern,
     results::UpdateResult,
-    serde_util,
     ClientSession,
     Collection,
 };
@@ -31,10 +30,7 @@ impl<T: Serialize + Send + Sync> Collection<T> {
         ReplaceOne {
             coll: CollRef::new(self),
             query,
-            replacement: serde_util::to_raw_document_buf_with_options(
-                replacement.borrow(),
-                self.human_readable_serialization(),
-            ),
+            replacement: bson::to_raw_document_buf(replacement.borrow()).map_err(Into::into),
             options: None,
             session: None,
         }

--- a/src/coll.rs
+++ b/src/coll.rs
@@ -101,7 +101,6 @@ struct CollectionInner {
     selection_criteria: Option<SelectionCriteria>,
     read_concern: Option<ReadConcern>,
     write_concern: Option<WriteConcern>,
-    human_readable_serialization: bool,
 }
 
 impl<T> Collection<T>
@@ -119,8 +118,6 @@ where
         let write_concern = options
             .write_concern
             .or_else(|| db.write_concern().cloned());
-        #[allow(deprecated)]
-        let human_readable_serialization = options.human_readable_serialization.unwrap_or_default();
 
         Self {
             inner: Arc::new(CollectionInner {
@@ -130,7 +127,6 @@ where
                 selection_criteria,
                 read_concern,
                 write_concern,
-                human_readable_serialization,
             }),
             _phantom: Default::default(),
         }
@@ -212,10 +208,6 @@ where
         )?;
         self.client().execute_operation(op, None).await?;
         Ok(())
-    }
-
-    pub(crate) fn human_readable_serialization(&self) -> bool {
-        self.inner.human_readable_serialization
     }
 }
 

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -17,7 +17,6 @@ use crate::{
 // field or struct doesn't fix it because that annotation isn't propagated by the code generator.
 // This works around that by defining it in a non-pub module and immediately re-exporting that
 // module's contents.
-#[allow(deprecated)]
 mod suppress_warning {
     use super::*;
 
@@ -36,14 +35,6 @@ mod suppress_warning {
 
         /// The default write concern for operations.
         pub write_concern: Option<WriteConcern>,
-
-        /// Sets the [`bson::SerializerOptions::human_readable`] option for the [`Bson`]
-        /// serializer. The default value is `false`.
-        /// Note: Specifying `true` for this value will decrease the performance of insert
-        /// operations.
-        #[deprecated = "This is a workaround for a potential bug related to RUST-1687, and should \
-                        not be used in new code."]
-        pub human_readable_serialization: Option<bool>,
     }
 }
 pub use suppress_warning::*;

--- a/src/serde_util.rs
+++ b/src/serde_util.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
-use bson::SerializerOptions;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    bson::{doc, Bson, Document, RawDocumentBuf},
+    bson::{doc, Bson, Document},
     bson_util::get_u64,
     error::{Error, Result},
     options::WriteConcern,
@@ -160,22 +159,6 @@ where
     };
 
     Ok(Some(date_time))
-}
-
-pub(crate) fn to_raw_document_buf_with_options<T: Serialize>(
-    doc: &T,
-    human_readable_serialization: bool,
-) -> Result<RawDocumentBuf> {
-    let raw_doc = if human_readable_serialization {
-        let doc = bson::to_document_with_options(
-            doc,
-            SerializerOptions::builder().human_readable(true).build(),
-        )?;
-        RawDocumentBuf::from_document(&doc)?
-    } else {
-        bson::to_raw_document_buf(doc)?
-    };
-    Ok(raw_doc)
 }
 
 pub(crate) fn write_concern_is_empty(write_concern: &Option<WriteConcern>) -> bool {

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -6,7 +6,7 @@ use crate::{
     Client,
     Namespace,
 };
-use bson::{rawdoc, RawDocumentBuf};
+use bson::{rawdoc, serde_helpers::HumanReadable, RawDocumentBuf};
 use futures::stream::{StreamExt, TryStreamExt};
 use once_cell::sync::Lazy;
 use semver::VersionReq;
@@ -1159,13 +1159,8 @@ async fn configure_human_readable_serialization() {
 
     let client = TestClient::new().await;
 
-    let collection_options = CollectionOptions::builder()
-        .human_readable_serialization(false)
-        .build();
-
-    let non_human_readable_collection: Collection<Data> = client
-        .database("db")
-        .collection_with_options("nonhumanreadable", collection_options);
+    let non_human_readable_collection: Collection<Data> =
+        client.database("db").collection("nonhumanreadable");
     non_human_readable_collection.drop().await.unwrap();
 
     non_human_readable_collection
@@ -1204,20 +1199,15 @@ async fn configure_human_readable_serialization() {
         .unwrap();
     assert!(doc.get_binary_generic("s").is_ok());
 
-    let collection_options = CollectionOptions::builder()
-        .human_readable_serialization(true)
-        .build();
-
-    let human_readable_collection: Collection<Data> = client
-        .database("db")
-        .collection_with_options("humanreadable", collection_options);
+    let human_readable_collection: Collection<HumanReadable<Data>> =
+        client.database("db").collection("humanreadable");
     human_readable_collection.drop().await.unwrap();
 
     human_readable_collection
-        .insert_one(Data {
+        .insert_one(HumanReadable(Data {
             id: 0,
             s: StringOrBytes("human readable!".into()),
-        })
+        }))
         .await
         .unwrap();
 
@@ -1231,10 +1221,10 @@ async fn configure_human_readable_serialization() {
     human_readable_collection
         .replace_one(
             doc! { "id": 0 },
-            Data {
+            HumanReadable(Data {
                 id: 1,
                 s: StringOrBytes("human readable!".into()),
-            },
+            }),
         )
         .await
         .unwrap();

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -373,13 +373,11 @@ impl CollectionOrDatabaseOptions {
         }
     }
 
-    #[allow(deprecated)]
     pub(crate) fn as_collection_options(&self) -> CollectionOptions {
         CollectionOptions {
             read_concern: self.read_concern.clone(),
             selection_criteria: self.selection_criteria.clone(),
             write_concern: self.write_concern.clone(),
-            human_readable_serialization: None,
         }
     }
 }


### PR DESCRIPTION
RUST-1764

This goes along with https://github.com/mongodb/bson-rust/pull/471; I'll remove the `[patch]` pointing at my repo when that goes in.