### PR TITLE
RUST-1819 Fix `list_collections` on Atlas for clustered collections

### DIFF
--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -196,8 +196,8 @@ impl ClusteredIndex {
         let value_option: Option<ValueUnion> = Deserialize::deserialize(deserializer)?;
         value_option
             .map(|value| match value {
-                ValueUnion::Bool(value) if value == true => Ok(ClusteredIndex::default()),
-                ValueUnion::Bool(_) => Err(serde::de::Error::custom(
+                ValueUnion::Bool(true) => Ok(ClusteredIndex::default()),
+                ValueUnion::Bool(false) => Err(serde::de::Error::custom(
                     "if clusteredIndex is a boolean it must be `true`",
                 )),
                 ValueUnion::ClusteredIndex(value) => Ok(value),

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -186,7 +186,7 @@ impl ClusteredIndex {
     where
         D: serde::Deserializer<'de>,
     {
-        #[derive(Deserialize)]
+        #[derive(Debug, Deserialize)]
         #[serde(untagged)]
         enum ValueUnion {
             Bool(bool),

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -194,15 +194,15 @@ impl ClusteredIndex {
         }
 
         let value_option: Option<ValueUnion> = Deserialize::deserialize(deserializer)?;
-        value_option.map(|value| 
-            match value {
+        value_option
+            .map(|value| match value {
                 ValueUnion::Bool(value) if value == true => Ok(ClusteredIndex::default()),
                 ValueUnion::Bool(_) => Err(serde::de::Error::custom(
                     "if clusteredIndex is a boolean it must be `true`",
                 )),
                 ValueUnion::ClusteredIndex(value) => Ok(value),
-            }
-        ).transpose()
+            })
+            .transpose()
     }
 }
 
@@ -391,16 +391,16 @@ pub struct RunCursorCommandOptions {
 
 #[cfg(test)]
 mod spec {
-    use serde_json::{from_value, json};
     use super::*;
+    use serde_json::{from_value, json};
 
     #[test]
     fn deserializes_clustered_index_option_from_bool() -> Result<(), Box<dyn std::error::Error>> {
         let input = json!({ "clusteredIndex": true });
         let options = from_value::<CreateCollectionOptions>(input)?;
-        let clustered_index = options.clustered_index.expect(
-            "deserialized options include clustered_index"
-        );
+        let clustered_index = options
+            .clustered_index
+            .expect("deserialized options include clustered_index");
         let default_index = ClusteredIndex::default();
         assert_eq!(clustered_index.key, default_index.key);
         assert_eq!(clustered_index.unique, default_index.unique);

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -104,7 +104,7 @@ pub struct CreateCollectionOptions {
     /// Options for supporting change stream pre- and post-images.
     pub change_stream_pre_and_post_images: Option<ChangeStreamPreAndPostImages>,
 
-    /// Options for clustered collections.
+    /// Options for clustered collections. This option is only available on server versions 5.3+.
     #[serde(default, deserialize_with = "ClusteredIndex::deserialize_self_or_true")]
     pub clustered_index: Option<ClusteredIndex>,
 

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -388,24 +388,3 @@ pub struct RunCursorCommandOptions {
     /// getMore commands.
     pub comment: Option<Bson>,
 }
-
-#[cfg(test)]
-mod spec {
-    use super::*;
-    use serde_json::{from_value, json};
-
-    #[test]
-    fn deserializes_clustered_index_option_from_bool() -> Result<(), Box<dyn std::error::Error>> {
-        let input = json!({ "clusteredIndex": true });
-        let options = from_value::<CreateCollectionOptions>(input)?;
-        let clustered_index = options
-            .clustered_index
-            .expect("deserialized options include clustered_index");
-        let default_index = ClusteredIndex::default();
-        assert_eq!(clustered_index.key, default_index.key);
-        assert_eq!(clustered_index.unique, default_index.unique);
-        assert_eq!(clustered_index.name, default_index.name);
-        assert_eq!(clustered_index.v, default_index.v);
-        Ok(())
-    }
-}

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -355,6 +355,10 @@ async fn clustered_index_list_collections() {
     let client = TestClient::new().await;
     let database = client.database("db");
 
+    if client.server_version_lt(5, 3) {
+        return;
+    }
+
     database
         .create_collection("clustered_index_collection")
         .clustered_index(ClusteredIndex::default())

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -7,6 +7,7 @@ use crate::{
     bson::{doc, Document},
     error::Result,
     options::{
+        ClusteredIndex,
         Collation,
         CreateCollectionOptions,
         IndexOptionDefaults,
@@ -337,4 +338,19 @@ async fn index_option_defaults_test(defaults: Option<IndexOptionDefaults>, name:
         Err(_) => None,
     };
     assert_eq!(event_defaults, defaults);
+}
+
+#[test]
+fn deserialize_clustered_index_option_from_bool() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let input = serde_json::json!({ "clusteredIndex": true });
+    let options = serde_json::from_value::<CreateCollectionOptions>(input)?;
+    let clustered_index = options
+        .clustered_index
+        .expect("deserialized options include clustered_index");
+    let default_index = ClusteredIndex::default();
+    assert_eq!(clustered_index.key, default_index.key);
+    assert_eq!(clustered_index.unique, default_index.unique);
+    assert_eq!(clustered_index.name, default_index.name);
+    assert_eq!(clustered_index.v, default_index.v);
+    Ok(())
 }


### PR DESCRIPTION
#1003

I wasn't able to reproduce this locally (seems like an Atlas-only issue), so this fix includes a deserialization test contributed by the user for a boolean value and a test of `list_collections` to ensure we can still deserialize from options properly.

This includes the changes from #1076; I'll rebase once that's merged.