### PR TITLE
Fix #1099 and allow `&mut ClientSession` to be used without moving

### DIFF
--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -123,13 +123,13 @@ impl<'a> Aggregate<'a, ImplicitSession> {
     /// Use the provided session when running the operation.
     pub fn session(
         self,
-        value: impl Into<&'a mut ClientSession>,
+        value: &'a mut ClientSession,
     ) -> Aggregate<'a, ExplicitSession<'a>> {
         Aggregate {
             target: self.target,
             pipeline: self.pipeline,
             options: self.options,
-            session: ExplicitSession(value.into()),
+            session: ExplicitSession(value),
         }
     }
 }

--- a/src/action/count.rs
+++ b/src/action/count.rs
@@ -133,8 +133,8 @@ impl<'a> CountDocuments<'a> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/create_collection.rs
+++ b/src/action/create_collection.rs
@@ -69,8 +69,8 @@ impl<'a> CreateCollection<'a> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/create_index.rs
+++ b/src/action/create_index.rs
@@ -96,8 +96,8 @@ impl<'a, M> CreateIndex<'a, M> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/delete.rs
+++ b/src/action/delete.rs
@@ -99,8 +99,8 @@ impl<'a> Delete<'a> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/distinct.rs
+++ b/src/action/distinct.rs
@@ -68,8 +68,8 @@ impl<'a> Distinct<'a> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/drop.rs
+++ b/src/action/drop.rs
@@ -51,8 +51,8 @@ impl<'a> DropDatabase<'a> {
     );
 
     /// Runs the drop using the provided session.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }
@@ -116,8 +116,8 @@ impl<'a> DropCollection<'a> {
     );
 
     /// Runs the drop using the provided session.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/drop_index.rs
+++ b/src/action/drop_index.rs
@@ -83,8 +83,8 @@ impl<'a> DropIndex<'a> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -110,13 +110,13 @@ impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     /// Use the provided session when running the operation.
     pub fn session<'s>(
         self,
-        value: impl Into<&'s mut ClientSession>,
+        value: &'s mut ClientSession,
     ) -> Find<'a, T, ExplicitSession<'s>> {
         Find {
             coll: self.coll,
             filter: self.filter,
             options: self.options,
-            session: ExplicitSession(value.into()),
+            session: ExplicitSession(value),
         }
     }
 }
@@ -184,8 +184,8 @@ impl<'a, T: Send + Sync> FindOne<'a, T> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/find_and_modify.rs
+++ b/src/action/find_and_modify.rs
@@ -192,8 +192,8 @@ impl<'a, T: Send + Sync> FindOneAndDelete<'a, T> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }
@@ -242,8 +242,8 @@ impl<'a, T: Send + Sync> FindOneAndUpdate<'a, T> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }
@@ -291,8 +291,8 @@ impl<'a, T: Send + Sync> FindOneAndReplace<'a, T> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/insert_many.rs
+++ b/src/action/insert_many.rs
@@ -78,8 +78,8 @@ impl<'a> InsertMany<'a> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/insert_one.rs
+++ b/src/action/insert_one.rs
@@ -74,8 +74,8 @@ impl<'a> InsertOne<'a> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/list_collections.rs
+++ b/src/action/list_collections.rs
@@ -95,13 +95,13 @@ impl<'a, M> ListCollections<'a, M, ImplicitSession> {
     /// Use the provided session when running the operation.
     pub fn session<'s>(
         self,
-        value: impl Into<&'s mut ClientSession>,
+        value: &'s mut ClientSession,
     ) -> ListCollections<'a, M, ExplicitSession<'s>> {
         ListCollections {
             db: self.db,
             options: self.options,
             mode: PhantomData,
-            session: ExplicitSession(value.into()),
+            session: ExplicitSession(value),
         }
     }
 }

--- a/src/action/list_databases.rs
+++ b/src/action/list_databases.rs
@@ -80,8 +80,8 @@ impl<'a, M> ListDatabases<'a, M> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/list_indexes.rs
+++ b/src/action/list_indexes.rs
@@ -102,12 +102,12 @@ impl<'a, Mode> ListIndexes<'a, Mode, ImplicitSession> {
     /// Use the provided session when running the operation.
     pub fn session(
         self,
-        value: impl Into<&'a mut ClientSession>,
+        value: &'a mut ClientSession,
     ) -> ListIndexes<'a, Mode, ExplicitSession<'a>> {
         ListIndexes {
             coll: self.coll,
             options: self.options,
-            session: ExplicitSession(value.into()),
+            session: ExplicitSession(value),
             _mode: PhantomData,
         }
     }

--- a/src/action/replace_one.rs
+++ b/src/action/replace_one.rs
@@ -75,8 +75,8 @@ impl<'a> ReplaceOne<'a> {
     }
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -90,8 +90,8 @@ impl<'a> RunCommand<'a> {
     );
 
     /// Run the command using the provided [`ClientSession`].
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }
@@ -163,13 +163,13 @@ impl<'a> RunCursorCommand<'a, ImplicitSession> {
     /// Run the command using the provided [`ClientSession`].
     pub fn session(
         self,
-        value: impl Into<&'a mut ClientSession>,
+        value: &'a mut ClientSession,
     ) -> RunCursorCommand<'a, ExplicitSession<'a>> {
         RunCursorCommand {
             db: self.db,
             command: self.command,
             options: self.options,
-            session: ExplicitSession(value.into()),
+            session: ExplicitSession(value),
         }
     }
 }

--- a/src/action/update.rs
+++ b/src/action/update.rs
@@ -125,8 +125,8 @@ impl<'a> Update<'a> {
     );
 
     /// Use the provided session when running the operation.
-    pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
-        self.session = Some(value.into());
+    pub fn session(mut self, value: &'a mut ClientSession) -> Self {
+        self.session = Some(value);
         self
     }
 }

--- a/src/action/watch.rs
+++ b/src/action/watch.rs
@@ -239,14 +239,14 @@ impl<'a> Watch<'a, ImplicitSession> {
     /// Use the provided ['ClientSession'].
     pub fn session<'s>(
         self,
-        session: impl Into<&'s mut ClientSession>,
+        session: &'s mut ClientSession,
     ) -> Watch<'a, ExplicitSession<'s>> {
         Watch {
             client: self.client,
             target: self.target,
             pipeline: self.pipeline,
             options: self.options,
-            session: ExplicitSession(session.into()),
+            session: ExplicitSession(session),
             cluster: self.cluster,
         }
     }


### PR DESCRIPTION
This is a breaking change, though in most cases I suspect it won't actually break code unless people are truly passing non-`ClientSession` types that are `Into<&mut ClientSession>`. None of the tests in the repo were doing this that I could find.

In any case, not sure if this is a good idea, just want to get some eyes on the issue.