### PR TITLE
RUST-1425 Clarify test event handling

### DIFF
--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -26,6 +26,9 @@ fi
 
 set +o errexit
 
+cargo_test test::csfle::bson_size_limits results.xml
+exit ${CARGO_RESULT}
+
 cargo_test test::csfle prose.xml
 cargo_test test::spec::client_side_encryption spec.xml
 

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -26,9 +26,6 @@ fi
 
 set +o errexit
 
-cargo_test test::csfle::bson_size_limits results.xml
-exit ${CARGO_RESULT}
-
 cargo_test test::csfle prose.xml
 cargo_test test::spec::client_side_encryption spec.xml
 

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -255,7 +255,7 @@ async fn cluster_time_in_commands() {
             .expect("operation should succeed");
 
         let (first_command_started, first_command_succeeded) = event_stream
-            .wait_for_successful_command_execution(Duration::from_secs(5), command_name)
+            .next_successful_command_execution(Duration::from_secs(5), command_name)
             .await
             .unwrap_or_else(|| {
                 panic!(
@@ -271,7 +271,7 @@ async fn cluster_time_in_commands() {
             .expect("should get cluster time from command response");
 
         let (second_command_started, _) = event_stream
-            .wait_for_successful_command_execution(Duration::from_secs(5), command_name)
+            .next_successful_command_execution(Duration::from_secs(5), command_name)
             .await
             .unwrap_or_else(|| {
                 panic!(
@@ -317,7 +317,7 @@ async fn cluster_time_in_commands() {
 
     // Wait for initial monitor check to complete and discover the server.
     event_stream
-        .wait_for_event(Duration::from_secs(5), |event| match event {
+        .next_match(Duration::from_secs(5), |event| match event {
             Event::Sdam(SdamEvent::ServerDescriptionChanged(e)) => {
                 !e.previous_description.server_type().is_available()
                     && e.new_description.server_type().is_available()

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -244,7 +244,7 @@ async fn cluster_time_in_commands() {
         F: Fn(Client) -> G,
         G: Future<Output = Result<R>>,
     {
-        let mut subscriber = event_buffer.subscribe();
+        let mut subscriber = event_buffer.stream();
 
         operation(client.clone())
             .await
@@ -311,7 +311,7 @@ async fn cluster_time_in_commands() {
         }
     }
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     let client = Client::with_options(options).unwrap();
 

--- a/src/cmap/test.rs
+++ b/src/cmap/test.rs
@@ -146,7 +146,7 @@ impl Executor {
     }
 
     async fn execute_test(self) {
-        let mut subscriber = self.state.events.subscribe();
+        let mut subscriber = self.state.events.stream();
 
         let (updater, mut receiver) = TopologyUpdater::channel();
 
@@ -262,7 +262,7 @@ impl Operation {
                 }
             }
             Operation::CheckIn { connection } => {
-                let mut subscriber = state.events.subscribe();
+                let mut subscriber = state.events.stream();
                 let conn = state.connections.write().await.remove(&connection).unwrap();
                 let id = conn.id;
                 // connections are checked in via tasks spawned in their drop implementation,
@@ -300,7 +300,7 @@ impl Operation {
                 }
             }
             Operation::Close => {
-                let mut subscriber = state.events.subscribe();
+                let mut subscriber = state.events.stream();
 
                 // pools are closed via their drop implementation
                 state.pool.write().await.take();

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -216,7 +216,7 @@ async fn connection_error_during_establishment() {
     pool.check_out().await.expect_err("check out should fail");
 
     event_stream
-        .wait_for_event(EVENT_TIMEOUT, |e| match e {
+        .next_match(EVENT_TIMEOUT, |e| match e {
             CmapEvent::ConnectionClosed(event) => {
                 event.connection_id == 1 && event.reason == ConnectionClosedReason::Error
             }
@@ -258,7 +258,7 @@ async fn connection_error_during_operation() {
         .expect_err("ping should fail due to fail point");
 
     event_stream
-        .wait_for_event(EVENT_TIMEOUT, |e| match e {
+        .next_match(EVENT_TIMEOUT, |e| match e {
             CmapEvent::ConnectionClosed(event) => {
                 event.connection_id == 1 && event.reason == ConnectionClosedReason::Error
             }

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -199,7 +199,7 @@ async fn connection_error_during_establishment() {
 
     let buffer = EventBuffer::<CmapEvent>::new();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     let mut options = ConnectionPoolOptions::from_client_options(&client_options);
     options.ready = Some(true);
@@ -249,7 +249,7 @@ async fn connection_error_during_operation() {
         FailPoint::fail_command(&["ping"], FailPointMode::Times(10)).close_connection(true);
     let _guard = client.enable_fail_point(fail_point).await.unwrap();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     client
         .database("test")

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -243,7 +243,7 @@ async fn load_balancing_test() {
     let mut conns = 0;
     while conns < max_pool_size * 2 {
         subscriber
-            .wait_for_event(Duration::from_secs(30), |event| {
+            .next_match(Duration::from_secs(30), |event| {
                 matches!(event, Event::Cmap(CmapEvent::ConnectionReady(_)))
             })
             .await

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -221,7 +221,7 @@ async fn load_balancing_test() {
         .build()
         .await;
 
-    let mut subscriber = client.events.subscribe_all();
+    let mut subscriber = client.events.stream_all();
 
     // wait for both servers pools to be saturated.
     for address in hosts {

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -277,7 +277,7 @@ async fn run_test(test_file: TestFile) {
     options.sdam_event_handler = Some(buffer.handler());
     options.test_options_mut().disable_monitoring_threads = true;
 
-    let mut event_subscriber = buffer.subscribe();
+    let mut event_subscriber = buffer.stream();
     let mut topology = Topology::new(options.clone()).unwrap();
 
     for (i, phase) in test_file.phases.into_iter().enumerate() {
@@ -598,7 +598,7 @@ async fn topology_closed_event_last() {
         .await;
     let events = client.events.clone();
 
-    let mut subscriber = events.subscribe_all();
+    let mut subscriber = events.stream_all();
 
     client
         .database(function_name!())
@@ -643,7 +643,7 @@ async fn heartbeat_events() {
         .build()
         .await;
 
-    let mut subscriber = client.events.subscribe_all();
+    let mut subscriber = client.events.stream_all();
 
     if client.is_load_balanced() {
         log_uncaptured("skipping heartbeat_events tests due to load-balanced topology");

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -375,7 +375,7 @@ async fn run_test(test_file: TestFile) {
             }
             Outcome::Events(EventsOutcome { events: expected }) => {
                 let actual = event_stream
-                    .collect_events(Duration::from_millis(500), |e| matches!(e, Event::Sdam(_)))
+                    .collect(Duration::from_millis(500), |e| matches!(e, Event::Sdam(_)))
                     .await
                     .into_iter()
                     .map(|e| e.unwrap_sdam_event());
@@ -609,7 +609,7 @@ async fn topology_closed_event_last() {
     drop(client);
 
     subscriber
-        .wait_for_event(Duration::from_millis(1000), |event| {
+        .next_match(Duration::from_millis(1000), |event| {
             matches!(event, Event::Sdam(SdamEvent::TopologyClosed(_)))
         })
         .await
@@ -617,7 +617,7 @@ async fn topology_closed_event_last() {
 
     // no further SDAM events should be emitted after the TopologyClosedEvent
     let event = subscriber
-        .wait_for_event(Duration::from_millis(1000), |event| {
+        .next_match(Duration::from_millis(1000), |event| {
             matches!(event, Event::Sdam(_))
         })
         .await;
@@ -651,14 +651,14 @@ async fn heartbeat_events() {
     }
 
     subscriber
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatStarted(_)))
         })
         .await
         .expect("should see server heartbeat started event");
 
     subscriber
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(_)))
         })
         .await
@@ -681,7 +681,7 @@ async fn heartbeat_events() {
     let _guard = fp_client.enable_fail_point(fail_point).await.unwrap();
 
     subscriber
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatFailed(_)))
         })
         .await

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -277,7 +277,7 @@ async fn run_test(test_file: TestFile) {
     options.sdam_event_handler = Some(buffer.handler());
     options.test_options_mut().disable_monitoring_threads = true;
 
-    let mut event_subscriber = buffer.stream();
+    let mut event_stream = buffer.stream();
     let mut topology = Topology::new(options.clone()).unwrap();
 
     for (i, phase) in test_file.phases.into_iter().enumerate() {
@@ -374,7 +374,7 @@ async fn run_test(test_file: TestFile) {
                 );
             }
             Outcome::Events(EventsOutcome { events: expected }) => {
-                let actual = event_subscriber
+                let actual = event_stream
                     .collect_events(Duration::from_millis(500), |e| matches!(e, Event::Sdam(_)))
                     .await
                     .into_iter()

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -116,14 +116,14 @@ async fn sdam_pool_management() {
     }
 
     subscriber
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::PoolReady(_)))
         })
         .await
         .expect("should see pool ready event");
 
     subscriber
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(_)))
         })
         .await
@@ -143,9 +143,7 @@ async fn sdam_pool_management() {
 
     // Since there is no deterministic ordering, simply collect all the events and check for their
     // presence.
-    let events = subscriber
-        .collect_events(Duration::from_secs(1), |_| true)
-        .await;
+    let events = subscriber.collect(Duration::from_secs(1), |_| true).await;
     assert!(events
         .iter()
         .any(|e| matches!(e, Event::Sdam(SdamEvent::ServerHeartbeatFailed(_)))));
@@ -196,7 +194,7 @@ async fn hello_ok_true() {
 
     // first heartbeat should be legacy hello but contain helloOk
     event_stream
-        .wait_for_event(Duration::from_millis(2000), |event| {
+        .next_match(Duration::from_millis(2000), |event| {
             if let Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) = event {
                 assert_eq!(e.reply.get_bool("helloOk"), Ok(true));
                 assert!(e.reply.get(LEGACY_HELLO_COMMAND_NAME_LOWERCASE).is_some());
@@ -211,7 +209,7 @@ async fn hello_ok_true() {
     // subsequent heartbeats should just be hello
     for _ in 0..3 {
         event_stream
-            .wait_for_event(Duration::from_millis(2000), |event| {
+            .next_match(Duration::from_millis(2000), |event| {
                 if let Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) = event {
                     assert!(e.reply.get("isWritablePrimary").is_some());
                     assert!(e.reply.get(LEGACY_HELLO_COMMAND_NAME_LOWERCASE).is_none());
@@ -276,7 +274,7 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
     // Wait until all three monitors have started.
     let mut seen_monitors = HashSet::new();
     event_stream
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             if let Event::Sdam(SdamEvent::ServerHeartbeatStarted(e)) = event {
                 seen_monitors.insert(e.server_address.clone());
             }
@@ -315,13 +313,13 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
         ))
         .await;
 
-    event_stream.wait_for_event(Duration::from_secs(1), |event| {
+    event_stream.next_match(Duration::from_secs(1), |event| {
         matches!(event, Event::Sdam(SdamEvent::ServerClosed(e)) if e.address == hosts[2])
     }).await.expect("should see server closed event");
 
     // Capture heartbeat events for 1 second. The monitor for the removed server should stop
     // publishing them.
-    let events = event_stream.collect_events(Duration::from_secs(1), |event| {
+    let events = event_stream.collect(Duration::from_secs(1), |event| {
         matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatStarted(e)) if e.server_address == hosts[2])
     }).await;
 

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -186,7 +186,7 @@ async fn hello_ok_true() {
 
     let buffer = EventBuffer::new();
 
-    let mut subscriber = buffer.stream();
+    let mut event_stream = buffer.stream();
 
     let mut options = setup_client_options.clone();
     options.sdam_event_handler = Some(buffer.handler());
@@ -195,7 +195,7 @@ async fn hello_ok_true() {
     let _client = Client::with_options(options).expect("client creation should succeed");
 
     // first heartbeat should be legacy hello but contain helloOk
-    subscriber
+    event_stream
         .wait_for_event(Duration::from_millis(2000), |event| {
             if let Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) = event {
                 assert_eq!(e.reply.get_bool("helloOk"), Ok(true));
@@ -210,7 +210,7 @@ async fn hello_ok_true() {
 
     // subsequent heartbeats should just be hello
     for _ in 0..3 {
-        subscriber
+        event_stream
             .wait_for_event(Duration::from_millis(2000), |event| {
                 if let Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) = event {
                     assert!(e.reply.get("isWritablePrimary").is_some());
@@ -270,12 +270,12 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
     let hosts = options.hosts.clone();
     let set_name = options.repl_set_name.clone().unwrap();
 
-    let mut subscriber = buffer.stream();
+    let mut event_stream = buffer.stream();
     let topology = Topology::new(options)?;
 
     // Wait until all three monitors have started.
     let mut seen_monitors = HashSet::new();
-    subscriber
+    event_stream
         .wait_for_event(Duration::from_millis(500), |event| {
             if let Event::Sdam(SdamEvent::ServerHeartbeatStarted(e)) = event {
                 seen_monitors.insert(e.server_address.clone());
@@ -315,13 +315,13 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
         ))
         .await;
 
-    subscriber.wait_for_event(Duration::from_secs(1), |event| {
+    event_stream.wait_for_event(Duration::from_secs(1), |event| {
         matches!(event, Event::Sdam(SdamEvent::ServerClosed(e)) if e.address == hosts[2])
     }).await.expect("should see server closed event");
 
     // Capture heartbeat events for 1 second. The monitor for the removed server should stop
     // publishing them.
-    let events = subscriber.collect_events(Duration::from_secs(1), |event| {
+    let events = event_stream.collect_events(Duration::from_secs(1), |event| {
         matches!(event, Event::Sdam(SdamEvent::ServerHeartbeatStarted(e)) if e.server_address == hosts[2])
     }).await;
 

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -103,7 +103,7 @@ async fn sdam_pool_management() {
         .build()
         .await;
 
-    let mut subscriber = client.events.subscribe_all();
+    let mut subscriber = client.events.stream_all();
 
     if !VersionReq::parse(">= 4.2.9")
         .unwrap()
@@ -186,7 +186,7 @@ async fn hello_ok_true() {
 
     let buffer = EventBuffer::new();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     let mut options = setup_client_options.clone();
     options.sdam_event_handler = Some(buffer.handler());
@@ -270,7 +270,7 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
     let hosts = options.hosts.clone();
     let set_name = options.repl_set_name.clone().unwrap();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
     let topology = Topology::new(options)?;
 
     // Wait until all three monitors have started.

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -724,7 +724,7 @@ async fn retry_commit_txn_check_out() {
     // wait for the mark unknown and subsequent succeeded heartbeat
     let mut primary = None;
     event_stream
-        .wait_for_event(Duration::from_secs(1), |e| {
+        .next_match(Duration::from_secs(1), |e| {
             if let Event::Sdam(SdamEvent::ServerDescriptionChanged(event)) = e {
                 if event.is_marked_unknown_event() {
                     primary = Some(event.address.clone());
@@ -741,7 +741,7 @@ async fn retry_commit_txn_check_out() {
     // heartbeatFrequencyMS (which is 2 minutes) and ignore the immediate check requests from the
     // ping command in the meantime due to already being in the middle of their checks.
     event_stream
-        .wait_for_event(Duration::from_secs(1), |e| {
+        .next_match(Duration::from_secs(1), |e| {
             if let Event::Sdam(SdamEvent::ServerDescriptionChanged(event)) = e {
                 if &event.address == primary.as_ref().unwrap()
                     && event.previous_description.server_type() == ServerType::Unknown
@@ -768,7 +768,7 @@ async fn retry_commit_txn_check_out() {
 
     // ensure the first check out attempt fails
     event_stream
-        .wait_for_event(Duration::from_secs(1), |e| {
+        .next_match(Duration::from_secs(1), |e| {
             matches!(e, Event::Cmap(CmapEvent::ConnectionCheckoutFailed(_)))
         })
         .await
@@ -776,7 +776,7 @@ async fn retry_commit_txn_check_out() {
 
     // ensure the second one succeeds
     event_stream
-        .wait_for_event(Duration::from_secs(1), |e| {
+        .next_match(Duration::from_secs(1), |e| {
             matches!(e, Event::Cmap(CmapEvent::ConnectionCheckedOut(_)))
         })
         .await

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -713,7 +713,7 @@ async fn retry_commit_txn_check_out() {
     let fail_point = FailPoint::fail_command(&["ping"], FailPointMode::Times(1)).error_code(11600);
     let _guard = setup_client.enable_fail_point(fail_point).await.unwrap();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
     client
         .database("foo")
         .run_command(doc! { "ping": 1 })

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -1252,7 +1252,7 @@ async fn insert_many_document_sequences() {
     collection.insert_many(docs).await.unwrap();
 
     let (started, _) = event_stream
-        .wait_for_successful_command_execution(Duration::from_millis(500), "insert")
+        .next_successful_command_execution(Duration::from_millis(500), "insert")
         .await
         .expect("did not observe successful command events for insert");
     let insert_documents = started.command.get_array("documents").unwrap();
@@ -1272,14 +1272,14 @@ async fn insert_many_document_sequences() {
     collection.insert_many(docs).await.unwrap();
 
     let (first_started, _) = event_stream
-        .wait_for_successful_command_execution(Duration::from_millis(500), "insert")
+        .next_successful_command_execution(Duration::from_millis(500), "insert")
         .await
         .expect("did not observe successful command events for insert");
     let first_batch_len = first_started.command.get_array("documents").unwrap().len();
     assert!(first_batch_len < total_docs);
 
     let (second_started, _) = event_stream
-        .wait_for_successful_command_execution(Duration::from_millis(500), "insert")
+        .next_successful_command_execution(Duration::from_millis(500), "insert")
         .await
         .expect("did not observe successful command events for insert");
     let second_batch_len = second_started.command.get_array("documents").unwrap().len();

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -1233,7 +1233,7 @@ async fn insert_many_document_sequences() {
 
     let client = Client::test_builder().monitor_events().build().await;
 
-    let mut subscriber = client.events.subscribe();
+    let mut subscriber = client.events.stream();
 
     let max_object_size = client.server_info.max_bson_object_size;
     let max_message_size = client.server_info.max_message_size_bytes;

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -1233,7 +1233,7 @@ async fn insert_many_document_sequences() {
 
     let client = Client::test_builder().monitor_events().build().await;
 
-    let mut subscriber = client.events.stream();
+    let mut event_stream = client.events.stream();
 
     let max_object_size = client.server_info.max_bson_object_size;
     let max_message_size = client.server_info.max_message_size_bytes;
@@ -1251,7 +1251,7 @@ async fn insert_many_document_sequences() {
     ];
     collection.insert_many(docs).await.unwrap();
 
-    let (started, _) = subscriber
+    let (started, _) = event_stream
         .wait_for_successful_command_execution(Duration::from_millis(500), "insert")
         .await
         .expect("did not observe successful command events for insert");
@@ -1271,14 +1271,14 @@ async fn insert_many_document_sequences() {
     let total_docs = docs.len();
     collection.insert_many(docs).await.unwrap();
 
-    let (first_started, _) = subscriber
+    let (first_started, _) = event_stream
         .wait_for_successful_command_execution(Duration::from_millis(500), "insert")
         .await
         .expect("did not observe successful command events for insert");
     let first_batch_len = first_started.command.get_array("documents").unwrap().len();
     assert!(first_batch_len < total_docs);
 
-    let (second_started, _) = subscriber
+    let (second_started, _) = event_stream
         .wait_for_successful_command_execution(Duration::from_millis(500), "insert")
         .await
         .expect("did not observe successful command events for insert");

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -382,7 +382,7 @@ async fn data_key_double_encryption() -> Result<()> {
             provider.as_string()
         );
         let found = events
-            .wait_for_event(
+            .next_match(
                 Duration::from_millis(500),
                 ok_pred(|ev| {
                     let ev = match ev.as_command_started_event() {
@@ -588,7 +588,6 @@ async fn bson_size_limits() -> Result<()> {
     let mut opts = get_client_options().await.clone();
     let buffer = EventBuffer::<Event>::new();
 
-    let mut events = buffer.stream();
     opts.command_event_handler = Some(buffer.handler());
     let client_encrypted =
         Client::encrypted_builder(opts, KV_NAMESPACE.clone(), vec![LOCAL_KMS.clone()])?
@@ -616,7 +615,7 @@ async fn bson_size_limits() -> Result<()> {
 
     // Test operation 3
     let value = "a".repeat(2_097_152);
-    events.clear_events(Duration::from_millis(500)).await;
+    let mut events = buffer.stream();
     coll.insert_many(vec![
         doc! {
             "_id": "over_2mib_1",
@@ -629,7 +628,7 @@ async fn bson_size_limits() -> Result<()> {
     ])
     .await?;
     let inserts = events
-        .collect_events(Duration::from_millis(500), |ev| {
+        .collect(Duration::from_millis(500), |ev| {
             let ev = match ev.as_command_started_event() {
                 Some(e) => e,
                 None => return false,
@@ -645,10 +644,10 @@ async fn bson_size_limits() -> Result<()> {
     doc.insert("unencrypted", "a".repeat(2_097_152 - 2_000));
     let mut doc2 = doc.clone();
     doc2.insert("_id", "encryption_exceeds_2mib_2");
-    events.clear_events(Duration::from_millis(500)).await;
+    let mut events = buffer.stream();
     coll.insert_many(vec![doc, doc2]).await?;
     let inserts = events
-        .collect_events(Duration::from_millis(500), |ev| {
+        .collect(Duration::from_millis(500), |ev| {
             let ev = match ev.as_command_started_event() {
                 Some(e) => e,
                 None => return false,
@@ -1631,7 +1630,7 @@ impl DeadlockTestCase {
         assert_eq!(found, Some(doc! { "_id": 0, "encrypted": "string0" }));
 
         let encrypted_events = encrypted_events
-            .collect_events(Duration::from_millis(500), |_| true)
+            .collect(Duration::from_millis(500), |_| true)
             .await;
         let client_count = encrypted_events
             .iter()
@@ -1648,7 +1647,7 @@ impl DeadlockTestCase {
         }
 
         let keyvault_commands = keyvault_events
-            .collect_events_map(Duration::from_millis(500), |ev| {
+            .collect_map(Duration::from_millis(500), |ev| {
                 ev.into_command_started_event()
             })
             .await;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -328,7 +328,7 @@ async fn data_key_double_encryption() -> Result<()> {
 
     // Testing each provider:
 
-    let mut events = client.events.subscribe();
+    let mut events = client.events.stream();
     let provider_keys: [(KmsProvider, MasterKey); 5] = [
         (
             KmsProvider::aws(),
@@ -588,7 +588,7 @@ async fn bson_size_limits() -> Result<()> {
     let mut opts = get_client_options().await.clone();
     let buffer = EventBuffer::<Event>::new();
 
-    let mut events = buffer.subscribe();
+    let mut events = buffer.stream();
     opts.command_event_handler = Some(buffer.handler());
     let client_encrypted =
         Client::encrypted_builder(opts, KV_NAMESPACE.clone(), vec![LOCAL_KMS.clone()])?
@@ -1551,7 +1551,7 @@ impl DeadlockTestCase {
             .build()
             .await;
 
-        let mut keyvault_events = client_keyvault.events.subscribe();
+        let mut keyvault_events = client_keyvault.events.stream();
         client_test
             .database("keyvault")
             .collection::<Document>("datakeys")
@@ -1589,7 +1589,7 @@ impl DeadlockTestCase {
         // Run test case
         let event_buffer = EventBuffer::new();
 
-        let mut encrypted_events = event_buffer.subscribe();
+        let mut encrypted_events = event_buffer.stream();
         let mut opts = get_client_options().await.clone();
         opts.max_pool_size = Some(self.max_pool_size);
         opts.command_event_handler = Some(event_buffer.handler());

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -100,7 +100,7 @@ async fn retry_read_pool_cleared() {
         .block_connection(Duration::from_secs(1));
     let _guard = client.enable_fail_point(fail_point).await.unwrap();
 
-    let mut subscriber = buffer.stream();
+    let mut event_stream = buffer.stream();
 
     let mut tasks: Vec<AsyncJoinHandle<_>> = Vec::new();
     for _ in 0..2 {
@@ -115,21 +115,21 @@ async fn retry_read_pool_cleared() {
         .collect::<Result<Vec<_>>>()
         .expect("all should succeed");
 
-    let _ = subscriber
+    let _ = event_stream
         .wait_for_event(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::ConnectionCheckedOut(_)))
         })
         .await
         .expect("first checkout should succeed");
 
-    let _ = subscriber
+    let _ = event_stream
         .wait_for_event(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::PoolCleared(_)))
         })
         .await
         .expect("pool clear should occur");
 
-    let next_cmap_events = subscriber
+    let next_cmap_events = event_stream
         .collect_events(Duration::from_millis(1000), |event| {
             matches!(event, Event::Cmap(_))
         })

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -100,7 +100,7 @@ async fn retry_read_pool_cleared() {
         .block_connection(Duration::from_secs(1));
     let _guard = client.enable_fail_point(fail_point).await.unwrap();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     let mut tasks: Vec<AsyncJoinHandle<_>> = Vec::new();
     for _ in 0..2 {

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -116,21 +116,21 @@ async fn retry_read_pool_cleared() {
         .expect("all should succeed");
 
     let _ = event_stream
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::ConnectionCheckedOut(_)))
         })
         .await
         .expect("first checkout should succeed");
 
     let _ = event_stream
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::PoolCleared(_)))
         })
         .await
         .expect("pool clear should occur");
 
     let next_cmap_events = event_stream
-        .collect_events(Duration::from_millis(1000), |event| {
+        .collect(Duration::from_millis(1000), |event| {
             matches!(event, Event::Cmap(_))
         })
         .await;

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -280,7 +280,7 @@ async fn retry_write_pool_cleared() {
         .error_labels(vec![RETRYABLE_WRITE_ERROR]);
     let _guard = client.enable_fail_point(fail_point).await.unwrap();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     let mut tasks: Vec<AsyncJoinHandle<_>> = Vec::new();
     for _ in 0..2 {

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -296,21 +296,21 @@ async fn retry_write_pool_cleared() {
         .expect("all should succeeed");
 
     let _ = event_stream
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::ConnectionCheckedOut(_)))
         })
         .await
         .expect("first checkout should succeed");
 
     let _ = event_stream
-        .wait_for_event(Duration::from_millis(500), |event| {
+        .next_match(Duration::from_millis(500), |event| {
             matches!(event, Event::Cmap(CmapEvent::PoolCleared(_)))
         })
         .await
         .expect("pool clear should occur");
 
     let next_cmap_events = event_stream
-        .collect_events(Duration::from_millis(1000), |event| {
+        .collect(Duration::from_millis(1000), |event| {
             matches!(event, Event::Cmap(_))
         })
         .await;

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -77,7 +77,7 @@ async fn streaming_min_heartbeat_frequency() {
             let mut event_stream = h.stream();
             for _ in 0..5 {
                 let event = event_stream
-                    .wait_for_event(Duration::from_millis(750), |e| {
+                    .next_match(Duration::from_millis(750), |e| {
                         matches!(e, Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) if e.server_address == address)
                     })
                     .await;
@@ -128,7 +128,7 @@ async fn heartbeat_frequency_is_respected() {
             let mut event_stream = h.stream();
 
             // collect events for 2 seconds, should see between 2 and 3 heartbeats.
-            let events = event_stream.collect_events(Duration::from_secs(3), |e| {
+            let events = event_stream.collect(Duration::from_secs(3), |e| {
                 matches!(e, Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) if e.server_address == address)
             }).await;
 
@@ -192,7 +192,7 @@ async fn rtt_is_updated() {
 
     // wait for multiple heartbeats, assert their RTT is > 0
     let events = event_stream
-        .collect_events(Duration::from_secs(2), |e| {
+        .collect(Duration::from_secs(2), |e| {
             if let Event::Sdam(SdamEvent::ServerDescriptionChanged(e)) = e {
                 assert!(
                     e.new_description.average_round_trip_time().unwrap() > Duration::from_millis(0)

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -74,7 +74,7 @@ async fn streaming_min_heartbeat_frequency() {
         let h = buffer.clone();
         tasks.push(runtime::spawn(async move {
 
-            let mut subscriber = h.subscribe();
+            let mut subscriber = h.stream();
             for _ in 0..5 {
                 let event = subscriber
                     .wait_for_event(Duration::from_millis(750), |e| {
@@ -125,7 +125,7 @@ async fn heartbeat_frequency_is_respected() {
         let h = buffer.clone();
         tasks.push(runtime::spawn(async move {
 
-            let mut subscriber = h.subscribe();
+            let mut subscriber = h.stream();
 
             // collect events for 2 seconds, should see between 2 and 3 heartbeats.
             let events = subscriber.collect_events(Duration::from_secs(3), |e| {
@@ -180,7 +180,7 @@ async fn rtt_is_updated() {
 
     let client = Client::with_options(options).unwrap();
 
-    let mut subscriber = buffer.subscribe();
+    let mut subscriber = buffer.stream();
 
     // run a find to wait for the primary to be discovered
     client

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -74,9 +74,9 @@ async fn streaming_min_heartbeat_frequency() {
         let h = buffer.clone();
         tasks.push(runtime::spawn(async move {
 
-            let mut subscriber = h.stream();
+            let mut event_stream = h.stream();
             for _ in 0..5 {
-                let event = subscriber
+                let event = event_stream
                     .wait_for_event(Duration::from_millis(750), |e| {
                         matches!(e, Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) if e.server_address == address)
                     })
@@ -125,10 +125,10 @@ async fn heartbeat_frequency_is_respected() {
         let h = buffer.clone();
         tasks.push(runtime::spawn(async move {
 
-            let mut subscriber = h.stream();
+            let mut event_stream = h.stream();
 
             // collect events for 2 seconds, should see between 2 and 3 heartbeats.
-            let events = subscriber.collect_events(Duration::from_secs(3), |e| {
+            let events = event_stream.collect_events(Duration::from_secs(3), |e| {
                 matches!(e, Event::Sdam(SdamEvent::ServerHeartbeatSucceeded(e)) if e.server_address == address)
             }).await;
 
@@ -180,7 +180,7 @@ async fn rtt_is_updated() {
 
     let client = Client::with_options(options).unwrap();
 
-    let mut subscriber = buffer.stream();
+    let mut event_stream = buffer.stream();
 
     // run a find to wait for the primary to be discovered
     client
@@ -191,7 +191,7 @@ async fn rtt_is_updated() {
         .unwrap();
 
     // wait for multiple heartbeats, assert their RTT is > 0
-    let events = subscriber
+    let events = event_stream
         .collect_events(Duration::from_secs(2), |e| {
             if let Event::Sdam(SdamEvent::ServerDescriptionChanged(e)) = e {
                 assert!(

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -246,7 +246,7 @@ async fn sessions_not_supported_implicit_session_ignored() {
         return;
     };
 
-    let mut subscriber = client.events.subscribe();
+    let mut subscriber = client.events.stream();
     let coll = client.database(name).collection(name);
 
     let _ = coll.find(doc! {}).await;

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -246,11 +246,11 @@ async fn sessions_not_supported_implicit_session_ignored() {
         return;
     };
 
-    let mut subscriber = client.events.stream();
+    let mut event_stream = client.events.stream();
     let coll = client.database(name).collection(name);
 
     let _ = coll.find(doc! {}).await;
-    let event = subscriber
+    let event = event_stream
         .filter_map_event(Duration::from_millis(500), |event| match event {
             Event::Command(CommandEvent::Started(command_started_event))
                 if command_started_event.command_name == "find" =>
@@ -264,7 +264,7 @@ async fn sessions_not_supported_implicit_session_ignored() {
     assert!(!event.command.contains_key("lsid"));
 
     let _ = coll.insert_one(doc! { "x": 1 }).await;
-    let event = subscriber
+    let event = event_stream
         .filter_map_event(Duration::from_millis(500), |event| match event {
             Event::Command(CommandEvent::Started(command_started_event))
                 if command_started_event.command_name == "insert" =>

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -251,7 +251,7 @@ async fn sessions_not_supported_implicit_session_ignored() {
 
     let _ = coll.find(doc! {}).await;
     let event = event_stream
-        .filter_map_event(Duration::from_millis(500), |event| match event {
+        .next_map(Duration::from_millis(500), |event| match event {
             Event::Command(CommandEvent::Started(command_started_event))
                 if command_started_event.command_name == "find" =>
             {
@@ -265,7 +265,7 @@ async fn sessions_not_supported_implicit_session_ignored() {
 
     let _ = coll.insert_one(doc! { "x": 1 }).await;
     let event = event_stream
-        .filter_map_event(Duration::from_millis(500), |event| match event {
+        .next_map(Duration::from_millis(500), |event| match event {
             Event::Command(CommandEvent::Started(command_started_event))
                 if command_started_event.command_name == "insert" =>
             {

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -84,14 +84,14 @@ async fn command_logging_truncation_default_limit() {
         COMMAND_TRACING_EVENT_TARGET.to_string(),
         tracing::Level::DEBUG,
     )]));
-    let mut tracing_subscriber = DEFAULT_GLOBAL_TRACING_HANDLER.subscribe();
+    let mut tracing_stream = DEFAULT_GLOBAL_TRACING_HANDLER.event_stream();
 
     let docs = iter::repeat(doc! { "x": "y" }).take(100);
     coll.insert_many(docs)
         .await
         .expect("insert many should succeed");
 
-    let events = tracing_subscriber
+    let events = tracing_stream
         .collect_events(Duration::from_millis(500), |_| true)
         .await;
     assert_eq!(events.len(), 2);
@@ -105,7 +105,7 @@ async fn command_logging_truncation_default_limit() {
     assert!(reply.len() <= DEFAULT_MAX_DOCUMENT_LENGTH_BYTES + 3); // +3 for trailing "..."
 
     coll.find(doc! {}).await.expect("find should succeed");
-    let succeeded = tracing_subscriber
+    let succeeded = tracing_stream
         .wait_for_event(Duration::from_millis(500), |e| {
             e.get_value_as_string("message") == "Command succeeded"
         })
@@ -126,7 +126,7 @@ async fn command_logging_truncation_explicit_limit() {
         COMMAND_TRACING_EVENT_TARGET.to_string(),
         tracing::Level::DEBUG,
     )]));
-    let mut tracing_subscriber = DEFAULT_GLOBAL_TRACING_HANDLER.subscribe();
+    let mut tracing_stream = DEFAULT_GLOBAL_TRACING_HANDLER.event_stream();
 
     client
         .database("tracing_test")
@@ -134,7 +134,7 @@ async fn command_logging_truncation_explicit_limit() {
         .await
         .expect("hello command should succeed");
 
-    let events = tracing_subscriber
+    let events = tracing_stream
         .collect_events(Duration::from_millis(500), |_| true)
         .await;
     assert_eq!(events.len(), 2);
@@ -175,14 +175,14 @@ async fn command_logging_truncation_mid_codepoint() {
         COMMAND_TRACING_EVENT_TARGET.to_string(),
         tracing::Level::DEBUG,
     )]));
-    let mut tracing_subscriber = DEFAULT_GLOBAL_TRACING_HANDLER.subscribe();
+    let mut tracing_stream = DEFAULT_GLOBAL_TRACING_HANDLER.event_stream();
 
     let docs = iter::repeat(doc! { "🤔": "🤔🤔🤔🤔🤔🤔" }).take(10);
     coll.insert_many(docs)
         .await
         .expect("insert many should succeed");
 
-    let started = tracing_subscriber
+    let started = tracing_stream
         .wait_for_event(Duration::from_millis(500), |e| {
             e.get_value_as_string("message") == "Command started"
         })
@@ -199,7 +199,7 @@ async fn command_logging_truncation_mid_codepoint() {
         .projection(doc! { "_id": 0, "🤔": 1 })
         .await
         .expect("find should succeed");
-    let succeeded = tracing_subscriber
+    let succeeded = tracing_stream
         .wait_for_event(Duration::from_millis(500), |e| {
             e.get_value_as_string("message") == "Command succeeded"
                 && e.get_value_as_string("commandName") == "find"

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -92,7 +92,7 @@ async fn command_logging_truncation_default_limit() {
         .expect("insert many should succeed");
 
     let events = tracing_stream
-        .collect_events(Duration::from_millis(500), |_| true)
+        .collect(Duration::from_millis(500), |_| true)
         .await;
     assert_eq!(events.len(), 2);
 
@@ -106,7 +106,7 @@ async fn command_logging_truncation_default_limit() {
 
     coll.find(doc! {}).await.expect("find should succeed");
     let succeeded = tracing_stream
-        .wait_for_event(Duration::from_millis(500), |e| {
+        .next_match(Duration::from_millis(500), |e| {
             e.get_value_as_string("message") == "Command succeeded"
         })
         .await
@@ -135,7 +135,7 @@ async fn command_logging_truncation_explicit_limit() {
         .expect("hello command should succeed");
 
     let events = tracing_stream
-        .collect_events(Duration::from_millis(500), |_| true)
+        .collect(Duration::from_millis(500), |_| true)
         .await;
     assert_eq!(events.len(), 2);
 
@@ -183,7 +183,7 @@ async fn command_logging_truncation_mid_codepoint() {
         .expect("insert many should succeed");
 
     let started = tracing_stream
-        .wait_for_event(Duration::from_millis(500), |e| {
+        .next_match(Duration::from_millis(500), |e| {
             e.get_value_as_string("message") == "Command started"
         })
         .await
@@ -200,7 +200,7 @@ async fn command_logging_truncation_mid_codepoint() {
         .await
         .expect("find should succeed");
     let succeeded = tracing_stream
-        .wait_for_event(Duration::from_millis(500), |e| {
+        .next_match(Duration::from_millis(500), |e| {
             e.get_value_as_string("message") == "Command succeeded"
                 && e.get_value_as_string("commandName") == "find"
         })

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -199,20 +199,21 @@ impl ClientEntity {
         count: usize,
         entities: Arc<RwLock<EntityMap>>,
     ) -> Result<()> {
-        crate::runtime::timeout(Duration::from_secs(10), async {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        crate::runtime::timeout(TIMEOUT, async {
+            let mut stream = self.events.stream_all();
+            let mut matched = 0;
             loop {
-                let (events, notified) = self.events.watch_all();
-                let matched = {
-                    let entities = &*entities.read().await;
-                    events
-                        .into_iter()
-                        .filter(|e| events_match(e, expected, Some(entities)).is_ok())
-                        .count()
+                let Some(ev) = stream.next(TIMEOUT).await else {
+                    continue;
                 };
-                if matched >= count {
-                    return Ok(());
+                let entities = &*entities.read().await;
+                if events_match(&ev, expected, Some(&entities)).is_ok() {
+                    matched += 1;
+                    if matched >= count {
+                        return Ok(());
+                    }
                 }
-                notified.await;
             }
         })
         .await?

--- a/src/test/spec/unified_runner/entity.rs
+++ b/src/test/spec/unified_runner/entity.rs
@@ -208,7 +208,7 @@ impl ClientEntity {
                     continue;
                 };
                 let entities = &*entities.read().await;
-                if events_match(&ev, expected, Some(&entities)).is_ok() {
+                if events_match(&ev, expected, Some(entities)).is_ok() {
                     matched += 1;
                     if matched >= count {
                         return Ok(());

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -316,7 +316,7 @@ impl TestRunner {
                 self.sync_workers().await;
 
                 let all_tracing_events = tracing_stream
-                    .collect_events(Duration::from_millis(1000), |_| true)
+                    .collect(Duration::from_millis(1000), |_| true)
                     .await;
 
                 for expectation in expected_messages {

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -244,12 +244,12 @@ impl TestRunner {
             }
 
             #[cfg(feature = "tracing-unstable")]
-            let (mut tracing_subscriber, _levels_guard) = {
+            let (mut tracing_stream, _levels_guard) = {
                 let tracing_levels =
                     max_verbosity_levels_for_test_case(&test_file.create_entities, test_case);
                 let guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(tracing_levels);
-                let subscriber = DEFAULT_GLOBAL_TRACING_HANDLER.subscribe();
-                (subscriber, guard)
+                let stream = DEFAULT_GLOBAL_TRACING_HANDLER.event_stream();
+                (stream, guard)
             };
 
             for operation in &test_case.operations {
@@ -315,7 +315,7 @@ impl TestRunner {
             if let Some(ref expected_messages) = test_case.expect_log_messages {
                 self.sync_workers().await;
 
-                let all_tracing_events = tracing_subscriber
+                let all_tracing_events = tracing_stream
                     .collect_events(Duration::from_millis(1000), |_| true)
                     .await;
 

--- a/src/test/util/event_buffer.rs
+++ b/src/test/util/event_buffer.rs
@@ -254,7 +254,7 @@ impl EventBuffer<Event> {
     }
 }
 
-/// Process events one at a time as they arrive asynchronously.
+/// Iterate one at a time over events in an `EventBuffer`.
 pub(crate) struct EventStream<'a, T> {
     buffer: &'a EventBuffer<T>,
     index: usize,
@@ -262,6 +262,21 @@ pub(crate) struct EventStream<'a, T> {
 }
 
 impl<'a, T: Clone> EventStream<'a, T> {
+    fn try_next(&mut self) -> Option<T> {
+        let events = self.buffer.inner.events.lock().unwrap();
+        if events.generation != self.generation {
+            panic!("EventBuffer cleared during EventStream iteration");
+        }
+        if events.data.len() > self.index {
+            let event = events.data[self.index].0.clone();
+            self.index += 1;
+            return Some(event);
+        }
+        None
+    }
+
+    /// Get the next unread event from the underlying buffer, waiting for a new one to arrive if all
+    /// current ones have been read.
     pub(crate) async fn next(&mut self, timeout: Duration) -> Option<T> {
         crate::runtime::timeout(timeout, async move {
             loop {
@@ -276,25 +291,9 @@ impl<'a, T: Clone> EventStream<'a, T> {
         .unwrap_or(None)
     }
 
-    fn try_next(&mut self) -> Option<T> {
-        let events = self.buffer.inner.events.lock().unwrap();
-        if events.generation != self.generation {
-            panic!("EventBuffer cleared during EventStream iteration");
-        }
-        if events.data.len() > self.index {
-            let event = events.data[self.index].0.clone();
-            self.index += 1;
-            return Some(event);
-        }
-        None
-    }
-
-    /// Consume and pass events to the provided closure until it returns Some or the timeout is hit.
-    pub(crate) async fn filter_map_event<F, R>(
-        &mut self,
-        timeout: Duration,
-        mut filter_map: F,
-    ) -> Option<R>
+    /// Get the next unread event for which the provided closure returnes `Some`, waiting for new
+    /// events to arrive if all current ones have been read.
+    pub(crate) async fn next_map<F, R>(&mut self, timeout: Duration, mut filter_map: F) -> Option<R>
     where
         F: FnMut(T) -> Option<R>,
     {
@@ -310,22 +309,25 @@ impl<'a, T: Clone> EventStream<'a, T> {
         .unwrap_or(None)
     }
 
-    /// Waits for an event to occur within the given duration that passes the given filter.
-    pub(crate) async fn wait_for_event<F>(&mut self, timeout: Duration, mut filter: F) -> Option<T>
+    /// Get the next unread event for which the provided closure returnes `true`, waiting for new
+    /// events to arrive if all current ones have been read.
+    pub(crate) async fn next_match<F>(&mut self, timeout: Duration, mut filter: F) -> Option<T>
     where
         F: FnMut(&T) -> bool,
     {
-        self.filter_map_event(timeout, |e| if filter(&e) { Some(e) } else { None })
+        self.next_map(timeout, |e| if filter(&e) { Some(e) } else { None })
             .await
     }
 
-    pub(crate) async fn collect_events<F>(&mut self, timeout: Duration, mut filter: F) -> Vec<T>
+    /// Collect all unread events matching a predicate, waiting up to a timeout for additional ones
+    /// to arrive.
+    pub(crate) async fn collect<F>(&mut self, timeout: Duration, mut filter: F) -> Vec<T>
     where
         F: FnMut(&T) -> bool,
     {
         let mut events = Vec::new();
         let _ = runtime::timeout(timeout, async {
-            while let Some(event) = self.wait_for_event(timeout, &mut filter).await {
+            while let Some(event) = self.next_match(timeout, &mut filter).await {
                 events.push(event);
             }
         })
@@ -334,17 +336,13 @@ impl<'a, T: Clone> EventStream<'a, T> {
     }
 
     #[cfg(feature = "in-use-encryption-unstable")]
-    pub(crate) async fn collect_events_map<F, R>(
-        &mut self,
-        timeout: Duration,
-        mut filter: F,
-    ) -> Vec<R>
+    pub(crate) async fn collect_map<F, R>(&mut self, timeout: Duration, mut filter: F) -> Vec<R>
     where
         F: FnMut(T) -> Option<R>,
     {
         let mut events = Vec::new();
         let _ = runtime::timeout(timeout, async {
-            while let Some(event) = self.filter_map_event(timeout, &mut filter).await {
+            while let Some(event) = self.next_map(timeout, &mut filter).await {
                 events.push(event);
             }
         })
@@ -352,13 +350,8 @@ impl<'a, T: Clone> EventStream<'a, T> {
         events
     }
 
-    #[cfg(feature = "in-use-encryption-unstable")]
-    pub(crate) async fn clear_events(&mut self, timeout: Duration) {
-        self.collect_events(timeout, |_| true).await;
-    }
-
-    /// Returns the received events without waiting for any more.
-    pub(crate) fn all<F>(&mut self, filter: F) -> Vec<T>
+    /// Collects all unread events matching a predicate without waiting for any more.
+    pub(crate) fn collect_now<F>(&mut self, filter: F) -> Vec<T>
     where
         F: Fn(&T) -> bool,
     {
@@ -380,17 +373,17 @@ impl<'a, T: Clone> EventStream<'a, T> {
 }
 
 impl<'a> EventStream<'a, Event> {
-    /// Waits for the next CommandStartedEvent/CommandFailedEvent pair.
+    /// Gets the next unread CommandStartedEvent/CommandFailedEvent pair.
     /// If the next CommandStartedEvent is associated with a CommandFailedEvent, this method will
     /// panic.
-    pub(crate) async fn wait_for_successful_command_execution(
+    pub(crate) async fn next_successful_command_execution(
         &mut self,
         timeout: Duration,
         command_name: impl AsRef<str>,
     ) -> Option<(CommandStartedEvent, CommandSucceededEvent)> {
         runtime::timeout(timeout, async {
             let started = self
-                .filter_map_event(Duration::MAX, |event| match event {
+                .next_map(Duration::MAX, |event| match event {
                     Event::Command(CommandEvent::Started(s))
                         if s.command_name == command_name.as_ref() =>
                     {
@@ -402,7 +395,7 @@ impl<'a> EventStream<'a, Event> {
                 .unwrap();
 
             let succeeded = self
-                .filter_map_event(Duration::MAX, |event| match event {
+                .next_map(Duration::MAX, |event| match event {
                     Event::Command(CommandEvent::Succeeded(s))
                         if s.request_id == started.request_id =>
                     {

--- a/src/test/util/event_buffer.rs
+++ b/src/test/util/event_buffer.rs
@@ -107,10 +107,13 @@ impl<T> EventBuffer<T> {
         out
     }
 
+    /// Clear all cached events.  This will cause any derived `EventStream`s to error.
     pub(crate) fn clear_cached_events(&mut self) {
         self.invalidate(|data| data.clear());
     }
 
+    /// Remove all cached events that don't match the predicate.  This will cause any derived
+    /// `EventStream`s to error.
     pub(crate) fn retain(&mut self, mut f: impl FnMut(&T) -> bool) {
         self.invalidate(|data| data.retain(|(ev, _)| f(ev)));
     }

--- a/src/test/util/trace.rs
+++ b/src/test/util/trace.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use tracing::{field::Field, span, subscriber::Interest, Level, Metadata};
 
-use super::event_buffer::{EventBuffer, EventSubscriber};
+use super::event_buffer::{EventBuffer, EventStream};
 
 /// Models the data reported in a tracing event.
 #[derive(Debug, Clone)]
@@ -139,8 +139,8 @@ impl TracingHandler {
 
     /// Returns a `TracingSubscriber` that will listen for tracing events broadcast by this handler.
 
-    pub(crate) fn subscribe(&self) -> EventSubscriber<TracingEvent> {
-        self.buffer.subscribe()
+    pub(crate) fn subscribe(&self) -> EventStream<TracingEvent> {
+        self.buffer.stream()
     }
 }
 

--- a/src/test/util/trace.rs
+++ b/src/test/util/trace.rs
@@ -100,8 +100,8 @@ impl Serialize for TracingEventValue {
 /// for the scope of a test using [`TracingHandler::set_levels`].
 ///
 /// The handler will listen for tracing events for its associated components/levels and
-/// publish them to a broadcast channel. To receive the broadcasted events, call
-/// [`TracingHandler::subscribe`] to create a new [`TracingSubscriber`].
+/// buffer them. To stream the buffered events, call
+/// [`TracingHandler::event_stream`] to create a new [`EventStream`].
 #[derive(Clone, Debug)]
 pub(crate) struct TracingHandler {
     buffer: EventBuffer<TracingEvent>,
@@ -137,9 +137,8 @@ impl TracingHandler {
         TracingLevelsGuard { handler: self }
     }
 
-    /// Returns a `TracingSubscriber` that will listen for tracing events broadcast by this handler.
-
-    pub(crate) fn subscribe(&self) -> EventStream<TracingEvent> {
+    /// Returns an `EventStream` that will yield events received by this handler.
+    pub(crate) fn event_stream(&self) -> EventStream<TracingEvent> {
         self.buffer.stream()
     }
 }


### PR DESCRIPTION
RUST-1425

I've spent some time trying various approaches here, and I've come to the conclusion that the status quo is good, actually.

The status quo:
* `EventBuffer`: a vector of timestamped events, with utilities for registering with a `Client` and fetching subsets of events (e.g. `CommandStarted`).
* `EventSubscriber`: a streaming view of events in an `EventBuffer`, with utilities for watching for events matching predicates.

Some approaches I've tried to boil this down to a single unified handler:
* Remove `EventSubscriber` entirely, convert all tests using it to check assumptions post-facto.  This would be an _enormous_ amount of work and there are quite a few tests that (subjectively) are easier to follow with the streaming approach.  Also, some tests use values from earlier events in subsequent test logic.
* Remove `EventSubscriber`, provide a `pop` method to pull events from the beginning of the buffer to replace streaming.  Along with the readability issues of the above, this makes it harder to reason about and validate the total state of the buffer without maintaining a parallel copy.
* Remove `EventSubscriber`, move its methods to `EventBuffer` and have them accept a `Cursor` that tracks the index and return a new `Cursor` where relevant.  This just makes things worse; the two views on the data are still there but the distinction is less clear, and dealing with passing the `Cursor` around is a hassle.
* Remove `EventSubscriber`, move its methods to `EventBuffer` using an internal cursor.  This has the same obfuscation issues as above; additionally, various tests spawn multiple `EventSubscribers` from a single `EventBuffer` which can't be easily expressed with them merged.

My position now is that buffering and streaming are both reasonable views of events generated during a span of action and which is more natural for a given test will depend quite a bit on the particulars.  What I've done in this PR is (hopefully) clarify that distinction and how it should be used:
* Rename `EventSubscriber` (and related methods/bindings) to `EventStream`.  "Subscriber" was reflective of the old implementation using a broadcast channel and linked subscribers; now that it's iterating over a buffer, I think "stream" is a clearer reflection of the core "one at a time" nature.
* Remove `EventBuffer::watch_all`, which I originally wrote hoping that it would be a replacement for `EventSubscriber` but turned out to be too awkward to use in practice.
* Update documentation to make recommended usage clear (and remove obsolete mentions of broadcast/subscription).