### PR TITLE
RUST-1991 / RUST-2016 Fix non-CSFLE serverless tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -269,29 +269,15 @@ buildvariants:
     tasks:
       - test-plain-auth
 
-  - name: serverless-passthrough
-    patchable: false
-    display_name: "Serverless (Passthrough)"
+  - name: serverless
+    # patchable: false
+    display_name: "Serverless"
     run_on:
       - rhel80-small
     expansions:
       LIBMONGOCRYPT_OS: rhel-80-64-bit
       AUTH: auth
       SSL: ssl
-      SERVERLESS_PROXY_TYPE: passthrough
-    tasks:
-      - serverless-task-group
-
-  - name: serverless-terminating
-    patchable: false
-    display_name: "Serverless (Terminating)"
-    run_on:
-      - rhel80-small
-    expansions:
-      LIBMONGOCRYPT_OS: rhel-80-64-bit
-      AUTH: auth
-      SSL: ssl
-      SERVERLESS_PROXY_TYPE: terminating
     tasks:
       - serverless-task-group
 
@@ -414,11 +400,7 @@ task_groups:
           shell: "bash"
           script: |
             ${PREPARE_SHELL}
-            if [ "terminating" = "${SERVERLESS_PROXY_TYPE}" ]; then
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/setup-secrets.sh serverless_next
-            else
-              bash ${DRIVERS_TOOLS}/.evergreen/serverless/setup-secrets.sh
-            fi
+            bash ${DRIVERS_TOOLS}/.evergreen/serverless/setup-secrets.sh
             bash ${DRIVERS_TOOLS}/.evergreen/serverless/create-instance.sh
       - command: expansions.update
         params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -270,7 +270,7 @@ buildvariants:
       - test-plain-auth
 
   - name: serverless
-    # patchable: false
+    patchable: false
     display_name: "Serverless"
     run_on:
       - rhel80-small

--- a/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.json
+++ b/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.json
@@ -5,6 +5,7 @@
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeLogMessages": {
           "command": "debug"
         }

--- a/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.yml
+++ b/src/test/spec/json/command-logging-and-monitoring/logging/unacknowledged-write.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.16"
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeLogMessages:
         command: debug
   - database:

--- a/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
+++ b/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.json
@@ -1,10 +1,17 @@
 {
   "description": "unacknowledged-client-bulkWrite",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.7",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
   "createEntities": [
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeEvents": [
           "commandStartedEvent",
           "commandSucceededEvent",
@@ -112,11 +119,37 @@
               "$$unsetOrMatches": {}
             }
           }
+        },
+        {
+          "object": "collection",
+          "name": "find",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 333
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
         }
       ],
       "expectEvents": [
         {
           "client": "client",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {

--- a/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.yml
+++ b/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledged-client-bulkWrite.yml
@@ -1,10 +1,15 @@
 description: "unacknowledged-client-bulkWrite"
 
-schemaVersion: "1.1"
+schemaVersion: "1.7"
+
+runOnRequirements:
+  - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent
         - commandSucceededEvent
@@ -62,9 +67,21 @@ tests:
             $$unsetOrMatches: {}
           deleteResults:
             $$unsetOrMatches: {}
+      # Force completion of the w:0 write by executing a find on the same connection
+      - object: *collection
+        name: find
+        arguments:
+          filter: {}
+        expectResult:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 333 }
+          - { _id: 4, x: 44 }
+
     expectEvents:
       -
         client: *client
+        ignoreExtraEvents: true
         events:
           - commandStartedEvent:
               commandName: bulkWrite

--- a/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.json
+++ b/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.json
@@ -5,6 +5,7 @@
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeEvents": [
           "commandStartedEvent",
           "commandSucceededEvent",
@@ -70,17 +71,7 @@
           "object": "collection",
           "arguments": {
             "filter": {}
-          },
-          "expectResult": [
-            {
-              "_id": 1,
-              "x": 11
-            },
-            {
-              "_id": "unorderedBulkWriteInsertW0",
-              "x": 44
-            }
-          ]
+          }
         }
       ],
       "expectEvents": [

--- a/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.yml
+++ b/src/test/spec/json/command-logging-and-monitoring/monitoring/unacknowledgedBulkWrite.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.7"
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent
         - commandSucceededEvent
@@ -41,10 +42,6 @@ tests:
         object: *collection
         arguments:
           filter: { }
-        expectResult: [
-          { _id: 1, x: 11 },
-          { _id: "unorderedBulkWriteInsertW0", x: 44 }
-        ]
     expectEvents:
       - client: *client
         ignoreExtraEvents: true

--- a/src/test/spec/json/crud/README.md
+++ b/src/test/spec/json/crud/README.md
@@ -70,7 +70,7 @@ WriteError's `details` property.
 Test that `MongoClient.bulkWrite` properly handles `writeModels` inputs containing a number of writes greater than
 `maxWriteBatchSize`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -98,7 +98,7 @@ command. Assert that the length of `firstEvent.command.ops` is `maxWriteBatchSiz
 Test that `MongoClient.bulkWrite` properly handles a `writeModels` input which constructs an `ops` array larger than
 `maxMessageSizeBytes`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -137,7 +137,7 @@ driver exposes `operationId`s in its CommandStartedEvents, assert that `firstEve
 
 Test that `MongoClient.bulkWrite` properly collects and reports `writeConcernError`s returned in separate batches.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with `retryWrites: false` configured and
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -182,7 +182,7 @@ Assert that two CommandStartedEvents were observed for the `bulkWrite` command.
 
 Test that `MongoClient.bulkWrite` handles individual write errors across batches for ordered and unordered bulk writes.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -237,7 +237,7 @@ Assert that one CommandStartedEvent was observed for the `bulkWrite` command.
 
 Test that `MongoClient.bulkWrite` properly iterates the results cursor when `getMore` is required.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -276,7 +276,8 @@ Assert that a CommandStartedEvent was observed for the `getMore` command.
 Test that `MongoClient.bulkWrite` executed within a transaction properly iterates the results cursor when `getMore` is
 required.
 
-This test must only be run on 8.0+ servers. This test must not be run against standalone servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test must not be run
+against standalone servers.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -318,7 +319,7 @@ Assert that a CommandStartedEvent was observed for the `getMore` command.
 
 Test that `MongoClient.bulkWrite` properly handles a failure that occurs when attempting a `getMore`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -369,7 +370,7 @@ Assert that a CommandStartedEvent was observed for the `killCursors` command.
 
 ### 10. `MongoClient.bulkWrite` returns error for unacknowledged too-large insert
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`).
 
@@ -423,7 +424,7 @@ Expect a client-side error due the size.
 Test that `MongoClient.bulkWrite` batch splits a bulk write when the addition of a new namespace to `nsInfo` causes the
 size of the message to exceed `maxMessageSizeBytes - 1000`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Repeat the following setup for each test case:
 
@@ -603,8 +604,8 @@ remainingBulkWriteBytes = maxMessageSizeBytes - 1122
 Test that `MongoClient.bulkWrite` returns an error if an operation provided exceeds `maxMessageSizeBytes` such that an
 empty `ops` payload would be sent.
 
-This test must only be run on 8.0+ servers. This test may be skipped by drivers that are not able to construct
-arbitrarily large documents.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test may be skipped by
+drivers that are not able to construct arbitrarily large documents.
 
 Construct a `MongoClient` (referred to as `client`). Perform a `hello` command using `client` and record the
 `maxMessageSizeBytes` value contained in the response.
@@ -649,7 +650,7 @@ This test is expected to be removed when [DRIVERS-2888](https://jira.mongodb.org
 
 Test that `MongoClient.bulkWrite` returns an error if the client has auto-encryption configured.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) configured with the following `AutoEncryptionOpts`:
 

--- a/src/test/spec/json/crud/unified/client-bulkWrite-delete-options.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-delete-options.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite delete options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-delete-options.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-delete-options.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite delete options"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-errorResponse.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-errorResponse.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.12",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-errorResponse.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-errorResponse.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite errorResponse"
 schemaVersion: "1.12"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-errors.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-errors.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.21",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-errors.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-errors.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite errors"
 schemaVersion: "1.21"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-mixed-namespaces.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-mixed-namespaces.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite with mixed namespaces",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-mixed-namespaces.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-mixed-namespaces.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite with mixed namespaces"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-options.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-options.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite top-level options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-options.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-options.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite top-level options"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-ordered.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-ordered.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite with ordered option",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-ordered.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-ordered.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite with ordered option"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-results.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-results.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite results",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-results.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-results.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite results"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-update-options.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-update-options.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite update options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-update-options.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-update-options.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite update options"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-update-pipeline.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-update-pipeline.json
@@ -1,9 +1,10 @@
 {
   "description": "client bulkWrite update pipeline",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-update-pipeline.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-update-pipeline.yml
@@ -1,7 +1,8 @@
 description: "client bulkWrite update pipeline"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/retryable-writes/README.md
+++ b/src/test/spec/json/retryable-writes/README.md
@@ -1,7 +1,5 @@
 # Retryable Write Tests
 
-______________________________________________________________________
-
 ## Introduction
 
 The YAML and JSON files in this directory are platform-independent tests meant to exercise a driver's implementation of
@@ -106,17 +104,238 @@ Drivers should test that transactions IDs are always included in commands for su
 
 The following tests ensure that retryable writes work properly with replica sets and sharded clusters.
 
-1. Test that retryable writes raise an exception when using the MMAPv1 storage engine. For this test, execute a write
-   operation, such as `insertOne`, which should generate an exception. Assert that the error message is the replacement
-   error message:
+### 1. Test that retryable writes raise an exception when using the MMAPv1 storage engine.
 
+For this test, execute a write operation, such as `insertOne`, which should generate an exception. Assert that the error
+message is the replacement error message:
+
+```
+This MongoDB deployment does not support retryable writes. Please add
+retryWrites=false to your connection string.
+```
+
+and the error code is 20.
+
+> [!NOTE]
+> Drivers that rely on `serverStatus` to determine the storage engine in use MAY skip this test for sharded clusters,
+> since `mongos` does not report this information in its `serverStatus` response.
+
+### 2. Test that drivers properly retry after encountering PoolClearedErrors.
+
+This test MUST be implemented by any driver that implements the CMAP specification.
+
+This test requires MongoDB 4.3.4+ for both the `errorLabels` and `blockConnection` fail point options.
+
+1. Create a client with maxPoolSize=1 and retryWrites=true. If testing against a sharded deployment, be sure to connect
+   to only a single mongos.
+
+2. Enable the following failpoint:
+
+   ```javascript
+   {
+       configureFailPoint: "failCommand",
+       mode: { times: 1 },
+       data: {
+           failCommands: ["insert"],
+           errorCode: 91,
+           blockConnection: true,
+           blockTimeMS: 1000,
+           errorLabels: ["RetryableWriteError"]
+       }
+   }
    ```
-   This MongoDB deployment does not support retryable writes. Please add
-   retryWrites=false to your connection string.
+
+3. Start two threads and attempt to perform an `insertOne` simultaneously on both.
+
+4. Verify that both `insertOne` attempts succeed.
+
+5. Via CMAP monitoring, assert that the first check out succeeds.
+
+6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+
+7. Via CMAP monitoring, assert that the second check out then fails due to a connection error.
+
+8. Via Command Monitoring, assert that exactly three `insert` CommandStartedEvents were observed in total.
+
+9. Disable the failpoint.
+
+### 3. Test that drivers return the original error after encountering a WriteConcernError with a RetryableWriteError label.
+
+This test MUST:
+
+- be implemented by any driver that implements the Command Monitoring specification,
+- only run against replica sets as mongos does not propagate the NoWritesPerformed label to the drivers.
+- be run against server versions 6.0 and above.
+
+Additionally, this test requires drivers to set a fail point after an `insertOne` operation but before the subsequent
+retry. Drivers that are unable to set a failCommand after the CommandSucceededEvent SHOULD use mocking or write a unit
+test to cover the same sequence of events.
+
+1. Create a client with `retryWrites=true`.
+
+2. Configure a fail point with error code `91` (ShutdownInProgress):
+
+   ```javascript
+   {
+       configureFailPoint: "failCommand",
+       mode: {times: 1},
+       data: {
+           failCommands: ["insert"],
+           errorLabels: ["RetryableWriteError"],
+           writeConcernError: { code: 91 }
+       }
+   }
    ```
 
-   and the error code is 20.
+3. Via the command monitoring CommandSucceededEvent, configure a fail point with error code `10107` (NotWritablePrimary)
+   and a NoWritesPerformed label:
 
-   [!NOTE]
-   storage engine in use MAY skip this test for sharded clusters, since `mongos` does not report this information in its
-   `serverStatus` response.
+   ```javascript
+   {
+       configureFailPoint: "failCommand",
+       mode: {times: 1},
+       data: {
+           failCommands: ["insert"],
+           errorCode: 10107,
+           errorLabels: ["RetryableWriteError", "NoWritesPerformed"]
+       }
+   }
+   ```
+
+   Drivers SHOULD only configure the `10107` fail point command if the the succeeded event is for the `91` error
+   configured in step 2.
+
+4. Attempt an `insertOne` operation on any record for any database and collection. For the resulting error, assert that
+   the associated error code is `91`.
+
+5. Disable the fail point:
+
+   ```javascript
+   {
+       configureFailPoint: "failCommand",
+       mode: "off"
+   }
+   ```
+
+### 4. Test that in a sharded cluster writes are retried on a different mongos when one is available.
+
+This test MUST be executed against a sharded cluster that has at least two mongos instances, supports
+`retryWrites=true`, has enabled the `configureFailPoint` command, and supports the `errorLabels` field (MongoDB 4.3.1+).
+
+> [!NOTE]
+> This test cannot reliably distinguish "retry on a different mongos due to server deprioritization" (the behavior
+> intended to be tested) from "retry on a different mongos due to normal SDAM randomized suitable server selection".
+> Verify relevant code paths are correctly executed by the tests using external means such as a logging, debugger, code
+> coverage tool, etc.
+
+1. Create two clients `s0` and `s1` that each connect to a single mongos from the sharded cluster. They must not connect
+   to the same mongos.
+
+2. Configure the following fail point for both `s0` and `s1`:
+
+   ```javascript
+   {
+       configureFailPoint: "failCommand",
+       mode: { times: 1 },
+       data: {
+           failCommands: ["insert"],
+           errorCode: 6,
+           errorLabels: ["RetryableWriteError"]
+       }
+   }
+   ```
+
+3. Create a client `client` with `retryWrites=true` that connects to the cluster using the same two mongoses as `s0` and
+   `s1`.
+
+4. Enable failed command event monitoring for `client`.
+
+5. Execute an `insert` command with `client`. Assert that the command failed.
+
+6. Assert that two failed command events occurred. Assert that the failed command events occurred on different mongoses.
+
+7. Disable the fail points on both `s0` and `s1`.
+
+### 5. Test that in a sharded cluster writes are retried on the same mongos when no others are available.
+
+This test MUST be executed against a sharded cluster that supports `retryWrites=true`, has enabled the
+`configureFailPoint` command, and supports the `errorLabels` field (MongoDB 4.3.1+).
+
+Note: this test cannot reliably distinguish "retry on a different mongos due to server deprioritization" (the behavior
+intended to be tested) from "retry on a different mongos due to normal SDAM behavior of randomized suitable server
+selection". Verify relevant code paths are correctly executed by the tests using external means such as a logging,
+debugger, code coverage tool, etc.
+
+1. Create a client `s0` that connects to a single mongos from the cluster.
+
+2. Configure the following fail point for `s0`:
+
+   ```javascript
+   {
+       configureFailPoint: "failCommand",
+       mode: { times: 1 },
+       data: {
+           failCommands: ["insert"],
+           errorCode: 6,
+           errorLabels: ["RetryableWriteError"],
+           closeConnection: true
+       }
+   }
+   ```
+
+3. Create a client `client` with `directConnection=false` (when not set by default) and `retryWrites=true` that connects
+   to the cluster using the same single mongos as `s0`.
+
+4. Enable succeeded and failed command event monitoring for `client`.
+
+5. Execute an `insert` command with `client`. Assert that the command succeeded.
+
+6. Assert that exactly one failed command event and one succeeded command event occurred. Assert that both events
+   occurred on the same mongos.
+
+7. Disable the fail point on `s0`.
+
+## Changelog
+
+- 2024-05-30: Migrated from reStructuredText to Markdown.
+
+- 2024-02-27: Convert legacy retryable writes tests to unified format.
+
+- 2024-02-21: Update prose test 4 and 5 to workaround SDAM behavior preventing\
+  execution of deprioritization code
+  paths.
+
+- 2024-01-05: Fix typo in prose test title.
+
+- 2024-01-03: Note server version requirements for fail point options and revise\
+  tests to specify the `errorLabels`
+  option at the top-level instead of within `writeConcernError`.
+
+- 2023-08-26: Add prose tests for retrying in a sharded cluster.
+
+- 2022-08-30: Add prose test verifying correct error handling for errors with\
+  the NoWritesPerformed label, which is to
+  return the original error.
+
+- 2022-04-22: Clarifications to `serverless` and `useMultipleMongoses`.
+
+- 2021-08-27: Add `serverless` to `runOn`. Clarify behavior of\
+  `useMultipleMongoses` for `LoadBalanced` topologies.
+
+- 2021-04-23: Add `load-balanced` to test topology requirements.
+
+- 2021-03-24: Add prose test verifying `PoolClearedErrors` are retried.
+
+- 2019-10-21: Add `errorLabelsContain` and `errorLabelsContain` fields to\
+  `result`
+
+- 2019-08-07: Add Prose Tests section
+
+- 2019-06-07: Mention $merge stage for aggregate alongside $out
+
+- 2019-03-01: Add top-level `runOn` field to denote server version and/or\
+  topology requirements requirements for the
+  test file. Removes the `minServerVersion` and `maxServerVersion` top-level fields, which are now expressed within
+  `runOn` elements.
+
+  Add test-level `useMultipleMongoses` field.

--- a/src/test/spec/json/retryable-writes/etc/templates/handshakeError.yml.template
+++ b/src/test/spec/json/retryable-writes/etc/templates/handshakeError.yml.template
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4" # For `serverless: forbid`
 
 runOnRequirements:
   - minServerVersion: "4.2"
@@ -54,6 +54,7 @@ tests:
     {%- if (operation.operation_name == 'clientBulkWrite') %}
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     {%- endif %}
     operations:
       - name: failPoint
@@ -102,6 +103,7 @@ tests:
     {%- if (operation.operation_name == 'clientBulkWrite') %}
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     {%- endif %}
     operations:
       - name: failPoint

--- a/src/test/spec/json/retryable-writes/unified/client-bulkWrite-clientErrors.json
+++ b/src/test/spec/json/retryable-writes/unified/client-bulkWrite-clientErrors.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/retryable-writes/unified/client-bulkWrite-clientErrors.yml
+++ b/src/test/spec/json/retryable-writes/unified/client-bulkWrite-clientErrors.yml
@@ -6,6 +6,7 @@ runOnRequirements:
       - replicaset
       - sharded
       - load-balanced
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/retryable-writes/unified/client-bulkWrite-serverErrors.json
+++ b/src/test/spec/json/retryable-writes/unified/client-bulkWrite-serverErrors.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/retryable-writes/unified/client-bulkWrite-serverErrors.yml
+++ b/src/test/spec/json/retryable-writes/unified/client-bulkWrite-serverErrors.yml
@@ -6,6 +6,7 @@ runOnRequirements:
       - replicaset
       - sharded
       - load-balanced
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/retryable-writes/unified/handshakeError.json
+++ b/src/test/spec/json/retryable-writes/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable writes handshake failures",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",
@@ -57,7 +57,8 @@
       "description": "client.clientBulkWrite succeeds after retryable handshake network error",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -165,7 +166,8 @@
       "description": "client.clientBulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/src/test/spec/json/retryable-writes/unified/handshakeError.yml
+++ b/src/test/spec/json/retryable-writes/unified/handshakeError.yml
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4" # For `serverless: forbid`
 
 runOnRequirements:
   - minServerVersion: "4.2"
@@ -53,6 +53,7 @@ tests:
   - description: "client.clientBulkWrite succeeds after retryable handshake network error"
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -98,6 +99,7 @@ tests:
   - description: "client.clientBulkWrite succeeds after retryable handshake server error (ShutdownInProgress)"
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/src/test/spec/json/transactions/unified/client-bulkWrite.json
+++ b/src/test/spec/json/transactions/unified/client-bulkWrite.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite transactions",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/transactions/unified/client-bulkWrite.yml
+++ b/src/test/spec/json/transactions/unified/client-bulkWrite.yml
@@ -1,11 +1,12 @@
 description: "client bulkWrite transactions"
-schemaVersion: "1.3"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     topologies:
       - replicaset
       - sharded
       - load-balanced
+    serverless: forbid
 
 createEntities:
   - client:

--- a/src/test/spec/json/transactions/unified/mongos-pin-auto-tests.py
+++ b/src/test/spec/json/transactions/unified/mongos-pin-auto-tests.py
@@ -322,6 +322,7 @@ def create_pin_test(op_name, error_name):
     if op_name == 'clientBulkWrite':
         test += '    runOnRequirements:\n'
         test += '      - minServerVersion: "8.0" # `bulkWrite` added to server 8.0"\n'
+        test += '        serverless: forbid\n'
     return test
 
 
@@ -337,6 +338,7 @@ def create_unpin_test(op_name, error_name):
     if op_name == 'clientBulkWrite':
         test += '    runOnRequirements:\n'
         test += '      - minServerVersion: "8.0" # `bulkWrite` added to server 8.0"\n'
+        test += '        serverless: forbid\n'
     return test
 
 

--- a/src/test/spec/json/versioned-api/crud-api-version-1.json
+++ b/src/test/spec/json/versioned-api/crud-api-version-1.json
@@ -431,7 +431,8 @@
       "description": "client bulkWrite appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/src/test/spec/json/versioned-api/crud-api-version-1.yml
+++ b/src/test/spec/json/versioned-api/crud-api-version-1.yml
@@ -160,6 +160,7 @@ tests:
   - description: "client bulkWrite appends declared API version"
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     operations:
       - name: clientBulkWrite
         object: *client


### PR DESCRIPTION
patch: https://spruce.mongodb.com/version/66cf5e63e89bfd00074df7de/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The non-CSFLE tests just required updating credentials in Evergreen and syncing with https://github.com/mongodb/specifications/commit/0984b0942b9d8aaa11610184d0be16b27a263ec3. The CSFLE tests seem to be failing for more nefarious reasons, so I filed RUST-2024 to look into that. Also filed RUST-2025 to switch over to using the secrets manager to avoid being affected by future credential rotations.