### PR TITLE
RUST-1857 Clean up names for multi-write errors

### DIFF
--- a/src/action/insert_many.rs
+++ b/src/action/insert_many.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::{
     coll::options::InsertManyOptions,
-    error::{BulkWriteError, BulkWriteFailure, Error, ErrorKind, Result},
+    error::{Error, ErrorKind, InsertError, InsertManyError, Result},
     operation::Insert as Op,
     options::WriteConcern,
     results::InsertManyResult,
@@ -105,7 +105,7 @@ impl<'a> Action for InsertMany<'a> {
             .unwrap_or(true);
         let encrypted = self.coll.client().should_auto_encrypt().await;
 
-        let mut cumulative_failure: Option<BulkWriteFailure> = None;
+        let mut cumulative_failure: Option<InsertManyError> = None;
         let mut error_labels: HashSet<String> = Default::default();
         let mut cumulative_result: Option<InsertManyResult> = None;
 
@@ -137,7 +137,7 @@ impl<'a> Action for InsertMany<'a> {
                 Err(e) => {
                     let labels = e.labels().clone();
                     match *e.kind {
-                        ErrorKind::BulkWrite(bw) => {
+                        ErrorKind::InsertMany(bw) => {
                             // for ordered inserts this size will be incorrect, but knowing the
                             // batch size isn't needed for ordered
                             // failures since we return immediately from
@@ -146,7 +146,7 @@ impl<'a> Action for InsertMany<'a> {
                                 + bw.write_errors.as_ref().map(|we| we.len()).unwrap_or(0);
 
                             let failure_ref =
-                                cumulative_failure.get_or_insert_with(BulkWriteFailure::new);
+                                cumulative_failure.get_or_insert_with(InsertManyError::new);
                             if let Some(write_errors) = bw.write_errors {
                                 for err in write_errors {
                                     let index = n_attempted + err.index;
@@ -154,7 +154,7 @@ impl<'a> Action for InsertMany<'a> {
                                     failure_ref
                                         .write_errors
                                         .get_or_insert_with(Default::default)
-                                        .push(BulkWriteError { index, ..err });
+                                        .push(InsertError { index, ..err });
                                 }
                             }
 
@@ -169,7 +169,7 @@ impl<'a> Action for InsertMany<'a> {
                                 // above.
                                 if let Some(failure) = cumulative_failure {
                                     return Err(Error::new(
-                                        ErrorKind::BulkWrite(failure),
+                                        ErrorKind::InsertMany(failure),
                                         Some(error_labels),
                                     ));
                                 }
@@ -184,7 +184,7 @@ impl<'a> Action for InsertMany<'a> {
 
         match cumulative_failure {
             Some(failure) => Err(Error::new(
-                ErrorKind::BulkWrite(failure),
+                ErrorKind::InsertMany(failure),
                 Some(error_labels),
             )),
             None => Ok(cumulative_result.unwrap_or_else(InsertManyResult::new)),

--- a/src/action/insert_many.rs
+++ b/src/action/insert_many.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::{
     coll::options::InsertManyOptions,
-    error::{Error, ErrorKind, InsertError, InsertManyError, Result},
+    error::{Error, ErrorKind, IndexedWriteError, InsertManyError, Result},
     operation::Insert as Op,
     options::WriteConcern,
     results::InsertManyResult,
@@ -154,7 +154,7 @@ impl<'a> Action for InsertMany<'a> {
                                     failure_ref
                                         .write_errors
                                         .get_or_insert_with(Default::default)
-                                        .push(InsertError { index, ..err });
+                                        .push(IndexedWriteError { index, ..err });
                                 }
                             }
 

--- a/src/action/insert_one.rs
+++ b/src/action/insert_one.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::{
     coll::options::{InsertManyOptions, InsertOneOptions},
-    error::{convert_bulk_errors, Result},
+    error::{convert_insert_many_error, Result},
     operation::Insert as Op,
     options::WriteConcern,
     results::InsertOneResult,
@@ -100,6 +100,6 @@ impl<'a> Action for InsertOne<'a> {
             .execute_operation(insert, self.session)
             .await
             .map(InsertOneResult::from_insert_many_result)
-            .map_err(convert_bulk_errors)
+            .map_err(convert_insert_many_error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -830,7 +830,7 @@ impl WriteError {
 /// [`insert_many`](crate::Collection::insert_many) operation.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-pub struct InsertError {
+pub struct IndexedWriteError {
     /// Index into the list of operations that this error corresponds to.
     #[serde(default)]
     pub index: usize,
@@ -855,7 +855,7 @@ pub struct InsertError {
     pub details: Option<Document>,
 }
 
-impl InsertError {
+impl IndexedWriteError {
     // If any new fields are added to InsertError, this implementation must be updated to redact
     // them per the CLAM spec.
     fn redact(&mut self) {
@@ -871,7 +871,7 @@ impl InsertError {
 #[non_exhaustive]
 pub struct InsertManyError {
     /// The error(s) that occurred on account of a non write concern failure.
-    pub write_errors: Option<Vec<InsertError>>,
+    pub write_errors: Option<Vec<IndexedWriteError>>,
 
     /// The error that occurred on account of write concern failure.
     pub write_concern_error: Option<WriteConcernError>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ use crate::{
     sdam::{ServerType, TopologyVersion},
 };
 
-pub use bulk_write::BulkWriteError as ClientBulkWriteError;
+pub use bulk_write::BulkWriteError;
 
 const RECOVERING_CODES: [i32; 5] = [11600, 11602, 13436, 189, 91];
 const NOTWRITABLEPRIMARY_CODES: [i32; 3] = [10107, 13435, 10058];
@@ -195,8 +195,8 @@ impl Error {
     fn is_write_concern_error(&self) -> bool {
         match *self.kind {
             ErrorKind::Write(WriteFailure::WriteConcernError(_)) => true,
-            ErrorKind::BulkWrite(ref bulk_write_error)
-                if bulk_write_error.write_concern_error.is_some() =>
+            ErrorKind::InsertMany(ref insert_many_error)
+                if insert_many_error.write_concern_error.is_some() =>
             {
                 true
             }
@@ -249,7 +249,7 @@ impl Error {
         matches!(
             self.kind.as_ref(),
             ErrorKind::Authentication { .. }
-                | ErrorKind::BulkWrite(_)
+                | ErrorKind::InsertMany(_)
                 | ErrorKind::Command(_)
                 | ErrorKind::Write(_)
         )
@@ -308,7 +308,7 @@ impl Error {
             ErrorKind::Command(command_error) => Some(command_error.code),
             // According to SDAM spec, write concern error codes MUST also be checked, and
             // writeError codes MUST NOT be checked.
-            ErrorKind::BulkWrite(BulkWriteFailure {
+            ErrorKind::InsertMany(InsertManyError {
                 write_concern_error: Some(wc_error),
                 ..
             }) => Some(wc_error.code),
@@ -323,7 +323,7 @@ impl Error {
     pub(crate) fn code(&self) -> Option<i32> {
         match self.kind.as_ref() {
             ErrorKind::Command(command_error) => Some(command_error.code),
-            ErrorKind::BulkWrite(BulkWriteFailure {
+            ErrorKind::InsertMany(InsertManyError {
                 write_concern_error: Some(wc_error),
                 ..
             }) => Some(wc_error.code),
@@ -334,15 +334,15 @@ impl Error {
     }
 
     /// Gets the message for this error, if applicable, for use in testing.
-    /// If this error is a BulkWriteError, the messages are concatenated.
+    /// If this error is an InsertManyError, the messages are concatenated.
     #[cfg(test)]
     pub(crate) fn message(&self) -> Option<String> {
         match self.kind.as_ref() {
             ErrorKind::Command(command_error) => Some(command_error.message.clone()),
             // since this is used primarily for errorMessageContains assertions in the unified
             // runner, we just concatenate all the relevant server messages into one for
-            // bulk errors.
-            ErrorKind::BulkWrite(BulkWriteFailure {
+            // insert many errors.
+            ErrorKind::InsertMany(InsertManyError {
                 write_concern_error,
                 write_errors,
                 inserted_ids: _,
@@ -382,7 +382,7 @@ impl Error {
                 WriteFailure::WriteConcernError(ref wce) => Some(wce.code_name.as_str()),
                 WriteFailure::WriteError(ref we) => we.code_name.as_deref(),
             },
-            ErrorKind::BulkWrite(ref bwe) => bwe
+            ErrorKind::InsertMany(ref bwe) => bwe
                 .write_concern_error
                 .as_ref()
                 .map(|wce| wce.code_name.as_str()),
@@ -481,21 +481,21 @@ impl Error {
         // This is intentionally written without a catch-all branch so that if new error
         // kinds are added we remember to reason about whether they need to be redacted.
         match *self.kind {
-            ErrorKind::BulkWrite(ref mut bwe) => {
-                if let Some(ref mut wes) = bwe.write_errors {
+            ErrorKind::InsertMany(ref mut insert_many_error) => {
+                if let Some(ref mut wes) = insert_many_error.write_errors {
                     for we in wes {
                         we.redact();
                     }
                 }
-                if let Some(ref mut wce) = bwe.write_concern_error {
+                if let Some(ref mut wce) = insert_many_error.write_concern_error {
                     wce.redact();
                 }
             }
-            ErrorKind::ClientBulkWrite(ref mut client_bulk_write_error) => {
-                for write_concern_error in client_bulk_write_error.write_concern_errors.iter_mut() {
+            ErrorKind::BulkWrite(ref mut bulk_write_error) => {
+                for write_concern_error in bulk_write_error.write_concern_errors.iter_mut() {
                     write_concern_error.redact();
                 }
-                for (_, write_error) in client_bulk_write_error.write_errors.iter_mut() {
+                for (_, write_error) in bulk_write_error.write_errors.iter_mut() {
                     write_error.redact();
                 }
             }
@@ -612,12 +612,13 @@ pub enum ErrorKind {
     #[error("{0}")]
     BsonSerialization(crate::bson::ser::Error),
 
-    /// An error occurred when trying to execute a write operation consisting of multiple writes.
-    #[error("An error occurred when trying to execute a write operation: {0:?}")]
-    BulkWrite(BulkWriteFailure),
+    /// An error occurred when trying to execute an [`insert_many`](crate::Collection::insert_many)
+    /// operation.
+    #[error("An error occurred when trying to execute an insert_many operation: {0:?}")]
+    InsertMany(InsertManyError),
 
     #[error("An error occurred when executing Client::bulk_write: {0:?}")]
-    ClientBulkWrite(ClientBulkWriteError),
+    BulkWrite(BulkWriteError),
 
     /// The server returned an error to an attempted operation.
     #[error("Command failed: {0}")]
@@ -706,7 +707,7 @@ impl ErrorKind {
     // TODO CLOUDP-105256 Remove this when Atlas Proxy error label behavior is fixed.
     fn get_write_concern_error(&self) -> Option<&WriteConcernError> {
         match self {
-            ErrorKind::BulkWrite(BulkWriteFailure {
+            ErrorKind::InsertMany(InsertManyError {
                 write_concern_error,
                 ..
             }) => write_concern_error.as_ref(),
@@ -825,11 +826,11 @@ impl WriteError {
     }
 }
 
-/// An error that occurred during a write operation consisting of multiple writes that wasn't due to
-/// being unable to satisfy a write concern.
+/// An individual write error that occurred during an
+/// [`insert_many`](crate::Collection::insert_many) operation.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
-pub struct BulkWriteError {
+pub struct InsertError {
     /// Index into the list of operations that this error corresponds to.
     #[serde(default)]
     pub index: usize,
@@ -854,8 +855,8 @@ pub struct BulkWriteError {
     pub details: Option<Document>,
 }
 
-impl BulkWriteError {
-    // If any new fields are added to BulkWriteError, this implementation must be updated to redact
+impl InsertError {
+    // If any new fields are added to InsertError, this implementation must be updated to redact
     // them per the CLAM spec.
     fn redact(&mut self) {
         self.message = "REDACTED".to_string();
@@ -863,13 +864,14 @@ impl BulkWriteError {
     }
 }
 
-/// The set of errors that occurred during a write operation.
+/// The set of errors that occurred during a call to
+/// [`insert_many`](crate::Collection::insert_many).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct BulkWriteFailure {
+pub struct InsertManyError {
     /// The error(s) that occurred on account of a non write concern failure.
-    pub write_errors: Option<Vec<BulkWriteError>>,
+    pub write_errors: Option<Vec<InsertError>>,
 
     /// The error that occurred on account of write concern failure.
     pub write_concern_error: Option<WriteConcernError>,
@@ -878,9 +880,9 @@ pub struct BulkWriteFailure {
     pub(crate) inserted_ids: HashMap<usize, Bson>,
 }
 
-impl BulkWriteFailure {
+impl InsertManyError {
     pub(crate) fn new() -> Self {
-        BulkWriteFailure {
+        InsertManyError {
             write_errors: None,
             write_concern_error: None,
             inserted_ids: Default::default(),
@@ -901,13 +903,13 @@ pub enum WriteFailure {
 }
 
 impl WriteFailure {
-    fn from_bulk_failure(bulk: BulkWriteFailure) -> Result<Self> {
-        if let Some(bulk_write_error) = bulk.write_errors.and_then(|es| es.into_iter().next()) {
+    fn from_insert_many_error(bulk: InsertManyError) -> Result<Self> {
+        if let Some(insert_error) = bulk.write_errors.and_then(|es| es.into_iter().next()) {
             let write_error = WriteError {
-                code: bulk_write_error.code,
-                code_name: bulk_write_error.code_name,
-                message: bulk_write_error.message,
-                details: bulk_write_error.details,
+                code: insert_error.code,
+                code_name: insert_error.code_name,
+                message: insert_error.message,
+                details: insert_error.details,
             };
             Ok(WriteFailure::WriteError(write_error))
         } else if let Some(wc_error) = bulk.write_concern_error {
@@ -993,14 +995,15 @@ pub enum GridFsFileIdentifier {
     Id(Bson),
 }
 
-/// Translates ErrorKind::BulkWriteError cases to ErrorKind::WriteErrors, leaving all other errors
-/// untouched.
-pub(crate) fn convert_bulk_errors(error: Error) -> Error {
+/// Translates ErrorKind::InsertMany to ErrorKind::Write, leaving all other errors untouched.
+pub(crate) fn convert_insert_many_error(error: Error) -> Error {
     match *error.kind {
-        ErrorKind::BulkWrite(bulk_failure) => match WriteFailure::from_bulk_failure(bulk_failure) {
-            Ok(failure) => Error::new(ErrorKind::Write(failure), Some(error.labels)),
-            Err(e) => e,
-        },
+        ErrorKind::InsertMany(insert_many_error) => {
+            match WriteFailure::from_insert_many_error(insert_many_error) {
+                Ok(failure) => Error::new(ErrorKind::Write(failure), Some(error.labels)),
+                Err(e) => e,
+            }
+        }
         _ => error,
     }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -42,11 +42,11 @@ use crate::{
         StreamDescription,
     },
     error::{
-        BulkWriteError,
-        BulkWriteFailure,
         CommandError,
         Error,
         ErrorKind,
+        InsertError,
+        InsertManyError,
         Result,
         WriteConcernError,
         WriteFailure,
@@ -441,7 +441,7 @@ pub(crate) struct WriteResponseBody<T = SingleWriteBody> {
     body: T,
 
     #[serde(rename = "writeErrors")]
-    write_errors: Option<Vec<BulkWriteError>>,
+    write_errors: Option<Vec<InsertError>>,
 
     #[serde(rename = "writeConcernError")]
     write_concern_error: Option<WriteConcernError>,
@@ -456,14 +456,14 @@ impl<T> WriteResponseBody<T> {
             return Ok(());
         };
 
-        let failure = BulkWriteFailure {
+        let failure = InsertManyError {
             write_errors: self.write_errors.clone(),
             write_concern_error: self.write_concern_error.clone(),
             inserted_ids: Default::default(),
         };
 
         Err(Error::new(
-            ErrorKind::BulkWrite(failure),
+            ErrorKind::InsertMany(failure),
             self.labels.clone(),
         ))
     }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -45,7 +45,7 @@ use crate::{
         CommandError,
         Error,
         ErrorKind,
-        InsertError,
+        IndexedWriteError,
         InsertManyError,
         Result,
         WriteConcernError,
@@ -441,7 +441,7 @@ pub(crate) struct WriteResponseBody<T = SingleWriteBody> {
     body: T,
 
     #[serde(rename = "writeErrors")]
-    write_errors: Option<Vec<InsertError>>,
+    write_errors: Option<Vec<IndexedWriteError>>,
 
     #[serde(rename = "writeConcernError")]
     write_concern_error: Option<WriteConcernError>,

--- a/src/operation/delete.rs
+++ b/src/operation/delete.rs
@@ -3,7 +3,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::Namespace,
     collation::Collation,
-    error::{convert_bulk_errors, Result},
+    error::{convert_insert_many_error, Result},
     operation::{
         append_options,
         remove_empty_write_concern,
@@ -87,7 +87,7 @@ impl OperationWithDefaults for Delete {
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
         let response: WriteResponseBody = response.body()?;
-        response.validate().map_err(convert_bulk_errors)?;
+        response.validate().map_err(convert_insert_many_error)?;
 
         Ok(DeleteResult {
             deleted_count: response.n,

--- a/src/operation/insert.rs
+++ b/src/operation/insert.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     checked::Checked,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    error::{BulkWriteFailure, Error, ErrorKind, Result},
+    error::{Error, ErrorKind, InsertManyError, Result},
     operation::{OperationWithDefaults, Retryability, WriteResponseBody},
     options::{InsertManyOptions, WriteConcern},
     results::InsertManyResult,
@@ -157,7 +157,7 @@ impl<'a> OperationWithDefaults for Insert<'a> {
 
         if response.write_errors.is_some() || response.write_concern_error.is_some() {
             return Err(Error::new(
-                ErrorKind::BulkWrite(BulkWriteFailure {
+                ErrorKind::InsertMany(InsertManyError {
                     write_errors: response.write_errors,
                     write_concern_error: response.write_concern_error,
                     inserted_ids: map,

--- a/src/operation/update.rs
+++ b/src/operation/update.rs
@@ -4,7 +4,7 @@ use crate::{
     bson::{doc, rawdoc, Document, RawArrayBuf, RawBson, RawDocumentBuf},
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    error::{convert_bulk_errors, Result},
+    error::{convert_insert_many_error, Result},
     operation::{OperationWithDefaults, Retryability, WriteResponseBody},
     options::{UpdateModifications, UpdateOptions, WriteConcern},
     results::UpdateResult,
@@ -165,7 +165,7 @@ impl OperationWithDefaults for Update {
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
         let response: WriteResponseBody<UpdateBody> = response.body_utf8_lossy()?;
-        response.validate().map_err(convert_bulk_errors)?;
+        response.validate().map_err(convert_insert_many_error)?;
 
         let modified_count = response.n_modified;
         let upserted_id = response

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -9,7 +9,7 @@ use crate::{
     bson::{doc, oid::ObjectId},
     client::Client,
     cmap::{conn::ConnectionGeneration, PoolGeneration},
-    error::{BulkWriteFailure, CommandError, Error, ErrorKind},
+    error::{CommandError, Error, ErrorKind, InsertManyError},
     event::sdam::SdamEvent,
     hello::{HelloCommandResponse, HelloReply, LastWrite, LEGACY_HELLO_COMMAND_NAME},
     options::{ClientOptions, ReadPreference, SelectionCriteria, ServerAddress},
@@ -175,14 +175,14 @@ pub enum ErrorType {
 #[serde(untagged)]
 pub enum ServerError {
     CommandError(CommandError),
-    WriteError(BulkWriteFailure),
+    WriteError(InsertManyError),
 }
 
 impl From<ServerError> for Error {
     fn from(server_error: ServerError) -> Self {
         match server_error {
             ServerError::CommandError(command_error) => ErrorKind::Command(command_error).into(),
-            ServerError::WriteError(bwf) => ErrorKind::BulkWrite(bwf).into(),
+            ServerError::WriteError(bwf) => ErrorKind::InsertMany(bwf).into(),
         }
     }
 }

--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -1,6 +1,6 @@
 use crate::{
     bson::{doc, Document},
-    error::{ClientBulkWriteError, ErrorKind},
+    error::{BulkWriteError, ErrorKind},
     options::WriteModel,
     test::{
         get_client_options,
@@ -137,7 +137,7 @@ async fn write_concern_error_batches() {
     ];
     let error = client.bulk_write(models).ordered(false).await.unwrap_err();
 
-    let ErrorKind::ClientBulkWrite(bulk_write_error) = *error.kind else {
+    let ErrorKind::BulkWrite(bulk_write_error) = *error.kind else {
         panic!("Expected bulk write error, got {:?}", error);
     };
 
@@ -184,7 +184,7 @@ async fn write_error_batches() {
         .await
         .unwrap_err();
 
-    let ErrorKind::ClientBulkWrite(bulk_write_error) = *error.kind else {
+    let ErrorKind::BulkWrite(bulk_write_error) = *error.kind else {
         panic!("Expected bulk write error, got {:?}", error);
     };
 
@@ -200,7 +200,7 @@ async fn write_error_batches() {
 
     let error = client.bulk_write(models).ordered(true).await.unwrap_err();
 
-    let ErrorKind::ClientBulkWrite(bulk_write_error) = *error.kind else {
+    let ErrorKind::BulkWrite(bulk_write_error) = *error.kind else {
         panic!("Expected bulk write error, got {:?}", error);
     };
 
@@ -371,7 +371,7 @@ async fn failed_cursor_iteration() {
     };
     assert_eq!(source.code(), Some(8));
 
-    let ErrorKind::ClientBulkWrite(ClientBulkWriteError {
+    let ErrorKind::BulkWrite(BulkWriteError {
         partial_result: Some(partial_result),
         ..
     }) = *error.kind

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -431,7 +431,7 @@ async fn large_insert_unordered_with_errors() {
         .expect_err("should get error")
         .kind
     {
-        ErrorKind::BulkWrite(ref failure) => {
+        ErrorKind::InsertMany(ref failure) => {
             let mut write_errors = failure
                 .write_errors
                 .clone()
@@ -469,7 +469,7 @@ async fn large_insert_ordered_with_errors() {
         .expect_err("should get error")
         .kind
     {
-        ErrorKind::BulkWrite(ref failure) => {
+        ErrorKind::InsertMany(ref failure) => {
             let write_errors = failure
                 .write_errors
                 .clone()
@@ -1095,7 +1095,7 @@ fn assert_duplicate_key_error_with_utf8_replacement(error: &ErrorKind) {
             }
             e => panic!("expected WriteFailure::WriteError, got {:?} instead", e),
         },
-        ErrorKind::BulkWrite(ref failure) => match &failure.write_errors {
+        ErrorKind::InsertMany(ref failure) => match &failure.write_errors {
             Some(write_errors) => {
                 assert_eq!(write_errors.len(), 1);
                 assert_eq!(write_errors[0].code, 11000);

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -7,7 +7,7 @@ use crate::{
         CommandError,
         Error,
         ErrorKind,
-        InsertError,
+        IndexedWriteError,
         InsertManyError,
         WriteConcernError,
         WriteError,
@@ -265,7 +265,7 @@ fn error_redaction() {
                 ..
             }) => {
                 if let Some(write_errors) = write_errors {
-                    for InsertError {
+                    for IndexedWriteError {
                         code,
                         code_name,
                         message,
@@ -335,7 +335,7 @@ fn error_redaction() {
 
     let mut bulk_write_error = Error::new(
         ErrorKind::InsertMany(InsertManyError {
-            write_errors: Some(vec![InsertError {
+            write_errors: Some(vec![IndexedWriteError {
                 index: 0,
                 code: 123,
                 code_name: Some("CodeName".to_string()),

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -4,11 +4,11 @@ use crate::{
     bson::{doc, Document},
     client::options::ServerAddress,
     error::{
-        BulkWriteError,
-        BulkWriteFailure,
         CommandError,
         Error,
         ErrorKind,
+        InsertError,
+        InsertManyError,
         WriteConcernError,
         WriteError,
         WriteFailure,
@@ -259,13 +259,13 @@ fn error_redaction() {
                     assert_on_properties(code, code_name.unwrap(), message, details);
                 }
             },
-            ErrorKind::BulkWrite(BulkWriteFailure {
+            ErrorKind::InsertMany(InsertManyError {
                 write_errors,
                 write_concern_error,
                 ..
             }) => {
                 if let Some(write_errors) = write_errors {
-                    for BulkWriteError {
+                    for InsertError {
                         code,
                         code_name,
                         message,
@@ -334,8 +334,8 @@ fn error_redaction() {
     assert_is_redacted(write_error);
 
     let mut bulk_write_error = Error::new(
-        ErrorKind::BulkWrite(BulkWriteFailure {
-            write_errors: Some(vec![BulkWriteError {
+        ErrorKind::InsertMany(InsertManyError {
+            write_errors: Some(vec![InsertError {
                 index: 0,
                 code: 123,
                 code_name: Some("CodeName".to_string()),

--- a/src/test/spec/unified_runner/test_file.rs
+++ b/src/test/spec/unified_runner/test_file.rs
@@ -15,7 +15,7 @@ use crate::{
     bson::{doc, Bson, Deserializer as BsonDeserializer, Document},
     client::options::{ServerApi, ServerApiVersion},
     concern::{Acknowledgment, ReadConcernLevel},
-    error::{ClientBulkWriteError, Error, ErrorKind},
+    error::{BulkWriteError, Error, ErrorKind},
     gridfs::options::GridFsBucketOptions,
     options::{
         ClientOptions,
@@ -540,7 +540,7 @@ impl ExpectError {
 
         if let Some(ref expected_result) = self.expect_result {
             let actual_result = match *error.kind {
-                ErrorKind::ClientBulkWrite(ClientBulkWriteError {
+                ErrorKind::BulkWrite(BulkWriteError {
                     partial_result: Some(ref partial_result),
                     ..
                 }) => Some(
@@ -554,7 +554,7 @@ impl ExpectError {
         }
 
         if let Some(ref write_errors) = self.write_errors {
-            let ErrorKind::ClientBulkWrite(ClientBulkWriteError {
+            let ErrorKind::BulkWrite(BulkWriteError {
                 write_errors: ref actual_write_errors,
                 ..
             }) = *error.kind
@@ -572,7 +572,7 @@ impl ExpectError {
         }
 
         if let Some(ref write_concern_errors) = self.write_concern_errors {
-            let ErrorKind::ClientBulkWrite(ClientBulkWriteError {
+            let ErrorKind::BulkWrite(BulkWriteError {
                 write_concern_errors: ref actual_write_concern_errors,
                 ..
             }) = *error.kind


### PR DESCRIPTION
Main changes here:
- `ErrorKind::BulkWrite` -> `ErrorKind::InsertMany`
- `BulkWriteFailure` -> `InsertManyError`
- `BulkWriteError` -> `IndexedWriteError`
- `ErrorKind::ClientBulkWrite` -> `ErrorKind::BulkWrite`
- `ClientBulkWriteError` -> `BulkWriteError`

The first three changes were on types only used for the `insert_many` API.