### PR TITLE
RUST-1845 Support search index type field

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -886,6 +886,7 @@ tasks:
   - name: test-search-index
     commands:
       - command: subprocess.exec
+        type: test
         params:
           working_dir: src
           binary: bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use client::session::ClusterTime;
 pub use coll::Namespace;
 pub use index::IndexModel;
 pub use sdam::public::*;
-pub use search_index::SearchIndexModel;
+pub use search_index::{SearchIndexModel, SearchIndexType};
 
 /// A boxed future.
 pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;

--- a/src/search_index.rs
+++ b/src/search_index.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// Specifies the options for a search index.
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Default, TypedBuilder, Serialize, Deserialize)]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
@@ -13,8 +14,24 @@ pub struct SearchIndexModel {
     pub definition: Document,
 
     /// The name for this index, if present.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    /// The type for this index, if present.
+    #[serde(rename = "type")]
+    pub index_type: Option<SearchIndexType>,
+}
+
+/// Specifies the type of search index.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SearchIndexType {
+    /// A regular search index.
+    Search,
+    /// A vector search index.
+    VectorSearch,
+    /// An unknown type of search index.
+    #[serde(untagged)]
+    Other(String),
 }
 
 pub mod options {


### PR DESCRIPTION
RUST-1845

Pretty straightforward.  The test isn't patchable so [here's](https://spruce.mongodb.com/version/667af50538cea5000730c50e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) the passing run.