### PR TITLE
RUST-1860 Accept ergonomic conversions for specific option types

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -73,52 +73,7 @@ pub struct Single;
 #[allow(missing_docs)]
 pub struct Multiple;
 
-macro_rules! option_setters {
-    // Include options aggregate accessors.
-    (
-        $opt_field:ident: $opt_field_ty:ty;
-        $(
-            $(#[$($attrss:tt)*])*
-            $opt_name:ident: $opt_ty:ty,
-        )*
-    ) => {
-        #[allow(unused)]
-        fn options(&mut self) -> &mut $opt_field_ty {
-            self.$opt_field.get_or_insert_with(<$opt_field_ty>::default)
-        }
-
-        /// Set all options.  Note that this will replace all previous values set.
-        pub fn with_options(mut self, value: impl Into<Option<$opt_field_ty>>) -> Self {
-            self.$opt_field = value.into();
-            self
-        }
-
-        crate::action::option_setters!($opt_field_ty;
-            $(
-                $(#[$($attrss)*])*
-                $opt_name: $opt_ty,
-            )*
-        );
-    };
-    // Just generate field setters.
-    (
-        $opt_field_ty:ty;
-        $(
-            $(#[$($attrss:tt)*])*
-            $opt_name:ident: $opt_ty:ty,
-        )*
-    ) => {
-        $(
-            #[doc = concat!("Set the [`", stringify!($opt_field_ty), "::", stringify!($opt_name), "`] option.")]
-            $(#[$($attrss)*])*
-            pub fn $opt_name(mut self, value: $opt_ty) -> Self {
-                self.options().$opt_name = Some(value);
-                self
-            }
-        )*
-    };
-}
-use option_setters;
+use action_macro::option_setters;
 
 pub(crate) mod private {
     pub trait Sealed {}

--- a/src/action/csfle/create_data_key.rs
+++ b/src/action/csfle/create_data_key.rs
@@ -43,18 +43,9 @@ pub struct DataKeyOptions {
 }
 
 impl<'a> CreateDataKey<'a> {
-    option_setters! { options: DataKeyOptions; }
-
-    /// Set the [`DataKeyOptions::key_alt_names`] option.
-    pub fn key_alt_names(mut self, value: impl IntoIterator<Item = String>) -> Self {
-        self.options().key_alt_names = Some(value.into_iter().collect());
-        self
-    }
-
-    /// Set the [`DataKeyOptions::key_material`] option.
-    pub fn key_material(mut self, value: impl IntoIterator<Item = u8>) -> Self {
-        self.options().key_material = Some(value.into_iter().collect());
-        self
+    option_setters! { options: DataKeyOptions;
+        key_alt_names: Vec<String>,
+        key_material: Vec<u8>,
     }
 
     #[cfg(test)]


### PR DESCRIPTION
RUST-1860

The hammer of `proc_macro` looked like a good fit for this nail as well, since it means that the `option_setters!` macro can just have special handling for the specific types rather than having to handcode it for every action.