### PR TITLE
RUST-2008 Remove almost all uses of `add_expansions_to_env`

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -565,7 +565,14 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
+          include_expansions_in_env:
+            - DRIVERS_ATLAS_PUBLIC_API_KEY
+            - DRIVERS_ATLAS_PRIVATE_API_KEY
+            - DRIVERS_ATLAS_GROUP_ID
+            - DRIVERS_ATLAS_LAMBDA_USER
+            - DRIVERS_ATLAS_LAMBDA_PASSWORD
+            - LAMBDA_STACK_NAME
+            - MONGODB_VERSION
           env:
             MONGODB_VERSION: "7.0"
           args:
@@ -578,7 +585,11 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
+          include_expansions_in_env:
+            - DRIVERS_ATLAS_PUBLIC_API_KEY
+            - DRIVERS_ATLAS_PRIVATE_API_KEY
+            - DRIVERS_ATLAS_GROUP_ID
+            - CLUSTER_NAME
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
       - func: "upload test results"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -378,7 +378,7 @@ buildvariants:
 
   - name: search-index
     display_name: "Search Index Helpers"
-    patchable: false
+    #patchable: false
     run_on:
       - rhel87-small
     tasks:
@@ -902,7 +902,10 @@ tasks:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
+          include_expansions_in_env:
+            - PROJECT_DIRECTORY
+            - MONGODB_URI
+            - PATH
           args:
             - .evergreen/run-search-index-test.sh
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -386,7 +386,7 @@ buildvariants:
 
   - name: aws-lambda
     display_name: "AWS Lambda"
-    #patchable: false
+    patchable: false
     run_on:
       - ubuntu2204-small
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -378,7 +378,7 @@ buildvariants:
 
   - name: search-index
     display_name: "Search Index Helpers"
-    #patchable: false
+    patchable: false
     run_on:
       - rhel87-small
     tasks:
@@ -386,7 +386,7 @@ buildvariants:
 
   - name: aws-lambda
     display_name: "AWS Lambda"
-    patchable: false
+    #patchable: false
     run_on:
       - ubuntu2204-small
     tasks:
@@ -610,7 +610,14 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
+          include_expansions_in_env:
+            - DRIVERS_ATLAS_PUBLIC_API_KEY
+            - DRIVERS_ATLAS_PRIVATE_API_KEY
+            - DRIVERS_ATLAS_GROUP_ID
+            - DRIVERS_ATLAS_LAMBDA_USER
+            - DRIVERS_ATLAS_LAMBDA_PASSWORD
+            - LAMBDA_STACK_NAME
+            - MONGODB_VERSION
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
@@ -621,7 +628,11 @@ task_groups:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
+          include_expansions_in_env:
+            - DRIVERS_ATLAS_PUBLIC_API_KEY
+            - DRIVERS_ATLAS_PRIVATE_API_KEY
+            - DRIVERS_ATLAS_GROUP_ID
+            - CLUSTER_NAME
           args:
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true
@@ -1102,9 +1113,22 @@ tasks:
         params:
           working_dir: src
           binary: bash
-          add_expansions_to_env: true
           args:
             - .evergreen/run-aws-lambda-test.sh
+          include_expansions_in_env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+            - DRIVERS_ATLAS_PUBLIC_API_KEY
+            - DRIVERS_ATLAS_PRIVATE_API_KEY
+            - DRIVERS_ATLAS_LAMBDA_USER
+            - DRIVERS_ATLAS_LAMBDA_PASSWORD
+            - DRIVERS_ATLAS_GROUP_ID
+            - LAMBDA_STACK_NAME
+            - PROJECT_DIRECTORY
+            - DRIVERS_TOOLS
+            - CLUSTER_NAME
+            - MONGODB_URI
           env:
             TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/.evergreen/aws-lambda-test
             AWS_REGION: us-east-1

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1173,7 +1173,11 @@ functions:
         binary: bash
         args:
           - .evergreen/create-expansions.sh
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - is_patch
+          - version_id
+          - project
+          - LIBMONGOCRYPT_OS
     - command: expansions.update
       params:
         file: src/expansion.yml
@@ -1391,7 +1395,15 @@ functions:
         binary: sh
         args:
           - ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - AUTH
+          - SSL
+          - TOPOLOGY
+          - LOAD_BALANCER
+          - REQUIRE_API_VERSION
+          - MONGODB_VERSION
+          - ORCHESTRATION_FILE
+          - MONGODB_BINARIES
     - command: expansions.update
       params:
         file: mo-expansion.yml
@@ -1401,19 +1413,11 @@ functions:
         binary: bash
         args:
           - .evergreen/generate-uri.sh
-        add_expansions_to_env: true
-    - command: expansions.update
-      params:
-        file: src/uri-expansions.yml
-
-  "generate uris":
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: bash
-        args:
-          - .evergreen/generate-uri.sh
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - MONGODB_URI
+          - SINGLE_MONGOS_LB_URI
+          - MULTI_MONGOS_LB_URI
     - command: expansions.update
       params:
         file: src/uri-expansions.yml
@@ -1529,7 +1533,25 @@ functions:
         binary: bash
         args:
           - .evergreen/run-csfle-tests.sh
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - OPENSSL
+          - OS
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - FLE_AWS_KEY
+          - FLE_AWS_SECRET
+          - FLE_AZURE_TENANTID
+          - FLE_AZURE_CLIENTID
+          - FLE_AZURE_CLIENTSECRET
+          - FLE_GCP_EMAIL
+          - FLE_GCP_PRIVATEKEY
+          - CSFLE_LOCAL_KEY
+          - CSFLE_TLS_CERT_DIR
+          - CRYPT_SHARED_LIB_PATH
+          - DISABLE_CRYPT_SHARED
+          - ON_DEMAND_GCP_CREDS_SHOULD_SUCCEED
+          - AZURE_IMDS_MOCK_PORT
 
   "run csfle serverless tests":
     - command: shell.exec
@@ -1669,7 +1691,8 @@ functions:
       type: test
       params:
         working_dir: src
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
         binary: bash
         args:
           - .evergreen/check-semgrep.sh

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1418,6 +1418,7 @@ functions:
           - MONGODB_URI
           - SINGLE_MONGOS_LB_URI
           - MULTI_MONGOS_LB_URI
+          - SSL
     - command: expansions.update
       params:
         file: src/uri-expansions.yml
@@ -1430,9 +1431,6 @@ functions:
         binary: bash
         args:
           - .evergreen/run-tests.sh
-        # The driver uses the absence/presence of variables defined in the project's settings to
-        # determine how to create a test client, so the relevant expansions here MUST be listed
-        # explicitly rather than setting add_expansions_to_env: true.
         include_expansions_in_env:
           - PROJECT_DIRECTORY
           - OPENSSL
@@ -1451,7 +1449,6 @@ functions:
         binary: bash
         args:
           - .evergreen/run-sync-tests.sh
-        # Ditto comment above regarding explicitly listing expansions.
         include_expansions_in_env:
           - PROJECT_DIRECTORY
           - MONGODB_URI
@@ -1535,22 +1532,17 @@ functions:
           - .evergreen/run-csfle-tests.sh
         include_expansions_in_env:
           - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+          - MONGODB_URI
+          - MONGOCRYPT_LIB_DIR
           - OPENSSL
           - OS
+          - LD_LIBRARY_PATH
           - AWS_ACCESS_KEY_ID
           - AWS_SECRET_ACCESS_KEY
-          - FLE_AWS_KEY
-          - FLE_AWS_SECRET
-          - FLE_AZURE_TENANTID
-          - FLE_AZURE_CLIENTID
-          - FLE_AZURE_CLIENTSECRET
-          - FLE_GCP_EMAIL
-          - FLE_GCP_PRIVATEKEY
           - CSFLE_LOCAL_KEY
-          - CSFLE_TLS_CERT_DIR
           - CRYPT_SHARED_LIB_PATH
           - DISABLE_CRYPT_SHARED
-          - ON_DEMAND_GCP_CREDS_SHOULD_SUCCEED
           - AZURE_IMDS_MOCK_PORT
 
   "run csfle serverless tests":
@@ -1693,6 +1685,8 @@ functions:
         working_dir: src
         include_expansions_in_env:
           - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+          - MONGOCRYPT_LIB_DIR
         binary: bash
         args:
           - .evergreen/check-semgrep.sh

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-source ./.evergreen/env.sh
+source .evergreen/env.sh
 source .evergreen/cargo-test.sh
 
 set -o xtrace

--- a/.evergreen/run-sync-tests.sh
+++ b/.evergreen/run-sync-tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-. ${PREPARE_SHELL}
-
 set -o errexit
 set -o pipefail
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// [`ErrorKind`](enum.ErrorKind.html) is wrapped in an `Arc` to allow the errors to be
 /// cloned.
 #[derive(Clone, Debug, Error)]
-#[error("Kind: {kind}, labels: {labels:?}, backtrace: {bt}")]
+#[cfg_attr(test, error("Kind: {kind}, labels: {labels:?}, backtrace: {bt}"))]
+#[cfg_attr(not(test), error("Kind: {kind}, labels: {labels:?}"))]
 #[non_exhaustive]
 pub struct Error {
     /// The type of error that occurred.
@@ -59,6 +60,7 @@ pub struct Error {
     pub(crate) wire_version: Option<i32>,
     #[source]
     pub(crate) source: Option<Box<Error>>,
+    #[cfg(test)]
     bt: Arc<std::backtrace::Backtrace>,
 }
 
@@ -91,6 +93,7 @@ impl Error {
             labels,
             wire_version: None,
             source: None,
+            #[cfg(test)]
             bt: Arc::new(std::backtrace::Backtrace::capture()),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// [`ErrorKind`](enum.ErrorKind.html) is wrapped in an `Arc` to allow the errors to be
 /// cloned.
 #[derive(Clone, Debug, Error)]
-#[error("Kind: {kind}, labels: {labels:?}")]
+#[error("Kind: {kind}, labels: {labels:?}, backtrace: {bt}")]
 #[non_exhaustive]
 pub struct Error {
     /// The type of error that occurred.
@@ -59,6 +59,7 @@ pub struct Error {
     pub(crate) wire_version: Option<i32>,
     #[source]
     pub(crate) source: Option<Box<Error>>,
+    bt: Arc<std::backtrace::Backtrace>,
 }
 
 impl Error {
@@ -90,6 +91,7 @@ impl Error {
             labels,
             wire_version: None,
             source: None,
+            bt: Arc::new(std::backtrace::Backtrace::capture()),
         }
     }
 

--- a/src/test/spec/v2_runner/csfle.rs
+++ b/src/test/spec/v2_runner/csfle.rs
@@ -73,5 +73,15 @@ pub(crate) fn set_auto_enc(builder: TestClientBuilder, test: &Test) -> TestClien
         );
         kms_providers.clear(&KmsProvider::other("awsTemporaryNoSessionToken"));
     }
+
+    if let Ok(val) = std::env::var("CRYPT_SHARED_LIB_PATH") {
+        if !val.is_empty() {
+            enc_opts
+                .extra_options
+                .get_or_insert_with(|| doc! {})
+                .insert("cryptSharedLibPath", val);
+        }
+    }
+
     builder.encrypted_options(enc_opts)
 }


### PR DESCRIPTION
RUST-2008

The "almost" here is the serverless tests, which are already failing so there's no way to test if edits here would work :(  Filed RUST-2016 for that.

Passing runs for the non-patchable variants:
* [search index](https://spruce.mongodb.com/version/66bd01bb138cb1000799558a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
* [aws lambda](https://spruce.mongodb.com/version/66be25c90c608400077d709c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)