### PR TITLE
Add deserialize-utf8-lossy feature to always deserialize using lossy UTF-8 conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ snappy-compression = ["dep:snap"]
 # The In Use Encryption API is unstable and may have backwards-incompatible changes in minor version updates.
 in-use-encryption-unstable = ["dep:mongocrypt", "dep:rayon", "dep:num_cpus"]
 
+deserialize-utf8-lossy = []
+
 # Enables support for emitting tracing events.
 # The tracing API is unstable and may have backwards-incompatible changes in minor version updates.
 # TODO: pending https://github.com/tokio-rs/tracing/issues/2036 stop depending directly on log.

--- a/src/change_stream.rs
+++ b/src/change_stream.rs
@@ -159,7 +159,7 @@ where
     /// ```
     pub async fn next_if_any(&mut self) -> Result<Option<T>> {
         Ok(match NextInBatchFuture::new(self).await? {
-            BatchValue::Some { doc, .. } => Some(bson::from_slice(doc.as_bytes())?),
+            BatchValue::Some { doc, .. } => Some(crate::de::from_slice(doc.as_bytes())?),
             BatchValue::Empty | BatchValue::Exhausted => None,
         })
     }

--- a/src/change_stream/session.rs
+++ b/src/change_stream/session.rs
@@ -149,7 +149,7 @@ where
                     match bv {
                         BatchValue::Some { doc, .. } => {
                             self.data.document_returned = true;
-                            return Ok(Some(bson::from_slice(doc.as_bytes())?));
+                            return Ok(Some(crate::de::from_slice(doc.as_bytes())?));
                         }
                         BatchValue::Empty | BatchValue::Exhausted => return Ok(None),
                     }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -270,7 +270,7 @@ impl<T> Cursor<T> {
     where
         T: Deserialize<'a>,
     {
-        bson::from_slice(self.current().as_bytes()).map_err(Error::from)
+        crate::de::from_slice(self.current().as_bytes()).map_err(Error::from)
     }
 
     /// Update the type streamed values will be parsed as.

--- a/src/cursor/common.rs
+++ b/src/cursor/common.rs
@@ -278,7 +278,7 @@ where
             Poll::Pending => return Poll::Pending,
             Poll::Ready(bv) => match bv? {
                 BatchValue::Some { doc, .. } => {
-                    return Poll::Ready(Some(Ok(bson::from_slice(doc.as_bytes())?)))
+                    return Poll::Ready(Some(Ok(crate::de::from_slice(doc.as_bytes())?)))
                 }
                 BatchValue::Empty => continue,
                 BatchValue::Exhausted => return Poll::Ready(None),

--- a/src/cursor/session.rs
+++ b/src/cursor/session.rs
@@ -306,7 +306,7 @@ impl<T> SessionCursor<T> {
     where
         T: Deserialize<'a>,
     {
-        bson::from_slice(self.current().as_bytes()).map_err(Error::from)
+        crate::de::from_slice(self.current().as_bytes()).map_err(Error::from)
     }
 
     /// Update the type streamed values will be parsed as.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,3 +81,13 @@ compile_error!(
     "The feature 'compat-3-0-0' must be enabled to ensure forward compatibility with future \
      versions of this crate."
 );
+
+#[cfg(not(feature = "deserialize-utf8-lossy"))]
+pub(crate) mod de {
+    pub(crate) use ::bson::from_slice;
+}
+
+#[cfg(feature = "deserialize-utf8-lossy")]
+pub(crate) mod de {
+    pub(crate) use ::bson::from_slice_utf8_lossy as from_slice;
+}


### PR DESCRIPTION
Useful if you need to read from a collection created by a driver for another programming language.

See #799