### PR TITLE
RUST-1973 Example client usage targeting WasmEdge

### DIFF
--- a/etc/wasmedge/.cargo/config.toml
+++ b/etc/wasmedge/.cargo/config.toml
@@ -1,0 +1,3 @@
+[build]
+target = "wasm32-wasi"
+rustflags = ["--cfg", "wasmedge", "--cfg", "tokio_unstable"]

--- a/etc/wasmedge/.gitignore
+++ b/etc/wasmedge/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/etc/wasmedge/Cargo.toml
+++ b/etc/wasmedge/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [patch.crates-io]
 tokio = { git = "https://github.com/second-state/wasi_tokio.git", branch = "v1.36.x" }
 socket2 = { git = "https://github.com/second-state/socket2.git", branch = "v0.5.x" }
-#hyper = { git = "https://github.com/second-state/wasi_hyper.git", branch = "v0.14.x" }
 
 [dependencies]
 mongodb = { path = "../../", default_features = false, features = ["compat-3-0-0", "rustls-tls"] }

--- a/etc/wasmedge/Cargo.toml
+++ b/etc/wasmedge/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wasmedge_mongodb"
+version = "0.1.0"
+edition = "2021"
+
+[patch.crates-io]
+tokio = { git = "https://github.com/second-state/wasi_tokio.git", branch = "v1.36.x" }
+socket2 = { git = "https://github.com/second-state/socket2.git", branch = "v0.5.x" }
+#hyper = { git = "https://github.com/second-state/wasi_hyper.git", branch = "v0.14.x" }
+
+[dependencies]
+mongodb = { path = "../../", default_features = false, features = ["compat-3-0-0", "rustls-tls"] }
+tokio = { version = "1", features = ["io-util", "fs", "net", "time", "rt", "macros"] }

--- a/etc/wasmedge/README.md
+++ b/etc/wasmedge/README.md
@@ -1,0 +1,9 @@
+Please note: using the MongoDB Rust driver on WasmEdge is unsupported!
+
+This example program requires:
+* WasmEdge (https://wasmedge.org/docs/start/install/)
+* The Rust wasm toolchain (`rustup target add wasm32-wasi`)
+
+To compile: `cargo build --target wasm32-wasi --release`
+
+To run: `wasmedge target/wasm32-wasi/release/wasmedge_mongodb.wasm`

--- a/etc/wasmedge/src/main.rs
+++ b/etc/wasmedge/src/main.rs
@@ -1,0 +1,4 @@
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    println!("Hello, world!");
+}

--- a/etc/wasmedge/src/main.rs
+++ b/etc/wasmedge/src/main.rs
@@ -1,4 +1,7 @@
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    println!("Hello, world!");
+    let client = mongodb::Client::with_uri_str("mongodb://127.0.0.1:27017")
+        .await
+        .unwrap();
+    println!("{:?}", client.list_database_names().await);
 }

--- a/src/client/auth/oidc.rs
+++ b/src/client/auth/oidc.rs
@@ -714,6 +714,7 @@ fn validate_address_with_allowed_hosts(
     mechanism_properties: Option<&Document>,
     address: &ServerAddress,
 ) -> Result<()> {
+    #[allow(irrefutable_let_patterns)]
     let hostname = if let ServerAddress::Tcp { host, .. } = address {
         host.as_str()
     } else {


### PR DESCRIPTION
RUST-1973

It turns out that the Rust driver does work on the WasmEdge runtime, at least enough for a very simple example program.  I had to disable setting TCP keepalive, but my understanding from reading the [DRIVERS ticket](https://jira.mongodb.org/browse/DRIVERS-383) that introduced it is that it's there to help long-running client software be resilient to server crashes and isn't strictly critical for general driver use.

The other big caveat is that this relies on forked versions of `tokio` and `socket2` for WasmEdge support.  That's not unique to the MongoDB driver, though, the [mysql example](https://github.com/second-state/microservice-rust-mysql) has the same requirement.