### PR TITLE
RUST-1966 Fix zlib compression level test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -171,7 +171,7 @@ buildvariants:
 
   - name: compression
     display_name: "Compression"
-    patchable: false
+    #patchable: false
     run_on:
       - rhel87-small
     expansions:

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -211,10 +211,6 @@ async fn run_tests(path: &[&str], skipped_files: &[&str]) {
                                 )
                             });
 
-                        dbg!(expected_key);
-                        dbg!(expected_value);
-                        dbg!(actual_value);
-
                         if let Some(expected_number) = get_int(expected_value) {
                             let actual_number = get_int(actual_value).unwrap_or_else(|| {
                                 panic!(

--- a/src/client/options/test.rs
+++ b/src/client/options/test.rs
@@ -189,7 +189,7 @@ async fn run_tests(path: &[&str], skipped_files: &[&str]) {
                         })
                         .next()
                     {
-                        actual_options.insert("zlibCompressionLevel", zlib_compression_level);
+                        actual_options.insert("zlibcompressionlevel", zlib_compression_level);
                     }
                 }
 
@@ -210,6 +210,10 @@ async fn run_tests(path: &[&str], skipped_files: &[&str]) {
                                     test_case.description, expected_key
                                 )
                             });
+
+                        dbg!(expected_key);
+                        dbg!(expected_value);
+                        dbg!(actual_value);
 
                         if let Some(expected_number) = get_int(expected_value) {
                             let actual_number = get_int(actual_value).unwrap_or_else(|| {


### PR DESCRIPTION
RUST-1966

The actual parsing is fine, but the document for comparison would end up with both "zlibcompressionlevel" and "zlibCompressionLevel" keys.