### PR TITLE
RUST-1821 EOL support for 3.6

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -87,9 +87,9 @@ buildvariants:
       SSL: ssl
     tasks:
       # Ubuntu 22.04 does not support MongoDB versions below 6.0.
-      - name: .standalone !.3.6 !.4.0 !.4.2 !.4.4 !.5.0
-      - name: .replicaset !.3.6 !.4.0 !.4.2 !.4.4 !.5.0
-      - name: .sharded !.3.6 !.4.0 !.4.2 !.4.4 !.5.0
+      - name: .standalone !.4.0 !.4.2 !.4.4 !.5.0
+      - name: .replicaset !.4.0 !.4.2 !.4.4 !.5.0
+      - name: .sharded !.4.0 !.4.2 !.4.4 !.5.0
 
   - name: macos-11.00
     display_name: "MacOS 11.00"
@@ -193,7 +193,7 @@ buildvariants:
     tasks:
       # The Stable API was introduced in MongoDB version 5.0. Drivers Evergreen Tools only supports
       # setting REQUIRE_API_VERSION on standalones.
-      - .standalone !.3.6 !.4.0 !.4.2 !.4.4
+      - .standalone !.4.0 !.4.2 !.4.4
 
   - name: sync-api
     display_name: "Sync API"

--- a/.evergreen/generate-tasks/src/main.rs
+++ b/.evergreen/generate-tasks/src/main.rs
@@ -1,5 +1,5 @@
 static VERSIONS: &[&str] = &[
-    "3.6", "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest",
+    "4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "8.0", "rapid", "latest",
 ];
 
 static TOPOLOGIES: &[(&str, &str)] = &[

--- a/.evergreen/suite-tasks.yml
+++ b/.evergreen/suite-tasks.yml
@@ -3,15 +3,6 @@
 
 tasks:
 
-  - name: test-3.6-standalone
-    tags: [3.6, standalone]
-    commands:
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: 3.6
-          TOPOLOGY: server
-      - func: "run driver test suite"
-
   - name: test-4.0-standalone
     tags: [4.0, standalone]
     commands:
@@ -93,15 +84,6 @@ tasks:
           TOPOLOGY: server
       - func: "run driver test suite"
 
-  - name: test-3.6-replicaset
-    tags: [3.6, replicaset]
-    commands:
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: 3.6
-          TOPOLOGY: replica_set
-      - func: "run driver test suite"
-
   - name: test-4.0-replicaset
     tags: [4.0, replicaset]
     commands:
@@ -181,15 +163,6 @@ tasks:
         vars:
           MONGODB_VERSION: latest
           TOPOLOGY: replica_set
-      - func: "run driver test suite"
-
-  - name: test-3.6-sharded
-    tags: [3.6, sharded]
-    commands:
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: 3.6
-          TOPOLOGY: sharded_cluster
       - func: "run driver test suite"
 
   - name: test-4.0-sharded

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more details, including features, runnable examples, troubleshooting resourc
 ## Installation
 ### Requirements
 - Rust 1.64+ (See the [MSRV policy](#minimum-supported-rust-version-msrv-policy) for more information)
-- MongoDB 3.6+
+- MongoDB 4.0+
 
 #### Supported Platforms
 

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -13,8 +13,8 @@ use crate::{
     serde_util,
 };
 
-const DRIVER_MIN_DB_VERSION: &str = "3.6";
-const DRIVER_MIN_WIRE_VERSION: i32 = 6;
+const DRIVER_MIN_DB_VERSION: &str = "4.0";
+const DRIVER_MIN_WIRE_VERSION: i32 = 7;
 const DRIVER_MAX_WIRE_VERSION: i32 = 21;
 
 /// Enum representing the possible types of servers that the driver can connect to.

--- a/src/test/spec/json/server-discovery-and-monitoring/README.rst
+++ b/src/test/spec/json/server-discovery-and-monitoring/README.rst
@@ -262,6 +262,32 @@ Run the following test(s) on MongoDB 4.4+.
              mode: "off",
          });
 
+Heartbeat Tests
+~~~~~~~~~~~~~~~
+
+1. Test that ``ServerHeartbeatStartedEvent`` is emitted before the monitoring socket was created
+
+   #. Create a mock TCP server (example shown below) that pushes a ``client connected`` event to a shared array when a client connects and a ``client hello received`` event when the server receives the client hello and then closes the connection::
+         
+        let events = [];
+        server = createServer(clientSocket => {
+          events.push('client connected');
+
+          clientSocket.on('data', () => {
+            events.push('client hello received');
+            clientSocket.destroy();
+          });
+        });
+        server.listen(9999);
+
+   #. Create a client with ``serverSelectionTimeoutMS: 500`` and listen to ``ServerHeartbeatStartedEvent`` and ``ServerHeartbeatFailedEvent``, pushing the event name to the same shared array as the mock TCP server
+    
+   #. Attempt to connect client to previously created TCP server, catching the error when the client fails to connect
+
+   #. Assert that the first four elements in the array are: ::
+
+        ['serverHeartbeatStartedEvent', 'client connected', 'client hello received', 'serverHeartbeatFailedEvent']
+
 .. Section for links.
 
 .. _Server Description Equality: /source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#server-description-equality

--- a/src/test/spec/json/server-discovery-and-monitoring/rs/compatible.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/rs/compatible.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/src/test/spec/json/server-discovery-and-monitoring/rs/compatible.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/rs/compatible.yml
@@ -12,7 +12,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
                     ok: 1,

--- a/src/test/spec/json/server-discovery-and-monitoring/rs/compatible_unknown.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/rs/compatible_unknown.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/test/spec/json/server-discovery-and-monitoring/rs/compatible_unknown.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/rs/compatible_unknown.yml
@@ -12,7 +12,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
         ],
         outcome: {

--- a/src/test/spec/json/server-discovery-and-monitoring/sharded/compatible.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/sharded/compatible.json
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/test/spec/json/server-discovery-and-monitoring/sharded/compatible.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/sharded/compatible.yml
@@ -17,7 +17,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
         outcome: {

--- a/src/test/spec/json/server-discovery-and-monitoring/single/compatible.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/single/compatible.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/test/spec/json/server-discovery-and-monitoring/single/compatible.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/single/compatible.yml
@@ -8,7 +8,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
         outcome: {

--- a/src/test/spec/json/server-discovery-and-monitoring/single/too_old_then_upgraded.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/single/too_old_then_upgraded.json
@@ -1,5 +1,5 @@
 {
-  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6",
+  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 21",
   "uri": "mongodb://a",
   "phases": [
     {
@@ -35,7 +35,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/src/test/spec/json/server-discovery-and-monitoring/single/too_old_then_upgraded.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/single/too_old_then_upgraded.yml
@@ -1,4 +1,4 @@
-description: "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6"
+description: "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 21"
 uri: "mongodb://a"
 phases: [
     {
@@ -29,7 +29,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
         outcome: {


### PR DESCRIPTION
RUST-1821

The driver ticket includes
> Cleanup/refactor any code that isn't needed anymore (code needed to support server version 3.6)

I took a look around the driver code and didn't find anything in particular that special cases 3.6 or <4.0.