### PR TITLE
RUST-1967 Fix cloud provider test binaries

### DIFF
--- a/.evergreen/aws-ecs-test/src/main.rs
+++ b/.evergreen/aws-ecs-test/src/main.rs
@@ -1,14 +1,17 @@
-use mongodb::{bson::Document, Client};
+use mongodb::{
+    bson::{doc, Document},
+    Client,
+};
 
 #[tokio::main]
 async fn main() {
     let uri = std::env::var("MONGODB_URI").expect("no URI given!");
     let client = Client::with_uri_str(&uri).await.unwrap();
-    
+
     client
         .database("aws")
         .collection::<Document>("somecoll")
-        .find_one(None, None)
+        .find_one(doc! {})
         .await
         .unwrap();
 }

--- a/.evergreen/azure-kms-test/src/main.rs
+++ b/.evergreen/azure-kms-test/src/main.rs
@@ -1,7 +1,10 @@
 use mongodb::{
     bson::doc,
-    Client, client_encryption::{ClientEncryption, MasterKey}, mongocrypt::ctx::KmsProvider, Namespace,
+    client_encryption::{ClientEncryption, MasterKey},
     error::Result,
+    mongocrypt::ctx::KmsProvider,
+    Client,
+    Namespace,
 };
 
 use std::env;
@@ -19,11 +22,10 @@ async fn main() -> Result<()> {
         .expect("KEY_VAULT_ENDPOINT environment variable should be set");
 
     c.create_data_key(MasterKey::Azure {
-        key_vault_endpoint: key_vault_endpoint,
-        key_name: key_name,
+        key_vault_endpoint,
+        key_name,
         key_version: None,
     })
-    .run()
     .await?;
 
     println!("Azure KMS integration test passed!");

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -216,7 +216,7 @@ buildvariants:
 
   - name: aws-auth
     display_name: "AWS Authentication"
-    patchable: false
+    #patchable: false
     run_on:
       - ubuntu2004-small
     expansions:
@@ -226,7 +226,7 @@ buildvariants:
 
   - name: azure-kms
     display_name: "Azure KMS"
-    patchable: false
+    #patchable: false
     run_on:
       # The Azure CLI is not available on RHEL/Ubuntu machines.
       - debian11-small
@@ -387,7 +387,7 @@ buildvariants:
 
   - name: aws-lambda
     display_name: "AWS Lambda"
-    patchable: false
+    #patchable: false
     run_on:
       - ubuntu2204-small
     tasks:


### PR DESCRIPTION
RUST-1967

These also got hit by my rustfmt-on-save editor configuration; I can revert that if it's annoying.  The actual updates are all just tweaking some call sites for the fluent API changes.