### PR TITLE
RUST-1971 / RUST-1975 Update Atlas connectivity credentials

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -207,7 +207,7 @@ buildvariants:
 
   - name: atlas-connectivity
     display_name: "Atlas Connectivity"
-    #patchable: false
+    patchable: false
     run_on:
       - rhel87-small
     tasks:
@@ -1484,16 +1484,6 @@ functions:
           - AWS_SECRET_ACCESS_KEY
           - AWS_SESSION_TOKEN
           - DRIVERS_TOOLS
-          - MONGO_ATLAS_SERVERLESS_URI
-          - MONGO_ATLAS_SERVERLESS_URI_SRV
-          - MONGO_ATLAS_REPL_URI
-          - MONGO_ATLAS_REPL_URI_SRV
-          - MONGO_ATLAS_SHARDED_URI
-          - MONGO_ATLAS_SHARDED_URI_SRV
-          - MONGO_ATLAS_TLS11_URI
-          - MONGO_ATLAS_TLS11_URI_SRV
-          - MONGO_ATLAS_TLS12_URI
-          - MONGO_ATLAS_TLS12_URI_SRV
           - PROJECT_DIRECTORY
 
   "start csfle servers":

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -207,7 +207,7 @@ buildvariants:
 
   - name: atlas-connectivity
     display_name: "Atlas Connectivity"
-    patchable: false
+    #patchable: false
     run_on:
       - rhel87-small
     tasks:
@@ -1468,31 +1468,33 @@ functions:
           .evergreen/run-serverless-tests.sh
 
   "run atlas tests":
-    - command: shell.exec
+    - command: ec2.assume_role
+      params:
+        role_arn: ${aws_test_secrets_role}
+
+    - command: subprocess.exec
       type: test
       params:
         working_dir: src
-        silent: true
-        shell: bash
-        script: |
-          set +x
-          export MONGO_ATLAS_TESTS=1
-          export MONGO_ATLAS_FREE_TIER_REPL_URI='${MONGO_ATLAS_FREE_TIER_REPL_URI}'
-          export MONGO_ATLAS_FREE_TIER_REPL_URI_SRV='${MONGO_ATLAS_FREE_TIER_REPL_URI_SRV}'
-          export MONGO_ATLAS_SERVERLESS_URI='${MONGO_ATLAS_SERVERLESS_URI}'
-          export MONGO_ATLAS_SERVERLESS_URI_SRV='${MONGO_ATLAS_SERVERLESS_URI_SRV}'
-          export MONGO_ATLAS_REPL_URI='${MONGO_ATLAS_REPL_URI}'
-          export MONGO_ATLAS_REPL_URI_SRV='${MONGO_ATLAS_REPL_URI_SRV}'
-          export MONGO_ATLAS_SHARDED_URI='${MONGO_ATLAS_SHARDED_URI}'
-          export MONGO_ATLAS_SHARDED_URI_SRV='${MONGO_ATLAS_SHARDED_URI_SRV}'
-          export MONGO_ATLAS_TLS11_URI='${MONGO_ATLAS_TLS11_URI}'
-          export MONGO_ATLAS_TLS11_URI_SRV='${MONGO_ATLAS_TLS11_URI_SRV}'
-          export MONGO_ATLAS_TLS12_URI='${MONGO_ATLAS_TLS12_URI}'
-          export MONGO_ATLAS_TLS12_URI_SRV='${MONGO_ATLAS_TLS12_URI_SRV}'
-          export PROJECT_DIRECTORY='${PROJECT_DIRECTORY}'
-          set -x
-
-          .evergreen/run-atlas-tests.sh
+        binary: bash
+        args:
+          - .evergreen/run-atlas-tests.sh
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+          - DRIVERS_TOOLS
+          - MONGO_ATLAS_SERVERLESS_URI
+          - MONGO_ATLAS_SERVERLESS_URI_SRV
+          - MONGO_ATLAS_REPL_URI
+          - MONGO_ATLAS_REPL_URI_SRV
+          - MONGO_ATLAS_SHARDED_URI
+          - MONGO_ATLAS_SHARDED_URI_SRV
+          - MONGO_ATLAS_TLS11_URI
+          - MONGO_ATLAS_TLS11_URI_SRV
+          - MONGO_ATLAS_TLS12_URI
+          - MONGO_ATLAS_TLS12_URI_SRV
+          - PROJECT_DIRECTORY
 
   "start csfle servers":
     - command: ec2.assume_role

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -6,8 +6,22 @@ set -o pipefail
 source .evergreen/env.sh
 source .evergreen/cargo-test.sh
 
+export MONGO_ATLAS_TESTS=1
+
+. "${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh" drivers/atlas_connect
+
+set +x
+export MONGO_ATLAS_FREE_TIER_REPL_URI="${atlas_free}"
+export MONGO_ATLAS_FREE_TIER_REPL_URI_SRV="${atlas_srv_free}"
+
+echo uri hash:
+echo "${MONGO_ATLAS_FREE_TIER_REPL_URI}" | shasum
+echo srv uri hash:
+echo "${MONGO_ATLAS_FREE_TIER_REPL_URI_SRV}" | shasum
+set -x
+
 set +o errexit
 
-cargo_test atlas_connectivity results.xml
+cargo_test atlas_free_tier_repl_set results.xml
 
 exit $CARGO_RESULT

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -8,20 +8,10 @@ source .evergreen/cargo-test.sh
 
 export MONGO_ATLAS_TESTS=1
 
-. "${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh" drivers/atlas_connect
-
-set +x
-export MONGO_ATLAS_FREE_TIER_REPL_URI="${atlas_free}"
-export MONGO_ATLAS_FREE_TIER_REPL_URI_SRV="${atlas_srv_free}"
-
-echo uri hash:
-echo "${MONGO_ATLAS_FREE_TIER_REPL_URI}" | shasum
-echo srv uri hash:
-echo "${MONGO_ATLAS_FREE_TIER_REPL_URI_SRV}" | shasum
-set -x
+source "${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh" drivers/atlas_connect
 
 set +o errexit
 
-cargo_test atlas_free_tier_repl_set results.xml
+cargo_test atlas_connectivity results.xml
 
 exit $CARGO_RESULT

--- a/src/test/atlas_connectivity.rs
+++ b/src/test/atlas_connectivity.rs
@@ -43,90 +43,66 @@ async fn run_test(uri_env_var: &str, resolver_config: Option<ResolverConfig>) {
 
 #[tokio::test]
 async fn atlas_free_tier_repl_set() {
-    run_test("MONGO_ATLAS_FREE_TIER_REPL_URI", None).await;
+    run_test("ATLAS_FREE", None).await;
 }
 
 #[tokio::test]
 async fn atlas_free_tier_repl_set_srv() {
-    run_test("MONGO_ATLAS_FREE_TIER_REPL_URI_SRV", None).await;
-    run_test(
-        "MONGO_ATLAS_FREE_TIER_REPL_URI_SRV",
-        Some(ResolverConfig::cloudflare()),
-    )
-    .await;
+    run_test("ATLAS_SRV_FREE", None).await;
+    run_test("ATLAS_SRV_FREE", Some(ResolverConfig::cloudflare())).await;
 }
 
 #[tokio::test]
 async fn atlas_serverless() {
-    run_test("MONGO_ATLAS_SERVERLESS_URI", None).await;
+    run_test("ATLAS_SERVERLESS", None).await;
 }
 
 #[tokio::test]
 async fn atlas_serverless_srv() {
-    run_test("MONGO_ATLAS_SERVERLESS_URI_SRV", None).await;
-    run_test(
-        "MONGO_ATLAS_SERVERLESS_URI_SRV",
-        Some(ResolverConfig::cloudflare()),
-    )
-    .await;
+    run_test("ATLAS_SRV_SERVERLESS", None).await;
+    run_test("ATLAS_SRV_SERVERLESS", Some(ResolverConfig::cloudflare())).await;
 }
 
 #[tokio::test]
 async fn atlas_repl_set() {
-    run_test("MONGO_ATLAS_REPL_URI", None).await;
+    run_test("ATLAS_REPL", None).await;
 }
 
 #[tokio::test]
 async fn atlas_repl_set_srv() {
-    run_test("MONGO_ATLAS_REPL_URI_SRV", None).await;
-    run_test(
-        "MONGO_ATLAS_REPL_URI_SRV",
-        Some(ResolverConfig::cloudflare()),
-    )
-    .await;
+    run_test("ATLAS_SRV_REPL", None).await;
+    run_test("ATLAS_SRV_REPL", Some(ResolverConfig::cloudflare())).await;
 }
 
 #[tokio::test]
 async fn atlas_sharded() {
-    run_test("MONGO_ATLAS_SHARDED_URI", None).await;
+    run_test("ATLAS_SHRD", None).await;
 }
 
 #[tokio::test]
 async fn atlas_sharded_srv() {
-    run_test("MONGO_ATLAS_SHARDED_URI_SRV", None).await;
-    run_test(
-        "MONGO_ATLAS_SHARDED_URI_SRV",
-        Some(ResolverConfig::cloudflare()),
-    )
-    .await;
+    run_test("ATLAS_SRV_SHRD", None).await;
+    run_test("ATLAS_SRV_SHRD", Some(ResolverConfig::cloudflare())).await;
 }
 
 #[tokio::test]
 async fn atlas_tls_11() {
-    run_test("MONGO_ATLAS_TLS11_URI", None).await;
+    run_test("ATLAS_TLS11", None).await;
 }
 
 #[tokio::test]
 async fn atlas_tls11_srv() {
-    run_test("MONGO_ATLAS_TLS11_URI_SRV", None).await;
-    run_test(
-        "MONGO_ATLAS_TLS11_URI_SRV",
-        Some(ResolverConfig::cloudflare()),
-    )
-    .await;
+    run_test("ATLAS_SRV_TLS11", None).await;
+    run_test("ATLAS_SRV_TLS11", Some(ResolverConfig::cloudflare())).await;
 }
 
 #[tokio::test]
 async fn atlas_tls_12() {
-    run_test("MONGO_ATLAS_TLS12_URI", None).await;
+    run_test("ATLAS_TLS12", None).await;
 }
 
 #[tokio::test]
 async fn atlas_tls12_srv() {
-    run_test("MONGO_ATLAS_TLS12_URI_SRV", None).await;
-    run_test(
-        "MONGO_ATLAS_TLS12_URI_SRV",
-        Some(ResolverConfig::cloudflare()),
-    )
-    .await;
+    run_test("ATLAS_SRV_TLS12", None).await;
+    run_test("ATLAS_SRV_TLS12", Some(ResolverConfig::cloudflare())).await;
 }


### PR DESCRIPTION
RUST-1971 / RUST-1975

The fixes for both were to pull credentials from the secrets manager rather than using static evergreen config values.  [Here's](https://spruce.mongodb.com/task/mongo_rust_driver_atlas_connectivity_test_atlas_connectivity_patch_90d788af2763d869b12f889eff8e681ecf7d1cec_666b10fce7646b000759d3ae_24_06_13_15_32_17?execution=0&sortBy=STATUS&sortDir=ASC) the passing run for these.