### PR TITLE
RUST-1890 Consolidate test event monitoring and client construction

### DIFF
--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -389,7 +389,7 @@ async fn session_usage() {
         F: Fn(EventClient) -> G,
         G: Future<Output = ()>,
     {
-        let client = EventClient::new().await;
+        let client = Client::test_builder().monitor_events().build().await;
         operation(client.clone()).await;
         let mut events = client.events.clone();
         #[allow(deprecated)]
@@ -408,8 +408,7 @@ async fn session_usage() {
 #[tokio::test]
 #[function_name::named]
 async fn implicit_session_returned_after_immediate_exhaust() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if client.is_standalone() {
         return;
     }
@@ -453,8 +452,7 @@ async fn implicit_session_returned_after_immediate_exhaust() {
 #[tokio::test]
 #[function_name::named]
 async fn implicit_session_returned_after_exhaust_by_get_more() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if client.is_standalone() {
         return;
     }
@@ -508,8 +506,7 @@ async fn implicit_session_returned_after_exhaust_by_get_more() {
 #[tokio::test]
 #[function_name::named]
 async fn find_and_getmore_share_session() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if client.is_standalone() {
         log_uncaptured(
             "skipping find_and_getmore_share_session due to unsupported topology: Standalone",

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -1,14 +1,13 @@
 use bson::{doc, Document};
 use futures::{future::BoxFuture, FutureExt};
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     coll::options::CollectionOptions,
     error::Result,
     event::command::CommandEvent,
     options::ReadConcern,
     test::log_uncaptured,
+    Client,
     ClientSession,
     Collection,
 };
@@ -119,8 +118,7 @@ fn all_session_ops() -> impl Iterator<Item = Operation> {
 /// Test 1 from the causal consistency specification.
 #[tokio::test]
 async fn new_session_operation_time_null() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -136,8 +134,7 @@ async fn new_session_operation_time_null() {
 /// Test 2 from the causal consistency specification.
 #[tokio::test]
 async fn first_read_no_after_cluser_time() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -176,8 +173,7 @@ async fn first_read_no_after_cluser_time() {
 /// Test 3 from the causal consistency specification.
 #[tokio::test]
 async fn first_op_update_op_time() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured("skipping first_op_update_op_time due to unsupported topology: standalone");
@@ -227,8 +223,7 @@ async fn first_op_update_op_time() {
 /// Test 4 from the causal consistency specification.
 #[tokio::test]
 async fn read_includes_after_cluster_time() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -270,8 +265,7 @@ async fn read_includes_after_cluster_time() {
 /// Test 5 from the causal consistency specification.
 #[tokio::test]
 async fn find_after_write_includes_after_cluster_time() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -316,8 +310,7 @@ async fn find_after_write_includes_after_cluster_time() {
 /// Test 6 from the causal consistency specification.
 #[tokio::test]
 async fn not_causally_consistent_omits_after_cluster_time() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -357,8 +350,7 @@ async fn not_causally_consistent_omits_after_cluster_time() {
 /// Test 7 from the causal consistency specification.
 #[tokio::test]
 async fn omit_after_cluster_time_standalone() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if !client.is_standalone() {
         log_uncaptured("skipping omit_after_cluster_time_standalone due to unsupported topology");
@@ -395,8 +387,7 @@ async fn omit_after_cluster_time_standalone() {
 /// Test 8 from the causal consistency specification.
 #[tokio::test]
 async fn omit_default_read_concern_level() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -437,8 +428,7 @@ async fn omit_default_read_concern_level() {
 /// Test 9 from the causal consistency specification.
 #[tokio::test]
 async fn test_causal_consistency_read_concern_merge() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if client.is_standalone() {
         log_uncaptured(
             "skipping test_causal_consistency_read_concern_merge due to unsupported topology: \
@@ -488,8 +478,7 @@ async fn test_causal_consistency_read_concern_merge() {
 /// Test 11 from the causal consistency specification.
 #[tokio::test]
 async fn omit_cluster_time_standalone() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if !client.is_standalone() {
         log_uncaptured("skipping omit_cluster_time_standalone due to unsupported topology");
         return;
@@ -512,8 +501,7 @@ async fn omit_cluster_time_standalone() {
 /// Test 12 from the causal consistency specification.
 #[tokio::test]
 async fn cluster_time_sent_in_commands() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if client.is_standalone() {
         log_uncaptured("skipping cluster_time_sent_in_commands due to unsupported topology");
         return;

--- a/src/cmap/test.rs
+++ b/src/cmap/test.rs
@@ -8,8 +8,6 @@ use tokio::sync::{Mutex, RwLock};
 
 use self::file::{Operation, TestFile, ThreadedOperation};
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     cmap::{
         establish::{ConnectionEstablisher, EstablisherOptions},
@@ -441,8 +439,7 @@ async fn cmap_spec_tests() {
         }
         options.hosts.drain(1..);
         options.direct_connection = Some(true);
-        #[allow(deprecated)]
-        let client = EventClient::with_options(options).await;
+        let client = crate::Client::test_builder().options(options).build().await;
         if let Some(ref run_on) = test_file.run_on {
             let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));
             if !can_run_on {

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -685,7 +685,7 @@ async fn command_contains_write_concern_aggregate() {
 #[function_name::named]
 async fn command_contains_write_concern_drop() {
     #[allow(deprecated)]
-    let client = Client::test_builder().event_client().build().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -1,12 +1,10 @@
 use std::time::Duration;
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, Bson, Document},
     error::ErrorKind,
     options::{Acknowledgment, ReadConcern, WriteConcern},
-    test::TestClient,
+    test::{EventClient, TestClient},
     Client,
     Collection,
 };
@@ -133,8 +131,7 @@ async fn unacknowledged_write_concern_rejected() {
 #[tokio::test]
 #[function_name::named]
 async fn snapshot_read_concern() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     // snapshot read concern was introduced in 4.0
     if client.server_version_lt(4, 0) {
         return;
@@ -190,8 +187,7 @@ async fn assert_event_contains_read_concern(client: &EventClient) {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_insert_one() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -232,8 +228,7 @@ async fn command_contains_write_concern_insert_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_insert_many() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -274,8 +269,7 @@ async fn command_contains_write_concern_insert_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_update_one() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -317,8 +311,7 @@ async fn command_contains_write_concern_update_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_update_many() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -362,8 +355,7 @@ async fn command_contains_write_concern_update_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_replace_one() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -405,8 +397,7 @@ async fn command_contains_write_concern_replace_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_delete_one() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -450,8 +441,7 @@ async fn command_contains_write_concern_delete_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_delete_many() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -498,8 +488,7 @@ async fn command_contains_write_concern_delete_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_delete() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -543,8 +532,7 @@ async fn command_contains_write_concern_find_one_and_delete() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_replace() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -588,8 +576,7 @@ async fn command_contains_write_concern_find_one_and_replace() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_update() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -633,8 +620,7 @@ async fn command_contains_write_concern_find_one_and_update() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_aggregate() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -731,8 +717,7 @@ async fn command_contains_write_concern_drop() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_create_collection() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let db = client.database("test");
     let coll: Collection<Document> = db.collection(function_name!());
 
@@ -772,7 +757,6 @@ async fn command_contains_write_concern_create_collection() {
     );
 }
 
-#[allow(deprecated)]
 fn command_write_concerns(client: &EventClient, key: &str) -> Vec<Document> {
     client
         .events

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -10,16 +10,15 @@ use crate::{
     error::Result,
     event::cmap::CmapEvent,
     options::ServerAddress,
-    runtime,
-    runtime::AsyncJoinHandle,
+    runtime::{self, AsyncJoinHandle},
     sdam::{description::topology::server_selection, Server},
     selection_criteria::{ReadPreference, SelectionCriteria},
     test::{
         get_client_options,
         log_uncaptured,
         run_spec_test,
-        util::event_buffer::EventBuffer,
         Event,
+        EventClient,
         FailCommandOptions,
         FailPoint,
         FailPointMode,
@@ -162,14 +161,11 @@ async fn load_balancing_test() {
 
     /// min_share is the lower bound for the % of times the the less selected server
     /// was selected. max_share is the upper bound.
-    async fn do_test(
-        client: &TestClient,
-        handler: &mut EventBuffer,
-        min_share: f64,
-        max_share: f64,
-        iterations: usize,
-    ) {
-        handler.clear_cached_events();
+    async fn do_test(client: &EventClient, min_share: f64, max_share: f64, iterations: usize) {
+        {
+            let mut events = client.events.clone();
+            events.clear_cached_events();
+        }
 
         let mut handles: Vec<AsyncJoinHandle<Result<()>>> = Vec::new();
         for _ in 0..10 {
@@ -189,7 +185,7 @@ async fn load_balancing_test() {
         }
 
         let mut tallies: HashMap<ServerAddress, u32> = HashMap::new();
-        for event in handler.get_command_started_events(&["find"]) {
+        for event in client.events.get_command_started_events(&["find"]) {
             *tallies.entry(event.connection.address.clone()).or_insert(0) += 1;
         }
 
@@ -215,9 +211,6 @@ async fn load_balancing_test() {
         }
     }
 
-    let mut buffer = EventBuffer::new();
-    #[allow(deprecated)]
-    let mut subscriber = buffer.subscribe();
     let mut options = get_client_options().await.clone();
     let max_pool_size = DEFAULT_MAX_POOL_SIZE;
     let hosts = options.hosts.clone();
@@ -225,9 +218,12 @@ async fn load_balancing_test() {
     options.min_pool_size = Some(max_pool_size);
     let client = Client::test_builder()
         .options(options)
-        .event_buffer(buffer.clone())
+        .monitor_events()
+        .retain_startup_events()
         .build()
         .await;
+    #[allow(deprecated)]
+    let mut subscriber = client.events.subscribe_all();
 
     // wait for both servers pools to be saturated.
     for address in hosts {
@@ -271,9 +267,9 @@ async fn load_balancing_test() {
         .expect("enabling failpoint should succeed");
 
     // verify that the lesser picked server (slower one) was picked less than 25% of the time.
-    do_test(&client, &mut buffer, 0.05, 0.25, 10).await;
+    do_test(&client, 0.05, 0.25, 10).await;
 
     // disable failpoint and rerun, should be back to even split
     drop(fp_guard);
-    do_test(&client, &mut buffer, 0.40, 0.50, 100).await;
+    do_test(&client, 0.40, 0.50, 100).await;
 }

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -5,8 +5,6 @@ use serde::Deserialize;
 
 use super::TestSdamEvent;
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, oid::ObjectId},
     client::Client,
@@ -593,14 +591,13 @@ async fn load_balanced() {
 #[function_name::named]
 async fn topology_closed_event_last() {
     let event_buffer = EventBuffer::new();
-    #[allow(deprecated)]
-    let client = EventClient::with_additional_options(
-        None,
-        Some(Duration::from_millis(50)),
-        None,
-        event_buffer.clone(),
-    )
-    .await;
+    let client = Client::test_builder()
+        .additional_options(None, false)
+        .await
+        .min_heartbeat_freq(Duration::from_millis(50))
+        .event_buffer(event_buffer.clone())
+        .build()
+        .await;
     #[allow(deprecated)]
     let mut subscriber = event_buffer.subscribe_all();
 
@@ -640,14 +637,13 @@ async fn heartbeat_events() {
     options.app_name = "heartbeat_events".to_string().into();
 
     let event_buffer = EventBuffer::new();
-    #[allow(deprecated)]
-    let client = EventClient::with_additional_options(
-        Some(options.clone()),
-        Some(Duration::from_millis(50)),
-        None,
-        event_buffer.clone(),
-    )
-    .await;
+    let client = Client::test_builder()
+        .additional_options(options.clone(), false)
+        .await
+        .min_heartbeat_freq(Duration::from_millis(50))
+        .event_buffer(event_buffer.clone())
+        .build()
+        .await;
 
     #[allow(deprecated)]
     let mut subscriber = event_buffer.subscribe_all();

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -590,16 +590,16 @@ async fn load_balanced() {
 #[tokio::test]
 #[function_name::named]
 async fn topology_closed_event_last() {
-    let event_buffer = EventBuffer::new();
     let client = Client::test_builder()
         .additional_options(None, false)
         .await
         .min_heartbeat_freq(Duration::from_millis(50))
-        .event_buffer(event_buffer.clone())
+        .monitor_events()
         .build()
         .await;
+    let events = client.events.clone();
     #[allow(deprecated)]
-    let mut subscriber = event_buffer.subscribe_all();
+    let mut subscriber = events.subscribe_all();
 
     client
         .database(function_name!())
@@ -636,17 +636,16 @@ async fn heartbeat_events() {
     options.heartbeat_freq = Some(Duration::from_millis(50));
     options.app_name = "heartbeat_events".to_string().into();
 
-    let event_buffer = EventBuffer::new();
     let client = Client::test_builder()
         .additional_options(options.clone(), false)
         .await
         .min_heartbeat_freq(Duration::from_millis(50))
-        .event_buffer(event_buffer.clone())
+        .monitor_events()
         .build()
         .await;
 
     #[allow(deprecated)]
-    let mut subscriber = event_buffer.subscribe_all();
+    let mut subscriber = client.events.subscribe_all();
 
     if client.is_load_balanced() {
         log_uncaptured("skipping heartbeat_events tests due to load-balanced topology");

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -98,17 +98,15 @@ async fn sdam_pool_management() {
     options.app_name = Some("SDAMPoolManagementTest".to_string());
     options.heartbeat_freq = Some(Duration::from_millis(50));
 
-    let event_buffer = EventBuffer::new();
-
     let client = Client::test_builder()
         .additional_options(options, false)
         .await
         .min_heartbeat_freq(Duration::from_millis(50))
-        .event_buffer(event_buffer.clone())
+        .monitor_events()
         .build()
         .await;
     #[allow(deprecated)]
-    let mut subscriber = event_buffer.subscribe_all();
+    let mut subscriber = client.events.subscribe_all();
 
     if !VersionReq::parse(">= 4.2.9")
         .unwrap()

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -6,8 +6,6 @@ use std::{
 use bson::doc;
 use semver::VersionReq;
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     client::options::{ClientOptions, ServerAddress},
     cmap::RawCommandResponse,
@@ -102,14 +100,13 @@ async fn sdam_pool_management() {
 
     let event_buffer = EventBuffer::new();
 
-    #[allow(deprecated)]
-    let client = EventClient::with_additional_options(
-        Some(options),
-        Some(Duration::from_millis(50)),
-        None,
-        event_buffer.clone(),
-    )
-    .await;
+    let client = Client::test_builder()
+        .additional_options(options, false)
+        .await
+        .min_heartbeat_freq(Duration::from_millis(50))
+        .event_buffer(event_buffer.clone())
+        .build()
+        .await;
     #[allow(deprecated)]
     let mut subscriber = event_buffer.subscribe_all();
 

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -801,11 +801,7 @@ async fn manual_shutdown_with_nothing() {
 /// Verifies that `Client::shutdown` succeeds when resources have been dropped.
 #[tokio::test]
 async fn manual_shutdown_with_resources() {
-    let events = EventBuffer::new();
-    let client = Client::test_builder()
-        .event_buffer(events.clone())
-        .build()
-        .await;
+    let client = Client::test_builder().monitor_events().build().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping manual_shutdown_with_resources: no transaction support");
         return;
@@ -839,6 +835,7 @@ async fn manual_shutdown_with_resources() {
         let _stream = bucket.open_upload_stream("test").await.unwrap();
     }
     let is_sharded = client.is_sharded();
+    let events = client.events.clone();
     client.into_client().shutdown().await;
     if !is_sharded {
         // killCursors doesn't always execute on sharded clusters due to connection pinning
@@ -862,11 +859,7 @@ async fn manual_shutdown_immediate_with_nothing() {
 /// Verifies that `Client::shutdown_immediate` succeeds without waiting for resources.
 #[tokio::test]
 async fn manual_shutdown_immediate_with_resources() {
-    let events = EventBuffer::new();
-    let client = Client::test_builder()
-        .event_buffer(events.clone())
-        .build()
-        .await;
+    let client = Client::test_builder().monitor_events().build().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping manual_shutdown_immediate_with_resources: no transaction support");
         return;
@@ -890,6 +883,7 @@ async fn manual_shutdown_immediate_with_resources() {
         .unwrap();
     let _stream = bucket.open_upload_stream("test").await.unwrap();
 
+    let events = client.events.clone();
     client.into_client().shutdown().immediate(true).await;
 
     assert!(events

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -1,11 +1,6 @@
 use std::{fmt::Debug, time::Duration};
 
-use crate::{
-    event::command::CommandEvent,
-    test::{util::event_buffer::EventBuffer, Event},
-    Client,
-    Namespace,
-};
+use crate::{event::command::CommandEvent, test::Event, Client, Namespace};
 use bson::{rawdoc, serde_helpers::HumanReadable, RawDocumentBuf};
 use futures::stream::{StreamExt, TryStreamExt};
 use once_cell::sync::Lazy;
@@ -1245,13 +1240,9 @@ async fn insert_many_document_sequences() {
         return;
     }
 
-    let buffer = EventBuffer::new();
-    let client = Client::test_builder()
-        .event_buffer(buffer.clone())
-        .build()
-        .await;
+    let client = Client::test_builder().monitor_events().build().await;
     #[allow(deprecated)]
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = client.events.subscribe();
 
     let max_object_size = client.server_info.max_bson_object_size;
     let max_message_size = client.server_info.max_message_size_bytes;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -51,11 +51,10 @@ use crate::{
     Namespace,
 };
 
-#[allow(deprecated)]
-use super::EventClient;
 use super::{
     get_client_options,
     log_uncaptured,
+    EventClient,
     FailCommandOptions,
     FailPoint,
     FailPointMode,
@@ -64,9 +63,8 @@ use super::{
 
 type Result<T> = anyhow::Result<T>;
 
-#[allow(deprecated)]
 async fn init_client() -> Result<(EventClient, Collection<Document>)> {
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let datakeys = client
         .database("keyvault")
         .collection_with_options::<Document>(

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1502,15 +1502,18 @@ impl DeadlockTestCase {
     async fn run(&self) -> Result<()> {
         // Setup
         let client_test = TestClient::new().await;
+        let events = EventBuffer::new();
+        let client_keyvault = Client::test_builder()
+            .options({
+                let mut opts = get_client_options().await.clone();
+                opts.max_pool_size = Some(1);
+                opts
+            })
+            .event_buffer(events.clone())
+            .build()
+            .await;
         #[allow(deprecated)]
-        let client_keyvault = EventClient::with_options({
-            let mut opts = get_client_options().await.clone();
-            opts.max_pool_size = Some(1);
-            opts
-        })
-        .await;
-        #[allow(deprecated)]
-        let mut keyvault_events = client_keyvault.events.subscribe();
+        let mut keyvault_events = events.subscribe();
         client_test
             .database("keyvault")
             .collection::<Document>("datakeys")

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -1502,18 +1502,17 @@ impl DeadlockTestCase {
     async fn run(&self) -> Result<()> {
         // Setup
         let client_test = TestClient::new().await;
-        let events = EventBuffer::new();
         let client_keyvault = Client::test_builder()
             .options({
                 let mut opts = get_client_options().await.clone();
                 opts.max_pool_size = Some(1);
                 opts
             })
-            .event_buffer(events.clone())
+            .monitor_events()
             .build()
             .await;
         #[allow(deprecated)]
-        let mut keyvault_events = events.subscribe();
+        let mut keyvault_events = client_keyvault.events.subscribe();
         client_test
             .database("keyvault")
             .collection::<Document>("datakeys")

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -3,13 +3,12 @@ use std::time::Duration;
 use futures::{future::Either, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 
-#[allow(deprecated)]
-use crate::test::util::EventClient;
 use crate::{
     bson::doc,
     options::{CreateCollectionOptions, CursorType, FindOptions},
     runtime,
     test::{log_uncaptured, TestClient, SERVERLESS},
+    Client,
 };
 
 #[tokio::test]
@@ -113,8 +112,7 @@ async fn session_cursor_next() {
 
 #[tokio::test]
 async fn batch_exhaustion() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     let coll = client
         .create_fresh_collection(
@@ -157,8 +155,7 @@ async fn batch_exhaustion() {
 
 #[tokio::test]
 async fn borrowed_deserialization() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Doc<'a> {

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -2,8 +2,6 @@ use std::cmp::Ord;
 
 use futures::stream::TryStreamExt;
 
-#[allow(deprecated)]
-use crate::test::util::EventClient;
 use crate::{
     action::Action,
     bson::{doc, Document},
@@ -17,6 +15,7 @@ use crate::{
     },
     results::{CollectionSpecification, CollectionType},
     test::util::TestClient,
+    Client,
     Database,
 };
 
@@ -318,8 +317,7 @@ async fn create_index_options_defaults_not_specified() {
 }
 
 async fn index_option_defaults_test(defaults: Option<IndexOptionDefaults>, name: &str) {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let db = client.database(name);
 
     db.create_collection(name)

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -1,12 +1,11 @@
 use futures::stream::TryStreamExt;
 
-#[allow(deprecated)]
-use crate::test::util::EventClient;
 use crate::{
     bson::doc,
     error::ErrorKind,
     options::{CommitQuorum, IndexOptions},
     test::{log_uncaptured, util::TestClient},
+    Client,
     IndexModel,
 };
 
@@ -203,9 +202,8 @@ async fn index_management_drops() {
 // Test that index management commands execute the expected database commands.
 #[tokio::test]
 #[function_name::named]
-#[allow(deprecated)]
 async fn index_management_executes_commands() {
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -195,7 +195,7 @@ async fn retry_read_different_mongos() {
     #[allow(deprecated)]
     let client = Client::test_builder()
         .options(client_options)
-        .event_client()
+        .monitor_events()
         .build()
         .await;
     let result = client
@@ -257,7 +257,7 @@ async fn retry_read_same_mongos() {
     #[allow(deprecated)]
     let client = Client::test_builder()
         .options(client_options)
-        .event_client()
+        .monitor_events()
         .build()
         .await;
     let result = client

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -606,7 +606,7 @@ async fn retry_write_different_mongos() {
     #[allow(deprecated)]
     let client = Client::test_builder()
         .options(client_options)
-        .event_client()
+        .monitor_events()
         .build()
         .await;
     let result = client
@@ -669,7 +669,7 @@ async fn retry_write_same_mongos() {
     #[allow(deprecated)]
     let client = Client::test_builder()
         .options(client_options)
-        .event_client()
+        .monitor_events()
         .build()
         .await;
     let result = client

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -56,14 +56,12 @@ async fn run_legacy() {
                 options.heartbeat_freq = Some(MIN_HEARTBEAT_FREQUENCY);
             }
 
-            #[allow(deprecated)]
-            let client = EventClient::with_additional_options(
-                options,
-                Some(Duration::from_millis(50)),
-                test_case.use_multiple_mongoses,
-                None,
-            )
-            .await;
+            let client = Client::test_builder()
+                .additional_options(options, test_case.use_multiple_mongoses.unwrap_or(false))
+                .await
+                .min_heartbeat_freq(Duration::from_millis(50))
+                .build()
+                .await;
 
             if let Some(ref run_on) = test_file.run_on {
                 let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -9,8 +9,6 @@ use tokio::sync::Mutex;
 
 use test_file::{TestFile, TestResult};
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, Document},
     error::{ErrorKind, Result, RETRYABLE_WRITE_ERROR},
@@ -182,8 +180,7 @@ async fn run_legacy() {
 #[tokio::test]
 #[function_name::named]
 async fn transaction_ids_excluded() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
         log_uncaptured("skipping transaction_ids_excluded due to test topology");
@@ -231,8 +228,7 @@ async fn transaction_ids_excluded() {
 #[tokio::test]
 #[function_name::named]
 async fn transaction_ids_included() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
         log_uncaptured("skipping transaction_ids_included due to test topology");

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -7,8 +7,6 @@ use std::{
 use futures::TryStreamExt;
 use futures_util::{future::try_join_all, FutureExt};
 
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, Document},
     client::options::ClientOptions,
@@ -19,7 +17,7 @@ use crate::{
         get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
-        util::Event,
+        util::{event_buffer::EventBuffer, Event},
         TestClient,
     },
     Client,
@@ -205,8 +203,7 @@ async fn implicit_session_after_connection() {
     );
 }
 
-#[allow(deprecated)]
-async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
+async fn spawn_mongocryptd(name: &str) -> Option<(TestClient, EventBuffer, Process)> {
     let util_client = TestClient::new().await;
     if util_client.server_version_lt(4, 2) {
         log_uncaptured(format!(
@@ -228,11 +225,15 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let options = ClientOptions::parse("mongodb://localhost:47017")
         .await
         .unwrap();
-    #[allow(deprecated)]
-    let client = EventClient::with_options(options).await;
+    let events = EventBuffer::new();
+    let client = Client::test_builder()
+        .options(options)
+        .event_buffer(events.clone())
+        .build()
+        .await;
     assert!(client.server_info.logical_session_timeout_minutes.is_none());
 
-    Some((client, process))
+    Some((client, events, process))
 }
 
 async fn clean_up_mongocryptd(mut process: Process, name: &str) {
@@ -246,12 +247,12 @@ async fn clean_up_mongocryptd(mut process: Process, name: &str) {
 async fn sessions_not_supported_implicit_session_ignored() {
     let name = "sessions_not_supported_implicit_session_ignored";
 
-    let Some((client, process)) = spawn_mongocryptd(name).await else {
+    let Some((client, events, process)) = spawn_mongocryptd(name).await else {
         return;
     };
 
     #[allow(deprecated)]
-    let mut subscriber = client.events.subscribe();
+    let mut subscriber = events.subscribe();
     let coll = client.database(name).collection(name);
 
     let _ = coll.find(doc! {}).await;
@@ -290,7 +291,7 @@ async fn sessions_not_supported_implicit_session_ignored() {
 async fn sessions_not_supported_explicit_session_error() {
     let name = "sessions_not_supported_explicit_session_error";
 
-    let Some((client, process)) = spawn_mongocryptd(name).await else {
+    let Some((client, _, process)) = spawn_mongocryptd(name).await else {
         return;
     };
 

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -96,7 +96,7 @@ async fn deserialize_recovery_token() {
 #[tokio::test]
 async fn convenient_api_custom_error() {
     #[allow(deprecated)]
-    let client = Client::test_builder().event_client().build().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_custom_error: no transaction support.");
         return;
@@ -129,7 +129,7 @@ async fn convenient_api_custom_error() {
 #[tokio::test]
 async fn convenient_api_returned_value() {
     #[allow(deprecated)]
-    let client = Client::test_builder().event_client().build().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_returned_value: no transaction support.");
         return;
@@ -157,7 +157,7 @@ async fn convenient_api_returned_value() {
 #[tokio::test]
 async fn convenient_api_retry_timeout_callback() {
     #[allow(deprecated)]
-    let client = Client::test_builder().event_client().build().await;
+    let client = Client::test_builder().monitor_events().build().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_retry_timeout_callback: no transaction support.");
         return;
@@ -196,7 +196,7 @@ async fn convenient_api_retry_timeout_commit_unknown() {
     #[allow(deprecated)]
     let client = Client::test_builder()
         .options(options)
-        .event_client()
+        .monitor_events()
         .build()
         .await;
     if !client.supports_transactions() {
@@ -248,7 +248,7 @@ async fn convenient_api_retry_timeout_commit_transient() {
     #[allow(deprecated)]
     let client = Client::test_builder()
         .options(options)
-        .event_client()
+        .monitor_events()
         .build()
         .await;
     if !client.supports_transactions() {

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -212,7 +212,7 @@ impl TestContext {
         #[cfg(feature = "in-use-encryption-unstable")]
         let builder = csfle::set_auto_enc(builder, test);
         #[allow(deprecated)]
-        let client = builder.event_client().build().await;
+        let client = builder.monitor_events().build().await;
 
         // TODO RUST-900: Remove this extraneous call.
         if internal_client.is_sharded()

--- a/src/test/spec/write_error.rs
+++ b/src/test/spec/write_error.rs
@@ -1,16 +1,14 @@
-#[allow(deprecated)]
-use crate::test::EventClient;
 use crate::{
     bson::{doc, Document},
     error::{ErrorKind, WriteFailure},
     test::log_uncaptured,
+    Client,
     Collection,
 };
 
 #[tokio::test]
 async fn details() {
-    #[allow(deprecated)]
-    let client = EventClient::new().await;
+    let client = Client::test_builder().monitor_events().build().await;
 
     if client.server_version_lt(5, 0) {
         // SERVER-58399

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -117,6 +117,7 @@ impl TestClientBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub(crate) fn retain_startup_events(mut self, value: bool) -> Self {
         assert!(self.buffer.is_some());
         self.retain_startup_events = value;

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -146,8 +146,7 @@ impl TestClientBuilder {
         #[cfg(not(feature = "in-use-encryption-unstable"))]
         let client = Client::with_options(options).unwrap();
 
-        let client = TestClient::from_client(client).await;
-        client
+        TestClient::from_client(client).await
     }
 }
 

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -9,7 +9,6 @@ use crate::{
         command::{CommandEvent, CommandStartedEvent, CommandSucceededEvent},
         sdam::SdamEvent,
     },
-    options::ClientOptions,
     Client,
 };
 
@@ -163,15 +162,7 @@ impl EventClientBuilder {
 #[allow(deprecated)]
 impl EventClient {
     pub(crate) async fn new() -> Self {
-        EventClient::with_options(None).await
-    }
-
-    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
-        Client::test_builder()
-            .options(options)
-            .event_client()
-            .build()
-            .await
+        Client::test_builder().event_client().build().await
     }
 
     #[allow(dead_code)]

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -167,11 +167,6 @@ impl EventClientBuilder {
 }
 
 impl EventClient {
-    #[deprecated = "use TestClientBuilder::monitor_events"]
-    pub(crate) async fn new() -> Self {
-        Client::test_builder().monitor_events().build().await
-    }
-
     #[allow(dead_code)]
     pub(crate) fn into_client(self) -> crate::Client {
         self.client.into_client()

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use derive_more::From;
 use serde::Serialize;
 
@@ -171,23 +169,6 @@ impl EventClient {
     pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
         Client::test_builder()
             .options(options)
-            .event_buffer(None)
-            .event_client()
-            .build()
-            .await
-    }
-
-    pub(crate) async fn with_additional_options(
-        options: impl Into<Option<ClientOptions>>,
-        min_heartbeat_freq: Option<Duration>,
-        use_multiple_mongoses: Option<bool>,
-        event_handler: impl Into<Option<EventBuffer>>,
-    ) -> Self {
-        Client::test_builder()
-            .additional_options(options, use_multiple_mongoses.unwrap_or(false))
-            .await
-            .min_heartbeat_freq(min_heartbeat_freq)
-            .event_buffer(event_handler)
             .event_client()
             .build()
             .await

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -168,20 +168,13 @@ impl EventClient {
         EventClient::with_options(None).await
     }
 
-    async fn with_options_and_buffer(
-        options: impl Into<Option<ClientOptions>>,
-        handler: impl Into<Option<EventBuffer>>,
-    ) -> Self {
+    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
         Client::test_builder()
             .options(options)
-            .event_buffer(handler)
+            .event_buffer(None)
             .event_client()
             .build()
             .await
-    }
-
-    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
-        Self::with_options_and_buffer(options, None).await
     }
 
     pub(crate) async fn with_additional_options(


### PR DESCRIPTION
RUST-1890

This makes `EventClient` the sole way for tests to track events, and the builder the sole way to construct an `EventClient`.

I did attempt the parameterized `TestClient` path but the type machinery ended up more complicated there than it seemed like it was worth; the approach in this PR also has the advantage that the event handling code is nicely separated from the base `TestClient` code.