### PR TITLE
RUST-2024 Fix serverless CSFLE tests

### DIFF
--- a/.evergreen/cargo-test.sh
+++ b/.evergreen/cargo-test.sh
@@ -29,7 +29,12 @@ cargo_test() {
   TAIL_PID=$!
   LOG_UNCAPTURED=${LOG_PATH} RUST_BACKTRACE=1 cargo nextest run --profile ci $(cargo_test_options $1)
   ((CARGO_RESULT = ${CARGO_RESULT} || $?))
-  mv target/nextest/ci/junit.xml $2
+  if [[ -f "results.xml" ]]; then
+    mv results.xml previous.xml
+    merge-junit -o results.xml previous.xml target/nextest/ci/junit.xml
+  else
+    mv target/nextest/ci/junit.xml results.xml
+  fi
   kill ${TAIL_PID}
   rm ${LOG_PATH}
 }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -270,7 +270,7 @@ buildvariants:
       - test-plain-auth
 
   - name: serverless
-    patchable: false
+    #patchable: false
     display_name: "Serverless"
     run_on:
       - rhel80-small
@@ -1571,16 +1571,23 @@ functions:
       params:
         working_dir: src
         shell: bash
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - PROJECT_DIRECTORY
+          - MONGODB_URI
+          - MONGOCRYPT_LIB_DIR
+          - OPENSSL
+          - OS
+          - LD_LIBRARY_PATH
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - CSFLE_LOCAL_KEY
+          - CRYPT_SHARED_LIB_PATH
+          - DISABLE_CRYPT_SHARED
+          - AZURE_IMDS_MOCK_PORT
+          - SERVERLESS_ATLAS_USER
+          - SERVERLESS_ATLAS_PASSWORD
         script: |
-          ${PREPARE_SHELL}
-
-          # Exported without xtrace to avoid leaking credentials
-          set +o xtrace
-          export SERVERLESS_ATLAS_USER=${SERVERLESS_ATLAS_USER}
-          export SERVERLESS_ATLAS_PASSWORD=${SERVERLESS_ATLAS_PASSWORD}
-          set -o xtrace
-
           export SINGLE_MONGOS_LB_URI=${SERVERLESS_URI}
           . .evergreen/generate-uri.sh
           export SERVERLESS=serverless

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -270,7 +270,7 @@ buildvariants:
       - test-plain-auth
 
   - name: serverless
-    #patchable: false
+    patchable: false
     display_name: "Serverless"
     run_on:
       - rhel80-small

--- a/.evergreen/fetch-drivers-tools.sh
+++ b/.evergreen/fetch-drivers-tools.sh
@@ -8,4 +8,5 @@ if [[ -z "$DRIVERS_TOOLS" ]]; then
 fi
 
 rm -rf $DRIVERS_TOOLS
-git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+#git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
+git clone -b RUST-2024/serverless-csfle https://github.com/abr-egn/drivers-evergreen-tools.git $DRIVERS_TOOLS

--- a/.evergreen/fetch-drivers-tools.sh
+++ b/.evergreen/fetch-drivers-tools.sh
@@ -8,5 +8,4 @@ if [[ -z "$DRIVERS_TOOLS" ]]; then
 fi
 
 rm -rf $DRIVERS_TOOLS
-#git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS
-git clone -b RUST-2024/serverless-csfle https://github.com/abr-egn/drivers-evergreen-tools.git $DRIVERS_TOOLS
+git clone https://github.com/mongodb-labs/drivers-evergreen-tools.git $DRIVERS_TOOLS

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -12,6 +12,6 @@ source "${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh" drivers/a
 
 set +o errexit
 
-cargo_test atlas_connectivity results.xml
+cargo_test atlas_connectivity
 
 exit $CARGO_RESULT

--- a/.evergreen/run-aws-tests.sh
+++ b/.evergreen/run-aws-tests.sh
@@ -18,12 +18,10 @@ FEATURE_FLAGS+=("aws-auth")
 
 set +o errexit
 
-cargo_test auth_aws auth_aws.xml
-cargo_test lambda_examples::auth::test_handler lambda_handler.xml
-cargo_test spec::auth spec.xml
-cargo_test uri_options uri_options.xml
-cargo_test connection_string connection_string.xml
-
-merge-junit -o results.xml auth_aws.xml lambda_handler.xml spec.xml uri_options.xml connection_string.xml
+cargo_test auth_aws
+cargo_test lambda_examples::auth::test_handler
+cargo_test spec::auth
+cargo_test uri_options
+cargo_test connection_string
 
 exit $CARGO_RESULT

--- a/.evergreen/run-connection-string-tests.sh
+++ b/.evergreen/run-connection-string-tests.sh
@@ -11,10 +11,8 @@ FEATURE_FLAGS+=("aws-auth")
 
 set +o errexit
 
-cargo_test spec::auth spec.xml
-cargo_test uri_options uri_options.xml
-cargo_test connection_string connection_string.xml
-
-merge-junit -o results.xml spec.xml uri_options.xml connection_string.xml
+cargo_test spec::auth
+cargo_test uri_options
+cargo_test connection_string
 
 exit ${CARGO_RESULT}

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -26,14 +26,12 @@ fi
 
 set +o errexit
 
-cargo_test test::csfle prose.xml
-cargo_test test::spec::client_side_encryption spec.xml
+cargo_test test::csfle
+cargo_test test::spec::client_side_encryption
 
 # Unset variables for on-demand credential failure tests.
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
-cargo_test test::csfle::on_demand_aws_failure failure.xml
-
-merge-junit -o results.xml prose.xml spec.xml failure.xml
+cargo_test test::csfle::on_demand_aws_failure
 
 exit ${CARGO_RESULT}

--- a/.evergreen/run-plain-tests.sh
+++ b/.evergreen/run-plain-tests.sh
@@ -8,6 +8,6 @@ source .evergreen/cargo-test.sh
 
 set +o errexit
 
-MONGO_PLAIN_AUTH_TEST=1 cargo_test plain results.xml
+MONGO_PLAIN_AUTH_TEST=1 cargo_test plain
 
 exit $CARGO_RESULT

--- a/.evergreen/run-search-index-test.sh
+++ b/.evergreen/run-search-index-test.sh
@@ -13,6 +13,6 @@ export INDEX_MANAGEMENT_TEST_PROSE=1
 
 set +o errexit
 
-cargo_test test::spec::index_management results.xml
+cargo_test test::spec::index_management
 
 exit ${CARGO_RESULT}

--- a/.evergreen/run-serverless-tests.sh
+++ b/.evergreen/run-serverless-tests.sh
@@ -10,17 +10,15 @@ export SERVERLESS="serverless"
 
 set +o errexit
 
-cargo_test test::spec::crud crud.xml
-cargo_test test::spec::retryable_reads retryable_reads.xml
-cargo_test test::spec::retryable_writes retryable_writes.xml
-cargo_test test::spec::versioned_api versioned_api.xml
-cargo_test test::spec::sessions sessions.xml
-cargo_test test::spec::transactions transactions.xml
-cargo_test test::spec::load_balancers load_balancers.xml
-cargo_test test::cursor cursor.xml
-cargo_test test::spec::collection_management coll.xml
-cargo_test test::spec::command_monitoring_unified monitoring.xml
-
-merge-junit -o results.xml crud.xml retryable_reads.xml retryable_writes.xml versioned_api.xml sessions.xml transactions.xml load_balancers.xml cursor.xml coll.xml monitoring.xml
+cargo_test test::spec::crud
+cargo_test test::spec::retryable_reads
+cargo_test test::spec::retryable_writes
+cargo_test test::spec::versioned_api
+cargo_test test::spec::sessions
+cargo_test test::spec::transactions
+cargo_test test::spec::load_balancers
+cargo_test test::cursor
+cargo_test test::spec::collection_management
+cargo_test test::spec::command_monitoring_unified
 
 exit $CARGO_RESULT

--- a/.evergreen/run-sync-tests.sh
+++ b/.evergreen/run-sync-tests.sh
@@ -12,6 +12,6 @@ echo "cargo test options: $(cargo_test_options)"
 
 set +o errexit
 
-cargo_test sync results.xml
+cargo_test sync
 
 exit $CARGO_RESULT

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -31,7 +31,7 @@ echo "cargo test options: $(cargo_test_options)"
 
 set +o errexit
 
-cargo_test "" results.xml
+cargo_test ""
 
 # cargo-nextest doesn't support doc tests
 RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)

--- a/.evergreen/run-x509-tests.sh
+++ b/.evergreen/run-x509-tests.sh
@@ -17,6 +17,6 @@ export SUBJECT=$(echo "$SUBJECT" | awk '{$1=$1;print}')
 
 set +o errexit
 
-MONGO_X509_USER="$SUBJECT" cargo_test x509_auth results.xml
+MONGO_X509_USER="$SUBJECT" cargo_test x509_auth
 
 exit ${CARGO_RESULT}

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.yml
@@ -3,6 +3,7 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
RUST-2024

There were three independent problems happening here:
* The serverless tests and serverless csfle tests were both trying to merge results into `results.xml`, and the second one would fail because the merge tool (appropriately) won't overwrite a file without an additional flag set.  Fixed this by changing the test script to do a rolling merge, which also has the nice effect that our tests don't need to include output file names or an explicit merge step any more.
* Many of the serverless tests were failing because `CRYPT_SHARED_LIB_PATH` wasn't being set; I tracked this down to a bug in the serverless setup scripts in drivers-evergreen-tools.  I've sent https://github.com/mongodb-labs/drivers-evergreen-tools/pull/491 for that and in the meanwhile pointed our testing at my branch with the fix.
* A few of the legacy tests were failing because of CLOUDP-267864; this just needed a test file sync to pick up the serverless skip for those tests.