### PR TITLE
RUST-1997 Fix evergreen benchmarks config

### DIFF
--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -138,10 +138,7 @@ functions:
     - command: expansions.update
       params:
         file: mo-expansion.yml
-
-  "run driver benchmarks":
     - command: shell.exec
-      type: test
       params:
         shell: bash
         working_dir: "src"
@@ -150,7 +147,20 @@ functions:
           export MONGODB_URI="${MONGODB_URI}"
           export SSL="${SSL}"
           . .evergreen/generate-uri.sh
+    - command: expansions.update
+      params:
+        file: src/uri-expansions.yml
 
+  "run driver benchmarks":
+    - command: shell.exec
+      type: test
+      params:
+        shell: bash
+        working_dir: "src"
+        include_expansions_in_env:
+          - MONGODB_URI
+        script: |
+          ${PREPARE_SHELL}
           .evergreen/run-driver-benchmarks.sh
 
   "run bson benchmarks":


### PR DESCRIPTION
RUST-1997

Passing run [here](https://spruce.mongodb.com/version/66aa826b58c08f00070bf7ef/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (except for gridfs on a sharded deployment, for which I've filed RUST-2010).