### PR TITLE
RUST-1795 Add an [in]stability note for mongocrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ features = ["sync"]
 | `zlib-compression`           | Enable support for compressing messages with [`zlib`](https://zlib.net/). |
 | `zstd-compression`           | Enable support for compressing messages with [`zstd`](http://facebook.github.io/zstd/). |
 | `snappy-compression`         | Enable support for compressing messages with [`snappy`](http://google.github.io/snappy/). |
-| `in-use-encryption`          | Enable support for client-side field level encryption and queryable encryption. |
+| `in-use-encryption`          | Enable support for client-side field level encryption and queryable encryption.  Note that re-exports from the `mongocrypt` crate may change in backwards-incompatible ways while that crate is below version 1.0. |
 | `tracing-unstable`           | Enable support for emitting [`tracing`](https://docs.rs/tracing/latest/tracing/) events. This API is unstable and may be subject to breaking changes in minor releases. |
 | `compat-3-0-0`               | Required for future compatibility if default features are disabled. |
 


### PR DESCRIPTION
RUST-1795

This adds a note that the pre-1.0 `mongocrypt` re-export shouldn't be considered to be stable.

I did do a once-over to see if there are any areas of particularly high risk and the short answer is it's really hard to tell with an API that wraps C ☹️  Anything that currently uses constant string values in C to represent an enum ([`Algorithm`](https://docs.rs/mongocrypt/latest/mongocrypt/ctx/enum.Algorithm.html) for example) could change in the C API to have semi-structured data the way KMS providers did.  There are also functions in C that accept a binary buffer where the contents expected could change arbitrarily.