### PR TITLE
RUST-1879 Convert read/write concern operation tests to unified format

### DIFF
--- a/src/test/spec.rs
+++ b/src/test/spec.rs
@@ -24,7 +24,7 @@ mod sessions;
 #[cfg(feature = "tracing-unstable")]
 mod trace;
 mod transactions;
-pub mod unified_runner;
+pub(crate) mod unified_runner;
 mod v2_runner;
 mod versioned_api;
 mod write_error;

--- a/src/test/spec/json/read-write-concern/README.rst
+++ b/src/test/spec/json/read-write-concern/README.rst
@@ -1,6 +1,6 @@
-=======================
-Connection String Tests
-=======================
+============================
+Read and Write Concern Tests
+============================
 
 The YAML and JSON files in this directory tree are platform-independent tests
 that drivers can use to prove their conformance to the Read and Write Concern 
@@ -57,19 +57,7 @@ Operation
 
 These tests check that the default write concern is omitted in operations.
 
-The spec test format is an extension of `transactions spec tests <https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst>`_ with the following additions:
-
-- ``writeConcern`` in the ``databaseOptions`` or ``collectionOptions`` may be an empty document to indicate a `server default write concern <https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#servers-default-writeconcern>`_. For example, in libmongoc:
-
-    .. code:: c
-
-       /* Create a default write concern, and set on a collection object. */
-       mongoc_write_concern_t *wc = mongoc_write_concern_new ();
-       mongoc_collection_set_write_concern (collection, wc);
-
-    If the driver has no way to explicitly set a default write concern on a database or collection, ignore the empty ``writeConcern`` document and continue with the test.
-- The operations ``createIndex``, ``dropIndex`` are introduced.
-
+The tests utilize the `Unified Test Format <../../unified-test-format/unified-test-format.md>`__.
 
 Use as unit tests
 =================

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-2.6.json
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-2.6.json
@@ -1,19 +1,55 @@
 {
-  "data": [
-    {
-      "_id": 1,
-      "x": 11
-    },
-    {
-      "_id": 2,
-      "x": 22
-    }
-  ],
-  "collection_name": "default_write_concern_coll",
-  "database_name": "default_write_concern_db",
-  "runOn": [
+  "description": "default-write-concern-2.6",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
     {
       "minServerVersion": "2.6"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "default-write-concern-tests",
+        "databaseOptions": {
+          "writeConcern": {}
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll",
+        "collectionOptions": {
+          "writeConcern": {}
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "default-write-concern-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
     }
   ],
   "tests": [
@@ -22,32 +58,36 @@
       "operations": [
         {
           "name": "deleteOne",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {}
           },
-          "result": {
+          "expectResult": {
             "deletedCount": 1
           }
         }
       ],
-      "expectations": [
+      "expectEvents": [
         {
-          "command_started_event": {
-            "command": {
-              "delete": "default_write_concern_coll",
-              "deletes": [
-                {
-                  "q": {},
-                  "limit": 1
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 1
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
                 }
-              ],
-              "writeConcern": null
+              }
             }
-          }
+          ]
         }
       ]
     },
@@ -56,32 +96,36 @@
       "operations": [
         {
           "name": "deleteMany",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {}
           },
-          "result": {
+          "expectResult": {
             "deletedCount": 2
           }
         }
       ],
-      "expectations": [
+      "expectEvents": [
         {
-          "command_started_event": {
-            "command": {
-              "delete": "default_write_concern_coll",
-              "deletes": [
-                {
-                  "q": {},
-                  "limit": 0
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 0
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
                 }
-              ],
-              "writeConcern": null
+              }
             }
-          }
+          ]
         }
       ]
     },
@@ -90,30 +134,24 @@
       "operations": [
         {
           "name": "bulkWrite",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "ordered": true,
             "requests": [
               {
-                "name": "deleteMany",
-                "arguments": {
+                "deleteMany": {
                   "filter": {}
                 }
               },
               {
-                "name": "insertOne",
-                "arguments": {
+                "insertOne": {
                   "document": {
                     "_id": 1
                   }
                 }
               },
               {
-                "name": "updateOne",
-                "arguments": {
+                "updateOne": {
                   "filter": {
                     "_id": 1
                   },
@@ -125,16 +163,14 @@
                 }
               },
               {
-                "name": "insertOne",
-                "arguments": {
+                "insertOne": {
                   "document": {
                     "_id": 2
                   }
                 }
               },
               {
-                "name": "replaceOne",
-                "arguments": {
+                "replaceOne": {
                   "filter": {
                     "_id": 1
                   },
@@ -144,16 +180,14 @@
                 }
               },
               {
-                "name": "insertOne",
-                "arguments": {
+                "insertOne": {
                   "document": {
                     "_id": 3
                   }
                 }
               },
               {
-                "name": "updateMany",
-                "arguments": {
+                "updateMany": {
                   "filter": {
                     "_id": 1
                   },
@@ -165,8 +199,7 @@
                 }
               },
               {
-                "name": "deleteOne",
-                "arguments": {
+                "deleteOne": {
                   "filter": {
                     "_id": 3
                   }
@@ -176,10 +209,177 @@
           }
         }
       ],
-      "outcome": {
-        "collection": {
-          "name": "default_write_concern_coll",
-          "data": [
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 0
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 1
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 1
+                        }
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 2
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "x": 2
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 3
+                        }
+                      },
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll",
+                  "deletes": [
+                    {
+                      "q": {
+                        "_id": 3
+                      },
+                      "limit": 1
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "default-write-concern-tests",
+          "documents": [
             {
               "_id": 1,
               "x": 3
@@ -189,136 +389,6 @@
             }
           ]
         }
-      },
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "delete": "default_write_concern_coll",
-              "deletes": [
-                {
-                  "q": {},
-                  "limit": 0
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "default_write_concern_coll",
-              "documents": [
-                {
-                  "_id": 1
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "update": "default_write_concern_coll",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$set": {
-                      "x": 1
-                    }
-                  }
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "default_write_concern_coll",
-              "documents": [
-                {
-                  "_id": 2
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "update": "default_write_concern_coll",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "x": 2
-                  }
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "default_write_concern_coll",
-              "documents": [
-                {
-                  "_id": 3
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "update": "default_write_concern_coll",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$set": {
-                      "x": 3
-                    }
-                  },
-                  "multi": true
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "delete": "default_write_concern_coll",
-              "deletes": [
-                {
-                  "q": {
-                    "_id": 3
-                  },
-                  "limit": 1
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        }
       ]
     },
     {
@@ -326,10 +396,7 @@
       "operations": [
         {
           "name": "insertOne",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "document": {
               "_id": 3
@@ -338,10 +405,7 @@
         },
         {
           "name": "insertMany",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "documents": [
               {
@@ -354,10 +418,51 @@
           }
         }
       ],
-      "outcome": {
-        "collection": {
-          "name": "default_write_concern_coll",
-          "data": [
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 4
+                    },
+                    {
+                      "_id": 5
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "default-write-concern-tests",
+          "documents": [
             {
               "_id": 1,
               "x": 11
@@ -377,37 +482,6 @@
             }
           ]
         }
-      },
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "default_write_concern_coll",
-              "documents": [
-                {
-                  "_id": 3
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "default_write_concern_coll",
-              "documents": [
-                {
-                  "_id": 4
-                },
-                {
-                  "_id": 5
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        }
       ]
     },
     {
@@ -415,10 +489,7 @@
       "operations": [
         {
           "name": "updateOne",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 1
@@ -432,10 +503,7 @@
         },
         {
           "name": "updateMany",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 2
@@ -449,10 +517,7 @@
         },
         {
           "name": "replaceOne",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 2
@@ -463,10 +528,98 @@
           }
         }
       ],
-      "outcome": {
-        "collection": {
-          "name": "default_write_concern_coll",
-          "data": [
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 1
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 1
+                        }
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 2
+                      },
+                      "u": {
+                        "$set": {
+                          "x": 2
+                        }
+                      },
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll",
+                  "updates": [
+                    {
+                      "q": {
+                        "_id": 2
+                      },
+                      "u": {
+                        "x": 3
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "default-write-concern-tests",
+          "documents": [
             {
               "_id": 1,
               "x": 1
@@ -476,67 +629,6 @@
               "x": 3
             }
           ]
-        }
-      },
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "update": "default_write_concern_coll",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 1
-                  },
-                  "u": {
-                    "$set": {
-                      "x": 1
-                    }
-                  }
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "update": "default_write_concern_coll",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 2
-                  },
-                  "u": {
-                    "$set": {
-                      "x": 2
-                    }
-                  },
-                  "multi": true
-                }
-              ],
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "update": "default_write_concern_coll",
-              "updates": [
-                {
-                  "q": {
-                    "_id": 2
-                  },
-                  "u": {
-                    "x": 3
-                  }
-                }
-              ],
-              "writeConcern": null
-            }
-          }
         }
       ]
     }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-2.6.yml
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-2.6.yml
@@ -1,215 +1,296 @@
-# Test that setting a default write concern does not add a write concern
-# to the command sent over the wire.
+# Test that setting a default write concern does not add a write concern to the command sent over the wire.
 # Test operations that require 2.6+ server.
 
-data:
-  - {_id: 1, x: 11}
-  - {_id: 2, x: 22}
-collection_name: &collection_name default_write_concern_coll
-database_name: &database_name default_write_concern_db
+description: default-write-concern-2.6
 
-runOn:
-    - minServerVersion: "2.6"
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "2.6"
+
+createEntities:
+  -
+    client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  -
+    database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database_name default-write-concern-tests
+      databaseOptions:
+        writeConcern: {}
+  -
+    collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection_name coll
+      collectionOptions:
+        writeConcern: {}
+
+initialData:
+  -
+    collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
 
 tests:
-  - description: DeleteOne omits default write concern
+  -
+    description: DeleteOne omits default write concern
     operations:
-      - name: deleteOne
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: deleteOne
+        object: *collection0
         arguments:
           filter: {}
-        result:
+        expectResult:
           deletedCount: 1
-    expectations:
-      - command_started_event:
-          command:
-            delete: *collection_name
-            deletes:
-              - {q: {}, limit: 1}
-            writeConcern: null
-  - description: DeleteMany omits default write concern
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes: [ { q: {}, limit: 1 } ]
+                writeConcern: { $$exists: false }
+  -
+    description: DeleteMany omits default write concern
     operations:
-      - name: deleteMany
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: deleteMany
+        object: *collection0
         arguments:
           filter: {}
-        result:
+        expectResult:
           deletedCount: 2
-    expectations:
-      - command_started_event:
-          command:
-            delete: *collection_name
-            deletes: [{q: {}, limit: 0}]
-            writeConcern: null
-  - description: BulkWrite with all models omits default write concern
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes: [ { q: {}, limit: 0 } ]
+                writeConcern: { $$exists: false }
+  -
+    description: BulkWrite with all models omits default write concern
     operations:
-      - name: bulkWrite
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: bulkWrite
+        object: *collection0
         arguments:
           ordered: true
           requests:
-            - name: deleteMany
-              arguments:
+            -
+              deleteMany:
                 filter: {}
-            - name: insertOne
-              arguments:
-                document: {_id: 1}
-            - name: updateOne
-              arguments:
-                filter: {_id: 1}
-                update: {$set: {x: 1}}
-            - name: insertOne
-              arguments:
-                document: {_id: 2}
-            - name: replaceOne
-              arguments:
-                filter: {_id: 1}
-                replacement: {x: 2}
-            - name: insertOne
-              arguments:
-                document: {_id: 3}
-            - name: updateMany
-              arguments:
-                filter: {_id: 1}
-                update: {$set: {x: 3}}
-            - name: deleteOne
-              arguments:
-                filter: {_id: 3}
+            -
+              insertOne:
+                document: { _id: 1 }
+            -
+              updateOne:
+                filter: { _id: 1 }
+                update: { $set: { x: 1 } }
+            -
+              insertOne:
+                document: { _id: 2 }
+            -
+              replaceOne:
+                filter: { _id: 1 }
+                replacement: { x: 2 }
+            -
+              insertOne:
+                document: { _id: 3 }
+            -
+              updateMany:
+                filter: { _id: 1 }
+                update: { $set: { x: 3 } }
+            -
+              deleteOne:
+                filter: { _id: 3 }
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes: [ { q: {}, limit: 0 } ]
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents: [ { _id: 1 } ]
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: { _id: 1 }
+                    u: { $set: { x: 1 } }
+                    upsert: { $$unsetOrMatches: false }
+                    multi: { $$unsetOrMatches: false }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents: [ { _id: 2 } ]
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: { _id: 1 }
+                    u: { x: 2 }
+                    upsert: { $$unsetOrMatches: false }
+                    multi: { $$unsetOrMatches: false }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents: [ { _id: 3 } ]
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: { _id: 1 }
+                    u: { $set: { x: 3 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes: [ { q: { _id: 3 }, limit: 1 } ]
+                writeConcern: { $$exists: false }
     outcome:
-      collection:
-        name: *collection_name
-        data:
-          - {_id: 1, x: 3}
-          - {_id: 2}
-    expectations:
-      - command_started_event:
-          command:
-            delete: *collection_name
-            deletes: [{q: {}, limit: 0}]
-            writeConcern: null
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 1}
-            writeConcern: null
-      - command_started_event:
-          command:
-            update: *collection_name
-            updates:
-              - {q: {_id: 1}, u: {$set: {x: 1}}}
-            writeConcern: null
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 2}
-            writeConcern: null
-      - command_started_event:
-          command:
-            update: *collection_name
-            updates:
-              - {q: {_id: 1}, u: {x: 2}}
-            writeConcern: null
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 3}
-            writeConcern: null
-      - command_started_event:
-          command:
-            update: *collection_name
-            updates: 
-              - {q: {_id: 1}, u: {$set: {x: 3}}, multi: true}
-            writeConcern: null
-      - command_started_event:
-          command:
-            delete: *collection_name
-            deletes: [{q: {_id: 3}, limit: 1}]
-            writeConcern: null
-  - description: 'InsertOne and InsertMany omit default write concern'
+      -
+        collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 3 }
+          - { _id: 2 }
+  -
+    description: InsertOne and InsertMany omit default write concern
     operations:
-      - name: insertOne
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: insertOne
+        object: *collection0
         arguments:
-          document: {_id: 3}
-      - name: insertMany
-        object: collection
-        collectionOptions: {writeConcern: {}}
+          document: { _id: 3 }
+      -
+        name: insertMany
+        object: *collection0
         arguments:
           documents:
-            - {_id: 4}
-            - {_id: 5}
+            - { _id: 4 }
+            - { _id: 5 }
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents: [ { _id: 3 } ]
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents: [ { _id: 4 }, { _id: 5 } ]
+                writeConcern: { $$exists: false }
     outcome:
-      collection:
-        name: *collection_name
-        data:
-          - {_id: 1, x: 11}
-          - {_id: 2, x: 22}
-          - {_id: 3}
-          - {_id: 4}
-          - {_id: 5}
-    expectations:
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 3}
-            writeConcern: null
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - {_id: 4}
-              - {_id: 5}
-            writeConcern: null
-  - description: 'UpdateOne, UpdateMany, and ReplaceOne omit default write concern'
+      -
+        collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3 }
+          - { _id: 4 }
+          - { _id: 5 }
+  -
+    description: UpdateOne, UpdateMany, and ReplaceOne omit default write concern
     operations:
-      - name: updateOne
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: updateOne
+        object: *collection0
         arguments:
-          filter: {_id: 1}
-          update: {$set: {x: 1}}
-      - name: updateMany
-        object: collection
-        collectionOptions: {writeConcern: {}}
+          filter: { _id: 1 }
+          update: { $set: { x: 1 } }
+      -
+        name: updateMany
+        object: *collection0
         arguments:
-          filter: {_id: 2}
-          update: {$set: {x: 2}}
-      - name: replaceOne
-        object: collection
-        collectionOptions: {writeConcern: {}}
+          filter: { _id: 2 }
+          update: { $set: { x: 2 } }
+      -
+        name: replaceOne
+        object: *collection0
         arguments:
-          filter: {_id: 2}
-          replacement: {x: 3}
+          filter: { _id: 2 }
+          replacement: { x: 3 }
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: { _id: 1 }
+                    u: { $set: { x: 1 } }
+                    upsert: { $$unsetOrMatches: false }
+                    multi: { $$unsetOrMatches: false }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: { _id: 2 }
+                    u: { $set: { x: 2 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                update: *collection_name
+                updates:
+                  -
+                    q: { _id: 2 }
+                    u: { x: 3 }
+                    upsert: { $$unsetOrMatches: false }
+                    multi: { $$unsetOrMatches: false }
+                writeConcern: { $$exists: false }
     outcome:
-      collection:
-        name: *collection_name
-        data:
-          - {_id: 1, x: 1}
-          - {_id: 2, x: 3}
-    expectations:
-      - command_started_event:
-          command:
-            update: *collection_name
-            updates:
-              - {q: {_id: 1}, u: {$set: {x: 1}}}
-            writeConcern: null
-      - command_started_event:
-          command:
-            update: *collection_name
-            updates:
-              - {q: {_id: 2}, u: {$set: {x: 2}}, multi: true}
-            writeConcern: null
-      - command_started_event:
-          command:
-            update: *collection_name
-            updates:
-              - {q: {_id: 2}, u: {x: 3}}
-            writeConcern: null
+      -
+        collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 1 }
+          - { _id: 2, x: 3 }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-3.2.json
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-3.2.json
@@ -1,19 +1,55 @@
 {
-  "data": [
-    {
-      "_id": 1,
-      "x": 11
-    },
-    {
-      "_id": 2,
-      "x": 22
-    }
-  ],
-  "collection_name": "default_write_concern_coll",
-  "database_name": "default_write_concern_db",
-  "runOn": [
+  "description": "default-write-concern-3.2",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
     {
       "minServerVersion": "3.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "default-write-concern-tests",
+        "databaseOptions": {
+          "writeConcern": {}
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll",
+        "collectionOptions": {
+          "writeConcern": {}
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "default-write-concern-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
     }
   ],
   "tests": [
@@ -22,10 +58,7 @@
       "operations": [
         {
           "name": "findOneAndUpdate",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 1
@@ -39,10 +72,7 @@
         },
         {
           "name": "findOneAndReplace",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 2
@@ -54,10 +84,7 @@
         },
         {
           "name": "findOneAndDelete",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "filter": {
               "_id": 2
@@ -65,59 +92,71 @@
           }
         }
       ],
-      "outcome": {
-        "collection": {
-          "name": "default_write_concern_coll",
-          "data": [
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll",
+                  "query": {
+                    "_id": 1
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 1
+                    }
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll",
+                  "query": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "x": 2
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll",
+                  "query": {
+                    "_id": 2
+                  },
+                  "remove": true,
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "default-write-concern-tests",
+          "documents": [
             {
               "_id": 1,
               "x": 1
             }
           ]
-        }
-      },
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "findAndModify": "default_write_concern_coll",
-              "query": {
-                "_id": 1
-              },
-              "update": {
-                "$set": {
-                  "x": 1
-                }
-              },
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "findAndModify": "default_write_concern_coll",
-              "query": {
-                "_id": 2
-              },
-              "update": {
-                "x": 2
-              },
-              "writeConcern": null
-            }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "findAndModify": "default_write_concern_coll",
-              "query": {
-                "_id": 2
-              },
-              "remove": true,
-              "writeConcern": null
-            }
-          }
         }
       ]
     }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-3.2.yml
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-3.2.yml
@@ -1,58 +1,91 @@
-# Test that setting a default write concern does not add a write concern
-# to the command sent over the wire.
-# Test operations that require 3.2+ server, where findAndModify started
-# to accept a write concern.
+# Test that setting a default write concern does not add a write concern to the command sent over the wire.
+# Test operations that require 3.2+ server, where findAndModify started to accept a write concern.
 
-data:
-  - {_id: 1, x: 11}
-  - {_id: 2, x: 22}
-collection_name: &collection_name default_write_concern_coll
-database_name: &database_name default_write_concern_db
+description: default-write-concern-3.2
 
-runOn:
-    - minServerVersion: "3.2"
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.2"
+
+createEntities:
+  -
+    client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  -
+    database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database_name default-write-concern-tests
+      databaseOptions:
+        writeConcern: {}
+  -
+    collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection_name coll
+      collectionOptions:
+        writeConcern: {}
+
+initialData:
+  -
+    collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
 
 tests:
-  - description: 'findAndModify operations omit default write concern'
+  -
+    description: findAndModify operations omit default write concern
     operations:
-      - name: findOneAndUpdate
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: findOneAndUpdate
+        object: *collection0
         arguments:
-          filter: {_id: 1}
-          update: {$set: {x: 1}}
-      - name: findOneAndReplace
-        object: collection
-        collectionOptions: {writeConcern: {}}
+          filter: { _id: 1 }
+          update: { $set: { x: 1 } }
+      -
+        name: findOneAndReplace
+        object: *collection0
         arguments:
-          filter: {_id: 2}
-          replacement: {x: 2}
-      - name: findOneAndDelete
-        object: collection
-        collectionOptions: {writeConcern: {}}
+          filter: { _id: 2 }
+          replacement: { x: 2 }
+      -
+        name: findOneAndDelete
+        object: *collection0
         arguments:
-          filter: {_id: 2}
+          filter: { _id: 2 }
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                findAndModify: *collection_name
+                query: { _id: 1 }
+                update: { $set: { x: 1 } }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                findAndModify: *collection_name
+                query: { _id: 2 }
+                update: { x: 2 }
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                findAndModify: *collection_name
+                query: { _id: 2 }
+                remove: true
+                writeConcern: { $$exists: false }
     outcome:
-      collection:
-        name: *collection_name
-        data:
-          - {_id: 1, x: 1}
-    expectations:
-      - command_started_event:
-          command:
-            findAndModify: *collection_name
-            query: {_id: 1}
-            update: {$set: {x: 1}}
-            writeConcern: null
-      - command_started_event:
-          command:
-            findAndModify: *collection_name
-            query: {_id: 2}
-            update: {x: 2}
-            writeConcern: null
-      - command_started_event:
-          command:
-            findAndModify: *collection_name
-            query: {_id: 2}
-            remove: true
-            writeConcern: null
+      -
+        collectionName: *collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 1, x: 1 }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-3.4.json
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-3.4.json
@@ -1,30 +1,68 @@
 {
-  "data": [
-    {
-      "_id": 1,
-      "x": 11
-    },
-    {
-      "_id": 2,
-      "x": 22
-    }
-  ],
-  "collection_name": "default_write_concern_coll",
-  "database_name": "default_write_concern_db",
-  "runOn": [
+  "description": "default-write-concern-3.4",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
     {
       "minServerVersion": "3.4"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "default-write-concern-tests",
+        "databaseOptions": {
+          "writeConcern": {}
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll",
+        "collectionOptions": {
+          "writeConcern": {}
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "default-write-concern-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
     }
   ],
   "tests": [
     {
       "description": "Aggregate with $out omits default write concern",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "name": "aggregate",
           "arguments": {
             "pipeline": [
@@ -42,37 +80,45 @@
           }
         }
       ],
-      "outcome": {
-        "collection": {
-          "name": "other_collection_name",
-          "data": [
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$out": "other_collection_name"
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "other_collection_name",
+          "databaseName": "default-write-concern-tests",
+          "documents": [
             {
               "_id": 2,
               "x": 22
             }
           ]
-        }
-      },
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "aggregate": "default_write_concern_coll",
-              "pipeline": [
-                {
-                  "$match": {
-                    "_id": {
-                      "$gt": 1
-                    }
-                  }
-                },
-                {
-                  "$out": "other_collection_name"
-                }
-              ],
-              "writeConcern": null
-            }
-          }
         }
       ]
     },
@@ -80,39 +126,43 @@
       "description": "RunCommand with a write command omits default write concern (runCommand should never inherit write concern)",
       "operations": [
         {
-          "object": "database",
-          "databaseOptions": {
-            "writeConcern": {}
-          },
+          "object": "database0",
           "name": "runCommand",
-          "command_name": "delete",
           "arguments": {
             "command": {
-              "delete": "default_write_concern_coll",
+              "delete": "coll",
               "deletes": [
                 {
                   "q": {},
                   "limit": 1
                 }
               ]
-            }
+            },
+            "commandName": "delete"
           }
         }
       ],
-      "expectations": [
+      "expectEvents": [
         {
-          "command_started_event": {
-            "command": {
-              "delete": "default_write_concern_coll",
-              "deletes": [
-                {
-                  "q": {},
-                  "limit": 1
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 1
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
+                  }
                 }
-              ],
-              "writeConcern": null
+              }
             }
-          }
+          ]
         }
       ]
     },
@@ -120,10 +170,7 @@
       "description": "CreateIndex and dropIndex omits default write concern",
       "operations": [
         {
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "name": "createIndex",
           "arguments": {
             "keys": {
@@ -132,53 +179,61 @@
           }
         },
         {
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "name": "dropIndex",
           "arguments": {
             "name": "x_1"
           }
         }
       ],
-      "expectations": [
+      "expectEvents": [
         {
-          "command_started_event": {
-            "command": {
-              "createIndexes": "default_write_concern_coll",
-              "indexes": [
-                {
-                  "name": "x_1",
-                  "key": {
-                    "x": 1
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "coll",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
                   }
                 }
-              ],
-              "writeConcern": null
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "dropIndexes": "coll",
+                  "index": "x_1",
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "dropIndexes": "default_write_concern_coll",
-              "index": "x_1",
-              "writeConcern": null
-            }
-          }
+          ]
         }
       ]
     },
     {
       "description": "MapReduce omits default write concern",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "mapReduce",
-          "object": "collection",
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "arguments": {
             "map": {
               "$code": "function inc() { return emit(0, this.x + 1) }"
@@ -192,23 +247,30 @@
           }
         }
       ],
-      "expectations": [
+      "expectEvents": [
         {
-          "command_started_event": {
-            "command": {
-              "mapReduce": "default_write_concern_coll",
-              "map": {
-                "$code": "function inc() { return emit(0, this.x + 1) }"
-              },
-              "reduce": {
-                "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-              },
-              "out": {
-                "inline": 1
-              },
-              "writeConcern": null
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "mapReduce": "coll",
+                  "map": {
+                    "$code": "function inc() { return emit(0, this.x + 1) }"
+                  },
+                  "reduce": {
+                    "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+                  },
+                  "out": {
+                    "inline": 1
+                  },
+                  "writeConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
             }
-          }
+          ]
         }
       ]
     }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-3.4.yml
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-3.4.yml
@@ -1,95 +1,144 @@
-# Test that setting a default write concern does not add a write concern
-# to the command sent over the wire.
-# Test operations that require 3.4+ server, where all commands started
-# to accept a write concern.
+# Test that setting a default write concern does not add a write concern to the command sent over the wire.
+# Test operations that require 3.4+ server, where all commands started to accept a write concern.
 
-data:
-  - {_id: 1, x: 11}
-  - {_id: 2, x: 22}
-collection_name: &collection_name default_write_concern_coll
-database_name: &database_name default_write_concern_db
+description: default-write-concern-3.4
 
-runOn:
-    - minServerVersion: "3.4"
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "3.4"
+
+createEntities:
+  -
+    client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  -
+    database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database_name default-write-concern-tests
+      databaseOptions:
+        writeConcern: {}
+  -
+    collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection_name coll
+      collectionOptions:
+        writeConcern: {}
+
+initialData:
+  -
+    collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
 
 tests:
-  - description: Aggregate with $out omits default write concern
+  -
+    description: Aggregate with $out omits default write concern
+    # Serverless does not support $out stage
+    runOnRequirements:
+      - serverless: forbid
     operations:
-      - object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        object: *collection0
         name: aggregate
         arguments:
           pipeline: &out_pipeline
-            - $match: {_id: {$gt: 1}}
+            - $match: { _id: { $gt: 1 } }
             - $out: &other_collection_name "other_collection_name"
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                aggregate: *collection_name
+                pipeline: *out_pipeline
+                writeConcern: { $$exists: false }
     outcome:
-      collection:
-        name: *other_collection_name
-        data:
-          - {_id: 2, x: 22}
-    expectations:
-      - command_started_event:
-          command:
-            aggregate: *collection_name
-            pipeline: *out_pipeline
-            writeConcern: null
-  - description: RunCommand with a write command omits default write concern (runCommand should never inherit write concern)
+      -
+        collectionName: *other_collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 2, x: 22 }
+  -
+    description: RunCommand with a write command omits default write concern (runCommand should never inherit write concern)
     operations:
-      - object: database
-        databaseOptions: {writeConcern: {}}
+      -
+        object: *database0
         name: runCommand
-        command_name: delete
         arguments:
           command:
             delete: *collection_name
-            deletes:
-              - {q: {}, limit: 1}
-    expectations:
-      - command_started_event:
-          command:
-            delete: *collection_name
-            deletes:
-              - {q: {}, limit: 1}
-            writeConcern: null
-  - description: CreateIndex and dropIndex omits default write concern 
+            deletes: [ { q: {}, limit: 1 } ]
+          commandName: delete
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                delete: *collection_name
+                deletes: [ { q: {}, limit: 1 } ]
+                writeConcern: { $$exists: false }
+  -
+    description: CreateIndex and dropIndex omits default write concern 
     operations:
-      - object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        object: *collection0
         name: createIndex
         arguments:
-          keys: {x: 1}
-      - object: collection
-        collectionOptions: {writeConcern: {}}
+          keys: { x: 1 }
+      -
+        object: *collection0
         name: dropIndex
         arguments:
           name: x_1
-    expectations:
-      - command_started_event:
-          command:
-            createIndexes: *collection_name
-            indexes:
-              - name: x_1
-                key: {x: 1}
-            writeConcern: null
-      - command_started_event:
-          command:
-            dropIndexes: *collection_name
-            index: x_1
-            writeConcern: null
-  - description: MapReduce omits default write concern
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                createIndexes: *collection_name
+                indexes: [ { name: "x_1", key: { x: 1 } } ]
+                writeConcern: { $$exists: false }
+          -
+            commandStartedEvent:
+              command:
+                dropIndexes: *collection_name
+                index: x_1
+                writeConcern: { $$exists: false }
+  -
+    description: MapReduce omits default write concern
+    # Serverless does not support mapReduce operation
+    runOnRequirements:
+      - serverless: forbid
     operations:
-      - name: mapReduce
-        object: collection
-        collectionOptions: {writeConcern: {}}
+      -
+        name: mapReduce
+        object: *collection0
         arguments:
-          map: { $code: 'function inc() { return emit(0, this.x + 1) }' }
-          reduce: { $code: 'function sum(key, values) { return values.reduce((acc, x) => acc + x); }' }
+          map: { $code: "function inc() { return emit(0, this.x + 1) }" }
+          reduce: { $code: "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
           out: { inline: 1 }
-    expectations:
-      - command_started_event:
-          command:
-            mapReduce: *collection_name
-            map: { $code: 'function inc() { return emit(0, this.x + 1) }' }
-            reduce: { $code: 'function sum(key, values) { return values.reduce((acc, x) => acc + x); }' }
-            out: { inline: 1 }
-            writeConcern: null
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                mapReduce: *collection_name
+                map: { $code: "function inc() { return emit(0, this.x + 1) }" }
+                reduce: { $code: "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
+                out: { inline: 1 }
+                writeConcern: { $$exists: false }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-4.2.json
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-4.2.json
@@ -1,19 +1,55 @@
 {
-  "data": [
-    {
-      "_id": 1,
-      "x": 11
-    },
-    {
-      "_id": 2,
-      "x": 22
-    }
-  ],
-  "collection_name": "default_write_concern_coll",
-  "database_name": "default_write_concern_db",
-  "runOn": [
+  "description": "default-write-concern-4.2",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
     {
       "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "default-write-concern-tests",
+        "databaseOptions": {
+          "writeConcern": {}
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll",
+        "collectionOptions": {
+          "writeConcern": {}
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll",
+      "databaseName": "default-write-concern-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        }
+      ]
     }
   ],
   "tests": [
@@ -21,13 +57,7 @@
       "description": "Aggregate with $merge omits default write concern",
       "operations": [
         {
-          "object": "collection",
-          "databaseOptions": {
-            "writeConcern": {}
-          },
-          "collectionOptions": {
-            "writeConcern": {}
-          },
+          "object": "collection0",
           "name": "aggregate",
           "arguments": {
             "pipeline": [
@@ -47,41 +77,49 @@
           }
         }
       ],
-      "expectations": [
+      "expectEvents": [
         {
-          "command_started_event": {
-            "command": {
-              "aggregate": "default_write_concern_coll",
-              "pipeline": [
-                {
-                  "$match": {
-                    "_id": {
-                      "$gt": 1
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$merge": {
+                        "into": "other_collection_name"
+                      }
                     }
-                  }
-                },
-                {
-                  "$merge": {
-                    "into": "other_collection_name"
+                  ],
+                  "writeConcern": {
+                    "$$exists": false
                   }
                 }
-              ],
-              "writeConcern": null
+              }
             }
-          }
+          ]
         }
       ],
-      "outcome": {
-        "collection": {
-          "name": "other_collection_name",
-          "data": [
+      "outcome": [
+        {
+          "collectionName": "other_collection_name",
+          "databaseName": "default-write-concern-tests",
+          "documents": [
             {
               "_id": 2,
               "x": 22
             }
           ]
         }
-      }
+      ]
     }
   ]
 }

--- a/src/test/spec/json/read-write-concern/operation/default-write-concern-4.2.yml
+++ b/src/test/spec/json/read-write-concern/operation/default-write-concern-4.2.yml
@@ -1,36 +1,66 @@
-# Test that setting a default write concern does not add a write concern
-# to the command sent over the wire.
+# Test that setting a default write concern does not add a write concern to the command sent over the wire.
 # Test operations that require 4.2+ server.
 
-data:
-  - {_id: 1, x: 11}
-  - {_id: 2, x: 22}
-collection_name: &collection_name default_write_concern_coll
-database_name: &database_name default_write_concern_db
+description: default-write-concern-4.2
 
-runOn:
-    - minServerVersion: "4.2"
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+
+createEntities:
+  -
+    client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  -
+    database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database_name default-write-concern-tests
+      databaseOptions:
+        writeConcern: {}
+  -
+    collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection_name coll
+      collectionOptions:
+        writeConcern: {}
+
+initialData:
+  -
+    collectionName: *collection_name
+    databaseName: *database_name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
 
 tests:
-  - description: Aggregate with $merge omits default write concern
+  -
+    description: Aggregate with $merge omits default write concern
     operations:
-      - object: collection
-        databaseOptions: {writeConcern: {}}
-        collectionOptions: {writeConcern: {}}
+      -
+        object: *collection0
         name: aggregate
         arguments:
           pipeline: &merge_pipeline
-            - $match: {_id: {$gt: 1}}
-            - $merge: {into: &other_collection_name "other_collection_name" }
-    expectations:
-      - command_started_event:
-          command:
-            aggregate: *collection_name
-            pipeline: *merge_pipeline
-            # "null" fields will be checked for non-existence
-            writeConcern: null
+            - $match: { _id: { $gt: 1 } }
+            - $merge: { into: &other_collection_name "other_collection_name" }
+    expectEvents:
+      -
+        client: *client0
+        events:
+          -
+            commandStartedEvent:
+              command:
+                aggregate: *collection_name
+                pipeline: *merge_pipeline
+                writeConcern: { $$exists: false }
     outcome:
-      collection:
-        name: *other_collection_name
-        data:
-          - {_id: 2, x: 22}
+      -
+        collectionName: *other_collection_name
+        databaseName: *database_name
+        documents:
+          - { _id: 2, x: 22 }

--- a/src/test/spec/read_write_concern.rs
+++ b/src/test/spec/read_write_concern.rs
@@ -1,16 +1,9 @@
 mod connection_string;
 mod document;
-mod operation;
 
-use crate::{
-    bson::{Bson, Document},
-    error::Result,
-    options::WriteConcern,
-};
+use crate::test::spec::unified_runner::run_unified_tests;
 
-fn write_concern_to_document(write_concern: &WriteConcern) -> Result<Document> {
-    match bson::to_bson(&write_concern)? {
-        Bson::Document(doc) => Ok(doc),
-        _ => unreachable!(),
-    }
+#[tokio::test]
+async fn operation() {
+    run_unified_tests(&["read-write-concern", "operation"]).await;
 }

--- a/src/test/spec/read_write_concern/connection_string.rs
+++ b/src/test/spec/read_write_concern/connection_string.rs
@@ -54,8 +54,7 @@ async fn run_connection_string_test(test_file: TestFile) {
                         &normalize_write_concern_doc(
                             options
                                 .write_concern
-                                .map(|w| super::write_concern_to_document(&w)
-                                    .expect(&test_case.description))
+                                .map(|w| bson::to_document(&w).expect(&test_case.description))
                                 .unwrap_or_default()
                         ),
                         write_concern,

--- a/src/test/spec/read_write_concern/operation.rs
+++ b/src/test/spec/read_write_concern/operation.rs
@@ -1,6 +1,0 @@
-use crate::test::spec::v2_runner::run_v2_tests;
-
-#[tokio::test]
-async fn run() {
-    run_v2_tests(&["read-write-concern", "operation"]).await;
-}

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -51,6 +51,7 @@ const SKIPPED_OPERATIONS: &[&str] = &[
     "mapReduce",
 ];
 
+#[cfg(feature = "in-use-encryption-unstable")]
 pub(crate) fn run_v2_tests(spec: &'static [&'static str]) -> RunV2TestsAction {
     RunV2TestsAction {
         spec,


### PR DESCRIPTION
With this change, the CSFLE tests are the only remaining tests that use the v2 runner 🙂 Unfortunately we're using some of the v2 machinery for other tests, so we can't put the whole module behind the `in-use-encryption-unstable` feature flag.