### PR TITLE
RUST-2040 Fix mongocryptd tests

### DIFF
--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -24,6 +24,9 @@ fi
 
 . ./secrets-export.sh
 
+# Add mongodb binaries to path for mongocryptd
+PATH=${PATH}:${DRIVERS_TOOLS}/mongodb/bin
+
 set +o errexit
 
 cargo_test test::csfle


### PR DESCRIPTION
RUST-2040

[Passing run](https://spruce.mongodb.com/version/66eafe209e3d4a0007b6479d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

Apparently something changed in the drivers-evergreen-tools orchestration scripts that means the mongodb server binaries (which happens to include mongocryptd) are no longer in $PATH by default.