### PR TITLE
RUST-1921 Minor release script refactor

### DIFF
--- a/.evergreen/release-danger-do-not-run-manually.sh
+++ b/.evergreen/release-danger-do-not-run-manually.sh
@@ -13,19 +13,16 @@ set +x
 
 set -o errexit
 
-if [[ -z "$TAG" ]]; then
-  echo >&2 "\$TAG must be set to the git tag of the release"
-  exit 1
-fi
-
 if [[ -z "$TOKEN" ]]; then
   echo >&2 "\$TOKEN must be set to the crates.io authentication token"
   exit 1
 fi
 
-git fetch origin tag $TAG --no-tags
-git checkout $TAG
-
 source ./.evergreen/env.sh
 
-cargo publish --token $TOKEN
+EXTRA=""
+if [[ "${DRY_RUN}" == "yes" ]]; then
+  EXTRA="--dry-run"
+fi
+
+cargo publish --token $TOKEN ${EXTRA}

--- a/.evergreen/release-fetch-tag.sh
+++ b/.evergreen/release-fetch-tag.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+
+if [[ -z "$GIT_TAG" ]]; then
+  echo >&2 "\$GIT_TAG must be set to the git tag of the release"
+  exit 1
+fi
+
+git fetch origin tag $GIT_TAG --no-tags
+git checkout $GIT_TAG

--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -47,6 +47,15 @@ functions:
         ${PREPARE_SHELL}
         .evergreen/install-dependencies.sh rust
 
+  "fetch tag":
+    command: subprocess.exec
+    params:
+      working_dir: "src"
+      add_expansions_to_env: true
+      binary: bash
+      args:
+        - .evergreen/release-fetch-tag.sh
+
   "publish release":
     - command: shell.exec
       type: test
@@ -57,6 +66,7 @@ functions:
 
           TAG=${GIT_TAG}           \
           TOKEN=${CRATES_IO_TOKEN} \
+          DRY_RUN=${DRY_RUN}       \
           PROJECT_DIRECTORY="$(pwd)" \
             bash .evergreen/release-danger-do-not-run-manually.sh
 
@@ -65,9 +75,10 @@ tasks:
     commands:
       - func: "fetch source"
       - func: "install dependencies"
-      - func: "publish release"
+      - func: "fetch tag"
         vars:
           GIT_TAG: ${triggered_by_git_tag}
+      - func: "publish release"
 
 axes:
   - id: "os"


### PR DESCRIPTION
RUST-1921

This splits the "checkout git tag" part from the main release script to enable a later PR to sign/trace the release artifacts.  It also adds a way to enable dry-run mode for releases run through evergreen for ease of testing.