### PR TITLE
minor: update migration guide with bson-* feature removal

### DIFF
--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -137,3 +137,6 @@ In 2.x, most but not all option struct builders would allow value conversion via
 
 ## `comment_bson` is now `comment`
 In 2.x, the `AggregateOptions`, `FindOptions`, and `FindOneOptions` structs had both `comment_bson` and legacy `comment` fields.  In 3.x, `comment_bson` has been renamed to `comment`, replacing the legacy field.
+
+## `bson-*` features removed
+The 2.x driver provided features like `bson-chrono-0_4` that did not add any additional driver functionality but would enable the corresponding feature of the `bson` dependency.  These have been removed from 3.x; if your project needs specific `bson` features, you should list it as a top-level dependency with those features enabled.

--- a/migration-3.0.md
+++ b/migration-3.0.md
@@ -115,8 +115,6 @@ let options = ClientOptions::builder()
 ## Future-proof Features
 Starting in 3.0, if the Rust driver is compiled with `no-default-features` it will require the use of a `compat` feature; this provides the flexibility to make features optional in future versions of the driver.  Lack of this had prevented `rustls` and `dns-resolution` from becoming optional in 2.x; they are now optional in 3.0.
 
-In addition, we have removed the various `bson-*` features from the driver, as those can be selected by including `bson` as a direct dependency.
-
 ## ReadConcern / WriteConcern Helpers
 The Rust driver provides convenience helpers for constructing commonly used read or write concerns (e.g. "majority").  In 2.x, these were an overlapping mix of constants and methods (`ReadConcern::MAJORITY` and `ReadConcern::majority()`).  In 3.0, these are only provided as methods.
 


### PR DESCRIPTION
This only had a perfunctory mention in the "Future-proof Features" section, but that wasn't very descriptive and was easy to miss (e.g. #1152).