### PR TITLE
RUST-1935 Add an empty sbom

### DIFF
--- a/sbom.json
+++ b/sbom.json
@@ -1,0 +1,10 @@
+{
+    "serialNumber": "urn:uuid:32a42d94-3729-4ef1-8c0c-8c6f9f9e0f53",
+    "version": 1,
+    "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "metadata": {
+        "timestamp": "2024-05-01T15:43:13Z"
+    }
+}


### PR DESCRIPTION
RUST-1935

Since the Rust driver doesn't bundle any dependencies, our SBOM is empty.