### PR TITLE
RUST-1924 Generate and upload SSDLC compliance report

### DIFF
--- a/.evergreen/create-ssdlc-compliance-report.sh
+++ b/.evergreen/create-ssdlc-compliance-report.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+
+REPORT_FILE=".evergreen/${CRATE_VERSION}-ssdlc-compliance-report.md"
+SED_REPLACE="s/RELEASE_VERSION/${CRATE_VERSION}/g"
+
+sed $SED_REPLACE .evergreen/ssdlc-compliance-report-template.md > ${REPORT_FILE}

--- a/.evergreen/create-ssdlc-compliance-report.sh
+++ b/.evergreen/create-ssdlc-compliance-report.sh
@@ -6,4 +6,4 @@ set -o xtrace
 REPORT_FILE=".evergreen/${CRATE_VERSION}-ssdlc-compliance-report.md"
 SED_REPLACE="s/RELEASE_VERSION/${CRATE_VERSION}/g"
 
-sed $SED_REPLACE .evergreen/ssdlc-compliance-report-template.md > ${REPORT_FILE}
+sed ${SED_REPLACE} .evergreen/ssdlc-compliance-report-template.md > ${REPORT_FILE}

--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -29,7 +29,6 @@
 #
 # Make sure to remove the changes from 1 and 2 before merging!
 
-
 exec_timeout_secs: 3600 
 
 functions:
@@ -176,6 +175,25 @@ functions:
         content_type: text/plain
         display_name: signature-
 
+  "create and upload SSDLC compliance report":
+    - command: subprocess.exec
+      params:
+        working_dir: "src"
+        include_expansions_in_env:
+          - CRATE_VERSION
+        binary: bash
+        args:
+          - .evergreen/create-ssdlc-compliance-report.sh
+    - command: s3.put
+      params:
+        aws_key: ${S3_UPLOAD_AWS_KEY}
+        aws_secret: ${S3_UPLOAD_AWS_SECRET}
+        local_file: src/.evergreen/${CRATE_VERSION}-ssdlc-compliance-report.md
+        remote_file: rust-driver/${TEST_PREFIX}${CRATE_VERSION}-ssdlc-compliance-report.md
+        bucket: cdn-origin-rust-driver
+        permissions: private
+        content_type: text/markdown
+
 tasks:
   - name: "publish-release"
     commands:
@@ -187,6 +205,7 @@ tasks:
       - func: "publish papertrail"
       - func: "sign release"
       - func: "save signature"
+      - func: "create and upload SSDLC compliance report"
 
 axes:
   - id: "os"

--- a/.evergreen/ssdlc-compliance-report-template.md
+++ b/.evergreen/ssdlc-compliance-report-template.md
@@ -1,0 +1,32 @@
+# MongoDB Rust Driver SSDLC Compliance Report
+
+### Release Version: RELEASE_VERSION
+
+**Release Creator**
+The creator of this release can be determined by visiting
+https://github.com/mongodb/mongo-rust-driver/releases/tag/vRELEASE_VERSION.
+
+**Process Document**
+TODO RUST-1918 Link to "How We Develop Software" document
+
+**Tool used to track third party vulnerabilities**
+N/A; the Rust driver does not bundle third-party dependencies
+
+**Third-Party Dependency Information**
+N/A; the Rust driver does not bundle third-party dependencies
+
+**Static Analysis Findings**
+TODO RUST-1920 Link to static analysis report
+
+**Signature Information**
+The release signature for this version can be found by visiting
+https://downloads.mongodb.org/rust-driver/mongodb-RELEASE_VERSION.sig.
+
+**Security Testing Report**
+TODO RUST-1955 Link to security testing report
+
+**Security Assessment Report**
+N/A; non-goal for client libraries
+
+**Known Vulnerabilities**
+None

--- a/.evergreen/ssdlc-compliance-report-template.md
+++ b/.evergreen/ssdlc-compliance-report-template.md
@@ -16,7 +16,8 @@ N/A; the Rust driver does not bundle third-party dependencies
 N/A; the Rust driver does not bundle third-party dependencies
 
 **Static Analysis Findings**
-TODO RUST-1920 Link to static analysis report
+To request a copy of the static analysis report, please contact
+the MongoDB Rust driver team.
 
 **Signature Information**
 The release signature for this version can be found by visiting


### PR DESCRIPTION
Uses the minimal format outlined here: https://gist.github.com/rtimmons/8253d1dfcc5f233bdb2d9c73b8e5c129

Dry run release patch with file: https://spruce.mongodb.com/version/6668c6e0b542fb0007a803b2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC