### PR TITLE
RUST-1994 Add a benchmark for client connection

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -221,7 +221,7 @@ async fn run_benchmarks(
             // Run command, including client setup time
             BenchmarkId::RunCommandColdStart => {
                 let run_command_options = bench::run_command::Options {
-                    num_iter: 1,
+                    num_iter: 100,
                     uri: uri.to_string(),
                     cold_start: true,
                 };


### PR DESCRIPTION
RUST-1994

I want to make sure that implementing the new connection routine there's no performance regression; this adds a benchmark that includes the client connection time in the measurement.

[This](https://spruce.mongodb.com/version/66acf77d9608260007ce6132/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is a benchmark run with these changes.

cargo-deny failure is unrelated.