### PR TITLE
RUST-1890 Remove some uses of EventClient

### DIFF
--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -386,12 +386,15 @@ async fn session_usage() {
     #[allow(deprecated)]
     async fn session_usage_test<F, G>(command_name: &str, operation: F)
     where
-        F: Fn(EventClient) -> G,
+        F: Fn(Client) -> G,
         G: Future<Output = ()>,
     {
-        let client = EventClient::new().await;
-        operation(client.clone()).await;
-        let mut events = client.events.clone();
+        let client = Client::test_builder()
+            .monitor_command_events()
+            .build()
+            .await;
+        operation(client.clone().into_client()).await;
+        let mut events = client.event_buffer().clone();
         #[allow(deprecated)]
         let (command_started, _) = events.get_successful_command_execution(command_name);
         assert!(

--- a/src/cmap/test.rs
+++ b/src/cmap/test.rs
@@ -8,8 +8,6 @@ use tokio::sync::{Mutex, RwLock};
 
 use self::file::{Operation, TestFile, ThreadedOperation};
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     cmap::{
         establish::{ConnectionEstablisher, EstablisherOptions},
@@ -441,8 +439,7 @@ async fn cmap_spec_tests() {
         }
         options.hosts.drain(1..);
         options.direct_connection = Some(true);
-        #[allow(deprecated)]
-        let client = EventClient::with_options(options).await;
+        let client = crate::Client::test_builder().options(options).build().await;
         if let Some(ref run_on) = test_file.run_on {
             let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));
             if !can_run_on {

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -5,8 +5,6 @@ use serde::Deserialize;
 
 use super::TestSdamEvent;
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, oid::ObjectId},
     client::Client,
@@ -593,14 +591,13 @@ async fn load_balanced() {
 #[function_name::named]
 async fn topology_closed_event_last() {
     let event_buffer = EventBuffer::new();
-    #[allow(deprecated)]
-    let client = EventClient::with_additional_options(
-        None,
-        Some(Duration::from_millis(50)),
-        None,
-        event_buffer.clone(),
-    )
-    .await;
+    let client = Client::test_builder()
+        .additional_options(None, false)
+        .await
+        .min_heartbeat_freq(Duration::from_millis(50))
+        .event_buffer(event_buffer.clone())
+        .build()
+        .await;
     #[allow(deprecated)]
     let mut subscriber = event_buffer.subscribe_all();
 
@@ -640,14 +637,13 @@ async fn heartbeat_events() {
     options.app_name = "heartbeat_events".to_string().into();
 
     let event_buffer = EventBuffer::new();
-    #[allow(deprecated)]
-    let client = EventClient::with_additional_options(
-        Some(options.clone()),
-        Some(Duration::from_millis(50)),
-        None,
-        event_buffer.clone(),
-    )
-    .await;
+    let client = Client::test_builder()
+        .additional_options(options.clone(), false)
+        .await
+        .min_heartbeat_freq(Duration::from_millis(50))
+        .event_buffer(event_buffer.clone())
+        .build()
+        .await;
 
     #[allow(deprecated)]
     let mut subscriber = event_buffer.subscribe_all();

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -6,8 +6,6 @@ use std::{
 use bson::doc;
 use semver::VersionReq;
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     client::options::{ClientOptions, ServerAddress},
     cmap::RawCommandResponse,
@@ -102,14 +100,13 @@ async fn sdam_pool_management() {
 
     let event_buffer = EventBuffer::new();
 
-    #[allow(deprecated)]
-    let client = EventClient::with_additional_options(
-        Some(options),
-        Some(Duration::from_millis(50)),
-        None,
-        event_buffer.clone(),
-    )
-    .await;
+    let client = Client::test_builder()
+        .additional_options(options, false)
+        .await
+        .min_heartbeat_freq(Duration::from_millis(50))
+        .event_buffer(event_buffer.clone())
+        .build()
+        .await;
     #[allow(deprecated)]
     let mut subscriber = event_buffer.subscribe_all();
 

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1502,15 +1502,18 @@ impl DeadlockTestCase {
     async fn run(&self) -> Result<()> {
         // Setup
         let client_test = TestClient::new().await;
+        let events = EventBuffer::new();
+        let client_keyvault = Client::test_builder()
+            .options({
+                let mut opts = get_client_options().await.clone();
+                opts.max_pool_size = Some(1);
+                opts
+            })
+            .event_buffer(events.clone())
+            .build()
+            .await;
         #[allow(deprecated)]
-        let client_keyvault = EventClient::with_options({
-            let mut opts = get_client_options().await.clone();
-            opts.max_pool_size = Some(1);
-            opts
-        })
-        .await;
-        #[allow(deprecated)]
-        let mut keyvault_events = client_keyvault.events.subscribe();
+        let mut keyvault_events = events.subscribe();
         client_test
             .database("keyvault")
             .collection::<Document>("datakeys")

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -56,14 +56,12 @@ async fn run_legacy() {
                 options.heartbeat_freq = Some(MIN_HEARTBEAT_FREQUENCY);
             }
 
-            #[allow(deprecated)]
-            let client = EventClient::with_additional_options(
-                options,
-                Some(Duration::from_millis(50)),
-                test_case.use_multiple_mongoses,
-                None,
-            )
-            .await;
+            let client = Client::test_builder()
+                .additional_options(options, test_case.use_multiple_mongoses.unwrap_or(false))
+                .await
+                .min_heartbeat_freq(Duration::from_millis(50))
+                .build()
+                .await;
 
             if let Some(ref run_on) = test_file.run_on {
                 let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -7,8 +7,6 @@ use std::{
 use futures::TryStreamExt;
 use futures_util::{future::try_join_all, FutureExt};
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, Document},
     client::options::ClientOptions,
@@ -19,7 +17,7 @@ use crate::{
         get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
-        util::Event,
+        util::{event_buffer::EventBuffer, Event},
         TestClient,
     },
     Client,
@@ -205,8 +203,7 @@ async fn implicit_session_after_connection() {
     );
 }
 
-#[allow(deprecated)]
-async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
+async fn spawn_mongocryptd(name: &str) -> Option<(TestClient, EventBuffer, Process)> {
     let util_client = TestClient::new().await;
     if util_client.server_version_lt(4, 2) {
         log_uncaptured(format!(
@@ -228,11 +225,15 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let options = ClientOptions::parse("mongodb://localhost:47017")
         .await
         .unwrap();
-    #[allow(deprecated)]
-    let client = EventClient::with_options(options).await;
+    let events = EventBuffer::new();
+    let client = Client::test_builder()
+        .options(options)
+        .event_buffer(events.clone())
+        .build()
+        .await;
     assert!(client.server_info.logical_session_timeout_minutes.is_none());
 
-    Some((client, process))
+    Some((client, events, process))
 }
 
 async fn clean_up_mongocryptd(mut process: Process, name: &str) {
@@ -246,12 +247,12 @@ async fn clean_up_mongocryptd(mut process: Process, name: &str) {
 async fn sessions_not_supported_implicit_session_ignored() {
     let name = "sessions_not_supported_implicit_session_ignored";
 
-    let Some((client, process)) = spawn_mongocryptd(name).await else {
+    let Some((client, events, process)) = spawn_mongocryptd(name).await else {
         return;
     };
 
     #[allow(deprecated)]
-    let mut subscriber = client.events.subscribe();
+    let mut subscriber = events.subscribe();
     let coll = client.database(name).collection(name);
 
     let _ = coll.find(doc! {}).await;
@@ -290,7 +291,7 @@ async fn sessions_not_supported_implicit_session_ignored() {
 async fn sessions_not_supported_explicit_session_error() {
     let name = "sessions_not_supported_explicit_session_error";
 
-    let Some((client, process)) = spawn_mongocryptd(name).await else {
+    let Some((client, _, process)) = spawn_mongocryptd(name).await else {
         return;
     };
 

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -117,6 +117,7 @@ impl TestClientBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub(crate) fn retain_startup_events(mut self, value: bool) -> Self {
         assert!(self.buffer.is_some());
         self.retain_startup_events = value;

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -9,7 +9,6 @@ use crate::{
         command::{CommandEvent, CommandStartedEvent, CommandSucceededEvent},
         sdam::SdamEvent,
     },
-    options::ClientOptions,
     Client,
 };
 
@@ -163,15 +162,7 @@ impl EventClientBuilder {
 #[allow(deprecated)]
 impl EventClient {
     pub(crate) async fn new() -> Self {
-        EventClient::with_options(None).await
-    }
-
-    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
-        Client::test_builder()
-            .options(options)
-            .event_client()
-            .build()
-            .await
+        Client::test_builder().event_client().build().await
     }
 
     #[allow(dead_code)]

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use derive_more::From;
 use serde::Serialize;
 
@@ -171,23 +169,6 @@ impl EventClient {
     pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
         Client::test_builder()
             .options(options)
-            .event_buffer(None)
-            .event_client()
-            .build()
-            .await
-    }
-
-    pub(crate) async fn with_additional_options(
-        options: impl Into<Option<ClientOptions>>,
-        min_heartbeat_freq: Option<Duration>,
-        use_multiple_mongoses: Option<bool>,
-        event_handler: impl Into<Option<EventBuffer>>,
-    ) -> Self {
-        Client::test_builder()
-            .additional_options(options, use_multiple_mongoses.unwrap_or(false))
-            .await
-            .min_heartbeat_freq(min_heartbeat_freq)
-            .event_buffer(event_handler)
             .event_client()
             .build()
             .await

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -168,20 +168,13 @@ impl EventClient {
         EventClient::with_options(None).await
     }
 
-    async fn with_options_and_buffer(
-        options: impl Into<Option<ClientOptions>>,
-        handler: impl Into<Option<EventBuffer>>,
-    ) -> Self {
+    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
         Client::test_builder()
             .options(options)
-            .event_buffer(handler)
+            .event_buffer(None)
             .event_client()
             .build()
             .await
-    }
-
-    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
-        Self::with_options_and_buffer(options, None).await
     }
 
     pub(crate) async fn with_additional_options(


### PR DESCRIPTION
RUST-1890

This removes uses of `EventClient::with_options` / `with_additional_options` in favor of using `Client::test_builder` and explicitly passing an `EventBuffer` around with it.

I'm not sure this change is worth the churn, honestly.  Given that it just means things have to pass around `(TestClient, EventBuffer)` anyway it seems better to keep them bundled in a struct.  I'm inclined to undo that part of this PR and update the rest to be removing the direct constructors in favor of the builder (so keep `EventClient` and `TestClientBuilder::event_client()` but get rid of `EventClient::new` / `with_options` / `with_additional_options`).  Thoughts?