### PR TITLE
minor: add compat-3-0-0 to features table

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,19 @@ features = ["sync"]
 
 ### All Feature Flags
 
-| Feature                      | Description                                                                                                                                                             |
-|:-----------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `dns-resolver`               | Enable DNS resolution to allow `mongodb+srv` URI handling.  **Enabled by default.**                                                                                     |
-| `rustls-tls`                 | Use [`rustls`](https://docs.rs/rustls/latest/rustls/) for TLS connection handling.  **Enabled by default.**                                                             |
-| `openssl-tls`                | Use [`openssl`](https://docs.rs/openssl/latest/openssl/) for TLS connection handling.                                                                                   |
-| `sync`                       | Expose the synchronous API (`mongodb::sync`).                                                                                                                           |
-| `aws-auth`                   | Enable support for the MONGODB-AWS authentication mechanism.                                                                                                            |
-| `zlib-compression`           | Enable support for compressing messages with [`zlib`](https://zlib.net/)                                                                                                |
-| `zstd-compression`           | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/).                                                                                 |
-| `snappy-compression`         | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/)                                                                                |
-| `in-use-encryption-unstable` | Enable support for client-side field level encryption and queryable encryption. This API is unstable and may be subject to breaking changes in minor releases.          |
+| Feature                      | Description |
+|:-----------------------------|:-----------------------------|
+| `dns-resolver`               | Enable DNS resolution to allow `mongodb+srv` URI handling.  **Enabled by default.** |
+| `rustls-tls`                 | Use [`rustls`](https://docs.rs/rustls/latest/rustls/) for TLS connection handling.  **Enabled by default.** |
+| `openssl-tls`                | Use [`openssl`](https://docs.rs/openssl/latest/openssl/) for TLS connection handling. |
+| `sync`                       | Expose the synchronous API (`mongodb::sync`). |
+| `aws-auth`                   | Enable support for the MONGODB-AWS authentication mechanism. |
+| `zlib-compression`           | Enable support for compressing messages with [`zlib`](https://zlib.net/) |
+| `zstd-compression`           | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/). |
+| `snappy-compression`         | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/) |
+| `in-use-encryption-unstable` | Enable support for client-side field level encryption and queryable encryption. This API is unstable and may be subject to breaking changes in minor releases. |
 | `tracing-unstable`           | Enable support for emitting [`tracing`](https://docs.rs/tracing/latest/tracing/) events. This API is unstable and may be subject to breaking changes in minor releases. |
+| `compat-3-0-0`               | Required for future compatibility if default features are disabled. |
 
 ## Web Framework Examples
 ### Actix

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ features = ["sync"]
 | `openssl-tls`                | Use [`openssl`](https://docs.rs/openssl/latest/openssl/) for TLS connection handling. |
 | `sync`                       | Expose the synchronous API (`mongodb::sync`). |
 | `aws-auth`                   | Enable support for the MONGODB-AWS authentication mechanism. |
-| `zlib-compression`           | Enable support for compressing messages with [`zlib`](https://zlib.net/) |
+| `zlib-compression`           | Enable support for compressing messages with [`zlib`](https://zlib.net/). |
 | `zstd-compression`           | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/). |
 | `snappy-compression`         | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/) |
 | `in-use-encryption-unstable` | Enable support for client-side field level encryption and queryable encryption. This API is unstable and may be subject to breaking changes in minor releases. |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ features = ["sync"]
 | `aws-auth`                   | Enable support for the MONGODB-AWS authentication mechanism. |
 | `zlib-compression`           | Enable support for compressing messages with [`zlib`](https://zlib.net/). |
 | `zstd-compression`           | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/). |
-| `snappy-compression`         | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/) |
+| `snappy-compression`         | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/). |
 | `in-use-encryption-unstable` | Enable support for client-side field level encryption and queryable encryption. This API is unstable and may be subject to breaking changes in minor releases. |
 | `tracing-unstable`           | Enable support for emitting [`tracing`](https://docs.rs/tracing/latest/tracing/) events. This API is unstable and may be subject to breaking changes in minor releases. |
 | `compat-3-0-0`               | Required for future compatibility if default features are disabled. |


### PR DESCRIPTION
I also removed a bunch of whitespace from the table that wasn't needed for rendering and (IMO) made it harder to read in text.