### PR TITLE
RUST-1968 Fix openssl test on windows

### DIFF
--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -24,11 +24,12 @@ if [[ "$OSTYPE" == "cygwin" ]]; then
   export NVM_SYMLINK
   NVM_ARTIFACTS_PATH=$(cygpath -w "$NODE_ARTIFACTS_PATH/bin")
   export NVM_ARTIFACTS_PATH
-  export OPENSSL_DIR="C:\\openssl"
-  OPENSSL_LIB_PATH=$(cygpath $OPENSSL_DIR/lib)
   PATH=$(cygpath $NVM_SYMLINK):$(cygpath $NVM_HOME):$PATH
   export PATH
   echo "updated path on windows PATH=$PATH"
+
+  export OPENSSL_INCLUDE_DIR="C:\\Program Files\\OpenSSL-Win64\\include"
+  export OPENSSL_LIB_DIR="C:\\Program Files\\OpenSSL-Win64\\lib\\VC\\x64\\MD"
 else
   # Turn off tracing for the very-spammy nvm script.
   set +o xtrace


### PR DESCRIPTION
RUST-1968

[Passing run](https://spruce.mongodb.com/version/66f1af11a5704e0007658688/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

The new openssl installation on the Windows evergreen hosts has a _very_ nonstandard setup, both for dynamic and static linking; fortunately, the Rust openssl wrapper is quite flexible in how it can be built.  This sets it up to statically link to avoid having to futz around with `PATH`.