### PR TITLE
RUST-1920 Annotate sarif report with mongodb ratings

### DIFF
--- a/.evergreen/check-semgrep.sh
+++ b/.evergreen/check-semgrep.sh
@@ -2,23 +2,29 @@
 
 set -o errexit
 
-source ./.evergreen/env.sh
-
-. ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
-PYTHON=$(find_python3)
+if [ -t 0 ] ; then
+    # Interactive shell
+    PYTHON3=${PYTHON3:-"python3"}
+else
+    # Evergreen run (probably)
+    source ./.evergreen/env.sh
+    source ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+    PYTHON3=$(find_python3)
+fi
 
 if [[ -f "semgrep/bin/activate" ]]; then
-    echo 'using existing virtualenv'
+    echo 'Using existing virtualenv...'
     . semgrep/bin/activate
 else
-    echo 'Creating new virtualenv'  
-    ${PYTHON} -m venv semgrep
-    echo 'Activating new virtualenv'
+    echo 'Creating new virtualenv...'
+    ${PYTHON3} -m venv semgrep
+    echo 'Activating new virtualenv...'
     . semgrep/bin/activate
+    echo 'Installing semgrep...'
     python3 -m pip install semgrep
 fi
 
-# Generate a SARIF report
-semgrep --config p/rust --sarif > mongo-rust-driver.json.sarif
-# And human-readable output
+# Show human-readable output
 semgrep --config p/rust --error
+# Generate a SARIF report
+semgrep --config p/rust --quiet --sarif -o sarif.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Cargo.lock
 .cargo
 .rustup
 mongocryptd.pid
+semgrep/
+sarif.json

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,2 +1,3 @@
 benchmarks/
 src/test/
+etc/

--- a/src/client/auth/scram.rs
+++ b/src/client/auth/scram.rs
@@ -317,7 +317,7 @@ impl ScramVersion {
         let normalized_password = match self {
             ScramVersion::Sha1 => {
                 // nosemgrep: insecure-hashes
-                let mut md5 = Md5::new();
+                let mut md5 = Md5::new(); // mongodb rating: No Fix Needed
                 md5.update(format!("{}:mongo:{}", username, password));
                 Cow::Owned(hex::encode(md5.finalize()))
             }

--- a/src/runtime/tls_rustls.rs
+++ b/src/runtime/tls_rustls.rs
@@ -143,7 +143,7 @@ fn make_rustls_config(cfg: TlsOptions) -> Result<rustls::ClientConfig> {
 
     if let Some(true) = cfg.allow_invalid_certificates {
         // nosemgrep: rustls-dangerous
-        config
+        config // mongodb rating: No Fix Needed
             .dangerous()
             .set_certificate_verifier(Arc::new(NoCertVerifier {}));
     }


### PR DESCRIPTION
RUST-1920

The requirements for static analysis include annotating findings with the MongoDB risk rating; this PR adds code comments that will be included in the semgrep report with the appropriate rating for the two current findings.

Additionally, the report needs to be "archived in some internal repository", and _not_ included as a release artifact, so I updated the `check-semgrep.sh` script to work when run interactively.  If it makes sense to you, I'll update the release instructions to include uploading a report to a team Drive folder.