### PR TITLE
RUST-1827 remove generic parameter to `Command`

### DIFF
--- a/src/bson_util.rs
+++ b/src/bson_util.rs
@@ -182,9 +182,9 @@ pub(crate) fn extend_raw_document_buf(
     this: &mut RawDocumentBuf,
     other: RawDocumentBuf,
 ) -> Result<()> {
-    let mut keys: HashSet<&str> = HashSet::new();
+    let mut keys: HashSet<String> = HashSet::new();
     for elem in this.iter_elements() {
-        keys.insert(elem?.key());
+        keys.insert(elem?.key().to_owned());
     }
     for result in other.iter() {
         let (k, v) = result?;

--- a/src/bson_util.rs
+++ b/src/bson_util.rs
@@ -76,16 +76,6 @@ pub(crate) fn to_raw_bson_array_ser<T: Serialize>(values: &[T]) -> Result<RawBso
     Ok(RawBson::Array(array))
 }
 
-#[cfg(test)]
-pub(crate) fn sort_document(document: &mut Document) {
-    let temp = std::mem::take(document);
-
-    let mut elements: Vec<_> = temp.into_iter().collect();
-    elements.sort_by(|e1, e2| e1.0.cmp(&e2.0));
-
-    document.extend(elements);
-}
-
 pub(crate) fn first_key(document: &Document) -> Option<&str> {
     document.keys().next().map(String::as_str)
 }

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -14,6 +14,7 @@ mod x509;
 
 use std::{borrow::Cow, fmt::Debug, str::FromStr};
 
+use bson::RawDocumentBuf;
 use derivative::Derivative;
 use hmac::{digest::KeyInit, Mac};
 use rand::Rng;
@@ -509,9 +510,9 @@ impl Credential {
 
     /// If the mechanism is missing, append the appropriate mechanism negotiation key-value-pair to
     /// the provided hello or legacy hello command document.
-    pub(crate) fn append_needed_mechanism_negotiation(&self, command: &mut Document) {
+    pub(crate) fn append_needed_mechanism_negotiation(&self, command: &mut RawDocumentBuf) {
         if let (Some(username), None) = (self.username.as_ref(), self.mechanism.as_ref()) {
-            command.insert(
+            command.append(
                 "saslSupportedMechs",
                 format!("{}.{}", self.resolved_source(), username),
             );
@@ -613,7 +614,7 @@ pub(crate) enum ClientFirst {
 }
 
 impl ClientFirst {
-    pub(crate) fn to_document(&self) -> Document {
+    pub(crate) fn to_document(&self) -> RawDocumentBuf {
         match self {
             Self::Scram(version, client_first) => client_first.to_command(version).body,
             Self::X509(command) => command.body.clone(),

--- a/src/client/auth/oidc.rs
+++ b/src/client/auth/oidc.rs
@@ -401,7 +401,7 @@ fn make_spec_auth_command(
     payload: Vec<u8>,
     server_api: Option<&ServerApi>,
 ) -> Command {
-    let body = doc! {
+    let body = rawdoc! {
         "saslStart": 1,
         "mechanism": MONGODB_OIDC_STR,
         "payload": Binary { subtype: BinarySubtype::Generic, bytes: payload },

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -460,7 +460,7 @@ impl ClientFirst {
         let mut cmd = sasl_start.into_command();
 
         if self.include_db {
-            cmd.body.insert("db", self.source.clone());
+            cmd.body.append("db", self.source.clone());
         }
 
         cmd

--- a/src/client/auth/x509.rs
+++ b/src/client/auth/x509.rs
@@ -1,5 +1,7 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
+    bson::Document,
     client::options::ServerApi,
     cmap::{Command, Connection, RawCommandResponse},
     error::{Error, Result},
@@ -16,13 +18,13 @@ pub(crate) fn build_client_first(
     credential: &Credential,
     server_api: Option<&ServerApi>,
 ) -> Command {
-    let mut auth_command_doc = doc! {
+    let mut auth_command_doc = rawdoc! {
         "authenticate": 1,
         "mechanism": "MONGODB-X509",
     };
 
     if let Some(ref username) = credential.username {
-        auth_command_doc.insert("username", username);
+        auth_command_doc.append("username", username.as_str());
     }
 
     let mut command = Command::new("authenticate", "$external", auth_command_doc);

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -17,10 +17,7 @@ use crate::{
 #[serde_with::skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct Command<T = Document>
-where
-    T: Serialize,
-{
+pub(crate) struct Command {
     #[serde(skip)]
     pub(crate) name: String,
 
@@ -28,7 +25,7 @@ where
     pub(crate) exhaust_allowed: bool,
 
     #[serde(flatten)]
-    pub(crate) body: T,
+    pub(crate) body: RawDocumentBuf,
 
     #[serde(skip)]
     pub(crate) document_sequences: Vec<DocumentSequence>,
@@ -58,11 +55,8 @@ where
     recovery_token: Option<Document>,
 }
 
-impl<T> Command<T>
-where
-    T: Serialize,
-{
-    pub(crate) fn new(name: impl ToString, target_db: impl ToString, body: T) -> Self {
+impl Command {
+    pub(crate) fn new(name: impl ToString, target_db: impl ToString, body: RawDocumentBuf) -> Self {
         Self {
             name: name.to_string(),
             target_db: target_db.to_string(),
@@ -85,7 +79,7 @@ where
         name: String,
         target_db: String,
         read_concern: Option<ReadConcern>,
-        body: T,
+        body: RawDocumentBuf,
     ) -> Self {
         Self {
             name,

--- a/src/cmap/conn/wire/message.rs
+++ b/src/cmap/conn/wire/message.rs
@@ -2,7 +2,6 @@ use std::io::Read;
 
 use bitflags::bitflags;
 use bson::{doc, Array, Document};
-use serde::Serialize;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[cfg(any(
@@ -48,10 +47,7 @@ pub(crate) struct DocumentSequence {
 impl Message {
     /// Creates a `Message` from a given `Command`. Note that the `response_to` field must be set
     /// manually.
-    pub(crate) fn from_command<T: Serialize>(
-        command: Command<T>,
-        request_id: Option<i32>,
-    ) -> Result<Self> {
+    pub(crate) fn from_command(command: Command, request_id: Option<i32>) -> Result<Self> {
         let document_payload = bson::to_raw_document_buf(&command)?;
 
         let mut flags = MessageFlags::empty();

--- a/src/cmap/establish/handshake/test.rs
+++ b/src/cmap/establish/handshake/test.rs
@@ -1,5 +1,9 @@
+use std::ops::Deref;
+
+use bson::rawdoc;
+
 use super::Handshaker;
-use crate::{bson::doc, cmap::establish::handshake::HandshakerOptions, options::DriverInfo};
+use crate::{cmap::establish::handshake::HandshakerOptions, options::DriverInfo};
 
 #[test]
 fn metadata_no_options() {
@@ -17,10 +21,16 @@ fn metadata_no_options() {
     });
 
     let metadata = handshaker.command.body.get_document("client").unwrap();
-    assert!(!metadata.contains_key("application"));
+    assert!(!matches!(metadata.get("application"), Ok(Some(_))));
 
     let driver = metadata.get_document("driver").unwrap();
-    assert_eq!(driver.keys().collect::<Vec<_>>(), vec!["name", "version"]);
+    assert_eq!(
+        driver
+            .iter_elements()
+            .map(|e| e.unwrap().key())
+            .collect::<Vec<_>>(),
+        vec!["name", "version"]
+    );
     assert_eq!(driver.get_str("name"), Ok("mongo-rust-driver"));
     assert_eq!(driver.get_str("version"), Ok(env!("CARGO_PKG_VERSION")));
 
@@ -58,11 +68,17 @@ fn metadata_with_options() {
     let metadata = handshaker.command.body.get_document("client").unwrap();
     assert_eq!(
         metadata.get_document("application"),
-        Ok(&doc! { "name": app_name })
+        Ok(rawdoc! { "name": app_name }.deref())
     );
 
     let driver = metadata.get_document("driver").unwrap();
-    assert_eq!(driver.keys().collect::<Vec<_>>(), vec!["name", "version"]);
+    assert_eq!(
+        driver
+            .iter_elements()
+            .map(|e| e.unwrap().key())
+            .collect::<Vec<_>>(),
+        vec!["name", "version"]
+    );
     assert_eq!(
         driver.get_str("name"),
         Ok(format!("mongo-rust-driver|{}", name).as_str())

--- a/src/cmap/establish/handshake/test.rs
+++ b/src/cmap/establish/handshake/test.rs
@@ -5,8 +5,8 @@ use bson::rawdoc;
 use super::Handshaker;
 use crate::{cmap::establish::handshake::HandshakerOptions, options::DriverInfo};
 
-#[test]
-fn metadata_no_options() {
+#[tokio::test]
+async fn metadata_no_options() {
     let handshaker = Handshaker::new(HandshakerOptions {
         app_name: None,
         #[cfg(any(
@@ -20,7 +20,8 @@ fn metadata_no_options() {
         load_balanced: false,
     });
 
-    let metadata = handshaker.command.body.get_document("client").unwrap();
+    let command = handshaker.build_command(None).await.unwrap().0;
+    let metadata = command.body.get_document("client").unwrap();
     assert!(!matches!(metadata.get("application"), Ok(Some(_))));
 
     let driver = metadata.get_document("driver").unwrap();
@@ -39,8 +40,8 @@ fn metadata_no_options() {
     assert_eq!(os.get_str("architecture"), Ok(std::env::consts::ARCH));
 }
 
-#[test]
-fn metadata_with_options() {
+#[tokio::test]
+async fn metadata_with_options() {
     let app_name = "myspace 2.0";
     let name = "even better Rust driver";
     let version = "the best version, of course";
@@ -64,8 +65,8 @@ fn metadata_with_options() {
     };
 
     let handshaker = Handshaker::new(options);
-
-    let metadata = handshaker.command.body.get_document("client").unwrap();
+    let command = handshaker.build_command(None).await.unwrap().0;
+    let metadata = command.body.get_document("client").unwrap();
     assert_eq!(
         metadata.get_document("application"),
         Ok(rawdoc! { "name": app_name }.deref())

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -1,3 +1,4 @@
+use bson::rawdoc;
 use serde::Deserialize;
 
 use super::EVENT_TIMEOUT;
@@ -54,7 +55,7 @@ async fn acquire_connection_and_send_command() {
     );
     let mut connection = pool.check_out().await.unwrap();
 
-    let body = doc! { "listDatabases": 1 };
+    let body = rawdoc! { "listDatabases": 1 };
     let read_pref = ReadPreference::PrimaryPreferred {
         options: Default::default(),
     };

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -294,12 +294,6 @@ where
     }
 }
 
-pub(crate) trait CommandBody: Serialize {
-    fn should_redact(&self) -> bool {
-        false
-    }
-}
-
 fn should_redact_body(body: &RawDocumentBuf) -> bool {
     if let Some(Ok((command_name, _))) = body.into_iter().next() {
         HELLO_COMMAND_NAMES.contains(command_name.to_lowercase().as_str())

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -104,15 +104,12 @@ pub(crate) trait Operation {
     /// The output type of this operation.
     type O;
 
-    /// The format of the command body constructed in `build`.
-    type Command: CommandBody;
-
     /// The name of the server side command associated with this operation.
     const NAME: &'static str;
 
     /// Returns the command that should be sent to the server as part of this operation.
     /// The operation may store some additional state that is required for handling the response.
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>>;
+    fn build(&mut self, description: &StreamDescription) -> Result<Command>;
 
     /// Parse the response for the atClusterTime field.
     /// Depending on the operation, this may be found in different locations.
@@ -161,15 +158,12 @@ pub(crate) trait OperationWithDefaults: Send + Sync {
     /// The output type of this operation.
     type O;
 
-    /// The format of the command body constructed in `build`.
-    type Command: CommandBody;
-
     /// The name of the server side command associated with this operation.
     const NAME: &'static str;
 
     /// Returns the command that should be sent to the server as part of this operation.
     /// The operation may store some additional state that is required for handling the response.
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>>;
+    fn build(&mut self, description: &StreamDescription) -> Result<Command>;
 
     /// Parse the response for the atClusterTime field.
     /// Depending on the operation, this may be found in different locations.
@@ -254,9 +248,8 @@ where
     T: Send + Sync,
 {
     type O = T::O;
-    type Command = T::Command;
     const NAME: &'static str = T::NAME;
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         self.build(description)
     }
     fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
@@ -307,32 +300,19 @@ pub(crate) trait CommandBody: Serialize {
     }
 }
 
-impl CommandBody for Document {
-    fn should_redact(&self) -> bool {
-        if let Some(command_name) = bson_util::first_key(self) {
-            HELLO_COMMAND_NAMES.contains(command_name.to_lowercase().as_str())
-                && self.contains_key("speculativeAuthenticate")
-        } else {
-            false
-        }
+fn should_redact_body(body: &RawDocumentBuf) -> bool {
+    if let Some(Ok((command_name, _))) = body.into_iter().next() {
+        HELLO_COMMAND_NAMES.contains(command_name.to_lowercase().as_str())
+            && body.get("speculativeAuthenticate").ok().flatten().is_some()
+    } else {
+        false
     }
 }
 
-impl CommandBody for RawDocumentBuf {
-    fn should_redact(&self) -> bool {
-        if let Some(Ok((command_name, _))) = self.into_iter().next() {
-            HELLO_COMMAND_NAMES.contains(command_name.to_lowercase().as_str())
-                && self.get("speculativeAuthenticate").ok().flatten().is_some()
-        } else {
-            false
-        }
-    }
-}
-
-impl<T: CommandBody> Command<T> {
+impl Command {
     pub(crate) fn should_redact(&self) -> bool {
         let name = self.name.to_lowercase();
-        REDACTED_COMMANDS.contains(name.as_str()) || self.body.should_redact()
+        REDACTED_COMMANDS.contains(name.as_str()) || should_redact_body(&self.body)
     }
 
     pub(crate) fn should_compress(&self) -> bool {

--- a/src/operation/abort_transaction.rs
+++ b/src/operation/abort_transaction.rs
@@ -37,7 +37,7 @@ impl OperationWithDefaults for AbortTransaction {
         };
         if let Some(ref write_concern) = self.write_concern() {
             if !write_concern.is_empty() {
-                append_ser(&mut body, "writeConcern", write_concern);
+                append_ser(&mut body, "writeConcern", write_concern)?;
             }
         }
 

--- a/src/operation/abort_transaction.rs
+++ b/src/operation/abort_transaction.rs
@@ -1,5 +1,7 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
+    bson_util::append_ser,
     client::session::TransactionPin,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::Result,
@@ -26,17 +28,16 @@ impl AbortTransaction {
 
 impl OperationWithDefaults for AbortTransaction {
     type O = ();
-    type Command = Document;
 
     const NAME: &'static str = "abortTransaction";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: 1,
         };
         if let Some(ref write_concern) = self.write_concern() {
             if !write_concern.is_empty() {
-                body.insert("writeConcern", bson::to_bson(write_concern)?);
+                append_ser(&mut body, "writeConcern", write_concern);
             }
         }
 

--- a/src/operation/aggregate.rs
+++ b/src/operation/aggregate.rs
@@ -45,7 +45,6 @@ impl Aggregate {
 // the equivalent delegations.
 impl OperationWithDefaults for Aggregate {
     type O = CursorSpecification;
-    type Command = Document;
 
     const NAME: &'static str = "aggregate";
 
@@ -69,7 +68,7 @@ impl OperationWithDefaults for Aggregate {
             Self::NAME.to_string(),
             self.target.db_name().to_string(),
             self.options.as_ref().and_then(|o| o.read_concern.clone()),
-            body,
+            (&body).try_into()?,
         ))
     }
 

--- a/src/operation/aggregate/change_stream.rs
+++ b/src/operation/aggregate/change_stream.rs
@@ -41,7 +41,6 @@ impl ChangeStreamAggregate {
 
 impl OperationWithDefaults for ChangeStreamAggregate {
     type O = (CursorSpecification, ChangeStreamData);
-    type Command = Document;
 
     const NAME: &'static str = "aggregate";
 

--- a/src/operation/bulk_write.rs
+++ b/src/operation/bulk_write.rs
@@ -171,11 +171,9 @@ where
 {
     type O = R;
 
-    type Command = RawDocumentBuf;
-
     const NAME: &'static str = "bulkWrite";
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         let max_message_size: usize =
             Checked::new(description.max_message_size_bytes).try_into()?;
         let max_operations: usize = Checked::new(description.max_write_batch_size).try_into()?;

--- a/src/operation/commit_transaction.rs
+++ b/src/operation/commit_transaction.rs
@@ -1,11 +1,16 @@
 use std::time::Duration;
 
-use bson::{doc, Document};
+use bson::rawdoc;
 
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, OperationWithDefaults, Retryability},
+    operation::{
+        append_options_to_raw_document,
+        remove_empty_write_concern,
+        OperationWithDefaults,
+        Retryability,
+    },
     options::{Acknowledgment, TransactionOptions, WriteConcern},
 };
 
@@ -23,17 +28,16 @@ impl CommitTransaction {
 
 impl OperationWithDefaults for CommitTransaction {
     type O = ();
-    type Command = Document;
 
     const NAME: &'static str = "commitTransaction";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: 1,
         };
 
         remove_empty_write_concern!(self.options);
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(
             Self::NAME.to_string(),

--- a/src/operation/count.rs
+++ b/src/operation/count.rs
@@ -1,15 +1,16 @@
+use bson::rawdoc;
 use serde::Deserialize;
 
 use crate::{
-    bson::{doc, Document},
+    bson::doc,
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::{options::EstimatedDocumentCountOptions, Namespace},
     error::{Error, Result},
-    operation::{append_options, OperationWithDefaults, Retryability},
+    operation::{OperationWithDefaults, Retryability},
     selection_criteria::SelectionCriteria,
 };
 
-use super::ExecutionContext;
+use super::{append_options_to_raw_document, ExecutionContext};
 
 pub(crate) struct Count {
     ns: Namespace,
@@ -24,16 +25,15 @@ impl Count {
 
 impl OperationWithDefaults for Count {
     type O = u64;
-    type Command = Document;
 
     const NAME: &'static str = "count";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: self.ns.coll.clone(),
         };
 
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new_read(
             Self::NAME.to_string(),

--- a/src/operation/count_documents.rs
+++ b/src/operation/count_documents.rs
@@ -76,7 +76,6 @@ impl CountDocuments {
 
 impl OperationWithDefaults for CountDocuments {
     type O = u64;
-    type Command = Document;
 
     const NAME: &'static str = Aggregate::NAME;
 

--- a/src/operation/create.rs
+++ b/src/operation/create.rs
@@ -1,9 +1,10 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
     operation::{
-        append_options,
+        append_options_to_raw_document,
         remove_empty_write_concern,
         OperationWithDefaults,
         WriteConcernOnlyBody,
@@ -28,17 +29,16 @@ impl Create {
 
 impl OperationWithDefaults for Create {
     type O = ();
-    type Command = Document;
 
     const NAME: &'static str = "create";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: self.ns.coll.clone(),
         };
 
         remove_empty_write_concern!(self.options);
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(
             Self::NAME.to_string(),

--- a/src/operation/delete.rs
+++ b/src/operation/delete.rs
@@ -47,7 +47,6 @@ impl Delete {
 
 impl OperationWithDefaults for Delete {
     type O = DeleteResult;
-    type Command = Document;
 
     const NAME: &'static str = "delete";
 
@@ -77,7 +76,7 @@ impl OperationWithDefaults for Delete {
         Ok(Command::new(
             Self::NAME.to_string(),
             self.ns.db.clone(),
-            body,
+            (&body).try_into()?,
         ))
     }
 

--- a/src/operation/drop_collection.rs
+++ b/src/operation/drop_collection.rs
@@ -1,9 +1,10 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
     operation::{
-        append_options,
+        append_options_to_raw_document,
         remove_empty_write_concern,
         OperationWithDefaults,
         WriteConcernOnlyBody,
@@ -28,17 +29,16 @@ impl DropCollection {
 
 impl OperationWithDefaults for DropCollection {
     type O = ();
-    type Command = Document;
 
     const NAME: &'static str = "drop";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: self.ns.coll.clone(),
         };
 
         remove_empty_write_concern!(self.options);
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(
             Self::NAME.to_string(),

--- a/src/operation/drop_database.rs
+++ b/src/operation/drop_database.rs
@@ -1,10 +1,11 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::DropDatabaseOptions,
     error::Result,
     operation::{
-        append_options,
+        append_options_to_raw_document,
         remove_empty_write_concern,
         OperationWithDefaults,
         WriteConcernOnlyBody,
@@ -28,17 +29,16 @@ impl DropDatabase {
 
 impl OperationWithDefaults for DropDatabase {
     type O = ();
-    type Command = Document;
 
     const NAME: &'static str = "dropDatabase";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: 1,
         };
 
         remove_empty_write_concern!(self.options);
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(
             Self::NAME.to_string(),

--- a/src/operation/drop_indexes.rs
+++ b/src/operation/drop_indexes.rs
@@ -1,8 +1,13 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options, remove_empty_write_concern, OperationWithDefaults},
+    operation::{
+        append_options_to_raw_document,
+        remove_empty_write_concern,
+        OperationWithDefaults,
+    },
     options::{DropIndexOptions, WriteConcern},
     Namespace,
 };
@@ -23,17 +28,16 @@ impl DropIndexes {
 
 impl OperationWithDefaults for DropIndexes {
     type O = ();
-    type Command = Document;
     const NAME: &'static str = "dropIndexes";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: self.ns.coll.clone(),
             "index": self.name.clone(),
         };
 
         remove_empty_write_concern!(self.options);
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(
             Self::NAME.to_string(),

--- a/src/operation/find_and_modify.rs
+++ b/src/operation/find_and_modify.rs
@@ -56,10 +56,9 @@ impl<T: DeserializeOwned> FindAndModify<T> {
 
 impl<T: DeserializeOwned> OperationWithDefaults for FindAndModify<T> {
     type O = Option<T>;
-    type Command = RawDocumentBuf;
     const NAME: &'static str = "findAndModify";
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         if let Some(ref options) = self.options {
             if options.hint.is_some() && description.max_wire_version.unwrap_or(0) < 8 {
                 return Err(ErrorKind::InvalidArgument {

--- a/src/operation/insert.rs
+++ b/src/operation/insert.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::{
-    bson::{rawdoc, Bson, RawDocument, RawDocumentBuf},
+    bson::{rawdoc, Bson, RawDocument},
     bson_util::{
         array_entry_size_bytes,
         extend_raw_document_buf,
@@ -52,11 +52,10 @@ impl<'a> Insert<'a> {
 
 impl<'a> OperationWithDefaults for Insert<'a> {
     type O = InsertManyResult;
-    type Command = RawDocumentBuf;
 
     const NAME: &'static str = "insert";
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         let max_doc_size: usize = Checked::new(description.max_bson_object_size).try_into()?;
         let max_message_size: usize =
             Checked::new(description.max_message_size_bytes).try_into()?;

--- a/src/operation/list_collections.rs
+++ b/src/operation/list_collections.rs
@@ -1,13 +1,14 @@
+use bson::rawdoc;
+
 use crate::{
-    bson::{doc, Document},
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    operation::{append_options, CursorBody, OperationWithDefaults, Retryability},
+    operation::{CursorBody, OperationWithDefaults, Retryability},
     options::{ListCollectionsOptions, ReadPreference, SelectionCriteria},
 };
 
-use super::ExecutionContext;
+use super::{append_options_to_raw_document, ExecutionContext};
 
 #[derive(Debug)]
 pub(crate) struct ListCollections {
@@ -32,12 +33,11 @@ impl ListCollections {
 
 impl OperationWithDefaults for ListCollections {
     type O = CursorSpecification;
-    type Command = Document;
 
     const NAME: &'static str = "listCollections";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body = doc! {
+        let mut body = rawdoc! {
             Self::NAME: 1,
         };
 
@@ -47,9 +47,9 @@ impl OperationWithDefaults for ListCollections {
                 name_only = false;
             }
         }
-        body.insert("nameOnly", name_only);
+        body.append("nameOnly", name_only);
 
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(Self::NAME.to_string(), self.db.clone(), body))
     }

--- a/src/operation/list_databases.rs
+++ b/src/operation/list_databases.rs
@@ -1,15 +1,16 @@
+use bson::rawdoc;
 use serde::Deserialize;
 
 use crate::{
-    bson::{doc, Document, RawDocumentBuf},
+    bson::{doc, RawDocumentBuf},
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::ListDatabasesOptions,
     error::Result,
-    operation::{append_options, OperationWithDefaults, Retryability},
+    operation::{OperationWithDefaults, Retryability},
     selection_criteria::{ReadPreference, SelectionCriteria},
 };
 
-use super::ExecutionContext;
+use super::{append_options_to_raw_document, ExecutionContext};
 
 #[derive(Debug)]
 pub(crate) struct ListDatabases {
@@ -25,17 +26,16 @@ impl ListDatabases {
 
 impl OperationWithDefaults for ListDatabases {
     type O = Vec<RawDocumentBuf>;
-    type Command = Document;
 
     const NAME: &'static str = "listDatabases";
 
     fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
-        let mut body: Document = doc! {
+        let mut body = rawdoc! {
             Self::NAME: 1,
             "nameOnly": self.name_only
         };
 
-        append_options(&mut body, self.options.as_ref())?;
+        append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(
             Self::NAME.to_string(),

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -15,10 +15,9 @@ pub(crate) struct RawOutput<Op>(pub(crate) Op);
 
 impl<Op: Operation> Operation for RawOutput<Op> {
     type O = RawCommandResponse;
-    type Command = Op::Command;
     const NAME: &'static str = Op::NAME;
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         self.0.build(description)
     }
 

--- a/src/operation/run_command.rs
+++ b/src/operation/run_command.rs
@@ -59,13 +59,12 @@ impl<'conn> RunCommand<'conn> {
 
 impl<'conn> OperationWithDefaults for RunCommand<'conn> {
     type O = Document;
-    type Command = RawDocumentBuf;
 
     // Since we can't actually specify a string statically here, we just put a descriptive string
     // that should fail loudly if accidentally passed to the server.
     const NAME: &'static str = "$genericRunCommand";
 
-    fn build(&mut self, _description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let command_name = self
             .command_name()
             .ok_or_else(|| ErrorKind::InvalidArgument {

--- a/src/operation/run_cursor_command.rs
+++ b/src/operation/run_cursor_command.rs
@@ -1,7 +1,6 @@
 use futures_util::FutureExt;
 
 use crate::{
-    bson::RawDocumentBuf,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     concern::WriteConcern,
     cursor::CursorSpecification,
@@ -34,11 +33,10 @@ impl<'conn> RunCursorCommand<'conn> {
 
 impl<'conn> Operation for RunCursorCommand<'conn> {
     type O = CursorSpecification;
-    type Command = RawDocumentBuf;
 
     const NAME: &'static str = "run_cursor_command";
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         self.run_command.build(description)
     }
 

--- a/src/operation/update.rs
+++ b/src/operation/update.rs
@@ -93,11 +93,10 @@ impl Update {
 
 impl OperationWithDefaults for Update {
     type O = UpdateResult;
-    type Command = RawDocumentBuf;
 
     const NAME: &'static str = "update";
 
-    fn build(&mut self, _description: &StreamDescription) -> Result<Command<Self::Command>> {
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
         let mut body = rawdoc! {
             Self::NAME: self.ns.coll.clone(),
         };

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use bson::{bson, Bson};
+use bson::{bson, rawdoc, Bson, RawBson};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -96,6 +96,15 @@ impl TopologyVersion {
 impl From<TopologyVersion> for Bson {
     fn from(tv: TopologyVersion) -> Self {
         bson!({
+            "processId": tv.process_id,
+            "counter": tv.counter
+        })
+    }
+}
+
+impl From<TopologyVersion> for RawBson {
+    fn from(tv: TopologyVersion) -> Self {
+        RawBson::Document(rawdoc! {
             "processId": tv.process_id,
             "counter": tv.counter
         })

--- a/src/sdam/description/topology.rs
+++ b/src/sdam/description/topology.rs
@@ -201,10 +201,10 @@ impl TopologyDescription {
         self.servers.get(address)
     }
 
-    pub(crate) fn update_command_with_read_pref<T: Serialize>(
+    pub(crate) fn update_command_with_read_pref(
         &self,
         address: &ServerAddress,
-        command: &mut Command<T>,
+        command: &mut Command,
         criteria: Option<&SelectionCriteria>,
     ) {
         let server_type = self
@@ -248,9 +248,9 @@ impl TopologyDescription {
         }
     }
 
-    fn update_command_read_pref_for_mongos<T: Serialize>(
+    fn update_command_read_pref_for_mongos(
         &self,
-        command: &mut Command<T>,
+        command: &mut Command,
         criteria: Option<&SelectionCriteria>,
     ) {
         let read_preference = match criteria {

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -10,7 +10,6 @@ use futures_util::{
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-use serde::Serialize;
 use tokio::sync::{
     mpsc::{self, UnboundedReceiver, UnboundedSender},
     watch::{self, Ref},
@@ -198,10 +197,10 @@ impl Topology {
     }
 
     /// Updates the given `command` as needed based on the `criteria`.
-    pub(crate) fn update_command_with_read_pref<T: Serialize>(
+    pub(crate) fn update_command_with_read_pref(
         &self,
         server_address: &ServerAddress,
-        command: &mut Command<T>,
+        command: &mut Command,
         criteria: Option<&SelectionCriteria>,
     ) {
         self.watcher

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -167,7 +167,7 @@ impl TestClient {
         );
         let server_info_doc = client
             .database("admin")
-            .run_command(hello.body)
+            .run_command(hello.body.try_into().unwrap())
             .await
             .unwrap();
         let server_info = bson::from_document(server_info_doc).unwrap();


### PR DESCRIPTION
I thought we had a jira ticket for this, but I didn't find one.

This has been bugging me for a while - the type parameter here was always `Document` or `RawDocumentBuf`, and there's no actual reason for it to differ across commands.  In most cases this was a nearly drop-in update, in some cases I had to do a bit more refactoring, and in a very few I kept the construction as `Document` and converted at the end because it seemed like it would be a giant hassle to do otherwise.