### PR TITLE
RUST-1902 Fix benchmarks for client 3.0 API

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -4,31 +4,18 @@ version = "0.1.0"
 authors = ["benjirewis <ben.rewis98@gmail.com>"]
 edition = "2018"
 
-[features]
-default = ["tokio-runtime"]
-tokio-runtime = [
-  "tokio/fs",
-  "tokio/macros",
-  "tokio/rt",
-  "tokio/rt-multi-thread",
-  "tokio-stream",
-  "mongodb/tokio-runtime"
-]
-async-std-runtime = ["async-std", "mongodb/async-std-runtime"]
-
 [dependencies]
-mongodb = { path = "..", default-features = false }
+mongodb = { path = ".." }
 serde_json = "1.0.59"
 once_cell = "1.19.0"
 clap = "2.33.3"
 indicatif = "0.15.0"
 async-trait = "0.1.41"
-tokio = { version = "1.6", features = ["sync"] }
+tokio = { version = "1.6", features = ["sync", "fs"] }
 tokio-util = "0.7"
-tokio-stream = { version = "0.1.6", features = ["io-util"], optional = true }
-# "unstable" feature is needed for `spawn_blocking`, which is only used in task setup
-async-std = { version = "1.9.0", optional = true, features = ["attributes", "unstable"] }
+tokio-stream = { version = "0.1.6", features = ["io-util"] }
 futures = "0.3.8"
 anyhow = "1.0.34"
 serde = "1"
 num_enum = "0.5"
+futures-util = "0.3.30"

--- a/benchmarks/src/bench.rs
+++ b/benchmarks/src/bench.rs
@@ -149,7 +149,7 @@ pub async fn drop_database(uri: &str, database: &str) -> Result<()> {
 
     let hello = client
         .database("admin")
-        .run_command(doc! { "hello": true }, None)
+        .run_command(doc! { "hello": true })
         .await?;
 
     client.database(&database).drop().await?;
@@ -162,10 +162,10 @@ pub async fn drop_database(uri: &str, database: &str) -> Result<()> {
         for host in options.hosts {
             client
                 .database("admin")
-                .run_command(
-                    doc! { "flushRouterConfig": 1 },
-                    SelectionCriteria::Predicate(Arc::new(move |s| s.address() == &host)),
-                )
+                .run_command(doc! { "flushRouterConfig": 1 })
+                .selection_criteria(SelectionCriteria::Predicate(Arc::new(move |s| {
+                    s.address() == &host
+                })))
                 .await?;
         }
     }

--- a/benchmarks/src/bench/find_many.rs
+++ b/benchmarks/src/bench/find_many.rs
@@ -3,7 +3,7 @@ use std::{convert::TryInto, path::PathBuf};
 use anyhow::{bail, Result};
 use futures::stream::StreamExt;
 use mongodb::{
-    bson::{Bson, Document, RawDocumentBuf},
+    bson::{doc, Bson, Document, RawDocumentBuf},
     Client,
     Collection,
     Database,
@@ -59,7 +59,7 @@ impl Benchmark for FindManyBenchmark {
 
         let coll = db.collection(&COLL_NAME);
         let docs = vec![doc.clone(); num_iter];
-        coll.insert_many(docs, None).await?;
+        coll.insert_many(docs).await?;
 
         Ok(FindManyBenchmark {
             db,
@@ -74,7 +74,7 @@ impl Benchmark for FindManyBenchmark {
             bench: &FindManyBenchmark,
         ) -> Result<()> {
             let coll = bench.coll.clone_with_type::<T>();
-            let mut cursor = coll.find(None, None).await?;
+            let mut cursor = coll.find(doc! {}).await?;
             while let Some(doc) = cursor.next().await {
                 doc?;
             }

--- a/benchmarks/src/bench/find_one.rs
+++ b/benchmarks/src/bench/find_one.rs
@@ -50,7 +50,7 @@ impl Benchmark for FindOneBenchmark {
         let coll = db.collection(&COLL_NAME);
         for i in 0..num_iter {
             doc.insert("_id", i as i32);
-            coll.insert_one(doc.clone(), None).await?;
+            coll.insert_one(doc.clone()).await?;
         }
 
         Ok(FindOneBenchmark {
@@ -63,9 +63,7 @@ impl Benchmark for FindOneBenchmark {
 
     async fn do_task(&self) -> Result<()> {
         for i in 0..self.num_iter {
-            self.coll
-                .find_one(Some(doc! { "_id": i as i32 }), None)
-                .await?;
+            self.coll.find_one(doc! { "_id": i as i32 }).await?;
         }
 
         Ok(())

--- a/benchmarks/src/bench/insert_many.rs
+++ b/benchmarks/src/bench/insert_many.rs
@@ -64,7 +64,7 @@ impl Benchmark for InsertManyBenchmark {
     async fn before_task(&mut self) -> Result<()> {
         self.coll.drop().await?;
         self.db
-            .create_collection(COLL_NAME.as_str(), None)
+            .create_collection(COLL_NAME.as_str())
             .await
             .context("create in before")?;
 
@@ -74,7 +74,7 @@ impl Benchmark for InsertManyBenchmark {
     async fn do_task(&self) -> Result<()> {
         let insertions = vec![&self.doc; self.num_copies];
         self.coll
-            .insert_many(insertions, None)
+            .insert_many(insertions)
             .await
             .context("insert many")?;
 

--- a/benchmarks/src/bench/insert_one.rs
+++ b/benchmarks/src/bench/insert_one.rs
@@ -64,7 +64,7 @@ impl Benchmark for InsertOneBenchmark {
     async fn before_task(&mut self) -> Result<()> {
         self.coll.drop().await?;
         self.db
-            .create_collection(COLL_NAME.as_str(), None)
+            .create_collection(COLL_NAME.as_str())
             .await
             .context("create collection")?;
 
@@ -74,7 +74,7 @@ impl Benchmark for InsertOneBenchmark {
     async fn do_task(&self) -> Result<()> {
         for _ in 0..self.num_iter {
             self.coll
-                .insert_one(&self.doc, None)
+                .insert_one(&self.doc)
                 .await
                 .context("insert one")?;
         }

--- a/benchmarks/src/bench/json_multi_export.rs
+++ b/benchmarks/src/bench/json_multi_export.rs
@@ -55,7 +55,7 @@ impl Benchmark for JsonMultiExportBenchmark {
 
                 for mut doc in docs {
                     doc.insert("file", i as i32);
-                    coll.insert_one(doc, None).await?;
+                    coll.insert_one(doc).await?;
                 }
 
                 let ok: anyhow::Result<()> = Ok(());
@@ -89,10 +89,7 @@ impl Benchmark for JsonMultiExportBenchmark {
                 let file_name = path.join(format!("ldjson{:03}.txt", i));
                 let mut file = File::open_write(&file_name).await.unwrap();
 
-                let mut cursor = coll_ref
-                    .find(Some(doc! { "file": i as i32 }), None)
-                    .await
-                    .unwrap();
+                let mut cursor = coll_ref.find(doc! { "file": i as i32 }).await.unwrap();
 
                 while let Some(doc) = cursor.try_next().await.unwrap() {
                     file.write_line(serde_json::to_string(&doc).unwrap().as_str())

--- a/benchmarks/src/bench/json_multi_import.rs
+++ b/benchmarks/src/bench/json_multi_import.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use futures::stream::TryStreamExt;
-use mongodb::{options::InsertManyOptions, Client, Collection, Database};
+use mongodb::{Client, Collection, Database};
 
 use crate::{
     bench::{Benchmark, COLL_NAME, DATABASE_NAME},
@@ -48,7 +48,7 @@ impl Benchmark for JsonMultiImportBenchmark {
 
     async fn before_task(&mut self) -> Result<()> {
         self.coll.drop().await?;
-        self.db.create_collection(COLL_NAME.as_str(), None).await?;
+        self.db.create_collection(COLL_NAME.as_str()).await?;
 
         Ok(())
     }
@@ -74,8 +74,7 @@ impl Benchmark for JsonMultiImportBenchmark {
                     docs.push(serde_json::from_str(&line).unwrap());
                 }
 
-                let opts = Some(InsertManyOptions::builder().ordered(false).build());
-                coll_ref.insert_many(docs, opts).await.unwrap();
+                coll_ref.insert_many(docs).ordered(false).await.unwrap();
             }));
         }
 

--- a/benchmarks/src/bench/run_command.rs
+++ b/benchmarks/src/bench/run_command.rs
@@ -40,7 +40,7 @@ impl Benchmark for RunCommandBenchmark {
         for _ in 0..self.num_iter {
             let _doc = self
                 .db
-                .run_command(self.cmd.clone(), None)
+                .run_command(self.cmd.clone())
                 .await
                 .context("run command")?;
         }

--- a/benchmarks/src/fs.rs
+++ b/benchmarks/src/fs.rs
@@ -64,7 +64,7 @@ impl BufReader {
         }
     }
 
-    pub(crate) fn lines(self) -> impl Stream<Item = std::io::Result<String>> {
+    pub(crate) fn lines(self) -> impl tokio_stream::Stream<Item = std::io::Result<String>> {
         tokio_stream::wrappers::LinesStream::new(self.inner.lines())
     }
 }


### PR DESCRIPTION
RUST-1902

When I looked to sanity check that https://github.com/mongodb/bson-rust/pull/483 hadn't caused a regression I discovered to my dismay that the whole benchmark suite has been broken since 3.0 :(

This PR fixes compilation, but the actual server-connecting benchmarks are still broken, I filed RUST-1997 for that.