### PR TITLE
RUST-1791 Publish an event changing topology state to unknown before closing

### DIFF
--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -428,12 +428,11 @@ impl TopologyWorker {
             while close_futures.next().await.is_some() {}
 
             if let Some(emitter) = self.event_emitter {
-                if !self.topology_description.servers.is_empty()
-                    && self.options.load_balanced != Some(true)
-                {
+                if !self.topology_description.servers.is_empty() {
                     let previous_description = self.topology_description;
                     let mut new_description = previous_description.clone();
                     new_description.servers.clear();
+                    new_description.topology_type = TopologyType::Unknown;
 
                     emitter
                         .emit(SdamEvent::TopologyDescriptionChanged(Box::new(

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.json
@@ -1,0 +1,88 @@
+{
+  "description": "loadbalanced-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 2
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {}
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "newDescription": {
+                  "type": "LoadBalanced"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/loadbalanced-emit-topology-changed-before-close.yml
@@ -1,0 +1,49 @@
+description: "loadbalanced-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - load-balanced
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and server connect event.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 2
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: # unknown -> unknown w disconnected server
+              previousDescription: 
+                type: "Unknown"
+              newDescription: {}
+          - topologyDescriptionChangedEvent:  # unknown w disconnected server -> loadBalanced
+              newDescription:
+                type: "LoadBalanced"
+          - topologyDescriptionChangedEvent:  # loadbalanced -> unknown
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/logging-loadbalanced.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/logging-loadbalanced.json
@@ -136,6 +136,22 @@
               "level": "debug",
               "component": "topology",
               "data": {
+                "message": "Topology description changed",
+                "topologyId": {
+                  "$$exists": true
+                },
+                "previousDescription": {
+                  "$$exists": true
+                },
+                "newDescription": {
+                  "$$exists": true
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "topology",
+              "data": {
                 "message": "Stopped topology monitoring",
                 "topologyId": {
                   "$$exists": true

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/logging-loadbalanced.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/logging-loadbalanced.yml
@@ -70,5 +70,12 @@ tests:
           - level: debug
             component: topology
             data:
+              message: "Topology description changed"
+              topologyId: { $$exists: true }
+              previousDescription: { $$exists: true } # loadBalanced topology
+              newDescription: { $$exists: true } # unknown topology
+          - level: debug
+            component: topology
+            data:
               message: "Stopped topology monitoring"
               topologyId: { $$exists: true }

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.json
@@ -1,0 +1,89 @@
+{
+  "description": "replicaset-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "replicaset"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 4
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "ReplicaSetWithPrimary"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/replicaset-emit-topology-changed-before-close.yml
@@ -1,0 +1,49 @@
+description: "replicaset-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - replicaset
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and 3 server connect events.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 4
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: {} # unknown -> replset no primary
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent:  # replicaset -> unknown
+              previousDescription:
+                type: "ReplicaSetWithPrimary"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.json
@@ -1,0 +1,108 @@
+{
+  "description": "sharded-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "sharded"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ],
+                  "useMultipleMongoses": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 3
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Sharded"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Sharded"
+                },
+                "newDescription": {
+                  "type": "Sharded"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Sharded"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/sharded-emit-topology-changed-before-close.yml
@@ -1,0 +1,62 @@
+description: "sharded-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - sharded
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+                useMultipleMongoses: true
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial cluster type change from unknown to sharded and connect events
+      # for each of 2 servers
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 3
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: # unknown -> unknown w disconnected server
+              previousDescription: 
+                type: "Unknown"
+              newDescription:
+                type: "Unknown"
+          - topologyDescriptionChangedEvent:  # server connected
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "Sharded"
+          - topologyDescriptionChangedEvent:  # server connected
+              previousDescription:
+                type: "Sharded"
+              newDescription:
+                type: "Sharded"
+          - topologyDescriptionChangedEvent:  # sharded -> unknown
+              previousDescription:
+                type: "Sharded"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.json
@@ -1,0 +1,97 @@
+{
+  "description": "standalone-emit-topology-description-changed-before-close",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "single"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "Topology lifecycle",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "topologyOpeningEvent",
+                    "topologyClosedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 2
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Single"
+                }
+              }
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Single"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/unified/standalone-emit-topology-changed-before-close.yml
@@ -1,0 +1,55 @@
+description: "standalone-emit-topology-description-changed-before-close"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - single
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "Topology lifecycle"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - topologyOpeningEvent
+                  - topologyClosedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and server connect event.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 2
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false 
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: # unknown -> unknown w disconnected server
+              previousDescription: 
+                type: "Unknown"
+              newDescription: 
+                type: "Unknown"
+          - topologyDescriptionChangedEvent:  # unknown w disconnected server -> standalone 
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "Single"
+          - topologyDescriptionChangedEvent:  # standalone -> unknown
+              previousDescription:
+                type: "Single"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -351,6 +351,8 @@ fn sdam_events_match(actual: &SdamEvent, expected: &ExpectedSdamEvent) -> Result
             }
             Ok(())
         }
+        (SdamEvent::TopologyOpening(_), ExpectedSdamEvent::TopologyOpening {}) => Ok(()),
+        (SdamEvent::TopologyClosed(_), ExpectedSdamEvent::TopologyClosed {}) => Ok(()),
         (
             SdamEvent::TopologyDescriptionChanged(actual),
             ExpectedSdamEvent::TopologyDescriptionChanged {

--- a/src/test/spec/unified_runner/matcher.rs
+++ b/src/test/spec/unified_runner/matcher.rs
@@ -352,9 +352,26 @@ fn sdam_events_match(actual: &SdamEvent, expected: &ExpectedSdamEvent) -> Result
             Ok(())
         }
         (
-            SdamEvent::TopologyDescriptionChanged(_),
-            ExpectedSdamEvent::TopologyDescriptionChanged {},
-        ) => Ok(()),
+            SdamEvent::TopologyDescriptionChanged(actual),
+            ExpectedSdamEvent::TopologyDescriptionChanged {
+                previous_description,
+                new_description,
+            },
+        ) => {
+            if let Some(expected_prev) = previous_description {
+                match_opt(
+                    &actual.previous_description.topology_type(),
+                    &expected_prev.topology_type,
+                )?;
+            }
+            if let Some(expected_new) = new_description {
+                match_opt(
+                    &actual.new_description.topology_type(),
+                    &expected_new.topology_type,
+                )?;
+            }
+            Ok(())
+        }
         (
             SdamEvent::ServerHeartbeatStarted(actual),
             ExpectedSdamEvent::ServerHeartbeatStarted { awaited },

--- a/src/test/spec/unified_runner/test_event.rs
+++ b/src/test/spec/unified_runner/test_event.rs
@@ -84,6 +84,10 @@ pub(crate) enum ExpectedSdamEvent {
         previous_description: Option<TestServerDescription>,
         new_description: Option<TestServerDescription>,
     },
+    #[serde(rename = "topologyOpeningEvent")]
+    TopologyOpening {},
+    #[serde(rename = "topologyClosedEvent")]
+    TopologyClosed {},
     #[serde(rename = "topologyDescriptionChangedEvent", rename_all = "camelCase")]
     TopologyDescriptionChanged {
         previous_description: Option<TestTopologyDescription>,
@@ -143,6 +147,10 @@ pub(crate) enum ObserveEvent {
     ConnectionCheckedIn,
     #[serde(rename = "serverDescriptionChangedEvent")]
     ServerDescriptionChanged,
+    #[serde(rename = "topologyOpeningEvent")]
+    TopologyOpening,
+    #[serde(rename = "topologyClosedEvent")]
+    TopologyClosed,
     #[serde(rename = "topologyDescriptionChangedEvent")]
     TopologyDescriptionChanged,
     #[serde(rename = "serverHeartbeatStartedEvent")]
@@ -177,6 +185,8 @@ impl ObserveEvent {
             ) => true,
             (Self::ConnectionCheckedOut, Event::Cmap(CmapEvent::ConnectionCheckedOut(_))) => true,
             (Self::ConnectionCheckedIn, Event::Cmap(CmapEvent::ConnectionCheckedIn(_))) => true,
+            (Self::TopologyOpening, Event::Sdam(SdamEvent::TopologyOpening(_))) => true,
+            (Self::TopologyClosed, Event::Sdam(SdamEvent::TopologyClosed(_))) => true,
             (
                 Self::TopologyDescriptionChanged,
                 Event::Sdam(SdamEvent::TopologyDescriptionChanged(_)),

--- a/src/test/spec/unified_runner/test_event.rs
+++ b/src/test/spec/unified_runner/test_event.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     test::Event,
     ServerType,
+    TopologyType,
 };
 use serde::Deserialize;
 
@@ -83,8 +84,11 @@ pub(crate) enum ExpectedSdamEvent {
         previous_description: Option<TestServerDescription>,
         new_description: Option<TestServerDescription>,
     },
-    #[serde(rename = "topologyDescriptionChangedEvent")]
-    TopologyDescriptionChanged {},
+    #[serde(rename = "topologyDescriptionChangedEvent", rename_all = "camelCase")]
+    TopologyDescriptionChanged {
+        previous_description: Option<TestTopologyDescription>,
+        new_description: Option<TestTopologyDescription>,
+    },
     #[serde(rename = "serverHeartbeatStartedEvent", rename_all = "camelCase")]
     ServerHeartbeatStarted { awaited: Option<bool> },
     #[serde(rename = "serverHeartbeatSucceededEvent", rename_all = "camelCase")]
@@ -98,6 +102,13 @@ pub(crate) enum ExpectedSdamEvent {
 pub(crate) struct TestServerDescription {
     #[serde(rename = "type")]
     pub(crate) server_type: Option<ServerType>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TestTopologyDescription {
+    #[serde(rename = "type")]
+    pub(crate) topology_type: Option<TopologyType>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize)]


### PR DESCRIPTION
RUST-1791

We were already publishing an event, just needed to update the topology type and add support for checking it in the unified runner.