### PR TITLE
RUST-1888 Remove incidental mutability from EventBuffer

### DIFF
--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -180,6 +180,8 @@ async fn first_op_update_op_time() {
     }
 
     for op in all_session_ops() {
+        client.events.clone().clear_cached_events();
+
         let mut session = client
             .start_session()
             .causal_consistency(true)

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -197,15 +197,12 @@ async fn first_op_update_op_time() {
         .await
         .unwrap();
 
-        #[allow(deprecated)]
-        let event = {
-            let mut events = client.events.clone();
-            events
-                .get_command_events(&[name])
-                .into_iter()
-                .find(|e| matches!(e, CommandEvent::Succeeded(_) | CommandEvent::Failed(_)))
-                .unwrap_or_else(|| panic!("no event found for {}", name))
-        };
+        let event = client
+            .events
+            .get_command_events(&[name])
+            .into_iter()
+            .find(|e| matches!(e, CommandEvent::Succeeded(_) | CommandEvent::Failed(_)))
+            .unwrap_or_else(|| panic!("no event found for {}", name));
 
         match event {
             CommandEvent::Succeeded(s) => {

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -696,10 +696,7 @@ async fn no_read_preference_to_standalone() {
         .await
         .unwrap();
 
-    #[allow(deprecated)]
-    let mut events = client.events.clone();
-    #[allow(deprecated)]
-    let command_started = events.get_successful_command_execution("find").0;
+    let command_started = client.events.get_successful_command_execution("find").0;
 
     assert!(!command_started.command.contains_key("$readPreference"));
 }

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -138,15 +138,12 @@ async fn batch_exhaustion() {
     assert_eq!(4, v.len());
 
     // Assert that the last `getMore` response always has id 0, i.e. is exhausted.
-    #[allow(deprecated)]
-    let replies: Vec<_> = {
-        let mut events = client.events.clone();
-        events
-            .get_command_events(&["getMore"])
-            .into_iter()
-            .filter_map(|e| e.as_command_succeeded().map(|e| e.reply.clone()))
-            .collect()
-    };
+    let replies: Vec<_> = client
+        .events
+        .get_command_events(&["getMore"])
+        .into_iter()
+        .filter_map(|e| e.as_command_succeeded().map(|e| e.reply.clone()))
+        .collect();
     let last = replies.last().unwrap();
     let cursor = last.get_document("cursor").unwrap();
     let id = cursor.get_i64("id").unwrap();

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -200,11 +200,7 @@ async fn retry_read_different_mongos() {
         .find(doc! {})
         .await;
     assert!(result.is_err());
-    #[allow(deprecated)]
-    let events = {
-        let mut events = client.events.clone();
-        events.get_command_events(&["find"])
-    };
+    let events = client.events.get_command_events(&["find"]);
     assert!(
         matches!(
             &events[..],
@@ -261,11 +257,7 @@ async fn retry_read_same_mongos() {
         .find(doc! {})
         .await;
     assert!(result.is_ok(), "{:?}", result);
-    #[allow(deprecated)]
-    let events = {
-        let mut events = client.events.clone();
-        events.get_command_events(&["find"])
-    };
+    let events = client.events.get_command_events(&["find"]);
     assert!(
         matches!(
             &events[..],

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -454,11 +454,7 @@ async fn retry_write_different_mongos() {
         .insert_one(doc! {})
         .await;
     assert!(result.is_err());
-    #[allow(deprecated)]
-    let events = {
-        let mut events = client.events.clone();
-        events.get_command_events(&["insert"])
-    };
+    let events = client.events.get_command_events(&["insert"]);
     assert!(
         matches!(
             &events[..],
@@ -516,11 +512,7 @@ async fn retry_write_same_mongos() {
         .insert_one(doc! {})
         .await;
     assert!(result.is_ok(), "{:?}", result);
-    #[allow(deprecated)]
-    let events = {
-        let mut events = client.events.clone();
-        events.get_command_events(&["insert"])
-    };
+    let events = client.events.get_command_events(&["insert"]);
     assert!(
         matches!(
             &events[..],

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -45,12 +45,13 @@ async fn transaction_ids_excluded() {
 
     let coll = client.init_db_and_coll(function_name!(), "coll").await;
 
-    #[allow(deprecated)]
-    let mut events = client.events.clone();
-    let mut excludes_txn_number = move |command_name: &str| -> bool {
-        #[allow(deprecated)]
-        let (started, _) = events.get_successful_command_execution(command_name);
-        !started.command.contains_key("txnNumber")
+    let excludes_txn_number = {
+        let events = client.events.clone();
+        move |command_name: &str| -> bool {
+            let (started, _) = events.get_successful_command_execution(command_name);
+            events.clone().clear_cached_events();
+            !started.command.contains_key("txnNumber")
+        }
     };
 
     coll.update_many(doc! {}, doc! { "$set": doc! { "x": 1 } })
@@ -93,12 +94,13 @@ async fn transaction_ids_included() {
 
     let coll = client.init_db_and_coll(function_name!(), "coll").await;
 
-    #[allow(deprecated)]
-    let mut events = client.events.clone();
-    let mut includes_txn_number = move |command_name: &str| -> bool {
-        #[allow(deprecated)]
-        let (started, _) = events.get_successful_command_execution(command_name);
-        started.command.contains_key("txnNumber")
+    let includes_txn_number = {
+        let events = client.events.clone();
+        move |command_name: &str| -> bool {
+            let (started, _) = events.get_successful_command_execution(command_name);
+            events.clone().clear_cached_events();
+            started.command.contains_key("txnNumber")
+        }
     };
 
     coll.insert_one(doc! { "x": 1 }).await.unwrap();

--- a/src/test/spec/write_error.rs
+++ b/src/test/spec/write_error.rs
@@ -30,11 +30,7 @@ async fn details() {
         ErrorKind::Write(WriteFailure::WriteError(e)) => e,
         _ => panic!("expected WriteError, got {:?}", err.kind),
     };
-    #[allow(deprecated)]
-    let (_, event) = {
-        let mut events = client.events.clone();
-        events.get_successful_command_execution("insert")
-    };
+    let (_, event) = client.events.get_successful_command_execution("insert");
     assert_eq!(write_err.code, 121 /* DocumentValidationFailure */);
     assert_eq!(
         &write_err.details.unwrap(),

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -6,12 +6,15 @@ use crate::{
     bson::doc,
     event::{
         cmap::CmapEvent,
-        command::{CommandEvent, CommandStartedEvent, CommandSucceededEvent},
+        command::{CommandEvent, CommandSucceededEvent},
         sdam::SdamEvent,
     },
     test::get_client_options,
     Client,
 };
+
+#[cfg(feature = "in-use-encryption-unstable")]
+use crate::event::command::CommandStartedEvent;
 
 #[derive(Clone, Debug, From, Serialize)]
 #[serde(untagged)]

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -89,21 +89,6 @@ impl CommandEvent {
         }
     }
 
-    pub(crate) fn request_id(&self) -> i32 {
-        match self {
-            CommandEvent::Started(event) => event.request_id,
-            CommandEvent::Failed(event) => event.request_id,
-            CommandEvent::Succeeded(event) => event.request_id,
-        }
-    }
-
-    pub(crate) fn as_command_started(&self) -> Option<&CommandStartedEvent> {
-        match self {
-            CommandEvent::Started(e) => Some(e),
-            _ => None,
-        }
-    }
-
     pub(crate) fn as_command_succeeded(&self) -> Option<&CommandSucceededEvent> {
         match self {
             CommandEvent::Succeeded(e) => Some(e),

--- a/src/test/util/event_buffer.rs
+++ b/src/test/util/event_buffer.rs
@@ -232,21 +232,14 @@ impl EventBuffer<Event> {
             .collect()
     }
 
-    /// Remove all command events from the buffer, returning those matching any of the command
-    /// names.
-    #[deprecated = "use immutable methods"]
-    pub(crate) fn get_command_events(&mut self, command_names: &[&str]) -> Vec<CommandEvent> {
-        let mut out = vec![];
-        self.retain(|ev| match ev {
-            Event::Command(cev) => {
-                if command_names.contains(&cev.command_name()) {
-                    out.push(cev.clone());
-                }
-                false
+    /// Gets all command events matching any of the command names.
+    pub(crate) fn get_command_events(&self, command_names: &[&str]) -> Vec<CommandEvent> {
+        self.filter_map(|e| match e {
+            Event::Command(cev) if command_names.iter().any(|&n| n == cev.command_name()) => {
+                Some(cev.clone())
             }
-            _ => true,
-        });
-        out
+            _ => None,
+        })
     }
 
     /// Gets the first started/succeeded pair of events for the given command name, popping off all

--- a/src/test/util/event_buffer.rs
+++ b/src/test/util/event_buffer.rs
@@ -255,7 +255,7 @@ impl EventBuffer<Event> {
         }
         match &cevs[0..2] {
             [CommandEvent::Started(started), CommandEvent::Succeeded(succeeded)] => {
-                return (started.clone(), succeeded.clone())
+                (started.clone(), succeeded.clone())
             }
             pair => panic!(
                 "First event pair for {:?} not (Started, Succeded): {:?}",


### PR DESCRIPTION
RUST-1888

`get_command_events` and `get_successful_command_execution` both had surprising mutation of the underlying event buffer that was only useful in a few niche cases; this updates them to be immutable.  The few places that needed the mutation (running tests in a loop on a shared client, interleaving tests and event assertions) now use an explicit buffer clear.