### PR TITLE
RUST-1627: Add automatic token acquisition for GCP

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -303,6 +303,7 @@ buildvariants:
     tasks:
       - testoidc_task_group
       - testazureoidc_task_group
+      - testgcpoidc_task_group
 
   - name: oidc-macos
     display_name: "OIDC Macos"
@@ -327,6 +328,7 @@ buildvariants:
     tasks:
       - testoidc_task_group
       - testazureoidc_task_group
+      - testgcpoidc_task_group
 
   - name: in-use-encryption
     display_name: "In-Use Encryption"
@@ -669,29 +671,29 @@ task_groups:
     tasks:
       - oidc-auth-test-azure-latest
 
-    - name: testgcpoidc_task_group
-      setup_group:
-        - func: fetch source
-        - func: prepare resources
-        - func: fix absolute paths
-        - func: make files executable
-        - command: subprocess.exec
-          params:
-            binary: bash
-            env:
-              GCPOIDC_VMNAME_PREFIX: "RUST_DRIVER"
-            args:
-              - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/setup.sh
-      teardown_task:
-        - command: subprocess.exec
-          params:
-            binary: bash
-            args:
-              - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/teardown.sh
-      setup_group_can_fail_task: true
-      setup_group_timeout_secs: 1800
-      tasks:
-        - oidc-auth-test-gcp-latest
+  - name: testgcpoidc_task_group
+    setup_group:
+      - func: fetch source
+      - func: prepare resources
+      - func: fix absolute paths
+      - func: make files executable
+      - command: subprocess.exec
+        params:
+          binary: bash
+          env:
+            GCPOIDC_VMNAME_PREFIX: "RUST_DRIVER"
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/setup.sh
+    teardown_task:
+      - command: subprocess.exec
+        params:
+          binary: bash
+          args:
+            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/teardown.sh
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    tasks:
+      - oidc-auth-test-gcp-latest
 
 #########
 # Tasks #
@@ -1367,12 +1369,12 @@ tasks:
           ${PREPARE_SHELL}
           git add .
           git commit -m "add files"
-          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
-          git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+          export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
+          git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD
           # Define the command to run on the gcp VM.
           # Ensure that we source the environment file created for us, set up any other variables we need,
           # and then run our test suite on the vm.
-          export AZUREOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
+          export GCPOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
                                      && PROJECT_DIRECTORY='.' .evergreen/install-dependencies.sh junit-dependencies\
                                      && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc  ./.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -669,6 +669,30 @@ task_groups:
     tasks:
       - oidc-auth-test-azure-latest
 
+    - name: testgcpoidc_task_group
+      setup_group:
+        - func: fetch source
+        - func: prepare resources
+        - func: fix absolute paths
+        - func: make files executable
+        - command: subprocess.exec
+          params:
+            binary: bash
+            env:
+              GCPOIDC_VMNAME_PREFIX: "RUST_DRIVER"
+            args:
+              - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/setup.sh
+      teardown_task:
+        - command: subprocess.exec
+          params:
+            binary: bash
+            args:
+              - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/teardown.sh
+      setup_group_can_fail_task: true
+      setup_group_timeout_secs: 1800
+      tasks:
+        - oidc-auth-test-gcp-latest
+
 #########
 # Tasks #
 #########
@@ -1324,10 +1348,34 @@ tasks:
           git commit -m "add files"
           export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
           git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+          # Define the command to run on the azure VM.
+          # Ensure that we source the environment file created for us, set up any other variables we need,
+          # and then run our test suite on the vm.
           export AZUREOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
                                      && PROJECT_DIRECTORY='.' .evergreen/install-dependencies.sh junit-dependencies\
                                      && PROJECT_DIRECTORY='.' OIDC_ENV=azure OIDC=oidc  ./.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
+
+  - name: "oidc-auth-test-gcp-latest"
+    commands:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |-
+          set -o errexit
+          ${PREPARE_SHELL}
+          git add .
+          git commit -m "add files"
+          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
+          git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+          # Define the command to run on the gcp VM.
+          # Ensure that we source the environment file created for us, set up any other variables we need,
+          # and then run our test suite on the vm.
+          export AZUREOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
+                                     && PROJECT_DIRECTORY='.' .evergreen/install-dependencies.sh junit-dependencies\
+                                     && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc  ./.evergreen/run-mongodb-oidc-test.sh"
+          bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh
 
 #############
 # Functions #

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -679,7 +679,6 @@ task_groups:
       - func: fix absolute paths
       - func: init test-results
       - func: make files executable
-      - func: install rust
       - command: shell.exec
         params:
           shell: bash
@@ -1371,19 +1370,21 @@ tasks:
         script: |-
           set -o errexit
           ${PREPARE_SHELL}
-          echo "!!!!!!!!!!"
-          echo "$PATH"
+          ./.evergreen/install-dependencies.sh rust
+          source .cargo/env
           # git add .
           # git commit -m "add files"
           export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
           # git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD
+          rustup default stable
           cargo test test::spec::oidc::gcp --features gcp-oidc --no-run
-          tar -czvf $GCPOIDC_DRIVERS_TAR_FILE ..
+          rm ../target/debug/deps/*.d
+          tar -czf $GCPOIDC_DRIVERS_TAR_FILE ../target/debug/deps/mongodb-*
           # Define the command to run on the gcp VM.
           # Ensure that we source the environment file created for us, set up any other variables we need,
           # and then run our test suite on the vm.
-          export GCPOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
-                                     && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc  ./.evergreen/run-mongodb-oidc-test.sh"
+          export GCPOIDC_TEST_CMD="ls -la . \
+                                   && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc ./src/.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh
 
 #############

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1349,17 +1349,24 @@ tasks:
         script: |-
           set -o errexit
           ${PREPARE_SHELL}
-          git add .
-          git commit -m "add files"
-          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
-          git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+           ./.evergreen/install-dependencies.sh rust
+          source .cargo/env
+          # git add .
+          # git commit -m "add files"
+          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tar
+          # git archive -o $AZUREOIDC_DRIVERS_TAR_FILE HEAD
+          rustup default stable
+          export RUSTFLAGS="-C target-feature=+crt-static"
+          cargo test test::spec::oidc::azure --features azure-oidc --no-run --target x86_64-unknown-linux-gnu
+          rm ./target/x86_64-unknown-linux-gnu/debug/deps/*.d
+          tar -cf $AZUREOIDC_DRIVERS_TAR_FILE ./target/x86_64-unknown-linux-gnu/debug/deps/mongodb-*
+          tar -uf $AZUREOIDC_DRIVERS_TAR_FILE ./.evergreen
+          gzip $AZUREOIDC_DRIVERS_TAR_FILE
+          export AZUREOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tar.gz
           # Define the command to run on the azure VM.
           # Ensure that we source the environment file created for us, set up any other variables we need,
           # and then run our test suite on the vm.
-          export AZUREOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
-                                     && PROJECT_DIRECTORY='.' .evergreen/install-dependencies.sh junit-dependencies\
-                                     && PROJECT_DIRECTORY='.' OIDC_ENV=azure OIDC=oidc  ./.evergreen/run-mongodb-oidc-test.sh"
-          bash $DRIVERS_TOOLS/.evergreen/auth_oidc/azure/run-driver-test.sh
+          export AZUREOIDC_TEST_CMD="PROJECT_DIRECTORY='.' OIDC_ENV=azure OIDC=oidc ./.evergreen/run-mongodb-oidc-test.sh"
 
   - name: "oidc-auth-test-gcp-latest"
     commands:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -35,7 +35,7 @@ post:
   - func: "cleanup"
 
 # Cause a timeout if a task does not complete within 150 minutes. TODO RUST-1721: reduce this.
-exec_timeout_secs: 9000
+exec_timeout_secs: 21600
 # What to do if the timeout is hit. Post-task functions will still run.
 timeout:
   - command: shell.exec
@@ -674,16 +674,20 @@ task_groups:
   - name: testgcpoidc_task_group
     setup_group:
       - func: fetch source
+      - func: create expansions
       - func: prepare resources
       - func: fix absolute paths
+      - func: init test-results
       - func: make files executable
-      - command: subprocess.exec
+      - func: install rust
+      - command: shell.exec
         params:
-          binary: bash
+          shell: bash
           env:
-            GCPOIDC_VMNAME_PREFIX: "RUST_DRIVER"
-          args:
-            - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/setup.sh
+            AZUREOIDC_VMNAME_PREFIX: "RUST_DRIVER"
+          script: |
+            ${PREPARE_SHELL}
+            ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/setup.sh
     teardown_task:
       - command: subprocess.exec
         params:
@@ -1367,15 +1371,18 @@ tasks:
         script: |-
           set -o errexit
           ${PREPARE_SHELL}
-          git add .
-          git commit -m "add files"
+          echo "!!!!!!!!!!"
+          echo "$PATH"
+          # git add .
+          # git commit -m "add files"
           export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
-          git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD
+          # git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD
+          cargo test test::spec::oidc::gcp --features gcp-oidc --no-run
+          tar -czvf $GCPOIDC_DRIVERS_TAR_FILE ..
           # Define the command to run on the gcp VM.
           # Ensure that we source the environment file created for us, set up any other variables we need,
           # and then run our test suite on the vm.
           export GCPOIDC_TEST_CMD="PROJECT_DIRECTORY='.' ./.evergreen/install-dependencies.sh rust\
-                                     && PROJECT_DIRECTORY='.' .evergreen/install-dependencies.sh junit-dependencies\
                                      && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc  ./.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1374,17 +1374,20 @@ tasks:
           source .cargo/env
           # git add .
           # git commit -m "add files"
-          export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tgz
+          export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tar
           # git archive -o $GCPOIDC_DRIVERS_TAR_FILE HEAD
           rustup default stable
-          cargo test test::spec::oidc::gcp --features gcp-oidc --no-run
-          rm ../target/debug/deps/*.d
-          tar -czf $GCPOIDC_DRIVERS_TAR_FILE ../target/debug/deps/mongodb-*
+          export RUSTFLAGS="-C target-feature=+crt-static"
+          cargo test test::spec::oidc::gcp --features gcp-oidc --no-run --target x86_64-unknown-linux-gnu
+          rm ./target/x86_64-unknown-linux-gnu/debug/deps/*.d
+          tar -cf $GCPOIDC_DRIVERS_TAR_FILE ./target/x86_64-unknown-linux-gnu/debug/deps/mongodb-*
+          tar -uf $GCPOIDC_DRIVERS_TAR_FILE ./.evergreen
+          gzip $GCPOIDC_DRIVERS_TAR_FILE
+          export GCPOIDC_DRIVERS_TAR_FILE=/tmp/mongo-rust-driver.tar.gz
           # Define the command to run on the gcp VM.
           # Ensure that we source the environment file created for us, set up any other variables we need,
           # and then run our test suite on the vm.
-          export GCPOIDC_TEST_CMD="ls -la . \
-                                   && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc ./src/.evergreen/run-mongodb-oidc-test.sh"
+          export GCPOIDC_TEST_CMD="ls -la && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc ./.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh
 
 #############

--- a/.evergreen/run-mongodb-oidc-test.sh
+++ b/.evergreen/run-mongodb-oidc-test.sh
@@ -3,9 +3,6 @@
 set +x          # Disable debug trace
 set -o errexit  # Exit the script with error if any of the commands fail
 
-source .evergreen/env.sh
-source .evergreen/cargo-test.sh
-
 echo "Running MONGODB-OIDC authentication tests"
 
 OIDC_ENV=${OIDC_ENV:-"test"}
@@ -15,6 +12,9 @@ export COVERAGE=1
 export AUTH="auth"
 
 if [ $OIDC_ENV == "test" ]; then
+
+    source .evergreen/env.sh
+    source .evergreen/cargo-test.sh
     # Make sure DRIVERS_TOOLS is set.
     if [ -z "$DRIVERS_TOOLS" ]; then
         echo "Must specify DRIVERS_TOOLS"
@@ -26,6 +26,8 @@ if [ $OIDC_ENV == "test" ]; then
     RESULT=$?
     cp target/nextest/ci/junit.xml results.xml
 elif [ $OIDC_ENV == "azure" ]; then
+    source .evergreen/env.sh
+    source .evergreen/cargo-test.sh
     source ./env.sh
 
     cargo nextest run test::spec::oidc::azure --no-capture --profile ci --features=azure-oidc
@@ -34,7 +36,7 @@ elif [ $OIDC_ENV == "azure" ]; then
 elif [ $OIDC_ENV == "gcp" ]; then
     source ./secrets-export.sh
 
-    cargo nextest run test::spec::oidc::gcp --no-capture --profile ci --features=gcp-oidc
+    ./target/debug/deps/mongodb-*  test::spec::oidc::gcp --nocapture
     RESULT=$?
 else
     echo "Unrecognized OIDC_ENV $OIDC_ENV"

--- a/.evergreen/run-mongodb-oidc-test.sh
+++ b/.evergreen/run-mongodb-oidc-test.sh
@@ -26,13 +26,10 @@ if [ $OIDC_ENV == "test" ]; then
     RESULT=$?
     cp target/nextest/ci/junit.xml results.xml
 elif [ $OIDC_ENV == "azure" ]; then
-    source .evergreen/env.sh
-    source .evergreen/cargo-test.sh
     source ./env.sh
 
-    cargo nextest run test::spec::oidc::azure --no-capture --profile ci --features=azure-oidc
+    ./target/x86_64-unknown-linux-gnu/debug/deps/mongodb-* test::spec::oidc::azure --nocapture
     RESULT=$?
-    cp target/nextest/ci/junit.xml results.xml
 elif [ $OIDC_ENV == "gcp" ]; then
     source ./secrets-export.sh
 

--- a/.evergreen/run-mongodb-oidc-test.sh
+++ b/.evergreen/run-mongodb-oidc-test.sh
@@ -29,6 +29,11 @@ elif [ $OIDC_ENV == "azure" ]; then
 
     cargo nextest run test::spec::oidc::azure --no-capture --profile ci --features=azure-oidc
     RESULT=$?
+elif [ $OIDC_ENV == "gcp" ]; then
+    source ./secrets-export.sh
+
+    cargo nextest run test::spec::oidc::gcp --no-capture --profile ci --features=gcp-oidc
+    RESULT=$?
 else
     echo "Unrecognized OIDC_ENV $OIDC_ENV"
     exit 1

--- a/.evergreen/run-mongodb-oidc-test.sh
+++ b/.evergreen/run-mongodb-oidc-test.sh
@@ -24,11 +24,13 @@ if [ $OIDC_ENV == "test" ]; then
 
     cargo nextest run test::spec::oidc::basic --no-capture --profile ci
     RESULT=$?
+    cp target/nextest/ci/junit.xml results.xml
 elif [ $OIDC_ENV == "azure" ]; then
     source ./env.sh
 
     cargo nextest run test::spec::oidc::azure --no-capture --profile ci --features=azure-oidc
     RESULT=$?
+    cp target/nextest/ci/junit.xml results.xml
 elif [ $OIDC_ENV == "gcp" ]; then
     source ./secrets-export.sh
 
@@ -39,5 +41,4 @@ else
     exit 1
 fi
 
-cp target/nextest/ci/junit.xml results.xml
 exit $RESULT

--- a/.evergreen/run-mongodb-oidc-test.sh
+++ b/.evergreen/run-mongodb-oidc-test.sh
@@ -36,7 +36,7 @@ elif [ $OIDC_ENV == "azure" ]; then
 elif [ $OIDC_ENV == "gcp" ]; then
     source ./secrets-export.sh
 
-    ./target/debug/deps/mongodb-*  test::spec::oidc::gcp --nocapture
+    ./target/x86_64-unknown-linux-gnu/debug/deps/mongodb-* test::spec::oidc::gcp --nocapture
     RESULT=$?
 else
     echo "Unrecognized OIDC_ENV $OIDC_ENV"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ azure-kms = ["dep:reqwest"]
 # Enable support for azure OIDC authentication.
 azure-oidc = ["dep:reqwest"]
 
+# Enable support for gcp OIDC authentication.
+gcp-oidc = ["dep:reqwest"]
+
 # Enable support for on-demand GCP KMS credentials.
 # This can only be used with the tokio-runtime feature flag.
 gcp-kms = ["dep:reqwest"]

--- a/src/client/auth/oidc.rs
+++ b/src/client/auth/oidc.rs
@@ -214,14 +214,14 @@ impl Callback {
 
     /// Create gcp callback.
     #[cfg(feature = "gcp-oidc")]
-    fn gcp_callback(resource: &str) -> StateInner {
+    fn gcp_callback(resource: &str) -> CallbackInner {
         use futures_util::FutureExt;
         let url = format!(
             "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience={}",
             resource
         );
-        StateInner {
-            callback: Self::new(
+        CallbackInner {
+            function: Self::new_function(
                 move |_| {
                     let url = url.clone();
                     async move {

--- a/src/client/auth/oidc.rs
+++ b/src/client/auth/oidc.rs
@@ -250,7 +250,7 @@ impl Callback {
                             .map_err(|e| {
                                 Error::authentication_error(
                                     MONGODB_OIDC_STR,
-                                    &format!("Failed to get access token from Azure IDMS: {}", e),
+                                    &format!("Failed to get access token from GCP IDMS: {}", e),
                                 )
                             });
                         let access_token = response?;

--- a/src/client/auth/oidc.rs
+++ b/src/client/auth/oidc.rs
@@ -229,7 +229,7 @@ impl Callback {
                         let response = crate::runtime::HttpClient::default()
                             .get(&url)
                             .headers(&[("Metadata-Flavor", "Google")])
-                            .send::<String>()
+                            .send_and_get_string()
                             .await
                             .map_err(|e| {
                                 Error::authentication_error(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,7 +3,8 @@ mod acknowledged_message;
     feature = "aws-auth",
     feature = "azure-kms",
     feature = "gcp-kms",
-    feature = "azure-oidc"
+    feature = "azure-oidc",
+    feature = "gcp-oidc"
 ))]
 mod http;
 mod join_handle;
@@ -36,7 +37,8 @@ use crate::{error::Result, options::ServerAddress};
     feature = "aws-auth",
     feature = "azure-kms",
     feature = "gcp-kms",
-    feature = "azure-oidc"
+    feature = "azure-oidc",
+    feature = "gcp-oidc"
 ))]
 pub(crate) use http::HttpClient;
 #[cfg(feature = "openssl-tls")]

--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -1268,7 +1268,8 @@ mod gcp {
     async fn machine_5_4_gcp_with_no_username() -> anyhow::Result<()> {
         get_env_or_skip!("OIDC");
 
-        let opts = ClientOptions::parse(mongodb_uri_single!()).await?;
+        let mut opts = ClientOptions::parse(mongodb_uri_single!()).await?;
+        opts.credential.as_mut().unwrap().source = None;
         let client = Client::with_options(opts)?;
         client
             .database("test")
@@ -1284,6 +1285,7 @@ mod gcp {
         use crate::client::auth::{ENVIRONMENT_PROP_STR, GCP_ENVIRONMENT_VALUE_STR};
 
         let mut opts = ClientOptions::parse(mongodb_uri_single!()).await?;
+        opts.credential.as_mut().unwrap().source = None;
         opts.credential.as_mut().unwrap().mechanism_properties = Some(doc! {
             ENVIRONMENT_PROP_STR: GCP_ENVIRONMENT_VALUE_STR,
         });


### PR DESCRIPTION
So, the tests here look quite weird. The GCP VM is incredibly slow, so I wasn't able to run `cargo test` on it. I tried, it took over 2 hours to compile the mongodb crate and timed out. So the strategy here is to _statically compile_ the test, tar it up, and run the binary. The VM doesn't even have the correct version of libc, which necessitates fully statically compiled test app. Since this worked, I went ahead and changed Azure to this too, since it also runs on a VM, which more than halved the runtime for the Azure test. I'm not sure why the Azure VM is so much snappier than the GCP VM, but it is what it is.