### PR TITLE
RUST-1449 Simplify test client creation

### DIFF
--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -19,7 +19,6 @@ use crate::{
         util::event_buffer::EventBuffer,
         Event,
         EventClient,
-        TestClient,
     },
     Client,
     Collection,
@@ -196,7 +195,7 @@ macro_rules! for_each_op {
 /// This test also satisifies the `endSession` testing requirement of prose test 5.
 #[tokio::test]
 async fn pool_is_lifo() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     // Wait for the implicit sessions created in TestClient::new to be returned to the pool.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -229,7 +228,7 @@ async fn pool_is_lifo() {
 #[tokio::test]
 #[function_name::named]
 async fn cluster_time_in_commands() {
-    let test_client = TestClient::new().await;
+    let test_client = Client::test_builder().build().await;
     if test_client.is_standalone() {
         log_uncaptured("skipping cluster_time_in_commands test due to standalone topology");
         return;
@@ -375,7 +374,7 @@ async fn cluster_time_in_commands() {
 #[tokio::test]
 #[function_name::named]
 async fn session_usage() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.is_standalone() {
         return;
     }

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -195,7 +195,7 @@ macro_rules! for_each_op {
 /// This test also satisifies the `endSession` testing requirement of prose test 5.
 #[tokio::test]
 async fn pool_is_lifo() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     // Wait for the implicit sessions created in TestClient::new to be returned to the pool.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -228,7 +228,7 @@ async fn pool_is_lifo() {
 #[tokio::test]
 #[function_name::named]
 async fn cluster_time_in_commands() {
-    let test_client = Client::test_builder().await;
+    let test_client = Client::for_test().await;
     if test_client.is_standalone() {
         log_uncaptured("skipping cluster_time_in_commands test due to standalone topology");
         return;
@@ -374,7 +374,7 @@ async fn cluster_time_in_commands() {
 #[tokio::test]
 #[function_name::named]
 async fn session_usage() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.is_standalone() {
         return;
     }
@@ -384,7 +384,7 @@ async fn session_usage() {
         F: Fn(EventClient) -> G,
         G: Future<Output = ()>,
     {
-        let client = Client::test_builder().monitor_events().await;
+        let client = Client::for_test().monitor_events().await;
         operation(client.clone()).await;
         let (command_started, _) = client.events.get_successful_command_execution(command_name);
         assert!(
@@ -401,7 +401,7 @@ async fn session_usage() {
 #[tokio::test]
 #[function_name::named]
 async fn implicit_session_returned_after_immediate_exhaust() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if client.is_standalone() {
         return;
     }
@@ -441,7 +441,7 @@ async fn implicit_session_returned_after_immediate_exhaust() {
 #[tokio::test]
 #[function_name::named]
 async fn implicit_session_returned_after_exhaust_by_get_more() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if client.is_standalone() {
         return;
     }
@@ -491,7 +491,7 @@ async fn implicit_session_returned_after_exhaust_by_get_more() {
 #[tokio::test]
 #[function_name::named]
 async fn find_and_getmore_share_session() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if client.is_standalone() {
         log_uncaptured(
             "skipping find_and_getmore_share_session due to unsupported topology: Standalone",

--- a/src/client/session/test.rs
+++ b/src/client/session/test.rs
@@ -195,7 +195,7 @@ macro_rules! for_each_op {
 /// This test also satisifies the `endSession` testing requirement of prose test 5.
 #[tokio::test]
 async fn pool_is_lifo() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     // Wait for the implicit sessions created in TestClient::new to be returned to the pool.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
@@ -228,7 +228,7 @@ async fn pool_is_lifo() {
 #[tokio::test]
 #[function_name::named]
 async fn cluster_time_in_commands() {
-    let test_client = Client::test_builder().build().await;
+    let test_client = Client::test_builder().await;
     if test_client.is_standalone() {
         log_uncaptured("skipping cluster_time_in_commands test due to standalone topology");
         return;
@@ -374,7 +374,7 @@ async fn cluster_time_in_commands() {
 #[tokio::test]
 #[function_name::named]
 async fn session_usage() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.is_standalone() {
         return;
     }
@@ -384,7 +384,7 @@ async fn session_usage() {
         F: Fn(EventClient) -> G,
         G: Future<Output = ()>,
     {
-        let client = Client::test_builder().monitor_events().build().await;
+        let client = Client::test_builder().monitor_events().await;
         operation(client.clone()).await;
         let (command_started, _) = client.events.get_successful_command_execution(command_name);
         assert!(
@@ -401,7 +401,7 @@ async fn session_usage() {
 #[tokio::test]
 #[function_name::named]
 async fn implicit_session_returned_after_immediate_exhaust() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if client.is_standalone() {
         return;
     }
@@ -441,7 +441,7 @@ async fn implicit_session_returned_after_immediate_exhaust() {
 #[tokio::test]
 #[function_name::named]
 async fn implicit_session_returned_after_exhaust_by_get_more() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if client.is_standalone() {
         return;
     }
@@ -491,7 +491,7 @@ async fn implicit_session_returned_after_exhaust_by_get_more() {
 #[tokio::test]
 #[function_name::named]
 async fn find_and_getmore_share_session() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if client.is_standalone() {
         log_uncaptured(
             "skipping find_and_getmore_share_session due to unsupported topology: Standalone",

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -118,7 +118,7 @@ fn all_session_ops() -> impl Iterator<Item = Operation> {
 /// Test 1 from the causal consistency specification.
 #[tokio::test]
 async fn new_session_operation_time_null() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -134,7 +134,7 @@ async fn new_session_operation_time_null() {
 /// Test 2 from the causal consistency specification.
 #[tokio::test]
 async fn first_read_no_after_cluser_time() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -172,7 +172,7 @@ async fn first_read_no_after_cluser_time() {
 /// Test 3 from the causal consistency specification.
 #[tokio::test]
 async fn first_op_update_op_time() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured("skipping first_op_update_op_time due to unsupported topology: standalone");
@@ -221,7 +221,7 @@ async fn first_op_update_op_time() {
 /// Test 4 from the causal consistency specification.
 #[tokio::test]
 async fn read_includes_after_cluster_time() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -262,7 +262,7 @@ async fn read_includes_after_cluster_time() {
 /// Test 5 from the causal consistency specification.
 #[tokio::test]
 async fn find_after_write_includes_after_cluster_time() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -306,7 +306,7 @@ async fn find_after_write_includes_after_cluster_time() {
 /// Test 6 from the causal consistency specification.
 #[tokio::test]
 async fn not_causally_consistent_omits_after_cluster_time() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -345,7 +345,7 @@ async fn not_causally_consistent_omits_after_cluster_time() {
 /// Test 7 from the causal consistency specification.
 #[tokio::test]
 async fn omit_after_cluster_time_standalone() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if !client.is_standalone() {
         log_uncaptured("skipping omit_after_cluster_time_standalone due to unsupported topology");
@@ -381,7 +381,7 @@ async fn omit_after_cluster_time_standalone() {
 /// Test 8 from the causal consistency specification.
 #[tokio::test]
 async fn omit_default_read_concern_level() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -421,7 +421,7 @@ async fn omit_default_read_concern_level() {
 /// Test 9 from the causal consistency specification.
 #[tokio::test]
 async fn test_causal_consistency_read_concern_merge() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if client.is_standalone() {
         log_uncaptured(
             "skipping test_causal_consistency_read_concern_merge due to unsupported topology: \
@@ -470,7 +470,7 @@ async fn test_causal_consistency_read_concern_merge() {
 /// Test 11 from the causal consistency specification.
 #[tokio::test]
 async fn omit_cluster_time_standalone() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if !client.is_standalone() {
         log_uncaptured("skipping omit_cluster_time_standalone due to unsupported topology");
         return;
@@ -489,7 +489,7 @@ async fn omit_cluster_time_standalone() {
 /// Test 12 from the causal consistency specification.
 #[tokio::test]
 async fn cluster_time_sent_in_commands() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if client.is_standalone() {
         log_uncaptured("skipping cluster_time_sent_in_commands due to unsupported topology");
         return;

--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -118,7 +118,7 @@ fn all_session_ops() -> impl Iterator<Item = Operation> {
 /// Test 1 from the causal consistency specification.
 #[tokio::test]
 async fn new_session_operation_time_null() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -134,7 +134,7 @@ async fn new_session_operation_time_null() {
 /// Test 2 from the causal consistency specification.
 #[tokio::test]
 async fn first_read_no_after_cluser_time() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -172,7 +172,7 @@ async fn first_read_no_after_cluser_time() {
 /// Test 3 from the causal consistency specification.
 #[tokio::test]
 async fn first_op_update_op_time() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured("skipping first_op_update_op_time due to unsupported topology: standalone");
@@ -221,7 +221,7 @@ async fn first_op_update_op_time() {
 /// Test 4 from the causal consistency specification.
 #[tokio::test]
 async fn read_includes_after_cluster_time() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -262,7 +262,7 @@ async fn read_includes_after_cluster_time() {
 /// Test 5 from the causal consistency specification.
 #[tokio::test]
 async fn find_after_write_includes_after_cluster_time() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -306,7 +306,7 @@ async fn find_after_write_includes_after_cluster_time() {
 /// Test 6 from the causal consistency specification.
 #[tokio::test]
 async fn not_causally_consistent_omits_after_cluster_time() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -345,7 +345,7 @@ async fn not_causally_consistent_omits_after_cluster_time() {
 /// Test 7 from the causal consistency specification.
 #[tokio::test]
 async fn omit_after_cluster_time_standalone() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if !client.is_standalone() {
         log_uncaptured("skipping omit_after_cluster_time_standalone due to unsupported topology");
@@ -381,7 +381,7 @@ async fn omit_after_cluster_time_standalone() {
 /// Test 8 from the causal consistency specification.
 #[tokio::test]
 async fn omit_default_read_concern_level() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.is_standalone() {
         log_uncaptured(
@@ -421,7 +421,7 @@ async fn omit_default_read_concern_level() {
 /// Test 9 from the causal consistency specification.
 #[tokio::test]
 async fn test_causal_consistency_read_concern_merge() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if client.is_standalone() {
         log_uncaptured(
             "skipping test_causal_consistency_read_concern_merge due to unsupported topology: \
@@ -470,7 +470,7 @@ async fn test_causal_consistency_read_concern_merge() {
 /// Test 11 from the causal consistency specification.
 #[tokio::test]
 async fn omit_cluster_time_standalone() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if !client.is_standalone() {
         log_uncaptured("skipping omit_cluster_time_standalone due to unsupported topology");
         return;
@@ -489,7 +489,7 @@ async fn omit_cluster_time_standalone() {
 /// Test 12 from the causal consistency specification.
 #[tokio::test]
 async fn cluster_time_sent_in_commands() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if client.is_standalone() {
         log_uncaptured("skipping cluster_time_sent_in_commands due to unsupported topology");
         return;

--- a/src/cmap/test.rs
+++ b/src/cmap/test.rs
@@ -441,7 +441,7 @@ async fn cmap_spec_tests() {
         }
         options.hosts.drain(1..);
         options.direct_connection = Some(true);
-        let client = crate::Client::test_builder().options(options).await;
+        let client = crate::Client::for_test().options(options).await;
         if let Some(ref run_on) = test_file.run_on {
             let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));
             if !can_run_on {

--- a/src/cmap/test.rs
+++ b/src/cmap/test.rs
@@ -441,7 +441,7 @@ async fn cmap_spec_tests() {
         }
         options.hosts.drain(1..);
         options.direct_connection = Some(true);
-        let client = crate::Client::test_builder().options(options).build().await;
+        let client = crate::Client::test_builder().options(options).await;
         if let Some(ref run_on) = test_file.run_on {
             let can_run_on = run_on.iter().any(|run_on| run_on.can_run_on(&client));
             if !can_run_on {

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -23,8 +23,8 @@ use crate::{
             event_buffer::EventBuffer,
             fail_point::{FailPoint, FailPointMode},
         },
-        TestClient,
     },
+    Client,
 };
 use semver::VersionReq;
 use std::time::Duration;
@@ -92,7 +92,7 @@ async fn concurrent_connections() {
     options.direct_connection = Some(true);
     options.hosts.drain(1..);
 
-    let client = TestClient::with_options(Some(options)).await;
+    let client = Client::test_builder().options(options).build().await;
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
     if !version.matches(&client.server_version) {
@@ -181,7 +181,10 @@ async fn connection_error_during_establishment() {
     client_options.direct_connection = Some(true);
     client_options.repl_set_name = None;
 
-    let client = TestClient::with_options(Some(client_options.clone())).await;
+    let client = Client::test_builder()
+        .options(client_options.clone())
+        .build()
+        .await;
     if !client.supports_fail_command() {
         log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",
@@ -236,7 +239,7 @@ async fn connection_error_during_operation() {
     options.hosts.drain(1..);
     options.max_pool_size = Some(1);
 
-    let client = TestClient::with_options(options).await;
+    let client = Client::test_builder().options(options).build().await;
     if !client.supports_fail_command() {
         log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -92,7 +92,7 @@ async fn concurrent_connections() {
     options.direct_connection = Some(true);
     options.hosts.drain(1..);
 
-    let client = Client::test_builder().options(options).await;
+    let client = Client::for_test().options(options).await;
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
     if !version.matches(&client.server_version) {
@@ -181,7 +181,7 @@ async fn connection_error_during_establishment() {
     client_options.direct_connection = Some(true);
     client_options.repl_set_name = None;
 
-    let client = Client::test_builder().options(client_options.clone()).await;
+    let client = Client::for_test().options(client_options.clone()).await;
     if !client.supports_fail_command() {
         log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",
@@ -236,7 +236,7 @@ async fn connection_error_during_operation() {
     options.hosts.drain(1..);
     options.max_pool_size = Some(1);
 
-    let client = Client::test_builder().options(options).await;
+    let client = Client::for_test().options(options).await;
     if !client.supports_fail_command() {
         log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",

--- a/src/cmap/test/integration.rs
+++ b/src/cmap/test/integration.rs
@@ -92,7 +92,7 @@ async fn concurrent_connections() {
     options.direct_connection = Some(true);
     options.hosts.drain(1..);
 
-    let client = Client::test_builder().options(options).build().await;
+    let client = Client::test_builder().options(options).await;
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
     if !version.matches(&client.server_version) {
@@ -181,10 +181,7 @@ async fn connection_error_during_establishment() {
     client_options.direct_connection = Some(true);
     client_options.repl_set_name = None;
 
-    let client = Client::test_builder()
-        .options(client_options.clone())
-        .build()
-        .await;
+    let client = Client::test_builder().options(client_options.clone()).await;
     if !client.supports_fail_command() {
         log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",
@@ -239,7 +236,7 @@ async fn connection_error_during_operation() {
     options.hosts.drain(1..);
     options.max_pool_size = Some(1);
 
-    let client = Client::test_builder().options(options).build().await;
+    let client = Client::test_builder().options(options).await;
     if !client.supports_fail_command() {
         log_uncaptured(format!(
             "skipping {} due to failCommand not being supported",

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -92,7 +92,7 @@ fn write_concern_deserialize() {
 #[tokio::test]
 #[function_name::named]
 async fn inconsistent_write_concern_rejected() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
 
     let coll = db.collection(function_name!());
@@ -112,7 +112,7 @@ async fn inconsistent_write_concern_rejected() {
 #[tokio::test]
 #[function_name::named]
 async fn unacknowledged_write_concern_rejected() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
     let wc = WriteConcern {
@@ -131,7 +131,7 @@ async fn unacknowledged_write_concern_rejected() {
 #[tokio::test]
 #[function_name::named]
 async fn snapshot_read_concern() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     // snapshot read concern was introduced in 4.0
     if client.server_version_lt(4, 0) {
         return;
@@ -186,7 +186,7 @@ async fn assert_event_contains_read_concern(client: &EventClient) {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_insert_one() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -227,7 +227,7 @@ async fn command_contains_write_concern_insert_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_insert_many() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -268,7 +268,7 @@ async fn command_contains_write_concern_insert_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_update_one() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -310,7 +310,7 @@ async fn command_contains_write_concern_update_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_update_many() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -354,7 +354,7 @@ async fn command_contains_write_concern_update_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_replace_one() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -396,7 +396,7 @@ async fn command_contains_write_concern_replace_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_delete_one() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -440,7 +440,7 @@ async fn command_contains_write_concern_delete_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_delete_many() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -487,7 +487,7 @@ async fn command_contains_write_concern_delete_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_delete() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -531,7 +531,7 @@ async fn command_contains_write_concern_find_one_and_delete() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_replace() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -575,7 +575,7 @@ async fn command_contains_write_concern_find_one_and_replace() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_update() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -619,7 +619,7 @@ async fn command_contains_write_concern_find_one_and_update() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_aggregate() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -669,7 +669,7 @@ async fn command_contains_write_concern_aggregate() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_drop() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -715,7 +715,7 @@ async fn command_contains_write_concern_drop() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_create_collection() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let db = client.database("test");
     let coll: Collection<Document> = db.collection(function_name!());
 

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -4,7 +4,7 @@ use crate::{
     bson::{doc, Bson, Document},
     error::ErrorKind,
     options::{Acknowledgment, ReadConcern, WriteConcern},
-    test::{EventClient, TestClient},
+    test::EventClient,
     Client,
     Collection,
 };
@@ -92,7 +92,7 @@ fn write_concern_deserialize() {
 #[tokio::test]
 #[function_name::named]
 async fn inconsistent_write_concern_rejected() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
 
     let coll = db.collection(function_name!());
@@ -112,7 +112,7 @@ async fn inconsistent_write_concern_rejected() {
 #[tokio::test]
 #[function_name::named]
 async fn unacknowledged_write_concern_rejected() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
     let wc = WriteConcern {

--- a/src/concern/test.rs
+++ b/src/concern/test.rs
@@ -92,7 +92,7 @@ fn write_concern_deserialize() {
 #[tokio::test]
 #[function_name::named]
 async fn inconsistent_write_concern_rejected() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
 
     let coll = db.collection(function_name!());
@@ -112,7 +112,7 @@ async fn inconsistent_write_concern_rejected() {
 #[tokio::test]
 #[function_name::named]
 async fn unacknowledged_write_concern_rejected() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
     let wc = WriteConcern {
@@ -131,7 +131,7 @@ async fn unacknowledged_write_concern_rejected() {
 #[tokio::test]
 #[function_name::named]
 async fn snapshot_read_concern() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     // snapshot read concern was introduced in 4.0
     if client.server_version_lt(4, 0) {
         return;
@@ -186,7 +186,7 @@ async fn assert_event_contains_read_concern(client: &EventClient) {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_insert_one() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -227,7 +227,7 @@ async fn command_contains_write_concern_insert_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_insert_many() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -268,7 +268,7 @@ async fn command_contains_write_concern_insert_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_update_one() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -310,7 +310,7 @@ async fn command_contains_write_concern_update_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_update_many() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -354,7 +354,7 @@ async fn command_contains_write_concern_update_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_replace_one() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -396,7 +396,7 @@ async fn command_contains_write_concern_replace_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_delete_one() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -440,7 +440,7 @@ async fn command_contains_write_concern_delete_one() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_delete_many() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -487,7 +487,7 @@ async fn command_contains_write_concern_delete_many() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_delete() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -531,7 +531,7 @@ async fn command_contains_write_concern_find_one_and_delete() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_replace() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -575,7 +575,7 @@ async fn command_contains_write_concern_find_one_and_replace() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_find_one_and_update() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -619,7 +619,7 @@ async fn command_contains_write_concern_find_one_and_update() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_aggregate() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -669,7 +669,7 @@ async fn command_contains_write_concern_aggregate() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_drop() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll: Collection<Document> = client.database("test").collection(function_name!());
 
     coll.drop().await.unwrap();
@@ -715,7 +715,7 @@ async fn command_contains_write_concern_drop() {
 #[tokio::test]
 #[function_name::named]
 async fn command_contains_write_concern_create_collection() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let db = client.database("test");
     let coll: Collection<Document> = db.collection(function_name!());
 

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -20,7 +20,6 @@ use crate::{
         util::fail_point::{FailPoint, FailPointMode},
         Event,
         EventClient,
-        TestClient,
     },
     Client,
     ServerInfo,
@@ -128,7 +127,10 @@ async fn load_balancing_test() {
 
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
-    let setup_client = TestClient::with_options(Some(setup_client_options)).await;
+    let setup_client = Client::test_builder()
+        .options(setup_client_options)
+        .build()
+        .await;
 
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -127,10 +127,7 @@ async fn load_balancing_test() {
 
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
-    let setup_client = Client::test_builder()
-        .options(setup_client_options)
-        .build()
-        .await;
+    let setup_client = Client::test_builder().options(setup_client_options).await;
 
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
@@ -220,7 +217,6 @@ async fn load_balancing_test() {
         .options(options)
         .monitor_events()
         .retain_startup_events()
-        .build()
         .await;
 
     let mut subscriber = client.events.stream_all();

--- a/src/sdam/description/topology/server_selection/test/in_window.rs
+++ b/src/sdam/description/topology/server_selection/test/in_window.rs
@@ -127,7 +127,7 @@ async fn load_balancing_test() {
 
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
-    let setup_client = Client::test_builder().options(setup_client_options).await;
+    let setup_client = Client::for_test().options(setup_client_options).await;
 
     let version = VersionReq::parse(">= 4.2.9").unwrap();
     // blockConnection failpoint option only supported in 4.2.9+.
@@ -213,7 +213,7 @@ async fn load_balancing_test() {
     let hosts = options.hosts.clone();
     options.local_threshold = Duration::from_secs(30).into();
     options.min_pool_size = Some(max_pool_size);
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .monitor_events()
         .retain_startup_events()

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -589,7 +589,7 @@ async fn load_balanced() {
 #[function_name::named]
 async fn topology_closed_event_last() {
     let client = Client::test_builder()
-        .sharded_use_first_host()
+        .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
         .build()
@@ -635,7 +635,7 @@ async fn heartbeat_events() {
 
     let client = Client::test_builder()
         .options(options.clone())
-        .sharded_use_first_host()
+        .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
         .build()

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -588,7 +588,7 @@ async fn load_balanced() {
 #[tokio::test]
 #[function_name::named]
 async fn topology_closed_event_last() {
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
@@ -632,7 +632,7 @@ async fn heartbeat_events() {
     options.heartbeat_freq = Some(Duration::from_millis(50));
     options.app_name = "heartbeat_events".to_string().into();
 
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options.clone())
         .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
@@ -666,7 +666,7 @@ async fn heartbeat_events() {
 
     options.app_name = None;
     options.heartbeat_freq = None;
-    let fp_client = Client::test_builder().options(options).await;
+    let fp_client = Client::for_test().options(options).await;
 
     let fail_point = FailPoint::fail_command(
         &[LEGACY_HELLO_COMMAND_NAME, "hello"],
@@ -687,7 +687,7 @@ async fn heartbeat_events() {
 #[tokio::test]
 #[function_name::named]
 async fn direct_connection() {
-    let test_client = Client::test_builder().await;
+    let test_client = Client::for_test().await;
     if !test_client.is_replica_set() {
         log_uncaptured("Skipping direct_connection test due to non-replica set topology");
         return;

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -592,7 +592,6 @@ async fn topology_closed_event_last() {
         .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
-        .build()
         .await;
     let events = client.events.clone();
 
@@ -638,7 +637,6 @@ async fn heartbeat_events() {
         .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
-        .build()
         .await;
 
     let mut subscriber = client.events.stream_all();
@@ -668,7 +666,7 @@ async fn heartbeat_events() {
 
     options.app_name = None;
     options.heartbeat_freq = None;
-    let fp_client = Client::test_builder().options(options).build().await;
+    let fp_client = Client::test_builder().options(options).await;
 
     let fail_point = FailPoint::fail_command(
         &[LEGACY_HELLO_COMMAND_NAME, "hello"],
@@ -689,7 +687,7 @@ async fn heartbeat_events() {
 #[tokio::test]
 #[function_name::named]
 async fn direct_connection() {
-    let test_client = Client::test_builder().build().await;
+    let test_client = Client::test_builder().await;
     if !test_client.is_replica_set() {
         log_uncaptured("Skipping direct_connection test due to non-replica set topology");
         return;

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -589,8 +589,7 @@ async fn load_balanced() {
 #[function_name::named]
 async fn topology_closed_event_last() {
     let client = Client::test_builder()
-        .additional_options(None, false)
-        .await
+        .sharded_use_first_host()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
         .build()
@@ -635,8 +634,8 @@ async fn heartbeat_events() {
     options.app_name = "heartbeat_events".to_string().into();
 
     let client = Client::test_builder()
-        .additional_options(options.clone(), false)
-        .await
+        .options(options.clone())
+        .sharded_use_first_host()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
         .build()

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -33,7 +33,6 @@ use crate::{
             fail_point::{FailPoint, FailPointMode},
         },
         Event,
-        TestClient,
     },
 };
 
@@ -670,7 +669,7 @@ async fn heartbeat_events() {
 
     options.app_name = None;
     options.heartbeat_freq = None;
-    let fp_client = TestClient::with_options(Some(options)).await;
+    let fp_client = Client::test_builder().options(options).build().await;
 
     let fail_point = FailPoint::fail_command(
         &[LEGACY_HELLO_COMMAND_NAME, "hello"],

--- a/src/sdam/description/topology/test/sdam.rs
+++ b/src/sdam/description/topology/test/sdam.rs
@@ -691,7 +691,7 @@ async fn heartbeat_events() {
 #[tokio::test]
 #[function_name::named]
 async fn direct_connection() {
-    let test_client = TestClient::new().await;
+    let test_client = Client::test_builder().build().await;
     if !test_client.is_replica_set() {
         log_uncaptured("Skipping direct_connection test due to non-replica set topology");
         return;

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -224,7 +224,7 @@ async fn hello_ok_true() {
 
 #[tokio::test]
 async fn repl_set_name_mismatch() -> crate::error::Result<()> {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.is_replica_set() {
         log_uncaptured("skipping repl_set_name_mismatch due to non-replica set topology");
         return Ok(());

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -99,7 +99,7 @@ async fn sdam_pool_management() {
 
     let client = Client::test_builder()
         .options(options)
-        .sharded_use_first_host()
+        .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
         .build()

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -98,8 +98,8 @@ async fn sdam_pool_management() {
     options.heartbeat_freq = Some(Duration::from_millis(50));
 
     let client = Client::test_builder()
-        .additional_options(options, false)
-        .await
+        .options(options)
+        .sharded_use_first_host()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
         .build()

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -21,7 +21,6 @@ use crate::{
             fail_point::{FailPoint, FailPointMode},
         },
         Event,
-        TestClient,
     },
     Client,
 };
@@ -36,7 +35,10 @@ async fn min_heartbeat_frequency() {
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
 
-    let setup_client = TestClient::with_options(Some(setup_client_options.clone())).await;
+    let setup_client = Client::test_builder()
+        .options(setup_client_options.clone())
+        .build()
+        .await;
 
     if !setup_client.supports_fail_command_appname_initial_handshake() {
         log_uncaptured(
@@ -173,7 +175,10 @@ async fn hello_ok_true() {
         return;
     }
 
-    let setup_client = TestClient::with_options(Some(setup_client_options.clone())).await;
+    let setup_client = Client::test_builder()
+        .options(setup_client_options.clone())
+        .build()
+        .await;
     if !VersionReq::parse(">= 4.4.5")
         .unwrap()
         .matches(&setup_client.server_version)

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -37,7 +37,6 @@ async fn min_heartbeat_frequency() {
 
     let setup_client = Client::test_builder()
         .options(setup_client_options.clone())
-        .build()
         .await;
 
     if !setup_client.supports_fail_command_appname_initial_handshake() {
@@ -102,7 +101,6 @@ async fn sdam_pool_management() {
         .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
         .monitor_events()
-        .build()
         .await;
 
     let mut subscriber = client.events.stream_all();
@@ -177,7 +175,6 @@ async fn hello_ok_true() {
 
     let setup_client = Client::test_builder()
         .options(setup_client_options.clone())
-        .build()
         .await;
     if !VersionReq::parse(">= 4.4.5")
         .unwrap()
@@ -229,7 +226,7 @@ async fn hello_ok_true() {
 
 #[tokio::test]
 async fn repl_set_name_mismatch() -> crate::error::Result<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.is_replica_set() {
         log_uncaptured("skipping repl_set_name_mismatch due to non-replica set topology");
         return Ok(());

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -35,7 +35,7 @@ async fn min_heartbeat_frequency() {
     setup_client_options.hosts.drain(1..);
     setup_client_options.direct_connection = Some(true);
 
-    let setup_client = Client::test_builder()
+    let setup_client = Client::for_test()
         .options(setup_client_options.clone())
         .await;
 
@@ -96,7 +96,7 @@ async fn sdam_pool_management() {
     options.app_name = Some("SDAMPoolManagementTest".to_string());
     options.heartbeat_freq = Some(Duration::from_millis(50));
 
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .use_single_mongos()
         .min_heartbeat_freq(Duration::from_millis(50))
@@ -173,7 +173,7 @@ async fn hello_ok_true() {
         return;
     }
 
-    let setup_client = Client::test_builder()
+    let setup_client = Client::for_test()
         .options(setup_client_options.clone())
         .await;
     if !VersionReq::parse(">= 4.4.5")
@@ -226,7 +226,7 @@ async fn hello_ok_true() {
 
 #[tokio::test]
 async fn repl_set_name_mismatch() -> crate::error::Result<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.is_replica_set() {
         log_uncaptured("skipping repl_set_name_mismatch due to non-replica set topology");
         return Ok(());

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -427,8 +427,7 @@ fn mixed_sync_and_async() -> Result<()> {
     const COLL_NAME: &str = "test";
 
     let sync_client = Client::with_options(CLIENT_OPTIONS.clone())?;
-    let async_client =
-        crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::for_test().await });
+    let async_client = crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::for_test().await });
     let sync_db = sync_client.database(DB_NAME);
     sync_db.drop().run()?;
     sync_db

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -234,7 +234,7 @@ fn typed_collection() {
 #[function_name::named]
 fn transactions() {
     let should_skip = crate::sync::TOKIO_RUNTIME.block_on(async {
-        let test_client = AsyncClient::test_builder().build().await;
+        let test_client = AsyncClient::test_builder().await;
         !test_client.supports_transactions()
     });
     if should_skip {
@@ -428,7 +428,7 @@ fn mixed_sync_and_async() -> Result<()> {
 
     let sync_client = Client::with_options(CLIENT_OPTIONS.clone())?;
     let async_client =
-        crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::test_builder().build().await });
+        crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::test_builder().await });
     let sync_db = sync_client.database(DB_NAME);
     sync_db.drop().run()?;
     sync_db

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -20,7 +20,7 @@ use crate::{
         WriteConcern,
     },
     sync::{Client, ClientSession, Collection},
-    test::TestClient as AsyncTestClient,
+    Client as AsyncClient,
 };
 
 fn init_db_and_coll(client: &Client, db_name: &str, coll_name: &str) -> Collection<Document> {
@@ -234,7 +234,7 @@ fn typed_collection() {
 #[function_name::named]
 fn transactions() {
     let should_skip = crate::sync::TOKIO_RUNTIME.block_on(async {
-        let test_client = AsyncTestClient::new().await;
+        let test_client = AsyncClient::test_builder().build().await;
         !test_client.supports_transactions()
     });
     if should_skip {
@@ -427,7 +427,8 @@ fn mixed_sync_and_async() -> Result<()> {
     const COLL_NAME: &str = "test";
 
     let sync_client = Client::with_options(CLIENT_OPTIONS.clone())?;
-    let async_client = crate::sync::TOKIO_RUNTIME.block_on(async { AsyncTestClient::new().await });
+    let async_client =
+        crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::test_builder().build().await });
     let sync_db = sync_client.database(DB_NAME);
     sync_db.drop().run()?;
     sync_db

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -234,7 +234,7 @@ fn typed_collection() {
 #[function_name::named]
 fn transactions() {
     let should_skip = crate::sync::TOKIO_RUNTIME.block_on(async {
-        let test_client = AsyncClient::test_builder().await;
+        let test_client = AsyncClient::for_test().await;
         !test_client.supports_transactions()
     });
     if should_skip {
@@ -428,7 +428,7 @@ fn mixed_sync_and_async() -> Result<()> {
 
     let sync_client = Client::with_options(CLIENT_OPTIONS.clone())?;
     let async_client =
-        crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::test_builder().await });
+        crate::sync::TOKIO_RUNTIME.block_on(async { AsyncClient::for_test().await });
     let sync_db = sync_client.database(DB_NAME);
     sync_db.drop().run()?;
     sync_db

--- a/src/test/auth_aws.rs
+++ b/src/test/auth_aws.rs
@@ -4,11 +4,9 @@ use bson::doc;
 
 use crate::{bson::Document, client::auth::aws::test_utils::*, test::DEFAULT_URI, Client};
 
-use super::TestClient;
-
 #[tokio::test]
 async fn auth_aws() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client.database("aws").collection::<Document>("somecoll");
 
     coll.find_one(doc! {}).await.unwrap();

--- a/src/test/auth_aws.rs
+++ b/src/test/auth_aws.rs
@@ -6,7 +6,7 @@ use crate::{bson::Document, client::auth::aws::test_utils::*, test::DEFAULT_URI,
 
 #[tokio::test]
 async fn auth_aws() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client.database("aws").collection::<Document>("somecoll");
 
     coll.find_one(doc! {}).await.unwrap();

--- a/src/test/auth_aws.rs
+++ b/src/test/auth_aws.rs
@@ -6,7 +6,7 @@ use crate::{bson::Document, client::auth::aws::test_utils::*, test::DEFAULT_URI,
 
 #[tokio::test]
 async fn auth_aws() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client.database("aws").collection::<Document>("somecoll");
 
     coll.find_one(doc! {}).await.unwrap();

--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -40,7 +40,7 @@ impl PartialBulkWriteResult {
 // CRUD prose test 3
 #[tokio::test]
 async fn max_write_batch_size_batching() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping max_write_batch_size_batching: bulkWrite requires 8.0+");
@@ -79,7 +79,7 @@ async fn max_write_batch_size_batching() {
 // CRUD prose test 4
 #[tokio::test]
 async fn max_message_size_bytes_batching() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping max_message_size_bytes_batching: bulkWrite requires 8.0+");
@@ -123,13 +123,12 @@ async fn max_message_size_bytes_batching() {
 async fn write_concern_error_batches() {
     let mut options = get_client_options().await.clone();
     options.retry_writes = Some(false);
-    if Client::test_builder().build().await.is_sharded() {
+    if Client::test_builder().await.is_sharded() {
         options.hosts.drain(1..);
     }
     let client = Client::test_builder()
         .options(options)
         .monitor_events()
-        .build()
         .await;
 
     if client.server_version_lt(8, 0) {
@@ -171,7 +170,7 @@ async fn write_concern_error_batches() {
 // CRUD prose test 6
 #[tokio::test]
 async fn write_error_batches() {
-    let mut client = Client::test_builder().monitor_events().build().await;
+    let mut client = Client::test_builder().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping write_error_batches: bulkWrite requires 8.0+");
@@ -228,7 +227,7 @@ async fn write_error_batches() {
 // CRUD prose test 7
 #[tokio::test]
 async fn successful_cursor_iteration() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping successful_cursor_iteration: bulkWrite requires 8.0+");
@@ -266,7 +265,7 @@ async fn successful_cursor_iteration() {
 // CRUD prose test 8
 #[tokio::test]
 async fn cursor_iteration_in_a_transaction() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.server_version_lt(8, 0) || client.is_standalone() {
         log_uncaptured(
@@ -316,13 +315,12 @@ async fn cursor_iteration_in_a_transaction() {
 #[tokio::test(flavor = "multi_thread")]
 async fn failed_cursor_iteration() {
     let mut options = get_client_options().await.clone();
-    if Client::test_builder().build().await.is_sharded() {
+    if Client::test_builder().await.is_sharded() {
         options.hosts.drain(1..);
     }
     let client = Client::test_builder()
         .options(options)
         .monitor_events()
-        .build()
         .await;
 
     if client.server_version_lt(8, 0) {
@@ -391,7 +389,7 @@ async fn failed_cursor_iteration() {
 async fn namespace_batch_splitting() {
     let first_namespace = Namespace::new("db", "coll");
 
-    let mut client = Client::test_builder().monitor_events().build().await;
+    let mut client = Client::test_builder().monitor_events().await;
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping namespace_batch_splitting: bulkWrite requires 8.0+");
         return;
@@ -499,7 +497,7 @@ async fn namespace_batch_splitting() {
 // CRUD prose test 12
 #[tokio::test]
 async fn too_large_client_error() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let max_message_size_bytes = client.server_info.max_message_size_bytes as usize;
 
     if client.server_version_lt(8, 0) {
@@ -544,7 +542,6 @@ async fn encryption_error() {
     let encrypted_options = AutoEncryptionOptions::new(Namespace::new("db", "coll"), kms_providers);
     let encrypted_client = Client::test_builder()
         .encrypted_options(encrypted_options)
-        .build()
         .await;
 
     let model = InsertOneModel::builder()
@@ -565,7 +562,7 @@ async fn encryption_error() {
 
 #[tokio::test]
 async fn unsupported_server_client_error() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     if client.server_version_gte(8, 0) {
         return;

--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -126,10 +126,7 @@ async fn write_concern_error_batches() {
     if Client::for_test().await.is_sharded() {
         options.hosts.drain(1..);
     }
-    let client = Client::for_test()
-        .options(options)
-        .monitor_events()
-        .await;
+    let client = Client::for_test().options(options).monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping write_concern_error_batches: bulkWrite requires 8.0+");
@@ -318,10 +315,7 @@ async fn failed_cursor_iteration() {
     if Client::for_test().await.is_sharded() {
         options.hosts.drain(1..);
     }
-    let client = Client::for_test()
-        .options(options)
-        .monitor_events()
-        .await;
+    let client = Client::for_test().options(options).monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping failed_cursor_iteration: bulkWrite requires 8.0+");

--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -14,8 +14,6 @@ use crate::{
     Namespace,
 };
 
-use super::TestClient;
-
 impl PartialBulkWriteResult {
     fn inserted_count(&self) -> i64 {
         match self {
@@ -125,7 +123,7 @@ async fn max_message_size_bytes_batching() {
 async fn write_concern_error_batches() {
     let mut options = get_client_options().await.clone();
     options.retry_writes = Some(false);
-    if TestClient::new().await.is_sharded() {
+    if Client::test_builder().build().await.is_sharded() {
         options.hosts.drain(1..);
     }
     let client = Client::test_builder()
@@ -318,7 +316,7 @@ async fn cursor_iteration_in_a_transaction() {
 #[tokio::test(flavor = "multi_thread")]
 async fn failed_cursor_iteration() {
     let mut options = get_client_options().await.clone();
-    if TestClient::new().await.is_sharded() {
+    if Client::test_builder().build().await.is_sharded() {
         options.hosts.drain(1..);
     }
     let client = Client::test_builder()

--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -40,7 +40,7 @@ impl PartialBulkWriteResult {
 // CRUD prose test 3
 #[tokio::test]
 async fn max_write_batch_size_batching() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping max_write_batch_size_batching: bulkWrite requires 8.0+");
@@ -79,7 +79,7 @@ async fn max_write_batch_size_batching() {
 // CRUD prose test 4
 #[tokio::test]
 async fn max_message_size_bytes_batching() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping max_message_size_bytes_batching: bulkWrite requires 8.0+");
@@ -123,10 +123,10 @@ async fn max_message_size_bytes_batching() {
 async fn write_concern_error_batches() {
     let mut options = get_client_options().await.clone();
     options.retry_writes = Some(false);
-    if Client::test_builder().await.is_sharded() {
+    if Client::for_test().await.is_sharded() {
         options.hosts.drain(1..);
     }
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .monitor_events()
         .await;
@@ -170,7 +170,7 @@ async fn write_concern_error_batches() {
 // CRUD prose test 6
 #[tokio::test]
 async fn write_error_batches() {
-    let mut client = Client::test_builder().monitor_events().await;
+    let mut client = Client::for_test().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping write_error_batches: bulkWrite requires 8.0+");
@@ -227,7 +227,7 @@ async fn write_error_batches() {
 // CRUD prose test 7
 #[tokio::test]
 async fn successful_cursor_iteration() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping successful_cursor_iteration: bulkWrite requires 8.0+");
@@ -265,7 +265,7 @@ async fn successful_cursor_iteration() {
 // CRUD prose test 8
 #[tokio::test]
 async fn cursor_iteration_in_a_transaction() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.server_version_lt(8, 0) || client.is_standalone() {
         log_uncaptured(
@@ -315,10 +315,10 @@ async fn cursor_iteration_in_a_transaction() {
 #[tokio::test(flavor = "multi_thread")]
 async fn failed_cursor_iteration() {
     let mut options = get_client_options().await.clone();
-    if Client::test_builder().await.is_sharded() {
+    if Client::for_test().await.is_sharded() {
         options.hosts.drain(1..);
     }
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .monitor_events()
         .await;
@@ -389,7 +389,7 @@ async fn failed_cursor_iteration() {
 async fn namespace_batch_splitting() {
     let first_namespace = Namespace::new("db", "coll");
 
-    let mut client = Client::test_builder().monitor_events().await;
+    let mut client = Client::for_test().monitor_events().await;
     if client.server_version_lt(8, 0) {
         log_uncaptured("skipping namespace_batch_splitting: bulkWrite requires 8.0+");
         return;
@@ -497,7 +497,7 @@ async fn namespace_batch_splitting() {
 // CRUD prose test 12
 #[tokio::test]
 async fn too_large_client_error() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let max_message_size_bytes = client.server_info.max_message_size_bytes as usize;
 
     if client.server_version_lt(8, 0) {
@@ -540,7 +540,7 @@ async fn encryption_error() {
     )])
     .unwrap();
     let encrypted_options = AutoEncryptionOptions::new(Namespace::new("db", "coll"), kms_providers);
-    let encrypted_client = Client::test_builder()
+    let encrypted_client = Client::for_test()
         .encrypted_options(encrypted_options)
         .await;
 
@@ -562,7 +562,7 @@ async fn encryption_error() {
 
 #[tokio::test]
 async fn unsupported_server_client_error() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     if client.server_version_gte(8, 0) {
         return;

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -31,7 +31,7 @@ async fn init_stream(
         ChangeStream<ChangeStreamEvent<Document>>,
     )>,
 > {
-    let init_client = Client::test_builder().await;
+    let init_client = Client::for_test().await;
     if !init_client.is_replica_set() && !init_client.is_sharded() {
         log_uncaptured("skipping change stream test on unsupported topology");
         return Ok(None);
@@ -47,7 +47,7 @@ async fn init_stream(
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
     }
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .monitor_events()
         .await;
@@ -586,7 +586,7 @@ async fn resume_uses_resume_after() -> Result<()> {
 
 #[tokio::test]
 async fn create_coll_pre_post() -> Result<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !VersionReq::parse(">=6.0")
         .unwrap()
         .matches(&client.server_version)
@@ -610,7 +610,7 @@ async fn create_coll_pre_post() -> Result<()> {
 // Prose test 19: large event splitting
 #[tokio::test]
 async fn split_large_event() -> Result<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !(client.server_version_matches(">= 6.0.9, < 6.1")
         || client.server_version_matches(">= 7.0"))
     {

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -17,7 +17,7 @@ use crate::{
     Collection,
 };
 
-use super::{get_client_options, log_uncaptured, EventClient, TestClient};
+use super::{get_client_options, log_uncaptured, EventClient};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -31,7 +31,7 @@ async fn init_stream(
         ChangeStream<ChangeStreamEvent<Document>>,
     )>,
 > {
-    let init_client = TestClient::new().await;
+    let init_client = Client::test_builder().build().await;
     if !init_client.is_replica_set() && !init_client.is_sharded() {
         log_uncaptured("skipping change stream test on unsupported topology");
         return Ok(None);
@@ -587,7 +587,7 @@ async fn resume_uses_resume_after() -> Result<()> {
 
 #[tokio::test]
 async fn create_coll_pre_post() -> Result<()> {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !VersionReq::parse(">=6.0")
         .unwrap()
         .matches(&client.server_version)

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -47,10 +47,7 @@ async fn init_stream(
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
     }
-    let client = Client::for_test()
-        .options(options)
-        .monitor_events()
-        .await;
+    let client = Client::for_test().options(options).monitor_events().await;
     let db = client.database("change_stream_tests");
     let coll = db.collection_with_options::<Document>(
         coll_name,

--- a/src/test/change_stream.rs
+++ b/src/test/change_stream.rs
@@ -31,7 +31,7 @@ async fn init_stream(
         ChangeStream<ChangeStreamEvent<Document>>,
     )>,
 > {
-    let init_client = Client::test_builder().build().await;
+    let init_client = Client::test_builder().await;
     if !init_client.is_replica_set() && !init_client.is_sharded() {
         log_uncaptured("skipping change stream test on unsupported topology");
         return Ok(None);
@@ -50,7 +50,6 @@ async fn init_stream(
     let client = Client::test_builder()
         .options(options)
         .monitor_events()
-        .build()
         .await;
     let db = client.database("change_stream_tests");
     let coll = db.collection_with_options::<Document>(
@@ -587,7 +586,7 @@ async fn resume_uses_resume_after() -> Result<()> {
 
 #[tokio::test]
 async fn create_coll_pre_post() -> Result<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !VersionReq::parse(">=6.0")
         .unwrap()
         .matches(&client.server_version)
@@ -611,7 +610,7 @@ async fn create_coll_pre_post() -> Result<()> {
 // Prose test 19: large event splitting
 #[tokio::test]
 async fn split_large_event() -> Result<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !(client.server_version_matches(">= 6.0.9, < 6.1")
         || client.server_version_matches(">= 7.0"))
     {

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -42,7 +42,7 @@ struct DriverMetadata {
 
 #[tokio::test]
 async fn metadata_sent_in_handshake() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     // skip on other topologies due to different currentOp behavior
     if !client.is_standalone() || !client.is_replica_set() {
@@ -166,7 +166,7 @@ async fn list_databases() {
         format!("{}3", function_name!()),
     ];
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     for name in expected_dbs {
         client.database(name).drop().await.unwrap();
@@ -205,7 +205,7 @@ async fn list_databases() {
 #[tokio::test]
 #[function_name::named]
 async fn list_database_names() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let expected_dbs = &[
         format!("{}1", function_name!()),
@@ -240,7 +240,7 @@ async fn list_database_names() {
 #[tokio::test]
 #[function_name::named]
 async fn list_authorized_databases() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping list_authorized_databases due to test configuration");
         return;
@@ -436,7 +436,7 @@ async fn scram_test(
 
 #[tokio::test]
 async fn scram_sha1() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_sha1 due to missing authentication");
         return;
@@ -457,7 +457,7 @@ async fn scram_sha1() {
 
 #[tokio::test]
 async fn scram_sha256() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping scram_sha256 due to test configuration");
         return;
@@ -477,7 +477,7 @@ async fn scram_sha256() {
 
 #[tokio::test]
 async fn scram_both() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping scram_both due to test configuration");
         return;
@@ -503,7 +503,7 @@ async fn scram_both() {
 
 #[tokio::test]
 async fn scram_missing_user_uri() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_missing_user_uri due to missing authentication");
         return;
@@ -513,7 +513,7 @@ async fn scram_missing_user_uri() {
 
 #[tokio::test]
 async fn scram_missing_user_options() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_missing_user_options due to missing authentication");
         return;
@@ -523,7 +523,7 @@ async fn scram_missing_user_options() {
 
 #[tokio::test]
 async fn saslprep() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping saslprep due to test configuration");
@@ -570,7 +570,7 @@ async fn x509_auth() {
         Err(_) => return,
     };
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let drop_user_result = client
         .database("$external")
         .run_command(doc! { "dropUser": &username })
@@ -601,7 +601,7 @@ async fn x509_auth() {
             .build(),
     );
 
-    let client = Client::test_builder().options(options).build().await;
+    let client = Client::test_builder().options(options).await;
     client
         .database(function_name!())
         .collection::<Document>(function_name!())
@@ -657,7 +657,7 @@ async fn plain_auth() {
 /// failure works.
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_commit_txn_check_out() {
-    let setup_client = Client::test_builder().build().await;
+    let setup_client = Client::test_builder().await;
     if !setup_client.is_replica_set() {
         log_uncaptured("skipping retry_commit_txn_check_out due to non-replicaset topology");
         return;
@@ -786,14 +786,14 @@ async fn retry_commit_txn_check_out() {
 /// Verifies that `Client::shutdown` succeeds.
 #[tokio::test]
 async fn manual_shutdown_with_nothing() {
-    let client = Client::test_builder().build().await.into_client();
+    let client = Client::test_builder().await.into_client();
     client.shutdown().await;
 }
 
 /// Verifies that `Client::shutdown` succeeds when resources have been dropped.
 #[tokio::test]
 async fn manual_shutdown_with_resources() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping manual_shutdown_with_resources: no transaction support");
         return;
@@ -844,14 +844,14 @@ async fn manual_shutdown_with_resources() {
 /// Verifies that `Client::shutdown_immediate` succeeds.
 #[tokio::test]
 async fn manual_shutdown_immediate_with_nothing() {
-    let client = Client::test_builder().build().await.into_client();
+    let client = Client::test_builder().await.into_client();
     client.shutdown().immediate(true).await;
 }
 
 /// Verifies that `Client::shutdown_immediate` succeeds without waiting for resources.
 #[tokio::test]
 async fn manual_shutdown_immediate_with_resources() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping manual_shutdown_immediate_with_resources: no transaction support");
         return;
@@ -889,7 +889,7 @@ async fn manual_shutdown_immediate_with_resources() {
 
 #[tokio::test]
 async fn find_one_and_delete_serde_consistency() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let coll = client
         .database("find_one_and_delete_serde_consistency")
@@ -924,7 +924,6 @@ async fn warm_connection_pool() {
             opts.min_pool_size = Some(10);
             opts
         })
-        .build()
         .await;
 
     client.warm_connection_pool().await;

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -42,7 +42,7 @@ struct DriverMetadata {
 
 #[tokio::test]
 async fn metadata_sent_in_handshake() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     // skip on other topologies due to different currentOp behavior
     if !client.is_standalone() || !client.is_replica_set() {
@@ -166,7 +166,7 @@ async fn list_databases() {
         format!("{}3", function_name!()),
     ];
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     for name in expected_dbs {
         client.database(name).drop().await.unwrap();
@@ -205,7 +205,7 @@ async fn list_databases() {
 #[tokio::test]
 #[function_name::named]
 async fn list_database_names() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let expected_dbs = &[
         format!("{}1", function_name!()),
@@ -240,7 +240,7 @@ async fn list_database_names() {
 #[tokio::test]
 #[function_name::named]
 async fn list_authorized_databases() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping list_authorized_databases due to test configuration");
         return;
@@ -436,7 +436,7 @@ async fn scram_test(
 
 #[tokio::test]
 async fn scram_sha1() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_sha1 due to missing authentication");
         return;
@@ -457,7 +457,7 @@ async fn scram_sha1() {
 
 #[tokio::test]
 async fn scram_sha256() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping scram_sha256 due to test configuration");
         return;
@@ -477,7 +477,7 @@ async fn scram_sha256() {
 
 #[tokio::test]
 async fn scram_both() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping scram_both due to test configuration");
         return;
@@ -503,7 +503,7 @@ async fn scram_both() {
 
 #[tokio::test]
 async fn scram_missing_user_uri() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_missing_user_uri due to missing authentication");
         return;
@@ -513,7 +513,7 @@ async fn scram_missing_user_uri() {
 
 #[tokio::test]
 async fn scram_missing_user_options() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_missing_user_options due to missing authentication");
         return;
@@ -523,7 +523,7 @@ async fn scram_missing_user_options() {
 
 #[tokio::test]
 async fn saslprep() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping saslprep due to test configuration");
@@ -570,7 +570,7 @@ async fn x509_auth() {
         Err(_) => return,
     };
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let drop_user_result = client
         .database("$external")
         .run_command(doc! { "dropUser": &username })
@@ -657,7 +657,7 @@ async fn plain_auth() {
 /// failure works.
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_commit_txn_check_out() {
-    let setup_client = TestClient::new().await;
+    let setup_client = Client::test_builder().build().await;
     if !setup_client.is_replica_set() {
         log_uncaptured("skipping retry_commit_txn_check_out due to non-replicaset topology");
         return;

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -601,7 +601,7 @@ async fn x509_auth() {
             .build(),
     );
 
-    let client = TestClient::with_options(Some(options)).await;
+    let client = Client::test_builder().options(options).build().await;
     client
         .database(function_name!())
         .collection::<Document>(function_name!())

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -42,7 +42,7 @@ struct DriverMetadata {
 
 #[tokio::test]
 async fn metadata_sent_in_handshake() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     // skip on other topologies due to different currentOp behavior
     if !client.is_standalone() || !client.is_replica_set() {
@@ -166,7 +166,7 @@ async fn list_databases() {
         format!("{}3", function_name!()),
     ];
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     for name in expected_dbs {
         client.database(name).drop().await.unwrap();
@@ -205,7 +205,7 @@ async fn list_databases() {
 #[tokio::test]
 #[function_name::named]
 async fn list_database_names() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let expected_dbs = &[
         format!("{}1", function_name!()),
@@ -240,7 +240,7 @@ async fn list_database_names() {
 #[tokio::test]
 #[function_name::named]
 async fn list_authorized_databases() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping list_authorized_databases due to test configuration");
         return;
@@ -436,7 +436,7 @@ async fn scram_test(
 
 #[tokio::test]
 async fn scram_sha1() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_sha1 due to missing authentication");
         return;
@@ -457,7 +457,7 @@ async fn scram_sha1() {
 
 #[tokio::test]
 async fn scram_sha256() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping scram_sha256 due to test configuration");
         return;
@@ -477,7 +477,7 @@ async fn scram_sha256() {
 
 #[tokio::test]
 async fn scram_both() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping scram_both due to test configuration");
         return;
@@ -503,7 +503,7 @@ async fn scram_both() {
 
 #[tokio::test]
 async fn scram_missing_user_uri() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_missing_user_uri due to missing authentication");
         return;
@@ -513,7 +513,7 @@ async fn scram_missing_user_uri() {
 
 #[tokio::test]
 async fn scram_missing_user_options() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.auth_enabled() {
         log_uncaptured("skipping scram_missing_user_options due to missing authentication");
         return;
@@ -523,7 +523,7 @@ async fn scram_missing_user_options() {
 
 #[tokio::test]
 async fn saslprep() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     if client.server_version_lt(4, 0) || !client.auth_enabled() {
         log_uncaptured("skipping saslprep due to test configuration");
@@ -570,7 +570,7 @@ async fn x509_auth() {
         Err(_) => return,
     };
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let drop_user_result = client
         .database("$external")
         .run_command(doc! { "dropUser": &username })
@@ -601,7 +601,7 @@ async fn x509_auth() {
             .build(),
     );
 
-    let client = Client::test_builder().options(options).await;
+    let client = Client::for_test().options(options).await;
     client
         .database(function_name!())
         .collection::<Document>(function_name!())
@@ -657,7 +657,7 @@ async fn plain_auth() {
 /// failure works.
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_commit_txn_check_out() {
-    let setup_client = Client::test_builder().await;
+    let setup_client = Client::for_test().await;
     if !setup_client.is_replica_set() {
         log_uncaptured("skipping retry_commit_txn_check_out due to non-replicaset topology");
         return;
@@ -786,14 +786,14 @@ async fn retry_commit_txn_check_out() {
 /// Verifies that `Client::shutdown` succeeds.
 #[tokio::test]
 async fn manual_shutdown_with_nothing() {
-    let client = Client::test_builder().await.into_client();
+    let client = Client::for_test().await.into_client();
     client.shutdown().await;
 }
 
 /// Verifies that `Client::shutdown` succeeds when resources have been dropped.
 #[tokio::test]
 async fn manual_shutdown_with_resources() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping manual_shutdown_with_resources: no transaction support");
         return;
@@ -844,14 +844,14 @@ async fn manual_shutdown_with_resources() {
 /// Verifies that `Client::shutdown_immediate` succeeds.
 #[tokio::test]
 async fn manual_shutdown_immediate_with_nothing() {
-    let client = Client::test_builder().await.into_client();
+    let client = Client::for_test().await.into_client();
     client.shutdown().immediate(true).await;
 }
 
 /// Verifies that `Client::shutdown_immediate` succeeds without waiting for resources.
 #[tokio::test]
 async fn manual_shutdown_immediate_with_resources() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping manual_shutdown_immediate_with_resources: no transaction support");
         return;
@@ -889,7 +889,7 @@ async fn manual_shutdown_immediate_with_resources() {
 
 #[tokio::test]
 async fn find_one_and_delete_serde_consistency() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let coll = client
         .database("find_one_and_delete_serde_consistency")
@@ -918,7 +918,7 @@ async fn find_one_and_delete_serde_consistency() {
 // Verifies that `Client::warm_connection_pool` succeeds.
 #[tokio::test]
 async fn warm_connection_pool() {
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options({
             let mut opts = get_client_options().await.clone();
             opts.min_pool_size = Some(10);

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -31,7 +31,7 @@ use crate::{
         WriteConcern,
     },
     results::DeleteResult,
-    test::{get_client_options, log_uncaptured, util::TestClient, EventClient},
+    test::{get_client_options, log_uncaptured, EventClient},
     Client,
     Collection,
     Cursor,
@@ -879,7 +879,7 @@ async fn count_documents_with_wc() {
         .build()
         .into();
 
-    let client = TestClient::with_options(Some(options)).await;
+    let client = Client::test_builder().options(options).build().await;
     let coll = client
         .database(function_name!())
         .collection(function_name!());

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -42,7 +42,7 @@ use crate::{
 #[tokio::test]
 #[function_name::named]
 async fn insert_err_details() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -97,7 +97,7 @@ async fn insert_err_details() {
 #[tokio::test]
 #[function_name::named]
 async fn count() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -118,7 +118,7 @@ async fn count() {
 #[tokio::test]
 #[function_name::named]
 async fn find() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -143,7 +143,7 @@ async fn find() {
 #[tokio::test]
 #[function_name::named]
 async fn update() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -180,7 +180,7 @@ async fn update() {
 #[tokio::test]
 #[function_name::named]
 async fn delete() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -203,7 +203,7 @@ async fn delete() {
 #[tokio::test]
 #[function_name::named]
 async fn aggregate_out() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -255,7 +255,7 @@ fn kill_cursors_sent(client: &EventClient) -> bool {
 #[tokio::test]
 #[function_name::named]
 async fn kill_cursors_on_drop() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -265,7 +265,7 @@ async fn kill_cursors_on_drop() {
         .await
         .unwrap();
 
-    let event_client = Client::test_builder().monitor_events().build().await;
+    let event_client = Client::test_builder().monitor_events().await;
     let coll = event_client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -287,7 +287,7 @@ async fn kill_cursors_on_drop() {
 #[tokio::test]
 #[function_name::named]
 async fn no_kill_cursors_on_exhausted() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -297,7 +297,7 @@ async fn no_kill_cursors_on_exhausted() {
         .await
         .unwrap();
 
-    let event_client = Client::test_builder().monitor_events().build().await;
+    let event_client = Client::test_builder().monitor_events().await;
     let coll = event_client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -376,7 +376,7 @@ async fn large_insert() {
 
     let docs = vec![LARGE_DOC.clone(); 35000];
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -419,7 +419,7 @@ async fn large_insert_unordered_with_errors() {
 
     let docs = multibatch_documents_with_duplicate_keys();
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -457,7 +457,7 @@ async fn large_insert_ordered_with_errors() {
 
     let docs = multibatch_documents_with_duplicate_keys();
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -490,7 +490,7 @@ async fn large_insert_ordered_with_errors() {
 #[tokio::test]
 #[function_name::named]
 async fn empty_insert() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -525,7 +525,7 @@ async fn find_allow_disk_use_not_specified() {
 
 #[function_name::named]
 async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>) {
-    let event_client = Client::test_builder().monitor_events().build().await;
+    let event_client = Client::test_builder().monitor_events().await;
     if event_client.server_version_lt(4, 3) {
         log_uncaptured("skipping allow_disk_use_test due to server version < 4.3");
         return;
@@ -545,14 +545,14 @@ async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>)
 #[tokio::test]
 #[function_name::named]
 async fn ns_not_found_suppression() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client.get_coll(function_name!(), function_name!());
     coll.drop().await.expect("drop should not fail");
     coll.drop().await.expect("drop should not fail");
 }
 
 async fn delete_hint_test(options: Option<DeleteOptions>, name: &str) {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll = client.database(name).collection::<Document>(name);
     let _: Result<DeleteResult> = coll
         .delete_many(doc! {})
@@ -595,7 +595,7 @@ async fn delete_hint_not_specified() {
 }
 
 async fn find_one_and_delete_hint_test(options: Option<FindOneAndDeleteOptions>, name: &str) {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     let req = VersionReq::parse(">= 4.2").unwrap();
     if options.is_some() && !req.matches(&client.server_version) {
@@ -648,7 +648,7 @@ async fn find_one_and_delete_hint_not_specified() {
 #[tokio::test]
 #[function_name::named]
 async fn find_one_and_delete_hint_server_version() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll = client
         .database(function_name!())
         .collection::<Document>("coll");
@@ -674,7 +674,7 @@ async fn find_one_and_delete_hint_server_version() {
 #[tokio::test]
 #[function_name::named]
 async fn no_read_preference_to_standalone() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if !client.is_standalone() {
         log_uncaptured("skipping no_read_preference_to_standalone due to test topology");
@@ -707,7 +707,7 @@ struct UserType {
 #[tokio::test]
 #[function_name::named]
 async fn typed_insert_one() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
@@ -752,7 +752,7 @@ where
 #[tokio::test]
 #[function_name::named]
 async fn typed_insert_many() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -783,7 +783,7 @@ async fn typed_insert_many() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_find_one_and_replace() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -812,7 +812,7 @@ async fn typed_find_one_and_replace() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_replace_one() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -837,7 +837,7 @@ async fn typed_replace_one() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_returns() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -879,7 +879,7 @@ async fn count_documents_with_wc() {
         .build()
         .into();
 
-    let client = Client::test_builder().options(options).build().await;
+    let client = Client::test_builder().options(options).await;
     let coll = client
         .database(function_name!())
         .collection(function_name!());
@@ -894,7 +894,7 @@ async fn count_documents_with_wc() {
 #[tokio::test]
 #[function_name::named]
 async fn collection_options_inherited() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     let read_concern = ReadConcern::majority();
     let selection_criteria = SelectionCriteria::ReadPreference(ReadPreference::Secondary {
@@ -932,7 +932,7 @@ async fn assert_options_inherited(client: &EventClient, command_name: &str) {
 #[tokio::test]
 #[function_name::named]
 async fn drop_skip_serializing_none() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll: Collection<Document> = client
         .database(function_name!())
         .collection(function_name!());
@@ -946,7 +946,7 @@ async fn collection_generic_bounds() {
     #[derive(Deserialize)]
     struct Foo;
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     // ensure this code successfully compiles
     let coll: Collection<Foo> = client
@@ -968,7 +968,7 @@ async fn collection_generic_bounds() {
 /// iterates without errors.
 #[tokio::test]
 async fn cursor_batch_size() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll("cursor_batch_size", "cursor_batch_size")
         .await;
@@ -1013,7 +1013,7 @@ async fn cursor_batch_size() {
 /// messages. See SERVER-24007 and related tickets for details.
 #[tokio::test]
 async fn invalid_utf8_response() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll("invalid_uft8_handling", "invalid_uft8_handling")
         .await;
@@ -1143,7 +1143,7 @@ async fn configure_human_readable_serialization() {
         s: StringOrBytes,
     }
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let non_human_readable_collection: Collection<Data> =
         client.database("db").collection("nonhumanreadable");
@@ -1231,7 +1231,7 @@ async fn insert_many_document_sequences() {
         return;
     }
 
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     let mut event_stream = client.events.stream();
 
@@ -1298,7 +1298,7 @@ async fn aggregate_with_generics() {
         len: i32,
     }
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let collection = client
         .database("aggregate_with_generics")
         .collection::<A>("aggregate_with_generics");

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -42,7 +42,7 @@ use crate::{
 #[tokio::test]
 #[function_name::named]
 async fn insert_err_details() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -97,7 +97,7 @@ async fn insert_err_details() {
 #[tokio::test]
 #[function_name::named]
 async fn count() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -118,7 +118,7 @@ async fn count() {
 #[tokio::test]
 #[function_name::named]
 async fn find() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -143,7 +143,7 @@ async fn find() {
 #[tokio::test]
 #[function_name::named]
 async fn update() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -180,7 +180,7 @@ async fn update() {
 #[tokio::test]
 #[function_name::named]
 async fn delete() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -203,7 +203,7 @@ async fn delete() {
 #[tokio::test]
 #[function_name::named]
 async fn aggregate_out() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -255,7 +255,7 @@ fn kill_cursors_sent(client: &EventClient) -> bool {
 #[tokio::test]
 #[function_name::named]
 async fn kill_cursors_on_drop() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -287,7 +287,7 @@ async fn kill_cursors_on_drop() {
 #[tokio::test]
 #[function_name::named]
 async fn no_kill_cursors_on_exhausted() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -376,7 +376,7 @@ async fn large_insert() {
 
     let docs = vec![LARGE_DOC.clone(); 35000];
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -419,7 +419,7 @@ async fn large_insert_unordered_with_errors() {
 
     let docs = multibatch_documents_with_duplicate_keys();
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -457,7 +457,7 @@ async fn large_insert_ordered_with_errors() {
 
     let docs = multibatch_documents_with_duplicate_keys();
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -490,7 +490,7 @@ async fn large_insert_ordered_with_errors() {
 #[tokio::test]
 #[function_name::named]
 async fn empty_insert() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -545,7 +545,7 @@ async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>)
 #[tokio::test]
 #[function_name::named]
 async fn ns_not_found_suppression() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client.get_coll(function_name!(), function_name!());
     coll.drop().await.expect("drop should not fail");
     coll.drop().await.expect("drop should not fail");
@@ -707,7 +707,7 @@ struct UserType {
 #[tokio::test]
 #[function_name::named]
 async fn typed_insert_one() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
@@ -752,7 +752,7 @@ where
 #[tokio::test]
 #[function_name::named]
 async fn typed_insert_many() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -783,7 +783,7 @@ async fn typed_insert_many() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_find_one_and_replace() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -812,7 +812,7 @@ async fn typed_find_one_and_replace() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_replace_one() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -837,7 +837,7 @@ async fn typed_replace_one() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_returns() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -932,7 +932,7 @@ async fn assert_options_inherited(client: &EventClient, command_name: &str) {
 #[tokio::test]
 #[function_name::named]
 async fn drop_skip_serializing_none() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll: Collection<Document> = client
         .database(function_name!())
         .collection(function_name!());
@@ -946,7 +946,7 @@ async fn collection_generic_bounds() {
     #[derive(Deserialize)]
     struct Foo;
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     // ensure this code successfully compiles
     let coll: Collection<Foo> = client
@@ -968,7 +968,7 @@ async fn collection_generic_bounds() {
 /// iterates without errors.
 #[tokio::test]
 async fn cursor_batch_size() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll("cursor_batch_size", "cursor_batch_size")
         .await;
@@ -1013,7 +1013,7 @@ async fn cursor_batch_size() {
 /// messages. See SERVER-24007 and related tickets for details.
 #[tokio::test]
 async fn invalid_utf8_response() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll("invalid_uft8_handling", "invalid_uft8_handling")
         .await;
@@ -1143,7 +1143,7 @@ async fn configure_human_readable_serialization() {
         s: StringOrBytes,
     }
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let non_human_readable_collection: Collection<Data> =
         client.database("db").collection("nonhumanreadable");
@@ -1298,7 +1298,7 @@ async fn aggregate_with_generics() {
         len: i32,
     }
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let collection = client
         .database("aggregate_with_generics")
         .collection::<A>("aggregate_with_generics");

--- a/src/test/coll.rs
+++ b/src/test/coll.rs
@@ -42,7 +42,7 @@ use crate::{
 #[tokio::test]
 #[function_name::named]
 async fn insert_err_details() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -97,7 +97,7 @@ async fn insert_err_details() {
 #[tokio::test]
 #[function_name::named]
 async fn count() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -118,7 +118,7 @@ async fn count() {
 #[tokio::test]
 #[function_name::named]
 async fn find() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -143,7 +143,7 @@ async fn find() {
 #[tokio::test]
 #[function_name::named]
 async fn update() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -180,7 +180,7 @@ async fn update() {
 #[tokio::test]
 #[function_name::named]
 async fn delete() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -203,7 +203,7 @@ async fn delete() {
 #[tokio::test]
 #[function_name::named]
 async fn aggregate_out() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -255,7 +255,7 @@ fn kill_cursors_sent(client: &EventClient) -> bool {
 #[tokio::test]
 #[function_name::named]
 async fn kill_cursors_on_drop() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -265,7 +265,7 @@ async fn kill_cursors_on_drop() {
         .await
         .unwrap();
 
-    let event_client = Client::test_builder().monitor_events().await;
+    let event_client = Client::for_test().monitor_events().await;
     let coll = event_client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -287,7 +287,7 @@ async fn kill_cursors_on_drop() {
 #[tokio::test]
 #[function_name::named]
 async fn no_kill_cursors_on_exhausted() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     let coll = db.collection(function_name!());
 
@@ -297,7 +297,7 @@ async fn no_kill_cursors_on_exhausted() {
         .await
         .unwrap();
 
-    let event_client = Client::test_builder().monitor_events().await;
+    let event_client = Client::for_test().monitor_events().await;
     let coll = event_client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -376,7 +376,7 @@ async fn large_insert() {
 
     let docs = vec![LARGE_DOC.clone(); 35000];
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -419,7 +419,7 @@ async fn large_insert_unordered_with_errors() {
 
     let docs = multibatch_documents_with_duplicate_keys();
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -457,7 +457,7 @@ async fn large_insert_ordered_with_errors() {
 
     let docs = multibatch_documents_with_duplicate_keys();
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -490,7 +490,7 @@ async fn large_insert_ordered_with_errors() {
 #[tokio::test]
 #[function_name::named]
 async fn empty_insert() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .database(function_name!())
         .collection::<Document>(function_name!());
@@ -525,7 +525,7 @@ async fn find_allow_disk_use_not_specified() {
 
 #[function_name::named]
 async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>) {
-    let event_client = Client::test_builder().monitor_events().await;
+    let event_client = Client::for_test().monitor_events().await;
     if event_client.server_version_lt(4, 3) {
         log_uncaptured("skipping allow_disk_use_test due to server version < 4.3");
         return;
@@ -545,14 +545,14 @@ async fn allow_disk_use_test(options: FindOptions, expected_value: Option<bool>)
 #[tokio::test]
 #[function_name::named]
 async fn ns_not_found_suppression() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client.get_coll(function_name!(), function_name!());
     coll.drop().await.expect("drop should not fail");
     coll.drop().await.expect("drop should not fail");
 }
 
 async fn delete_hint_test(options: Option<DeleteOptions>, name: &str) {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll = client.database(name).collection::<Document>(name);
     let _: Result<DeleteResult> = coll
         .delete_many(doc! {})
@@ -595,7 +595,7 @@ async fn delete_hint_not_specified() {
 }
 
 async fn find_one_and_delete_hint_test(options: Option<FindOneAndDeleteOptions>, name: &str) {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     let req = VersionReq::parse(">= 4.2").unwrap();
     if options.is_some() && !req.matches(&client.server_version) {
@@ -648,7 +648,7 @@ async fn find_one_and_delete_hint_not_specified() {
 #[tokio::test]
 #[function_name::named]
 async fn find_one_and_delete_hint_server_version() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll = client
         .database(function_name!())
         .collection::<Document>("coll");
@@ -674,7 +674,7 @@ async fn find_one_and_delete_hint_server_version() {
 #[tokio::test]
 #[function_name::named]
 async fn no_read_preference_to_standalone() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if !client.is_standalone() {
         log_uncaptured("skipping no_read_preference_to_standalone due to test topology");
@@ -707,7 +707,7 @@ struct UserType {
 #[tokio::test]
 #[function_name::named]
 async fn typed_insert_one() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
@@ -752,7 +752,7 @@ where
 #[tokio::test]
 #[function_name::named]
 async fn typed_insert_many() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -783,7 +783,7 @@ async fn typed_insert_many() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_find_one_and_replace() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -812,7 +812,7 @@ async fn typed_find_one_and_replace() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_replace_one() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -837,7 +837,7 @@ async fn typed_replace_one() {
 #[tokio::test]
 #[function_name::named]
 async fn typed_returns() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_typed_coll(function_name!(), function_name!())
         .await;
@@ -879,7 +879,7 @@ async fn count_documents_with_wc() {
         .build()
         .into();
 
-    let client = Client::test_builder().options(options).await;
+    let client = Client::for_test().options(options).await;
     let coll = client
         .database(function_name!())
         .collection(function_name!());
@@ -894,7 +894,7 @@ async fn count_documents_with_wc() {
 #[tokio::test]
 #[function_name::named]
 async fn collection_options_inherited() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     let read_concern = ReadConcern::majority();
     let selection_criteria = SelectionCriteria::ReadPreference(ReadPreference::Secondary {
@@ -932,7 +932,7 @@ async fn assert_options_inherited(client: &EventClient, command_name: &str) {
 #[tokio::test]
 #[function_name::named]
 async fn drop_skip_serializing_none() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll: Collection<Document> = client
         .database(function_name!())
         .collection(function_name!());
@@ -946,7 +946,7 @@ async fn collection_generic_bounds() {
     #[derive(Deserialize)]
     struct Foo;
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     // ensure this code successfully compiles
     let coll: Collection<Foo> = client
@@ -968,7 +968,7 @@ async fn collection_generic_bounds() {
 /// iterates without errors.
 #[tokio::test]
 async fn cursor_batch_size() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll("cursor_batch_size", "cursor_batch_size")
         .await;
@@ -1013,7 +1013,7 @@ async fn cursor_batch_size() {
 /// messages. See SERVER-24007 and related tickets for details.
 #[tokio::test]
 async fn invalid_utf8_response() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll("invalid_uft8_handling", "invalid_uft8_handling")
         .await;
@@ -1143,7 +1143,7 @@ async fn configure_human_readable_serialization() {
         s: StringOrBytes,
     }
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let non_human_readable_collection: Collection<Data> =
         client.database("db").collection("nonhumanreadable");
@@ -1231,7 +1231,7 @@ async fn insert_many_document_sequences() {
         return;
     }
 
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     let mut event_stream = client.events.stream();
 
@@ -1298,7 +1298,7 @@ async fn aggregate_with_generics() {
         len: i32,
     }
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let collection = client
         .database("aggregate_with_generics")
         .collection::<A>("aggregate_with_generics");

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -999,7 +999,7 @@ async fn custom_endpoint_setup(valid: bool) -> Result<ClientEncryption> {
         .map(update_provider)
         .collect();
     Ok(ClientEncryption::new(
-        TestClient::new().await.into_client(),
+        Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
         kms_providers,
     )?)
@@ -1539,7 +1539,7 @@ struct DeadlockTestCase {
 impl DeadlockTestCase {
     async fn run(&self) -> Result<()> {
         // Setup
-        let client_test = TestClient::new().await;
+        let client_test = Client::test_builder().build().await;
         let client_keyvault = Client::test_builder()
             .options({
                 let mut opts = get_client_options().await.clone();
@@ -1715,7 +1715,7 @@ async fn kms_tls() -> Result<()> {
 
 async fn run_kms_tls_test(endpoint: impl Into<String>) -> crate::error::Result<()> {
     // Setup
-    let kv_client = TestClient::new().await;
+    let kv_client = Client::test_builder().build().await;
     let client_encryption = ClientEncryption::new(
         kv_client.clone().into_client(),
         KV_NAMESPACE.clone(),
@@ -1797,7 +1797,7 @@ async fn kms_tls_options() -> Result<()> {
         add_correct_credentials,
     );
     let client_encryption_no_client_cert = ClientEncryption::new(
-        TestClient::new().await.into_client(),
+        Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
         providers_no_client_cert.clone(),
     )?;
@@ -1811,13 +1811,13 @@ async fn kms_tls_options() -> Result<()> {
         add_correct_credentials,
     );
     let client_encryption_with_tls = ClientEncryption::new(
-        TestClient::new().await.into_client(),
+        Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
         providers_with_tls.clone(),
     )?;
 
     let client_encryption_expired = ClientEncryption::new(
-        TestClient::new().await.into_client(),
+        Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
         update_providers(
             UNNAMED_KMS_PROVIDERS.clone(),
@@ -1827,7 +1827,7 @@ async fn kms_tls_options() -> Result<()> {
     )?;
 
     let client_encryption_invalid_hostname = ClientEncryption::new(
-        TestClient::new().await.into_client(),
+        Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
         update_providers(
             UNNAMED_KMS_PROVIDERS.clone(),
@@ -1854,7 +1854,7 @@ async fn kms_tls_options() -> Result<()> {
         }
     }));
     let client_encryption_with_names = ClientEncryption::new(
-        TestClient::new().await.into_client(),
+        Client::test_builder().build().await.into_client(),
         KV_NAMESPACE.clone(),
         named_providers,
     )?;
@@ -2337,7 +2337,7 @@ struct ExplicitEncryptionTestData {
 }
 
 async fn explicit_encryption_setup() -> Result<Option<ExplicitEncryptionTestData>> {
-    let key_vault_client = TestClient::new().await;
+    let key_vault_client = Client::test_builder().build().await;
     if key_vault_client.server_version_lt(6, 0) {
         log_uncaptured("skipping explicit encryption test: server below 6.0");
         return Ok(None);
@@ -2489,7 +2489,7 @@ fn write_err_code(err: &crate::error::Error) -> Option<i32> {
 }
 
 async fn unique_index_keyaltnames_setup() -> Result<(ClientEncryption, Binary)> {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let datakeys = client
         .database("keyvault")
         .collection::<Document>("datakeys");
@@ -2643,7 +2643,7 @@ struct DecryptionEventsTestdata {
 
 impl DecryptionEventsTestdata {
     async fn setup() -> Result<Option<Self>> {
-        let setup_client = TestClient::new().await;
+        let setup_client = Client::test_builder().build().await;
         if !setup_client.is_standalone() {
             log_uncaptured("skipping decryption events test: requires standalone topology");
             return Ok(None);
@@ -2783,7 +2783,7 @@ async fn on_demand_aws_success() -> Result<()> {
 #[cfg(feature = "gcp-kms")]
 #[tokio::test]
 async fn on_demand_gcp_credentials() -> Result<()> {
-    let util_client = TestClient::new().await.into_client();
+    let util_client = Client::test_builder().build().await.into_client();
     let client_encryption = ClientEncryption::new(
         util_client,
         KV_NAMESPACE.clone(),
@@ -3087,7 +3087,7 @@ async fn range_explicit_encryption() -> Result<()> {
     if !fle2v2_ok("range_explicit_encryption").await {
         return Ok(());
     }
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.server_version_lt(8, 0) || client.is_standalone() {
         log_uncaptured("Skipping range_explicit_encryption due to unsupported topology");
         return Ok(());
@@ -3163,7 +3163,7 @@ async fn range_explicit_encryption_test(
     bson_type: &str,
     range_options: RangeOptions,
 ) -> Result<()> {
-    let util_client = TestClient::new().await;
+    let util_client = Client::test_builder().build().await;
 
     let encrypted_fields =
         load_testdata(&format!("data/range-encryptedFields-{}.json", bson_type))?;
@@ -3202,7 +3202,7 @@ async fn range_explicit_encryption_test(
         .write_concern(WriteConcern::majority())
         .await?;
 
-    let key_vault_client = TestClient::new().await;
+    let key_vault_client = Client::test_builder().build().await;
 
     let client_encryption = ClientEncryption::new(
         key_vault_client.into_client(),

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -3440,8 +3440,6 @@ async fn range_explicit_encryption_defaults() -> Result<()> {
         return Ok(());
     }
 
-    dbg!(mongocrypt::version());
-
     // Setup
     let key_vault_client = Client::test_builder().build().await;
     let client_encryption = ClientEncryption::new(

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -73,7 +73,7 @@ use super::{get_client_options, log_uncaptured, EventClient, TestClient};
 type Result<T> = anyhow::Result<T>;
 
 async fn init_client() -> Result<(EventClient, Collection<Document>)> {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let datakeys = client
         .database("keyvault")
         .collection_with_options::<Document>(
@@ -999,7 +999,7 @@ async fn custom_endpoint_setup(valid: bool) -> Result<ClientEncryption> {
         .map(update_provider)
         .collect();
     Ok(ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         kms_providers,
     )?)
@@ -1539,8 +1539,8 @@ struct DeadlockTestCase {
 impl DeadlockTestCase {
     async fn run(&self) -> Result<()> {
         // Setup
-        let client_test = Client::test_builder().await;
-        let client_keyvault = Client::test_builder()
+        let client_test = Client::for_test().await;
+        let client_keyvault = Client::for_test()
             .options({
                 let mut opts = get_client_options().await.clone();
                 opts.max_pool_size = Some(1);
@@ -1714,7 +1714,7 @@ async fn kms_tls() -> Result<()> {
 
 async fn run_kms_tls_test(endpoint: impl Into<String>) -> crate::error::Result<()> {
     // Setup
-    let kv_client = Client::test_builder().await;
+    let kv_client = Client::for_test().await;
     let client_encryption = ClientEncryption::new(
         kv_client.clone().into_client(),
         KV_NAMESPACE.clone(),
@@ -1796,7 +1796,7 @@ async fn kms_tls_options() -> Result<()> {
         add_correct_credentials,
     );
     let client_encryption_no_client_cert = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         providers_no_client_cert.clone(),
     )?;
@@ -1810,13 +1810,13 @@ async fn kms_tls_options() -> Result<()> {
         add_correct_credentials,
     );
     let client_encryption_with_tls = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         providers_with_tls.clone(),
     )?;
 
     let client_encryption_expired = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         update_providers(
             UNNAMED_KMS_PROVIDERS.clone(),
@@ -1826,7 +1826,7 @@ async fn kms_tls_options() -> Result<()> {
     )?;
 
     let client_encryption_invalid_hostname = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         update_providers(
             UNNAMED_KMS_PROVIDERS.clone(),
@@ -1853,7 +1853,7 @@ async fn kms_tls_options() -> Result<()> {
         }
     }));
     let client_encryption_with_names = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         named_providers,
     )?;
@@ -2071,7 +2071,7 @@ async fn kms_tls_options() -> Result<()> {
 }
 
 async fn fle2v2_ok(name: &str) -> bool {
-    let setup_client = Client::test_builder().await;
+    let setup_client = Client::for_test().await;
     if setup_client.server_version_lt(7, 0) {
         log_uncaptured(format!("Skipping {}: not supported on server < 7.0", name));
         return false;
@@ -2336,7 +2336,7 @@ struct ExplicitEncryptionTestData {
 }
 
 async fn explicit_encryption_setup() -> Result<Option<ExplicitEncryptionTestData>> {
-    let key_vault_client = Client::test_builder().await;
+    let key_vault_client = Client::for_test().await;
     if key_vault_client.server_version_lt(6, 0) {
         log_uncaptured("skipping explicit encryption test: server below 6.0");
         return Ok(None);
@@ -2488,7 +2488,7 @@ fn write_err_code(err: &crate::error::Error) -> Option<i32> {
 }
 
 async fn unique_index_keyaltnames_setup() -> Result<(ClientEncryption, Binary)> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let datakeys = client
         .database("keyvault")
         .collection::<Document>("datakeys");
@@ -2642,7 +2642,7 @@ struct DecryptionEventsTestdata {
 
 impl DecryptionEventsTestdata {
     async fn setup() -> Result<Option<Self>> {
-        let setup_client = Client::test_builder().await;
+        let setup_client = Client::for_test().await;
         if !setup_client.is_standalone() {
             log_uncaptured("skipping decryption events test: requires standalone topology");
             return Ok(None);
@@ -2735,7 +2735,7 @@ async fn on_demand_aws_failure() -> Result<()> {
     }
 
     let ce = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         [(KmsProvider::aws(), doc! {}, None)],
     )?;
@@ -2761,7 +2761,7 @@ async fn on_demand_aws_success() -> Result<()> {
     }
 
     let ce = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         [(KmsProvider::aws(), doc! {}, None)],
     )?;
@@ -2782,7 +2782,7 @@ async fn on_demand_aws_success() -> Result<()> {
 #[cfg(feature = "gcp-kms")]
 #[tokio::test]
 async fn on_demand_gcp_credentials() -> Result<()> {
-    let util_client = Client::test_builder().await.into_client();
+    let util_client = Client::for_test().await.into_client();
     let client_encryption = ClientEncryption::new(
         util_client,
         KV_NAMESPACE.clone(),
@@ -2893,7 +2893,7 @@ async fn azure_imds_integration_failure() -> Result<()> {
     }
 
     let c = ClientEncryption::new(
-        Client::test_builder().await.into_client(),
+        Client::for_test().await.into_client(),
         KV_NAMESPACE.clone(),
         [(KmsProvider::azure(), doc! {}, None)],
     )?;
@@ -2987,7 +2987,7 @@ async fn auto_encryption_keys(master_key: impl Into<MasterKey>) -> Result<()> {
         return Ok(());
     }
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.server_version_lt(6, 0) {
         log_uncaptured("Skipping auto_encryption_key test: server < 6.0");
         return Ok(());
@@ -3086,7 +3086,7 @@ async fn range_explicit_encryption() -> Result<()> {
     if !fle2v2_ok("range_explicit_encryption").await {
         return Ok(());
     }
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.server_version_lt(8, 0) || client.is_standalone() {
         log_uncaptured("Skipping range_explicit_encryption due to unsupported topology");
         return Ok(());
@@ -3162,7 +3162,7 @@ async fn range_explicit_encryption_test(
     bson_type: &str,
     range_options: RangeOptions,
 ) -> Result<()> {
-    let util_client = Client::test_builder().await;
+    let util_client = Client::for_test().await;
 
     let encrypted_fields =
         load_testdata(&format!("data/range-encryptedFields-{}.json", bson_type))?;
@@ -3201,7 +3201,7 @@ async fn range_explicit_encryption_test(
         .write_concern(WriteConcern::majority())
         .await?;
 
-    let key_vault_client = Client::test_builder().await;
+    let key_vault_client = Client::for_test().await;
 
     let client_encryption = ClientEncryption::new(
         key_vault_client.into_client(),
@@ -3440,7 +3440,7 @@ async fn range_explicit_encryption_defaults() -> Result<()> {
     }
 
     // Setup
-    let key_vault_client = Client::test_builder().await;
+    let key_vault_client = Client::for_test().await;
     let client_encryption = ClientEncryption::new(
         key_vault_client.into_client(),
         KV_NAMESPACE.clone(),
@@ -3500,7 +3500,7 @@ async fn fle2_example() -> Result<()> {
     }
 
     // FLE 2 is not supported on Standalone topology.
-    let test_client = Client::test_builder().await;
+    let test_client = Client::for_test().await;
     if test_client.server_version_lt(7, 0) {
         log_uncaptured("skipping fle2 example: server below 7.0");
         return Ok(());

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -21,7 +21,7 @@ async fn tailable_cursor() {
         return;
     }
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .create_fresh_collection(
             function_name!(),
@@ -83,7 +83,7 @@ async fn tailable_cursor() {
 #[tokio::test]
 #[function_name::named]
 async fn session_cursor_next() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let mut session = client.start_session().await.unwrap();
 
     let coll = client
@@ -112,7 +112,7 @@ async fn session_cursor_next() {
 
 #[tokio::test]
 async fn batch_exhaustion() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     let coll = client
         .create_fresh_collection(
@@ -152,7 +152,7 @@ async fn batch_exhaustion() {
 
 #[tokio::test]
 async fn borrowed_deserialization() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Doc<'a> {
@@ -227,7 +227,7 @@ async fn borrowed_deserialization() {
 
 #[tokio::test]
 async fn session_cursor_with_type() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let mut session = client.start_session().await.unwrap();
     let coll = client.database("db").collection("coll");
@@ -250,7 +250,7 @@ async fn session_cursor_with_type() {
 
 #[tokio::test]
 async fn cursor_final_batch() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .create_fresh_collection("test_cursor_final_batch", "test", None)
         .await;

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -21,7 +21,7 @@ async fn tailable_cursor() {
         return;
     }
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .create_fresh_collection(
             function_name!(),
@@ -83,7 +83,7 @@ async fn tailable_cursor() {
 #[tokio::test]
 #[function_name::named]
 async fn session_cursor_next() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let mut session = client.start_session().await.unwrap();
 
     let coll = client
@@ -112,7 +112,7 @@ async fn session_cursor_next() {
 
 #[tokio::test]
 async fn batch_exhaustion() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     let coll = client
         .create_fresh_collection(
@@ -152,7 +152,7 @@ async fn batch_exhaustion() {
 
 #[tokio::test]
 async fn borrowed_deserialization() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Doc<'a> {
@@ -227,7 +227,7 @@ async fn borrowed_deserialization() {
 
 #[tokio::test]
 async fn session_cursor_with_type() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let mut session = client.start_session().await.unwrap();
     let coll = client.database("db").collection("coll");
@@ -250,7 +250,7 @@ async fn session_cursor_with_type() {
 
 #[tokio::test]
 async fn cursor_final_batch() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .create_fresh_collection("test_cursor_final_batch", "test", None)
         .await;

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -7,7 +7,7 @@ use crate::{
     bson::doc,
     options::{CreateCollectionOptions, CursorType, FindOptions},
     runtime,
-    test::{log_uncaptured, TestClient, SERVERLESS},
+    test::{log_uncaptured, SERVERLESS},
     Client,
 };
 
@@ -21,7 +21,7 @@ async fn tailable_cursor() {
         return;
     }
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .create_fresh_collection(
             function_name!(),
@@ -83,7 +83,7 @@ async fn tailable_cursor() {
 #[tokio::test]
 #[function_name::named]
 async fn session_cursor_next() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let mut session = client.start_session().await.unwrap();
 
     let coll = client
@@ -227,7 +227,7 @@ async fn borrowed_deserialization() {
 
 #[tokio::test]
 async fn session_cursor_with_type() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let mut session = client.start_session().await.unwrap();
     let coll = client.database("db").collection("coll");
@@ -250,7 +250,7 @@ async fn session_cursor_with_type() {
 
 #[tokio::test]
 async fn cursor_final_batch() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .create_fresh_collection("test_cursor_final_batch", "test", None)
         .await;

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -40,7 +40,7 @@ async fn get_coll_info(db: &Database, filter: Option<Document>) -> Vec<Collectio
 #[tokio::test]
 #[function_name::named]
 async fn list_collections() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -73,7 +73,7 @@ async fn list_collections() {
 #[tokio::test]
 #[function_name::named]
 async fn list_collections_filter() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -108,7 +108,7 @@ async fn list_collections_filter() {
 #[tokio::test]
 #[function_name::named]
 async fn list_collection_names() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -136,7 +136,7 @@ async fn list_collection_names() {
 #[tokio::test]
 #[function_name::named]
 async fn collection_management() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -220,7 +220,7 @@ async fn collection_management() {
 
 #[tokio::test]
 async fn db_aggregate() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     if client.server_version_lt(4, 0) {
         log_uncaptured("skipping db_aggregate due to server version < 4.0");
@@ -262,7 +262,7 @@ async fn db_aggregate() {
 
 #[tokio::test]
 async fn db_aggregate_disk_use() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     if client.server_version_lt(4, 0) {
         log_uncaptured("skipping db_aggregate_disk_use due to server version < 4.0");
@@ -319,7 +319,7 @@ async fn create_index_options_defaults_not_specified() {
 }
 
 async fn index_option_defaults_test(defaults: Option<IndexOptionDefaults>, name: &str) {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let db = client.database(name);
 
     db.create_collection(name)
@@ -352,7 +352,7 @@ fn deserialize_clustered_index_option_from_bool() {
 
 #[tokio::test]
 async fn clustered_index_list_collections() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let database = client.database("db");
 
     if client.server_version_lt(5, 3) {
@@ -386,7 +386,7 @@ async fn aggregate_with_generics() {
         str: String,
     }
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let database = client.database("aggregate_with_generics");
 
     if client.server_version_lt(5, 1) {

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -40,7 +40,7 @@ async fn get_coll_info(db: &Database, filter: Option<Document>) -> Vec<Collectio
 #[tokio::test]
 #[function_name::named]
 async fn list_collections() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -73,7 +73,7 @@ async fn list_collections() {
 #[tokio::test]
 #[function_name::named]
 async fn list_collections_filter() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -108,7 +108,7 @@ async fn list_collections_filter() {
 #[tokio::test]
 #[function_name::named]
 async fn list_collection_names() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -136,7 +136,7 @@ async fn list_collection_names() {
 #[tokio::test]
 #[function_name::named]
 async fn collection_management() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -220,7 +220,7 @@ async fn collection_management() {
 
 #[tokio::test]
 async fn db_aggregate() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     if client.server_version_lt(4, 0) {
         log_uncaptured("skipping db_aggregate due to server version < 4.0");
@@ -262,7 +262,7 @@ async fn db_aggregate() {
 
 #[tokio::test]
 async fn db_aggregate_disk_use() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     if client.server_version_lt(4, 0) {
         log_uncaptured("skipping db_aggregate_disk_use due to server version < 4.0");
@@ -319,7 +319,7 @@ async fn create_index_options_defaults_not_specified() {
 }
 
 async fn index_option_defaults_test(defaults: Option<IndexOptionDefaults>, name: &str) {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let db = client.database(name);
 
     db.create_collection(name)
@@ -352,7 +352,7 @@ fn deserialize_clustered_index_option_from_bool() {
 
 #[tokio::test]
 async fn clustered_index_list_collections() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let database = client.database("db");
 
     if client.server_version_lt(5, 3) {
@@ -386,7 +386,7 @@ async fn aggregate_with_generics() {
         str: String,
     }
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let database = client.database("aggregate_with_generics");
 
     if client.server_version_lt(5, 1) {

--- a/src/test/db.rs
+++ b/src/test/db.rs
@@ -16,7 +16,6 @@ use crate::{
         ValidationLevel,
     },
     results::{CollectionSpecification, CollectionType},
-    test::util::TestClient,
     Client,
     Cursor,
     Database,
@@ -41,7 +40,7 @@ async fn get_coll_info(db: &Database, filter: Option<Document>) -> Vec<Collectio
 #[tokio::test]
 #[function_name::named]
 async fn list_collections() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -74,7 +73,7 @@ async fn list_collections() {
 #[tokio::test]
 #[function_name::named]
 async fn list_collections_filter() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -109,7 +108,7 @@ async fn list_collections_filter() {
 #[tokio::test]
 #[function_name::named]
 async fn list_collection_names() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -137,7 +136,7 @@ async fn list_collection_names() {
 #[tokio::test]
 #[function_name::named]
 async fn collection_management() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database(function_name!());
     db.drop().await.unwrap();
 
@@ -221,7 +220,7 @@ async fn collection_management() {
 
 #[tokio::test]
 async fn db_aggregate() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     if client.server_version_lt(4, 0) {
         log_uncaptured("skipping db_aggregate due to server version < 4.0");
@@ -263,7 +262,7 @@ async fn db_aggregate() {
 
 #[tokio::test]
 async fn db_aggregate_disk_use() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     if client.server_version_lt(4, 0) {
         log_uncaptured("skipping db_aggregate_disk_use due to server version < 4.0");
@@ -353,7 +352,7 @@ fn deserialize_clustered_index_option_from_bool() {
 
 #[tokio::test]
 async fn clustered_index_list_collections() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let database = client.database("db");
 
     if client.server_version_lt(5, 3) {
@@ -387,7 +386,7 @@ async fn aggregate_with_generics() {
         str: String,
     }
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let database = client.database("aggregate_with_generics");
 
     if client.server_version_lt(5, 1) {

--- a/src/test/documentation_examples.rs
+++ b/src/test/documentation_examples.rs
@@ -8,7 +8,7 @@ use crate::{
     bson::{doc, Bson},
     error::Result,
     options::{ClientOptions, ServerApi, ServerApiVersion},
-    test::{log_uncaptured, TestClient, DEFAULT_URI},
+    test::{log_uncaptured, DEFAULT_URI},
     Client,
     Collection,
 };
@@ -1237,7 +1237,7 @@ type GenericResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[allow(unused_variables)]
 async fn stable_api_examples() -> GenericResult<()> {
-    let setup_client = TestClient::new().await;
+    let setup_client = Client::test_builder().build().await;
     if setup_client.server_version_lt(4, 9) {
         log_uncaptured("skipping stable API examples due to unsupported server version");
         return Ok(());
@@ -1366,7 +1366,7 @@ async fn stable_api_examples() -> GenericResult<()> {
 
 #[allow(unused_imports)]
 async fn aggregation_examples() -> GenericResult<()> {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database("aggregation_examples");
     db.drop().await?;
     aggregation_data::populate(&db).await?;
@@ -1498,7 +1498,7 @@ async fn aggregation_examples() -> GenericResult<()> {
 }
 
 async fn run_command_examples() -> Result<()> {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database("run_command_examples");
     db.drop().await?;
     db.collection::<Document>("restaurants")
@@ -1525,7 +1525,7 @@ async fn run_command_examples() -> Result<()> {
 }
 
 async fn index_examples() -> Result<()> {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let db = client.database("index_examples");
     db.drop().await?;
     db.collection::<Document>("records")
@@ -1596,7 +1596,7 @@ async fn change_streams_examples() -> Result<()> {
     use crate::{options::FullDocumentType, runtime};
     use std::time::Duration;
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.is_replica_set() && !client.is_sharded() {
         log_uncaptured("skipping change_streams_examples due to unsupported topology");
         return Ok(());
@@ -1740,7 +1740,7 @@ async fn convenient_transaction_examples() -> Result<()> {
 
 #[tokio::test]
 async fn test() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .database("documentation_examples")
         .collection("inventory");

--- a/src/test/documentation_examples.rs
+++ b/src/test/documentation_examples.rs
@@ -1237,7 +1237,7 @@ type GenericResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[allow(unused_variables)]
 async fn stable_api_examples() -> GenericResult<()> {
-    let setup_client = Client::test_builder().await;
+    let setup_client = Client::for_test().await;
     if setup_client.server_version_lt(4, 9) {
         log_uncaptured("skipping stable API examples due to unsupported server version");
         return Ok(());
@@ -1366,7 +1366,7 @@ async fn stable_api_examples() -> GenericResult<()> {
 
 #[allow(unused_imports)]
 async fn aggregation_examples() -> GenericResult<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("aggregation_examples");
     db.drop().await?;
     aggregation_data::populate(&db).await?;
@@ -1498,7 +1498,7 @@ async fn aggregation_examples() -> GenericResult<()> {
 }
 
 async fn run_command_examples() -> Result<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("run_command_examples");
     db.drop().await?;
     db.collection::<Document>("restaurants")
@@ -1525,7 +1525,7 @@ async fn run_command_examples() -> Result<()> {
 }
 
 async fn index_examples() -> Result<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("index_examples");
     db.drop().await?;
     db.collection::<Document>("records")
@@ -1596,7 +1596,7 @@ async fn change_streams_examples() -> Result<()> {
     use crate::{options::FullDocumentType, runtime};
     use std::time::Duration;
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.is_replica_set() && !client.is_sharded() {
         log_uncaptured("skipping change_streams_examples due to unsupported topology");
         return Ok(());
@@ -1667,7 +1667,7 @@ async fn convenient_transaction_examples() -> Result<()> {
     use crate::ClientSession;
     use futures::FutureExt;
 
-    let setup_client = Client::test_builder().await;
+    let setup_client = Client::for_test().await;
     if !setup_client.supports_transactions() {
         log_uncaptured(
             "skipping convenient transaction API examples due to no transaction support",
@@ -1740,7 +1740,7 @@ async fn convenient_transaction_examples() -> Result<()> {
 
 #[tokio::test]
 async fn test() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .database("documentation_examples")
         .collection("inventory");

--- a/src/test/documentation_examples.rs
+++ b/src/test/documentation_examples.rs
@@ -1237,7 +1237,7 @@ type GenericResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[allow(unused_variables)]
 async fn stable_api_examples() -> GenericResult<()> {
-    let setup_client = Client::test_builder().build().await;
+    let setup_client = Client::test_builder().await;
     if setup_client.server_version_lt(4, 9) {
         log_uncaptured("skipping stable API examples due to unsupported server version");
         return Ok(());
@@ -1366,7 +1366,7 @@ async fn stable_api_examples() -> GenericResult<()> {
 
 #[allow(unused_imports)]
 async fn aggregation_examples() -> GenericResult<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("aggregation_examples");
     db.drop().await?;
     aggregation_data::populate(&db).await?;
@@ -1498,7 +1498,7 @@ async fn aggregation_examples() -> GenericResult<()> {
 }
 
 async fn run_command_examples() -> Result<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("run_command_examples");
     db.drop().await?;
     db.collection::<Document>("restaurants")
@@ -1525,7 +1525,7 @@ async fn run_command_examples() -> Result<()> {
 }
 
 async fn index_examples() -> Result<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("index_examples");
     db.drop().await?;
     db.collection::<Document>("records")
@@ -1596,7 +1596,7 @@ async fn change_streams_examples() -> Result<()> {
     use crate::{options::FullDocumentType, runtime};
     use std::time::Duration;
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.is_replica_set() && !client.is_sharded() {
         log_uncaptured("skipping change_streams_examples due to unsupported topology");
         return Ok(());
@@ -1667,7 +1667,7 @@ async fn convenient_transaction_examples() -> Result<()> {
     use crate::ClientSession;
     use futures::FutureExt;
 
-    let setup_client = Client::test_builder().build().await;
+    let setup_client = Client::test_builder().await;
     if !setup_client.supports_transactions() {
         log_uncaptured(
             "skipping convenient transaction API examples due to no transaction support",
@@ -1740,7 +1740,7 @@ async fn convenient_transaction_examples() -> Result<()> {
 
 #[tokio::test]
 async fn test() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .database("documentation_examples")
         .collection("inventory");

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -13,7 +13,7 @@ use crate::{
 #[tokio::test]
 #[function_name::named]
 async fn index_management_creates() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -59,7 +59,7 @@ async fn index_management_creates() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_handles_duplicates() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -98,7 +98,7 @@ async fn index_management_handles_duplicates() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_lists() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -159,7 +159,7 @@ async fn index_management_lists() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_drops() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -203,7 +203,7 @@ async fn index_management_drops() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_executes_commands() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -294,7 +294,7 @@ async fn index_management_executes_commands() {
 #[tokio::test]
 #[function_name::named]
 async fn commit_quorum_error() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.is_standalone() {
         log_uncaptured("skipping commit_quorum_error due to standalone topology");
         return;

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -13,7 +13,7 @@ use crate::{
 #[tokio::test]
 #[function_name::named]
 async fn index_management_creates() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -59,7 +59,7 @@ async fn index_management_creates() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_handles_duplicates() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -98,7 +98,7 @@ async fn index_management_handles_duplicates() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_lists() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -159,7 +159,7 @@ async fn index_management_lists() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_drops() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -203,7 +203,7 @@ async fn index_management_drops() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_executes_commands() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -294,7 +294,7 @@ async fn index_management_executes_commands() {
 #[tokio::test]
 #[function_name::named]
 async fn commit_quorum_error() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.is_standalone() {
         log_uncaptured("skipping commit_quorum_error due to standalone topology");
         return;

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -4,7 +4,7 @@ use crate::{
     bson::doc,
     error::ErrorKind,
     options::{CommitQuorum, IndexOptions},
-    test::{log_uncaptured, util::TestClient},
+    test::log_uncaptured,
     Client,
     IndexModel,
 };
@@ -13,7 +13,7 @@ use crate::{
 #[tokio::test]
 #[function_name::named]
 async fn index_management_creates() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -59,7 +59,7 @@ async fn index_management_creates() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_handles_duplicates() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -98,7 +98,7 @@ async fn index_management_handles_duplicates() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_lists() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -159,7 +159,7 @@ async fn index_management_lists() {
 #[tokio::test]
 #[function_name::named]
 async fn index_management_drops() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client
         .init_db_and_coll(function_name!(), function_name!())
         .await;
@@ -294,7 +294,7 @@ async fn index_management_executes_commands() {
 #[tokio::test]
 #[function_name::named]
 async fn commit_quorum_error() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.is_standalone() {
         log_uncaptured("skipping commit_quorum_error due to standalone topology");
         return;

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -5,7 +5,7 @@ use futures::stream::StreamExt;
 use crate::{
     bson::{doc, Document},
     error::{CommandError, ErrorKind},
-    options::{Acknowledgment, ClientOptions, WriteConcern},
+    options::{Acknowledgment, WriteConcern},
     selection_criteria::SelectionCriteria,
     test::{get_client_options, log_uncaptured, EventClient},
     Collection,
@@ -16,13 +16,11 @@ async fn run_test<F: Future>(
     name: &str,
     test: impl Fn(EventClient, Database, Collection<Document>) -> F,
 ) {
-    let options = ClientOptions::builder()
-        .hosts(get_client_options().await.hosts.clone())
-        .retry_writes(false)
-        .build();
+    let mut options = get_client_options().await.clone();
+    options.retry_writes = Some(false);
     let client = crate::Client::test_builder()
-        .additional_options(options, false)
-        .await
+        .options(options)
+        .sharded_use_first_host()
         .monitor_events()
         .build()
         .await;

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -20,7 +20,7 @@ async fn run_test<F: Future>(
     options.retry_writes = Some(false);
     let client = crate::Client::test_builder()
         .options(options)
-        .sharded_use_first_host()
+        .use_single_mongos()
         .monitor_events()
         .build()
         .await;

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -18,7 +18,7 @@ async fn run_test<F: Future>(
 ) {
     let mut options = get_client_options().await.clone();
     options.retry_writes = Some(false);
-    let client = crate::Client::test_builder()
+    let client = crate::Client::for_test()
         .options(options)
         .use_single_mongos()
         .monitor_events()

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -22,7 +22,6 @@ async fn run_test<F: Future>(
         .options(options)
         .use_single_mongos()
         .monitor_events()
-        .build()
         .await;
 
     if !client.is_replica_set() {

--- a/src/test/spec/faas.rs
+++ b/src/test/spec/faas.rs
@@ -36,7 +36,7 @@ impl Drop for TempVars {
 async fn check_faas_handshake(vars: &[(&'static str, &str)]) -> Result<()> {
     let _tv = TempVars::set(vars);
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     client.list_database_names().await?;
 
     Ok(())

--- a/src/test/spec/faas.rs
+++ b/src/test/spec/faas.rs
@@ -36,7 +36,7 @@ impl Drop for TempVars {
 async fn check_faas_handshake(vars: &[(&'static str, &str)]) -> Result<()> {
     let _tv = TempVars::set(vars);
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     client.list_database_names().await?;
 
     Ok(())

--- a/src/test/spec/gridfs.rs
+++ b/src/test/spec/gridfs.rs
@@ -14,6 +14,7 @@ use crate::{
         util::fail_point::{FailPoint, FailPointMode},
         TestClient,
     },
+    Client,
 };
 
 #[tokio::test]
@@ -28,7 +29,7 @@ async fn run_unified() {
 
 #[tokio::test]
 async fn download_stream_across_buffers() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let options = GridFsBucketOptions::builder().chunk_size_bytes(3).build();
     let bucket = client
@@ -74,7 +75,7 @@ async fn download_stream_across_buffers() {
 
 #[tokio::test]
 async fn upload_stream() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let bucket_options = GridFsBucketOptions::builder().chunk_size_bytes(4).build();
     let bucket = client
         .database("upload_stream")
@@ -134,7 +135,7 @@ async fn upload_test(bucket: &GridFsBucket, data: &[u8], options: Option<GridFsU
 
 #[tokio::test]
 async fn upload_stream_multiple_buffers() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let bucket_options = GridFsBucketOptions::builder().chunk_size_bytes(3).build();
     let bucket = client
         .database("upload_stream_multiple_buffers")
@@ -191,7 +192,7 @@ async fn upload_stream_multiple_buffers() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn upload_stream_errors() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let client = if client.is_sharded() {
         let mut options = get_client_options().await.clone();
         options.hosts.drain(1..);
@@ -258,7 +259,7 @@ async fn upload_stream_errors() {
 
 #[tokio::test]
 async fn drop_aborts() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let bucket = client.database("upload_stream_abort").gridfs_bucket(None);
     bucket.drop().await.unwrap();
 
@@ -275,7 +276,7 @@ async fn drop_aborts() {
 
 #[tokio::test]
 async fn write_future_dropped() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let bucket = client
         .database("upload_stream_abort")
         .gridfs_bucket(GridFsBucketOptions::builder().chunk_size_bytes(1).build());
@@ -343,7 +344,7 @@ async fn assert_no_chunks_written(bucket: &GridFsBucket, id: &Bson) {
 #[tokio::test]
 async fn test_gridfs_bucket_find_one() {
     let data = &[1, 2, 3, 4];
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let options = GridFsBucketOptions::default();
     let bucket = client.database("gridfs_find_one").gridfs_bucket(options);

--- a/src/test/spec/gridfs.rs
+++ b/src/test/spec/gridfs.rs
@@ -28,7 +28,7 @@ async fn run_unified() {
 
 #[tokio::test]
 async fn download_stream_across_buffers() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let options = GridFsBucketOptions::builder().chunk_size_bytes(3).build();
     let bucket = client
@@ -74,7 +74,7 @@ async fn download_stream_across_buffers() {
 
 #[tokio::test]
 async fn upload_stream() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let bucket_options = GridFsBucketOptions::builder().chunk_size_bytes(4).build();
     let bucket = client
         .database("upload_stream")
@@ -134,7 +134,7 @@ async fn upload_test(bucket: &GridFsBucket, data: &[u8], options: Option<GridFsU
 
 #[tokio::test]
 async fn upload_stream_multiple_buffers() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let bucket_options = GridFsBucketOptions::builder().chunk_size_bytes(3).build();
     let bucket = client
         .database("upload_stream_multiple_buffers")
@@ -191,11 +191,11 @@ async fn upload_stream_multiple_buffers() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn upload_stream_errors() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let client = if client.is_sharded() {
         let mut options = get_client_options().await.clone();
         options.hosts.drain(1..);
-        Client::test_builder().options(options).build().await
+        Client::test_builder().options(options).await
     } else {
         client
     };
@@ -258,7 +258,7 @@ async fn upload_stream_errors() {
 
 #[tokio::test]
 async fn drop_aborts() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let bucket = client.database("upload_stream_abort").gridfs_bucket(None);
     bucket.drop().await.unwrap();
 
@@ -275,7 +275,7 @@ async fn drop_aborts() {
 
 #[tokio::test]
 async fn write_future_dropped() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let bucket = client
         .database("upload_stream_abort")
         .gridfs_bucket(GridFsBucketOptions::builder().chunk_size_bytes(1).build());
@@ -343,7 +343,7 @@ async fn assert_no_chunks_written(bucket: &GridFsBucket, id: &Bson) {
 #[tokio::test]
 async fn test_gridfs_bucket_find_one() {
     let data = &[1, 2, 3, 4];
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
 
     let options = GridFsBucketOptions::default();
     let bucket = client.database("gridfs_find_one").gridfs_bucket(options);

--- a/src/test/spec/gridfs.rs
+++ b/src/test/spec/gridfs.rs
@@ -28,7 +28,7 @@ async fn run_unified() {
 
 #[tokio::test]
 async fn download_stream_across_buffers() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let options = GridFsBucketOptions::builder().chunk_size_bytes(3).build();
     let bucket = client
@@ -74,7 +74,7 @@ async fn download_stream_across_buffers() {
 
 #[tokio::test]
 async fn upload_stream() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let bucket_options = GridFsBucketOptions::builder().chunk_size_bytes(4).build();
     let bucket = client
         .database("upload_stream")
@@ -134,7 +134,7 @@ async fn upload_test(bucket: &GridFsBucket, data: &[u8], options: Option<GridFsU
 
 #[tokio::test]
 async fn upload_stream_multiple_buffers() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let bucket_options = GridFsBucketOptions::builder().chunk_size_bytes(3).build();
     let bucket = client
         .database("upload_stream_multiple_buffers")
@@ -191,11 +191,11 @@ async fn upload_stream_multiple_buffers() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn upload_stream_errors() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let client = if client.is_sharded() {
         let mut options = get_client_options().await.clone();
         options.hosts.drain(1..);
-        Client::test_builder().options(options).await
+        Client::for_test().options(options).await
     } else {
         client
     };
@@ -258,7 +258,7 @@ async fn upload_stream_errors() {
 
 #[tokio::test]
 async fn drop_aborts() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let bucket = client.database("upload_stream_abort").gridfs_bucket(None);
     bucket.drop().await.unwrap();
 
@@ -275,7 +275,7 @@ async fn drop_aborts() {
 
 #[tokio::test]
 async fn write_future_dropped() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let bucket = client
         .database("upload_stream_abort")
         .gridfs_bucket(GridFsBucketOptions::builder().chunk_size_bytes(1).build());
@@ -343,7 +343,7 @@ async fn assert_no_chunks_written(bucket: &GridFsBucket, id: &Bson) {
 #[tokio::test]
 async fn test_gridfs_bucket_find_one() {
     let data = &[1, 2, 3, 4];
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let options = GridFsBucketOptions::default();
     let bucket = client.database("gridfs_find_one").gridfs_bucket(options);

--- a/src/test/spec/gridfs.rs
+++ b/src/test/spec/gridfs.rs
@@ -12,7 +12,6 @@ use crate::{
         get_client_options,
         spec::unified_runner::run_unified_tests,
         util::fail_point::{FailPoint, FailPointMode},
-        TestClient,
     },
     Client,
 };
@@ -196,7 +195,7 @@ async fn upload_stream_errors() {
     let client = if client.is_sharded() {
         let mut options = get_client_options().await.clone();
         options.hosts.drain(1..);
-        TestClient::with_options(options).await
+        Client::test_builder().options(options).build().await
     } else {
         client
     };

--- a/src/test/spec/index_management.rs
+++ b/src/test/spec/index_management.rs
@@ -35,7 +35,7 @@ async fn search_index_create_list() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -81,7 +81,7 @@ async fn search_index_create_multiple() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -145,7 +145,7 @@ async fn search_index_drop() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -199,7 +199,7 @@ async fn search_index_update() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -266,7 +266,7 @@ async fn search_index_drop_not_found() {
         log_uncaptured("Skipping index management prose test: INDEX_MANAGEMENT_TEST_PROSE not set");
         return;
     }
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll_name = ObjectId::new().to_hex();
     let coll0 = client
         .database("search_index_test")
@@ -296,7 +296,7 @@ async fn search_index_create_with_type() {
         log_uncaptured("Skipping index management prose test: INDEX_MANAGEMENT_TEST_PROSE not set");
         return;
     }
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll_name = ObjectId::new().to_hex();
     let db = client.database("search_index_test");
     db.create_collection(&coll_name).await.unwrap();
@@ -358,7 +358,7 @@ async fn search_index_requires_explicit_vector() {
         log_uncaptured("Skipping index management prose test: INDEX_MANAGEMENT_TEST_PROSE not set");
         return;
     }
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll_name = ObjectId::new().to_hex();
     let db = client.database("search_index_test");
     db.create_collection(&coll_name).await.unwrap();

--- a/src/test/spec/index_management.rs
+++ b/src/test/spec/index_management.rs
@@ -35,7 +35,7 @@ async fn search_index_create_list() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -81,7 +81,7 @@ async fn search_index_create_multiple() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -145,7 +145,7 @@ async fn search_index_drop() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -199,7 +199,7 @@ async fn search_index_update() {
     let start = Instant::now();
     let deadline = start + Duration::from_secs(60 * 5);
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let db = client.database("search_index_test");
     let coll_name = ObjectId::new().to_hex();
     db.create_collection(&coll_name).await.unwrap();
@@ -266,7 +266,7 @@ async fn search_index_drop_not_found() {
         log_uncaptured("Skipping index management prose test: INDEX_MANAGEMENT_TEST_PROSE not set");
         return;
     }
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll_name = ObjectId::new().to_hex();
     let coll0 = client
         .database("search_index_test")
@@ -296,7 +296,7 @@ async fn search_index_create_with_type() {
         log_uncaptured("Skipping index management prose test: INDEX_MANAGEMENT_TEST_PROSE not set");
         return;
     }
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll_name = ObjectId::new().to_hex();
     let db = client.database("search_index_test");
     db.create_collection(&coll_name).await.unwrap();
@@ -358,7 +358,7 @@ async fn search_index_requires_explicit_vector() {
         log_uncaptured("Skipping index management prose test: INDEX_MANAGEMENT_TEST_PROSE not set");
         return;
     }
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll_name = ObjectId::new().to_hex();
     let db = client.database("search_index_test");
     db.create_collection(&coll_name).await.unwrap();

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -6,7 +6,7 @@ use crate::{
     bson::doc,
     client::Client,
     options::{ClientOptions, ResolverConfig},
-    test::{get_client_options, log_uncaptured, run_spec_test, TestClient},
+    test::{get_client_options, log_uncaptured, run_spec_test},
 };
 
 #[derive(Debug, Deserialize)]
@@ -127,7 +127,7 @@ async fn run_test(mut test_file: TestFile) {
         Some(ref options) => options.ssl,
         None => true,
     };
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if requires_tls != client.options().tls_options().is_some() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch",
@@ -205,7 +205,7 @@ async fn run_test(mut test_file: TestFile) {
 
 #[tokio::test]
 async fn replica_set() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let skip =
         if client.is_replica_set() && client.options().repl_set_name.as_deref() != Some("repl0") {
             Some("repl_set_name != repl0")
@@ -228,7 +228,7 @@ async fn replica_set() {
 
 #[tokio::test]
 async fn load_balanced() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.is_load_balanced() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery::load_balanced due to unmet topology \
@@ -245,7 +245,7 @@ async fn load_balanced() {
 
 #[tokio::test]
 async fn sharded() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.is_sharded() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery::sharded due to unmet topology requirement \

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -127,7 +127,7 @@ async fn run_test(mut test_file: TestFile) {
         Some(ref options) => options.ssl,
         None => true,
     };
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if requires_tls != client.options().tls_options().is_some() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch",
@@ -205,7 +205,7 @@ async fn run_test(mut test_file: TestFile) {
 
 #[tokio::test]
 async fn replica_set() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let skip =
         if client.is_replica_set() && client.options().repl_set_name.as_deref() != Some("repl0") {
             Some("repl_set_name != repl0")
@@ -228,7 +228,7 @@ async fn replica_set() {
 
 #[tokio::test]
 async fn load_balanced() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.is_load_balanced() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery::load_balanced due to unmet topology \
@@ -245,7 +245,7 @@ async fn load_balanced() {
 
 #[tokio::test]
 async fn sharded() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.is_sharded() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery::sharded due to unmet topology requirement \

--- a/src/test/spec/initial_dns_seedlist_discovery.rs
+++ b/src/test/spec/initial_dns_seedlist_discovery.rs
@@ -127,7 +127,7 @@ async fn run_test(mut test_file: TestFile) {
         Some(ref options) => options.ssl,
         None => true,
     };
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if requires_tls != client.options().tls_options().is_some() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery test case due to TLS requirement mismatch",
@@ -205,7 +205,7 @@ async fn run_test(mut test_file: TestFile) {
 
 #[tokio::test]
 async fn replica_set() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let skip =
         if client.is_replica_set() && client.options().repl_set_name.as_deref() != Some("repl0") {
             Some("repl_set_name != repl0")
@@ -228,7 +228,7 @@ async fn replica_set() {
 
 #[tokio::test]
 async fn load_balanced() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.is_load_balanced() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery::load_balanced due to unmet topology \
@@ -245,7 +245,7 @@ async fn load_balanced() {
 
 #[tokio::test]
 async fn sharded() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.is_sharded() {
         log_uncaptured(
             "skipping initial_dns_seedlist_discovery::sharded due to unmet topology requirement \

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -36,7 +36,7 @@ async fn retry_releases_connection() {
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
 
-    let client = Client::test_builder().options(client_options).build().await;
+    let client = Client::test_builder().options(client_options).await;
     if !client.supports_fail_command() {
         log_uncaptured("skipping retry_releases_connection due to failCommand not being supported");
         return;
@@ -77,10 +77,7 @@ async fn retry_read_pool_cleared() {
         client_options.hosts.drain(1..);
     }
 
-    let client = Client::test_builder()
-        .options(client_options.clone())
-        .build()
-        .await;
+    let client = Client::test_builder().options(client_options.clone()).await;
     if !client.supports_block_connection() {
         log_uncaptured(
             "skipping retry_read_pool_cleared due to blockConnection not being supported",
@@ -172,7 +169,7 @@ async fn retry_read_different_mongos() {
         let mut opts = client_options.clone();
         opts.hosts.remove(ix);
         opts.direct_connection = Some(true);
-        let client = Client::test_builder().options(opts).build().await;
+        let client = Client::test_builder().options(opts).await;
         if !client.supports_fail_command() {
             log_uncaptured("skipping retry_read_different_mongos: requires failCommand");
             return;
@@ -187,7 +184,6 @@ async fn retry_read_different_mongos() {
     let client = Client::test_builder()
         .options(client_options)
         .monitor_events()
-        .build()
         .await;
     let result = client
         .database("test")
@@ -216,7 +212,7 @@ async fn retry_read_different_mongos() {
 // Retryable Reads Are Retried on the Same mongos if No Others are Available
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_read_same_mongos() {
-    let init_client = Client::test_builder().build().await;
+    let init_client = Client::test_builder().await;
     if !init_client.supports_fail_command() {
         log_uncaptured("skipping retry_read_same_mongos: requires failCommand");
         return;
@@ -232,7 +228,7 @@ async fn retry_read_same_mongos() {
     let fp_guard = {
         let mut client_options = client_options.clone();
         client_options.direct_connection = Some(true);
-        let client = Client::test_builder().options(client_options).build().await;
+        let client = Client::test_builder().options(client_options).await;
 
         let fail_point = FailPoint::fail_command(&["find"], FailPointMode::Times(1))
             .error_code(6)
@@ -243,7 +239,6 @@ async fn retry_read_same_mongos() {
     let client = Client::test_builder()
         .options(client_options)
         .monitor_events()
-        .build()
         .await;
     let result = client
         .database("test")

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -18,7 +18,6 @@ use crate::{
             fail_point::{FailPoint, FailPointMode},
         },
         Event,
-        TestClient,
     },
     Client,
 };
@@ -37,7 +36,7 @@ async fn retry_releases_connection() {
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
 
-    let client = TestClient::with_options(Some(client_options)).await;
+    let client = Client::test_builder().options(client_options).build().await;
     if !client.supports_fail_command() {
         log_uncaptured("skipping retry_releases_connection due to failCommand not being supported");
         return;
@@ -78,7 +77,10 @@ async fn retry_read_pool_cleared() {
         client_options.hosts.drain(1..);
     }
 
-    let client = TestClient::with_options(Some(client_options.clone())).await;
+    let client = Client::test_builder()
+        .options(client_options.clone())
+        .build()
+        .await;
     if !client.supports_block_connection() {
         log_uncaptured(
             "skipping retry_read_pool_cleared due to blockConnection not being supported",

--- a/src/test/spec/retryable_reads.rs
+++ b/src/test/spec/retryable_reads.rs
@@ -36,7 +36,7 @@ async fn retry_releases_connection() {
     client_options.retry_reads = Some(true);
     client_options.max_pool_size = Some(1);
 
-    let client = Client::test_builder().options(client_options).await;
+    let client = Client::for_test().options(client_options).await;
     if !client.supports_fail_command() {
         log_uncaptured("skipping retry_releases_connection due to failCommand not being supported");
         return;
@@ -77,7 +77,7 @@ async fn retry_read_pool_cleared() {
         client_options.hosts.drain(1..);
     }
 
-    let client = Client::test_builder().options(client_options.clone()).await;
+    let client = Client::for_test().options(client_options.clone()).await;
     if !client.supports_block_connection() {
         log_uncaptured(
             "skipping retry_read_pool_cleared due to blockConnection not being supported",
@@ -169,7 +169,7 @@ async fn retry_read_different_mongos() {
         let mut opts = client_options.clone();
         opts.hosts.remove(ix);
         opts.direct_connection = Some(true);
-        let client = Client::test_builder().options(opts).await;
+        let client = Client::for_test().options(opts).await;
         if !client.supports_fail_command() {
             log_uncaptured("skipping retry_read_different_mongos: requires failCommand");
             return;
@@ -181,7 +181,7 @@ async fn retry_read_different_mongos() {
         guards.push(client.enable_fail_point(fail_point).await.unwrap());
     }
 
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(client_options)
         .monitor_events()
         .await;
@@ -212,7 +212,7 @@ async fn retry_read_different_mongos() {
 // Retryable Reads Are Retried on the Same mongos if No Others are Available
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_read_same_mongos() {
-    let init_client = Client::test_builder().await;
+    let init_client = Client::for_test().await;
     if !init_client.supports_fail_command() {
         log_uncaptured("skipping retry_read_same_mongos: requires failCommand");
         return;
@@ -228,7 +228,7 @@ async fn retry_read_same_mongos() {
     let fp_guard = {
         let mut client_options = client_options.clone();
         client_options.direct_connection = Some(true);
-        let client = Client::test_builder().options(client_options).await;
+        let client = Client::for_test().options(client_options).await;
 
         let fail_point = FailPoint::fail_command(&["find"], FailPointMode::Times(1))
             .error_code(6)
@@ -236,7 +236,7 @@ async fn retry_read_same_mongos() {
         client.enable_fail_point(fail_point).await.unwrap()
     };
 
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(client_options)
         .monitor_events()
         .await;

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -199,7 +199,7 @@ async fn label_not_added(retry_reads: bool) {
     options.retry_reads = Some(retry_reads);
     let client = Client::test_builder()
         .options(options)
-        .sharded_use_first_host()
+        .use_single_mongos()
         .build()
         .await;
 

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -252,7 +252,10 @@ async fn retry_write_pool_cleared() {
         client_options.hosts.drain(1..);
     }
 
-    let client = TestClient::with_options(Some(client_options.clone())).await;
+    let client = Client::test_builder()
+        .options(client_options.clone())
+        .build()
+        .await;
     if !client.supports_block_connection() {
         log_uncaptured(
             "skipping retry_write_pool_cleared due to blockConnection not being supported",

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -200,7 +200,11 @@ async fn label_not_added(retry_reads: bool) {
         .hosts(vec![])
         .retry_reads(retry_reads)
         .build();
-    let client = TestClient::with_additional_options(Some(options)).await;
+    let client = Client::test_builder()
+        .additional_options(Some(options), false)
+        .await
+        .build()
+        .await;
 
     // Configuring a failpoint is only supported on 4.0+ replica sets and 4.1.5+ sharded clusters.
     let req = VersionReq::parse(">=4.0").unwrap();

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -11,7 +11,6 @@ use crate::{
         cmap::{CmapEvent, ConnectionCheckoutFailedReason},
         command::CommandEvent,
     },
-    options::ClientOptions,
     runtime,
     runtime::{spawn, AcknowledgedMessage, AsyncJoinHandle},
     test::{
@@ -196,13 +195,11 @@ async fn label_not_added_second_read_error() {
 
 #[function_name::named]
 async fn label_not_added(retry_reads: bool) {
-    let options = ClientOptions::builder()
-        .hosts(vec![])
-        .retry_reads(retry_reads)
-        .build();
+    let mut options = get_client_options().await.clone();
+    options.retry_reads = Some(retry_reads);
     let client = Client::test_builder()
-        .additional_options(Some(options), false)
-        .await
+        .options(options)
+        .sharded_use_first_host()
         .build()
         .await;
 

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -146,7 +146,7 @@ async fn transaction_ids_included() {
 #[tokio::test]
 #[function_name::named]
 async fn mmapv1_error_raised() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
 
     let req = semver::VersionReq::parse("<=4.0").unwrap();
     if !req.matches(&client.server_version) || !client.is_replica_set() {

--- a/src/test/spec/retryable_writes.rs
+++ b/src/test/spec/retryable_writes.rs
@@ -35,7 +35,7 @@ async fn run_unified() {
 #[tokio::test]
 #[function_name::named]
 async fn transaction_ids_excluded() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
         log_uncaptured("skipping transaction_ids_excluded due to test topology");
@@ -84,7 +84,7 @@ async fn transaction_ids_excluded() {
 #[tokio::test]
 #[function_name::named]
 async fn transaction_ids_included() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if !(client.is_replica_set() || client.is_sharded()) {
         log_uncaptured("skipping transaction_ids_included due to test topology");
@@ -145,7 +145,7 @@ async fn transaction_ids_included() {
 #[tokio::test]
 #[function_name::named]
 async fn mmapv1_error_raised() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
 
     let req = semver::VersionReq::parse("<=4.0").unwrap();
     if !req.matches(&client.server_version) || !client.is_replica_set() {
@@ -197,7 +197,7 @@ async fn label_not_added_second_read_error() {
 async fn label_not_added(retry_reads: bool) {
     let mut options = get_client_options().await.clone();
     options.retry_reads = Some(retry_reads);
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .use_single_mongos()
         .await;
@@ -252,7 +252,7 @@ async fn retry_write_pool_cleared() {
         client_options.hosts.drain(1..);
     }
 
-    let client = Client::test_builder().options(client_options.clone()).await;
+    let client = Client::for_test().options(client_options.clone()).await;
     if !client.supports_block_connection() {
         log_uncaptured(
             "skipping retry_write_pool_cleared due to blockConnection not being supported",
@@ -385,7 +385,7 @@ async fn retry_write_retryable_write_error() {
         });
     }
     client_options.test_options_mut().async_event_listener = Some(event_tx);
-    let client = Client::test_builder().options(client_options).await;
+    let client = Client::for_test().options(client_options).await;
     *listener_client.lock().await = Some(client.clone());
 
     if !client.is_replica_set() || client.server_version_lt(6, 0) {
@@ -430,7 +430,7 @@ async fn retry_write_different_mongos() {
         let mut opts = client_options.clone();
         opts.hosts.remove(ix);
         opts.direct_connection = Some(true);
-        let client = Client::test_builder().options(opts).await;
+        let client = Client::for_test().options(opts).await;
         if !client.supports_fail_command() {
             log_uncaptured("skipping retry_write_different_mongos: requires failCommand");
             return;
@@ -443,7 +443,7 @@ async fn retry_write_different_mongos() {
         guards.push(client.enable_fail_point(fail_point).await.unwrap());
     }
 
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(client_options)
         .monitor_events()
         .await;
@@ -474,7 +474,7 @@ async fn retry_write_different_mongos() {
 // Retryable Reads Are Retried on the Same mongos if No Others are Available
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_write_same_mongos() {
-    let init_client = Client::test_builder().await;
+    let init_client = Client::for_test().await;
     if !init_client.supports_fail_command() {
         log_uncaptured("skipping retry_write_same_mongos: requires failCommand");
         return;
@@ -490,7 +490,7 @@ async fn retry_write_same_mongos() {
     let fp_guard = {
         let mut client_options = client_options.clone();
         client_options.direct_connection = Some(true);
-        let client = Client::test_builder().options(client_options).await;
+        let client = Client::for_test().options(client_options).await;
 
         let fail_point = FailPoint::fail_command(&["insert"], FailPointMode::Times(1))
             .error_code(6)
@@ -499,7 +499,7 @@ async fn retry_write_same_mongos() {
         client.enable_fail_point(fail_point).await.unwrap()
     };
 
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(client_options)
         .monitor_events()
         .await;

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -15,7 +15,6 @@ use crate::{
             fail_point::{FailPoint, FailPointMode},
         },
         Event,
-        TestClient,
     },
     Client,
 };
@@ -46,7 +45,7 @@ async fn run_unified() {
 /// Streaming protocol prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn streaming_min_heartbeat_frequency() {
-    let test_client = TestClient::new().await;
+    let test_client = Client::test_builder().build().await;
     if test_client.is_load_balanced() {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
@@ -97,7 +96,7 @@ async fn streaming_min_heartbeat_frequency() {
 /// Variant of the previous prose test that checks for a non-minHeartbeatFrequencyMS value.
 #[tokio::test(flavor = "multi_thread")]
 async fn heartbeat_frequency_is_respected() {
-    let test_client = TestClient::new().await;
+    let test_client = Client::test_builder().build().await;
     if test_client.is_load_balanced() {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
@@ -148,7 +147,7 @@ async fn heartbeat_frequency_is_respected() {
 /// RTT prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn rtt_is_updated() {
-    let test_client = TestClient::new().await;
+    let test_client = Client::test_builder().build().await;
     if !test_client.supports_streaming_monitoring_protocol() {
         log_uncaptured(
             "skipping rtt_is_updated due to not supporting streaming monitoring protocol",

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -45,7 +45,7 @@ async fn run_unified() {
 /// Streaming protocol prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn streaming_min_heartbeat_frequency() {
-    let test_client = Client::test_builder().await;
+    let test_client = Client::for_test().await;
     if test_client.is_load_balanced() {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
@@ -96,7 +96,7 @@ async fn streaming_min_heartbeat_frequency() {
 /// Variant of the previous prose test that checks for a non-minHeartbeatFrequencyMS value.
 #[tokio::test(flavor = "multi_thread")]
 async fn heartbeat_frequency_is_respected() {
-    let test_client = Client::test_builder().await;
+    let test_client = Client::for_test().await;
     if test_client.is_load_balanced() {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
@@ -147,7 +147,7 @@ async fn heartbeat_frequency_is_respected() {
 /// RTT prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn rtt_is_updated() {
-    let test_client = Client::test_builder().await;
+    let test_client = Client::for_test().await;
     if !test_client.supports_streaming_monitoring_protocol() {
         log_uncaptured(
             "skipping rtt_is_updated due to not supporting streaming monitoring protocol",

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -45,7 +45,7 @@ async fn run_unified() {
 /// Streaming protocol prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn streaming_min_heartbeat_frequency() {
-    let test_client = Client::test_builder().build().await;
+    let test_client = Client::test_builder().await;
     if test_client.is_load_balanced() {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
@@ -96,7 +96,7 @@ async fn streaming_min_heartbeat_frequency() {
 /// Variant of the previous prose test that checks for a non-minHeartbeatFrequencyMS value.
 #[tokio::test(flavor = "multi_thread")]
 async fn heartbeat_frequency_is_respected() {
-    let test_client = Client::test_builder().build().await;
+    let test_client = Client::test_builder().await;
     if test_client.is_load_balanced() {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
@@ -147,7 +147,7 @@ async fn heartbeat_frequency_is_respected() {
 /// RTT prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn rtt_is_updated() {
-    let test_client = Client::test_builder().build().await;
+    let test_client = Client::test_builder().await;
     if !test_client.supports_streaming_monitoring_protocol() {
         log_uncaptured(
             "skipping rtt_is_updated due to not supporting streaming monitoring protocol",

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -220,10 +220,7 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let options = ClientOptions::parse("mongodb://localhost:47017")
         .await
         .unwrap();
-    let client = Client::for_test()
-        .options(options)
-        .monitor_events()
-        .await;
+    let client = Client::for_test().options(options).monitor_events().await;
     assert!(client.server_info.logical_session_timeout_minutes.is_none());
 
     Some((client, process))

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -19,7 +19,6 @@ use crate::{
         spec::unified_runner::run_unified_tests,
         util::Event,
         EventClient,
-        TestClient,
     },
     Client,
 };
@@ -27,7 +26,7 @@ use crate::{
 #[tokio::test(flavor = "multi_thread")]
 async fn run_unified() {
     let mut skipped_files = vec![];
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if client.is_sharded() && client.server_version_gte(7, 0) {
         // TODO RUST-1666: unskip this file
         skipped_files.push("snapshot-sessions.json");
@@ -41,7 +40,7 @@ async fn run_unified() {
 // Sessions prose test 1
 #[tokio::test]
 async fn snapshot_and_causal_consistency_are_mutually_exclusive() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     assert!(client
         .start_session()
         .snapshot(true)
@@ -53,8 +52,8 @@ async fn snapshot_and_causal_consistency_are_mutually_exclusive() {
 #[tokio::test(flavor = "multi_thread")]
 #[function_name::named]
 async fn explicit_session_created_on_same_client() {
-    let client0 = TestClient::new().await;
-    let client1 = TestClient::new().await;
+    let client0 = Client::test_builder().build().await;
+    let client1 = Client::test_builder().build().await;
 
     let mut session0 = client0.start_session().await.unwrap();
     let mut session1 = client1.start_session().await.unwrap();
@@ -200,7 +199,7 @@ async fn implicit_session_after_connection() {
 }
 
 async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
-    let util_client = TestClient::new().await;
+    let util_client = Client::test_builder().build().await;
     if util_client.server_version_lt(4, 2) {
         log_uncaptured(format!(
             "Skipping {name}: cannot spawn mongocryptd due to server version < 4.2"

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -26,7 +26,7 @@ use crate::{
 #[tokio::test(flavor = "multi_thread")]
 async fn run_unified() {
     let mut skipped_files = vec![];
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.is_sharded() && client.server_version_gte(7, 0) {
         // TODO RUST-1666: unskip this file
         skipped_files.push("snapshot-sessions.json");
@@ -40,7 +40,7 @@ async fn run_unified() {
 // Sessions prose test 1
 #[tokio::test]
 async fn snapshot_and_causal_consistency_are_mutually_exclusive() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     assert!(client
         .start_session()
         .snapshot(true)
@@ -52,8 +52,8 @@ async fn snapshot_and_causal_consistency_are_mutually_exclusive() {
 #[tokio::test(flavor = "multi_thread")]
 #[function_name::named]
 async fn explicit_session_created_on_same_client() {
-    let client0 = Client::test_builder().build().await;
-    let client1 = Client::test_builder().build().await;
+    let client0 = Client::test_builder().await;
+    let client1 = Client::test_builder().await;
 
     let mut session0 = client0.start_session().await.unwrap();
     let mut session1 = client1.start_session().await.unwrap();
@@ -199,7 +199,7 @@ async fn implicit_session_after_connection() {
 }
 
 async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
-    let util_client = Client::test_builder().build().await;
+    let util_client = Client::test_builder().await;
     if util_client.server_version_lt(4, 2) {
         log_uncaptured(format!(
             "Skipping {name}: cannot spawn mongocryptd due to server version < 4.2"
@@ -223,7 +223,6 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let client = Client::test_builder()
         .options(options)
         .monitor_events()
-        .build()
         .await;
     assert!(client.server_info.logical_session_timeout_minutes.is_none());
 

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -26,7 +26,7 @@ use crate::{
 #[tokio::test(flavor = "multi_thread")]
 async fn run_unified() {
     let mut skipped_files = vec![];
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.is_sharded() && client.server_version_gte(7, 0) {
         // TODO RUST-1666: unskip this file
         skipped_files.push("snapshot-sessions.json");
@@ -40,7 +40,7 @@ async fn run_unified() {
 // Sessions prose test 1
 #[tokio::test]
 async fn snapshot_and_causal_consistency_are_mutually_exclusive() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     assert!(client
         .start_session()
         .snapshot(true)
@@ -52,8 +52,8 @@ async fn snapshot_and_causal_consistency_are_mutually_exclusive() {
 #[tokio::test(flavor = "multi_thread")]
 #[function_name::named]
 async fn explicit_session_created_on_same_client() {
-    let client0 = Client::test_builder().await;
-    let client1 = Client::test_builder().await;
+    let client0 = Client::for_test().await;
+    let client1 = Client::for_test().await;
 
     let mut session0 = client0.start_session().await.unwrap();
     let mut session1 = client1.start_session().await.unwrap();
@@ -199,7 +199,7 @@ async fn implicit_session_after_connection() {
 }
 
 async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
-    let util_client = Client::test_builder().await;
+    let util_client = Client::for_test().await;
     if util_client.server_version_lt(4, 2) {
         log_uncaptured(format!(
             "Skipping {name}: cannot spawn mongocryptd due to server version < 4.2"
@@ -220,7 +220,7 @@ async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let options = ClientOptions::parse("mongodb://localhost:47017")
         .await
         .unwrap();
-    let client = Client::test_builder()
+    let client = Client::for_test()
         .options(options)
         .monitor_events()
         .await;

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -34,6 +34,7 @@ use crate::{
         COMMAND_TRACING_EVENT_TARGET,
         DEFAULT_MAX_DOCUMENT_LENGTH_BYTES,
     },
+    Client,
     TopologyType,
 };
 
@@ -77,7 +78,7 @@ fn tracing_truncation() {
 /// Prose test 1: Default truncation limit
 #[tokio::test]
 async fn command_logging_truncation_default_limit() {
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     let coll = client.init_db_and_coll("tracing_test", "truncation").await;
 
     let _levels_guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(HashMap::from([(

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -24,7 +24,6 @@ use crate::{
         get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
-        TestClient,
         DEFAULT_GLOBAL_TRACING_HANDLER,
         SERVER_API,
     },
@@ -121,7 +120,7 @@ async fn command_logging_truncation_default_limit() {
 async fn command_logging_truncation_explicit_limit() {
     let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(5);
-    let client = TestClient::with_options(Some(client_opts)).await;
+    let client = Client::test_builder().options(client_opts).build().await;
 
     let _levels_guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(HashMap::from([(
         COMMAND_TRACING_EVENT_TARGET.to_string(),
@@ -157,7 +156,7 @@ async fn command_logging_truncation_explicit_limit() {
 async fn command_logging_truncation_mid_codepoint() {
     let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(215);
-    let client = TestClient::with_options(Some(client_opts)).await;
+    let client = Client::test_builder().options(client_opts).build().await;
     // On non-standalone topologies the command includes a clusterTime and so gets truncated
     // differently.
     if !client.is_standalone() {

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -77,7 +77,7 @@ fn tracing_truncation() {
 /// Prose test 1: Default truncation limit
 #[tokio::test]
 async fn command_logging_truncation_default_limit() {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     let coll = client.init_db_and_coll("tracing_test", "truncation").await;
 
     let _levels_guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(HashMap::from([(
@@ -120,7 +120,7 @@ async fn command_logging_truncation_default_limit() {
 async fn command_logging_truncation_explicit_limit() {
     let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(5);
-    let client = Client::test_builder().options(client_opts).build().await;
+    let client = Client::test_builder().options(client_opts).await;
 
     let _levels_guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(HashMap::from([(
         COMMAND_TRACING_EVENT_TARGET.to_string(),
@@ -156,7 +156,7 @@ async fn command_logging_truncation_explicit_limit() {
 async fn command_logging_truncation_mid_codepoint() {
     let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(215);
-    let client = Client::test_builder().options(client_opts).build().await;
+    let client = Client::test_builder().options(client_opts).await;
     // On non-standalone topologies the command includes a clusterTime and so gets truncated
     // differently.
     if !client.is_standalone() {

--- a/src/test/spec/trace.rs
+++ b/src/test/spec/trace.rs
@@ -77,7 +77,7 @@ fn tracing_truncation() {
 /// Prose test 1: Default truncation limit
 #[tokio::test]
 async fn command_logging_truncation_default_limit() {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     let coll = client.init_db_and_coll("tracing_test", "truncation").await;
 
     let _levels_guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(HashMap::from([(
@@ -120,7 +120,7 @@ async fn command_logging_truncation_default_limit() {
 async fn command_logging_truncation_explicit_limit() {
     let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(5);
-    let client = Client::test_builder().options(client_opts).await;
+    let client = Client::for_test().options(client_opts).await;
 
     let _levels_guard = DEFAULT_GLOBAL_TRACING_HANDLER.set_levels(HashMap::from([(
         COMMAND_TRACING_EVENT_TARGET.to_string(),
@@ -156,7 +156,7 @@ async fn command_logging_truncation_explicit_limit() {
 async fn command_logging_truncation_mid_codepoint() {
     let mut client_opts = get_client_options().await.clone();
     client_opts.tracing_max_document_length_bytes = Some(215);
-    let client = Client::test_builder().options(client_opts).await;
+    let client = Client::for_test().options(client_opts).await;
     // On non-standalone topologies the command includes a clusterTime and so gets truncated
     // differently.
     if !client.is_standalone() {

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -46,7 +46,7 @@ async fn deserialize_recovery_token() {
         _str: String,
     }
 
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if !client.is_sharded() || client.server_version_lt(4, 2) {
         log_uncaptured("skipping deserialize_recovery_token due to test topology");
         return;
@@ -86,7 +86,7 @@ async fn deserialize_recovery_token() {
 
 #[tokio::test]
 async fn convenient_api_custom_error() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_custom_error: no transaction support.");
         return;
@@ -118,7 +118,7 @@ async fn convenient_api_custom_error() {
 
 #[tokio::test]
 async fn convenient_api_returned_value() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_returned_value: no transaction support.");
         return;
@@ -145,7 +145,7 @@ async fn convenient_api_returned_value() {
 
 #[tokio::test]
 async fn convenient_api_retry_timeout_callback() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_retry_timeout_callback: no transaction support.");
         return;
@@ -177,15 +177,12 @@ async fn convenient_api_retry_timeout_callback() {
 #[tokio::test(flavor = "multi_thread")]
 async fn convenient_api_retry_timeout_commit_unknown() {
     let mut options = get_client_options().await.clone();
-    if Client::test_builder().await.is_sharded() {
+    if Client::for_test().await.is_sharded() {
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
     }
 
-    let client = Client::test_builder()
-        .options(options)
-        .monitor_events()
-        .await;
+    let client = Client::for_test().options(options).monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured(
             "Skipping convenient_api_retry_timeout_commit_unknown: no transaction support.",
@@ -221,15 +218,12 @@ async fn convenient_api_retry_timeout_commit_unknown() {
 #[tokio::test(flavor = "multi_thread")]
 async fn convenient_api_retry_timeout_commit_transient() {
     let mut options = get_client_options().await.clone();
-    if Client::test_builder().await.is_sharded() {
+    if Client::for_test().await.is_sharded() {
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
     }
 
-    let client = Client::test_builder()
-        .options(options)
-        .monitor_events()
-        .await;
+    let client = Client::for_test().options(options).monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured(
             "Skipping convenient_api_retry_timeout_commit_transient: no transaction support.",

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -11,7 +11,6 @@ use crate::{
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
         util::fail_point::{FailPoint, FailPointMode},
-        TestClient,
     },
     Client,
     Collection,
@@ -47,7 +46,7 @@ async fn deserialize_recovery_token() {
         _str: String,
     }
 
-    let client = TestClient::new().await;
+    let client = Client::test_builder().build().await;
     if !client.is_sharded() || client.server_version_lt(4, 2) {
         log_uncaptured("skipping deserialize_recovery_token due to test topology");
         return;

--- a/src/test/spec/transactions.rs
+++ b/src/test/spec/transactions.rs
@@ -46,7 +46,7 @@ async fn deserialize_recovery_token() {
         _str: String,
     }
 
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if !client.is_sharded() || client.server_version_lt(4, 2) {
         log_uncaptured("skipping deserialize_recovery_token due to test topology");
         return;
@@ -86,7 +86,7 @@ async fn deserialize_recovery_token() {
 
 #[tokio::test]
 async fn convenient_api_custom_error() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_custom_error: no transaction support.");
         return;
@@ -118,7 +118,7 @@ async fn convenient_api_custom_error() {
 
 #[tokio::test]
 async fn convenient_api_returned_value() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_returned_value: no transaction support.");
         return;
@@ -145,7 +145,7 @@ async fn convenient_api_returned_value() {
 
 #[tokio::test]
 async fn convenient_api_retry_timeout_callback() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     if !client.supports_transactions() {
         log_uncaptured("Skipping convenient_api_retry_timeout_callback: no transaction support.");
         return;
@@ -177,7 +177,7 @@ async fn convenient_api_retry_timeout_callback() {
 #[tokio::test(flavor = "multi_thread")]
 async fn convenient_api_retry_timeout_commit_unknown() {
     let mut options = get_client_options().await.clone();
-    if Client::test_builder().build().await.is_sharded() {
+    if Client::test_builder().await.is_sharded() {
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
     }
@@ -185,7 +185,6 @@ async fn convenient_api_retry_timeout_commit_unknown() {
     let client = Client::test_builder()
         .options(options)
         .monitor_events()
-        .build()
         .await;
     if !client.supports_transactions() {
         log_uncaptured(
@@ -222,7 +221,7 @@ async fn convenient_api_retry_timeout_commit_unknown() {
 #[tokio::test(flavor = "multi_thread")]
 async fn convenient_api_retry_timeout_commit_transient() {
     let mut options = get_client_options().await.clone();
-    if Client::test_builder().build().await.is_sharded() {
+    if Client::test_builder().await.is_sharded() {
         options.direct_connection = Some(true);
         options.hosts.drain(1..);
     }
@@ -230,7 +229,6 @@ async fn convenient_api_retry_timeout_commit_transient() {
     let client = Client::test_builder()
         .options(options)
         .monitor_events()
-        .build()
         .await;
     if !client.supports_transactions() {
         log_uncaptured(

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -29,6 +29,7 @@ use crate::{
         SERVERLESS,
         SERVER_API,
     },
+    Client,
     ClientSession,
     ClusterTime,
     Collection,
@@ -81,7 +82,7 @@ pub(crate) struct TestRunner {
 impl TestRunner {
     pub(crate) async fn new() -> Self {
         Self {
-            internal_client: TestClient::new().await,
+            internal_client: Client::test_builder().build().await,
             entities: Default::default(),
             fail_point_guards: Default::default(),
             cluster_time: Default::default(),
@@ -488,7 +489,9 @@ impl TestRunner {
 
                     options.server_api = server_api;
 
-                    if client.use_multiple_mongoses() && TestClient::new().await.is_sharded() {
+                    if client.use_multiple_mongoses()
+                        && Client::test_builder().build().await.is_sharded()
+                    {
                         assert!(
                             options.hosts.len() > 1,
                             "[{}]: Test requires multiple mongos hosts",

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -92,7 +92,7 @@ impl TestRunner {
     pub(crate) async fn new_with_connection_string(connection_string: &str) -> Self {
         let options = ClientOptions::parse(connection_string).await.unwrap();
         Self {
-            internal_client: TestClient::with_options(Some(options)).await,
+            internal_client: Client::test_builder().options(options).build().await,
             entities: Arc::new(RwLock::new(EntityMap::new())),
             fail_point_guards: Arc::new(RwLock::new(Vec::new())),
             cluster_time: Default::default(),

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -82,7 +82,7 @@ pub(crate) struct TestRunner {
 impl TestRunner {
     pub(crate) async fn new() -> Self {
         Self {
-            internal_client: Client::test_builder().await,
+            internal_client: Client::for_test().await,
             entities: Default::default(),
             fail_point_guards: Default::default(),
             cluster_time: Default::default(),
@@ -92,7 +92,7 @@ impl TestRunner {
     pub(crate) async fn new_with_connection_string(connection_string: &str) -> Self {
         let options = ClientOptions::parse(connection_string).await.unwrap();
         Self {
-            internal_client: Client::test_builder().options(options).await,
+            internal_client: Client::for_test().options(options).await,
             entities: Arc::new(RwLock::new(EntityMap::new())),
             fail_point_guards: Arc::new(RwLock::new(Vec::new())),
             cluster_time: Default::default(),
@@ -489,7 +489,7 @@ impl TestRunner {
 
                     options.server_api = server_api;
 
-                    if client.use_multiple_mongoses() && Client::test_builder().await.is_sharded() {
+                    if client.use_multiple_mongoses() && Client::for_test().await.is_sharded() {
                         assert!(
                             options.hosts.len() > 1,
                             "[{}]: Test requires multiple mongos hosts",

--- a/src/test/spec/unified_runner/test_runner.rs
+++ b/src/test/spec/unified_runner/test_runner.rs
@@ -82,7 +82,7 @@ pub(crate) struct TestRunner {
 impl TestRunner {
     pub(crate) async fn new() -> Self {
         Self {
-            internal_client: Client::test_builder().build().await,
+            internal_client: Client::test_builder().await,
             entities: Default::default(),
             fail_point_guards: Default::default(),
             cluster_time: Default::default(),
@@ -92,7 +92,7 @@ impl TestRunner {
     pub(crate) async fn new_with_connection_string(connection_string: &str) -> Self {
         let options = ClientOptions::parse(connection_string).await.unwrap();
         Self {
-            internal_client: Client::test_builder().options(options).build().await,
+            internal_client: Client::test_builder().options(options).await,
             entities: Arc::new(RwLock::new(EntityMap::new())),
             fail_point_guards: Arc::new(RwLock::new(Vec::new())),
             cluster_time: Default::default(),
@@ -489,9 +489,7 @@ impl TestRunner {
 
                     options.server_api = server_api;
 
-                    if client.use_multiple_mongoses()
-                        && Client::test_builder().build().await.is_sharded()
-                    {
+                    if client.use_multiple_mongoses() && Client::test_builder().await.is_sharded() {
                         assert!(
                             options.hosts.len() > 1,
                             "[{}]: Test requires multiple mongos hosts",

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -97,7 +97,7 @@ struct FileContext {
 
 impl FileContext {
     async fn new(path: &std::path::Path) -> Self {
-        let internal_client = Client::test_builder().build().await;
+        let internal_client = Client::test_builder().await;
         let is_csfle_test = path.to_string_lossy().contains("client-side-encryption");
 
         Self {
@@ -216,7 +216,7 @@ impl TestContext {
         #[cfg(feature = "in-use-encryption")]
         let builder = csfle::set_auto_enc(builder, test);
 
-        let client = builder.monitor_events().build().await;
+        let client = builder.monitor_events().await;
 
         // TODO RUST-900: Remove this extraneous call.
         if internal_client.is_sharded()

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -331,7 +331,7 @@ impl crate::test::util::TestClientBuilder {
 
         self = self.options(options);
         if !use_multiple_mongoses {
-            self = self.sharded_use_first_host();
+            self = self.use_single_mongos();
         }
         self
     }

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -97,7 +97,7 @@ struct FileContext {
 
 impl FileContext {
     async fn new(path: &std::path::Path) -> Self {
-        let internal_client = TestClient::new().await;
+        let internal_client = Client::test_builder().build().await;
         let is_csfle_test = path.to_string_lossy().contains("client-side-encryption");
 
         Self {

--- a/src/test/spec/v2_runner.rs
+++ b/src/test/spec/v2_runner.rs
@@ -97,7 +97,7 @@ struct FileContext {
 
 impl FileContext {
     async fn new(path: &std::path::Path) -> Self {
-        let internal_client = Client::test_builder().await;
+        let internal_client = Client::for_test().await;
         let is_csfle_test = path.to_string_lossy().contains("client-side-encryption");
 
         Self {
@@ -206,7 +206,7 @@ impl TestContext {
         if additional_options.heartbeat_freq.is_none() {
             additional_options.heartbeat_freq = Some(MIN_HEARTBEAT_FREQUENCY);
         }
-        let builder = Client::test_builder()
+        let builder = Client::for_test()
             .options_for_multiple_mongoses(
                 additional_options,
                 test.use_multiple_mongoses.unwrap_or(false),

--- a/src/test/spec/write_error.rs
+++ b/src/test/spec/write_error.rs
@@ -8,7 +8,7 @@ use crate::{
 
 #[tokio::test]
 async fn details() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
 
     if client.server_version_lt(5, 0) {
         // SERVER-58399

--- a/src/test/spec/write_error.rs
+++ b/src/test/spec/write_error.rs
@@ -8,7 +8,7 @@ use crate::{
 
 #[tokio::test]
 async fn details() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
 
     if client.server_version_lt(5, 0) {
         // SERVER-58399

--- a/src/test/timeseries.rs
+++ b/src/test/timeseries.rs
@@ -7,7 +7,7 @@ type Result<T> = anyhow::Result<T>;
 
 #[tokio::test]
 async fn list_collections_timeseries() -> Result<()> {
-    let client = Client::test_builder().await;
+    let client = Client::for_test().await;
     if client.server_version_lt(5, 0) {
         log_uncaptured("Skipping list_collections_timeseries: timeseries require server >= 5.0");
         return Ok(());

--- a/src/test/timeseries.rs
+++ b/src/test/timeseries.rs
@@ -7,7 +7,7 @@ type Result<T> = anyhow::Result<T>;
 
 #[tokio::test]
 async fn list_collections_timeseries() -> Result<()> {
-    let client = Client::test_builder().build().await;
+    let client = Client::test_builder().await;
     if client.server_version_lt(5, 0) {
         log_uncaptured("Skipping list_collections_timeseries: timeseries require server >= 5.0");
         return Ok(());

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -62,7 +62,7 @@ impl Client {
             min_heartbeat_freq: None,
             #[cfg(feature = "in-use-encryption")]
             encrypted: None,
-            sharded_use_first_host: false,
+            use_single_mongos: false,
         }
     }
 }
@@ -72,7 +72,7 @@ pub(crate) struct TestClientBuilder {
     min_heartbeat_freq: Option<Duration>,
     #[cfg(feature = "in-use-encryption")]
     encrypted: Option<crate::client::csfle::options::AutoEncryptionOptions>,
-    sharded_use_first_host: bool,
+    use_single_mongos: bool,
 }
 
 impl TestClientBuilder {
@@ -84,8 +84,8 @@ impl TestClientBuilder {
     }
 
     /// When running against a sharded topology, only use the first configured host.
-    pub(crate) fn sharded_use_first_host(mut self) -> Self {
-        self.sharded_use_first_host = true;
+    pub(crate) fn use_single_mongos(mut self) -> Self {
+        self.use_single_mongos = true;
         self
     }
 
@@ -119,7 +119,7 @@ impl TestClientBuilder {
             options.test_options_mut().min_heartbeat_freq = Some(freq);
         }
 
-        if self.sharded_use_first_host {
+        if self.use_single_mongos {
             let tmp = TestClient::from_client(
                 Client::with_options(get_client_options().await.clone()).unwrap(),
             )

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -184,14 +184,6 @@ impl TestClient {
         }
     }
 
-    pub(crate) async fn with_additional_options(options: Option<ClientOptions>) -> Self {
-        Client::test_builder()
-            .additional_options(options, false)
-            .await
-            .build()
-            .await
-    }
-
     pub(crate) async fn create_user(
         &self,
         user: &str,

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -148,10 +148,6 @@ impl TestClientBuilder {
 
 impl TestClient {
     // TODO RUST-1449 Remove uses of direct constructors in favor of `TestClientBuilder`.
-    pub(crate) async fn new() -> Self {
-        Self::with_options(None).await
-    }
-
     pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
         Client::test_builder().options(options).build().await
     }
@@ -437,7 +433,7 @@ impl TestClient {
             }
             None => default_options,
         };
-        if Self::new().await.is_sharded() && !use_multiple_mongoses {
+        if Client::test_builder().build().await.is_sharded() && !use_multiple_mongoses {
             options.hosts = options.hosts.iter().take(1).cloned().collect();
         }
         options

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -58,7 +58,7 @@ impl std::ops::Deref for TestClient {
 }
 
 impl Client {
-    pub(crate) fn test_builder() -> TestClientBuilder {
+    pub(crate) fn for_test() -> TestClientBuilder {
         TestClientBuilder {
             options: None,
             min_heartbeat_freq: None,

--- a/src/test/util.rs
+++ b/src/test/util.rs
@@ -147,11 +147,6 @@ impl TestClientBuilder {
 }
 
 impl TestClient {
-    // TODO RUST-1449 Remove uses of direct constructors in favor of `TestClientBuilder`.
-    pub(crate) async fn with_options(options: impl Into<Option<ClientOptions>>) -> Self {
-        Client::test_builder().options(options).build().await
-    }
-
     async fn from_client(client: Client) -> Self {
         let hello = hello_command(
             client.options().server_api.as_ref(),

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -182,7 +182,7 @@ impl EventClient {
 
 #[tokio::test]
 async fn command_started_event_count() {
-    let client = Client::test_builder().monitor_events().await;
+    let client = Client::for_test().monitor_events().await;
     let coll = client.database("foo").collection("bar");
 
     for i in 0..10 {

--- a/src/test/util/event.rs
+++ b/src/test/util/event.rs
@@ -1,4 +1,7 @@
+use std::future::IntoFuture;
+
 use derive_more::From;
+use futures::{future::BoxFuture, FutureExt};
 use serde::Serialize;
 
 use super::{event_buffer::EventBuffer, TestClient, TestClientBuilder};
@@ -139,25 +142,34 @@ impl EventClientBuilder {
         self.retain_startup = true;
         self
     }
+}
 
-    pub(crate) async fn build(self) -> EventClient {
-        let mut inner = self.inner;
-        let mut options = match inner.options.take() {
-            Some(options) => options,
-            None => get_client_options().await.clone(),
-        };
-        let mut events = EventBuffer::new();
-        events.register(&mut options);
-        inner.options = Some(options);
+impl IntoFuture for EventClientBuilder {
+    type Output = EventClient;
 
-        let client = inner.build().await;
+    type IntoFuture = BoxFuture<'static, Self::Output>;
 
-        if !self.retain_startup {
-            // clear events from commands used to set up client.
-            events.retain(|ev| !matches!(ev, Event::Command(_)));
+    fn into_future(self) -> Self::IntoFuture {
+        async move {
+            let mut inner = self.inner;
+            let mut options = match inner.options.take() {
+                Some(options) => options,
+                None => get_client_options().await.clone(),
+            };
+            let mut events = EventBuffer::new();
+            events.register(&mut options);
+            inner.options = Some(options);
+
+            let client = inner.await;
+
+            if !self.retain_startup {
+                // clear events from commands used to set up client.
+                events.retain(|ev| !matches!(ev, Event::Command(_)));
+            }
+
+            EventClient { client, events }
         }
-
-        EventClient { client, events }
+        .boxed()
     }
 }
 
@@ -170,7 +182,7 @@ impl EventClient {
 
 #[tokio::test]
 async fn command_started_event_count() {
-    let client = Client::test_builder().monitor_events().build().await;
+    let client = Client::test_builder().monitor_events().await;
     let coll = client.database("foo").collection("bar");
 
     for i in 0..10 {


### PR DESCRIPTION
RUST-1449

Two main themes of changes in this PR:
* Removed the remaining uses of older `TestClient` construction methods in favor of `Client::test_builder`
* Cleaned up the `additional_options` tangle: moved the LB-specific initialization to be internal to the v2 test runner (the only thing that actually needed it / was using it) and provided the much simpler `sharded_use_first_host` for all the other places it was being called.

With this done, there's now only one way to make a `TestClient` and only one way to set options for it :)