### PR TITLE
RUST-1965 Use the implicit runtime when spawning tasks via the sync API

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -197,7 +197,7 @@ buildvariants:
 
   - name: sync-api
     display_name: "Sync API"
-    patchable: false
+    #patchable: false
     run_on:
       - rhel87-small
     expansions:

--- a/src/runtime/join_handle.rs
+++ b/src/runtime/join_handle.rs
@@ -14,7 +14,11 @@ impl<T> AsyncJoinHandle<T> {
         F: Future<Output = T> + Send + 'static,
         T: Send + 'static,
     {
+        #[cfg(not(feature = "sync"))]
         let handle = tokio::runtime::Handle::current();
+        #[cfg(feature = "sync")]
+        let handle = tokio::runtime::Handle::try_current()
+            .unwrap_or_else(|_| crate::sync::TOKIO_RUNTIME.handle().clone());
         AsyncJoinHandle(handle.spawn(fut))
     }
 }


### PR DESCRIPTION
RUST-1965

Without this, anything using handles that are tracked by the graceful shutdown support causes a panic.