### PR TITLE
minor: return an error if `bulk_write` is called on an unsupported server

### DIFF
--- a/src/operation.rs
+++ b/src/operation.rs
@@ -76,6 +76,7 @@ pub(crate) use update::{Update, UpdateOrReplace};
 
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
 const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
+const SERVER_8_0_0_WIRE_VERSION: i32 = 25;
 // The maximum number of bytes that may be included in a write payload when auto-encryption is
 // enabled.
 const MAX_ENCRYPTED_WRITE_SIZE: usize = 2_097_152;

--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -564,3 +564,21 @@ async fn encryption_error() {
         Some("bulkWrite does not currently support automatic encryption".to_string())
     );
 }
+
+#[tokio::test]
+async fn unsupported_server_client_error() {
+    let client = Client::test_builder().build().await;
+
+    if client.server_version_gte(8, 0) {
+        return;
+    }
+
+    let error = client
+        .bulk_write(vec![InsertOneModel::builder()
+            .namespace(Namespace::new("db", "coll"))
+            .document(doc! { "a": "b" })
+            .build()])
+        .await
+        .unwrap_err();
+    assert!(matches!(*error.kind, ErrorKind::IncompatibleServer { .. }));
+}


### PR DESCRIPTION
Attempting to call `bulk_write` on a 7.0 server currently yields the following error:
```
Error: Error { kind: Command(CommandError { code: 40415, code_name: "Location40415", message: "BSON field 'bulkWrite.errorsOnly' is an unknown field.", topology_version: None }), labels: {}, wire_version: Some(21), source: None }
```
This PR adds a more informative error to avoid confusion if/when users attempt to use this feature with 7.0.

This is a temporary fix; once the server error is improved, we can remove this check ([SERVER-91171](https://jira.mongodb.org/browse/SERVER-91171)).