### PR TITLE
RUST-1920 Use semgrep to generate SARIF reports

### DIFF
--- a/.evergreen/check-clippy.sh
+++ b/.evergreen/check-clippy.sh
@@ -8,13 +8,9 @@ source ./.evergreen/env.sh
 CLIPPY_VERSION=1.75.0
 
 rustup install $CLIPPY_VERSION
-cargo install clippy-sarif
 
 # Check with default features.
 cargo +$CLIPPY_VERSION clippy --all-targets -p mongodb -- -D warnings
 
 # Check with all features.
 cargo +$CLIPPY_VERSION clippy --all-targets --all-features -p mongodb -- -D warnings
-
-# Produce a SARIF report.
-cargo +$CLIPPY_VERSION clippy --all-targets --all-features -p mongodb --message-format=json -- -D warnings | clippy-sarif > clippy.sarif.json

--- a/.evergreen/check-semgrep.sh
+++ b/.evergreen/check-semgrep.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -o errexit
+
+source ./.evergreen/env.sh
+
+. ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+PYTHON=$(find_python3)
+
+if [[ -f "semgrep/bin/activate" ]]; then
+    echo 'using existing virtualenv'
+    . semgrep/bin/activate
+else
+    echo 'Creating new virtualenv'  
+    ${PYTHON} -m venv semgrep
+    echo 'Activating new virtualenv'
+    . semgrep/bin/activate
+    python3 -m pip install semgrep
+fi
+
+# Generate a SARIF report
+semgrep --config p/rust --sarif > mongo-rust-driver.json.sarif
+# And human-readable output
+semgrep --config p/rust --error

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -669,6 +669,11 @@ tasks:
     commands:
       - func: "check clippy"
 
+  - name: check-semgrep
+    tags: [lint]
+    commands:
+      - func: "check semgrep"
+
   - name: check-rustdoc
     tags: [lint]
     commands:
@@ -1771,6 +1776,16 @@ functions:
         script: |
           ${PREPARE_SHELL}
           .evergreen/check-clippy.sh
+
+  "check semgrep":
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        add_expansions_to_env: true
+        binary: bash
+        args:
+          - .evergreen/check-semgrep.sh
 
   "check rustdoc":
     - command: shell.exec

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,2 @@
+benchmarks/
+src/test/

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -316,6 +316,7 @@ impl ScramVersion {
     ) -> Result<Vec<u8>> {
         let normalized_password = match self {
             ScramVersion::Sha1 => {
+                // nosemgrep: insecure-hashes
                 let mut md5 = Md5::new();
                 md5.update(format!("{}:mongo:{}", username, password));
                 Cow::Owned(hex::encode(md5.finalize()))

--- a/src/runtime/tls_rustls.rs
+++ b/src/runtime/tls_rustls.rs
@@ -142,6 +142,7 @@ fn make_rustls_config(cfg: TlsOptions) -> Result<rustls::ClientConfig> {
     };
 
     if let Some(true) = cfg.allow_invalid_certificates {
+        // nosemgrep: rustls-dangerous
         config
             .dangerous()
             .set_certificate_verifier(Arc::new(NoCertVerifier {}));


### PR DESCRIPTION
RUST-1920

This switches from clippy to semgrep as the provider for SARIF reports.  The latter flagged a few spots in the driver code but both of them are false positives (support for the user requesting non-ideal options, basically) so I added comments to suppress those.