### PR TITLE
RUST-1913 Remove non_exhaustive from ErrorKind::GridFs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -607,7 +607,6 @@ pub enum ErrorKind {
 
     /// A GridFS error occurred.
     #[error("{0:?}")]
-    #[non_exhaustive]
     GridFs(GridFsErrorKind),
 
     #[error("Internal error: {message}")]


### PR DESCRIPTION
RUST-1913

The behavior of `#[non_exhaustive]` for a tuple variant is pretty surprising - it prevents matching on the variant at all, even with a wildcard for the body (see https://github.com/mongodb/mongo-rust-driver/issues/1071).  This removes that tag from the `GridFs` variant, which is consistent with our other simple wrapper variants (`BulkWrite`, `Command`, etc.).