### PR TITLE
RUST-1846 Test that `saslSupportedMechs` can contain arbitrary strings

### DIFF
--- a/src/cmap/establish.rs
+++ b/src/cmap/establish.rs
@@ -92,7 +92,7 @@ impl ConnectionEstablisher {
     }
 
     /// Establishes a connection.
-    pub(super) async fn establish_connection(
+    pub(crate) async fn establish_connection(
         &self,
         pending_connection: PendingConnection,
         credential: Option<&Credential>,

--- a/src/test/spec.rs
+++ b/src/test/spec.rs
@@ -8,6 +8,7 @@ mod connection_stepdown;
 mod crud;
 mod faas;
 mod gridfs;
+mod handshake;
 mod index_management;
 #[cfg(feature = "dns-resolver")]
 mod initial_dns_seedlist_discovery;

--- a/src/test/spec/handshake.rs
+++ b/src/test/spec/handshake.rs
@@ -1,0 +1,31 @@
+use std::time::Instant;
+
+use bson::oid::ObjectId;
+
+use crate::{
+    cmap::{
+        conn::PendingConnection,
+        establish::{ConnectionEstablisher, EstablisherOptions},
+    },
+    event::cmap::CmapEventEmitter,
+    test::get_client_options,
+};
+
+// Prose test 1: Test that the driver accepts an arbitrary auth mechanism
+#[tokio::test]
+async fn arbitrary_auth_mechanism() {
+    let options = get_client_options().await.clone();
+    let establisher =
+        ConnectionEstablisher::new(EstablisherOptions::from_client_options(&options)).unwrap();
+    let pending = PendingConnection {
+        id: 0,
+        address: options.hosts[0].clone(),
+        generation: crate::cmap::PoolGeneration::normal(),
+        event_emitter: CmapEventEmitter::new(None, ObjectId::new()),
+        time_created: Instant::now(),
+    };
+    let _ = establisher
+        .establish_connection(pending, None)
+        .await
+        .unwrap();
+}

--- a/src/test/spec/handshake.rs
+++ b/src/test/spec/handshake.rs
@@ -15,14 +15,14 @@ use crate::{
 #[tokio::test]
 async fn arbitrary_auth_mechanism() {
     let client_options = get_client_options().await;
-    let mut options = EstablisherOptions::from_client_options(&client_options);
+    let mut options = EstablisherOptions::from_client_options(client_options);
     options.test_patch_reply = Some(|reply| {
         reply
             .as_mut()
             .unwrap()
             .command_response
             .sasl_supported_mechs
-            .get_or_insert_with(|| vec![])
+            .get_or_insert_with(Vec::new)
             .push("ArBiTrArY!".to_string());
     });
     let establisher = ConnectionEstablisher::new(options).unwrap();

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -746,7 +746,7 @@ impl TestRunner {
 fn fill_kms_placeholders(
     kms_provider_map: HashMap<mongocrypt::ctx::KmsProvider, Document>,
 ) -> crate::test::csfle::KmsProviderList {
-    use crate::{bson::doc, test::csfle::ALL_KMS_PROVIDERS};
+    use crate::test::csfle::ALL_KMS_PROVIDERS;
 
     let placeholder = doc! { "$$placeholder": 1 };
     let all_kms_providers = ALL_KMS_PROVIDERS.clone();


### PR DESCRIPTION
RUST-1846

The specification says to mock the server response; Rust is bad at mocking things, I think what I've done here is the most reasonable moral equivalent.