### PR TITLE
RUST-2037 Fix logic for populating bulk write partial result

### DIFF
--- a/src/test/spec/json/crud/README.md
+++ b/src/test/spec/json/crud/README.md
@@ -59,7 +59,7 @@ Using a 5.0+ server, create a collection with
 }
 ```
 
-Enable [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) to observe
+Enable [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) to observe
 CommandSucceededEvents. Then, insert an invalid document (e.g. `{x: 1}`) and assert that a WriteError occurs, that its
 code is `121` (i.e. DocumentValidationFailure), and that its `details` property is accessible. Additionally, assert that
 a CommandSucceededEvent was observed and that the `writeErrors[0].errInfo` field in the response document matches the
@@ -73,7 +73,7 @@ Test that `MongoClient.bulkWrite` properly handles `writeModels` inputs containi
 This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxWriteBatchSize` value contained in the
 response. Then, construct the following write model (referred to as `model`):
 
@@ -101,7 +101,7 @@ Test that `MongoClient.bulkWrite` properly handles a `writeModels` input which c
 This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the following values from the response:
 `maxBsonObjectSize` and `maxMessageSizeBytes`. Then, construct the following document (referred to as `document`):
 
@@ -140,7 +140,7 @@ Test that `MongoClient.bulkWrite` properly collects and reports `writeConcernErr
 This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with `retryWrites: false` configured and
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxWriteBatchSize` value contained in the
 response. Then, configure the following fail point with `client`:
 
@@ -185,7 +185,7 @@ Test that `MongoClient.bulkWrite` handles individual write errors across batches
 This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxWriteBatchSize` value contained in the
 response.
 
@@ -240,7 +240,7 @@ Test that `MongoClient.bulkWrite` properly iterates the results cursor when `get
 This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxBsonObjectSize` value from the
 response.
 
@@ -280,7 +280,7 @@ This test must only be run on 8.0+ servers. This test must be skipped on Atlas S
 against standalone servers.
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxBsonObjectSize` value from the
 response.
 
@@ -322,7 +322,7 @@ Test that `MongoClient.bulkWrite` properly handles a failure that occurs when at
 This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxBsonObjectSize` value from the
 response. Then, configure the following fail point with `client`:
 
@@ -431,7 +431,7 @@ Repeat the following setup for each test case:
 ### Setup
 
 Construct a `MongoClient` (referred to as `client`) with
-[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the following values from the response:
 `maxBsonObjectSize` and `maxMessageSizeBytes`.
 
@@ -677,3 +677,19 @@ InsertOne {
 
 Execute `bulkWrite` on `client` with `model`. Assert that an error (referred to as `error`) is returned. Assert that
 `error` is a client error containing the message: "bulkWrite does not currently support automatic encryption".
+
+### 14. `explain` helpers allow users to specify `maxTimeMS`
+
+Drivers that provide multiple APIs to specify explain should ensure this test is run at least once with each distinct
+API. For example, the Node driver runs this test with option API (`collection.find({}, { explain: ... })`) and the
+fluent API (`collection.find({}).explain(...)`).
+
+Create a MongoClient with command monitoring enabled (referred to as `client`).
+
+Create a collection, referred to as `collection`, with the namespace `explain-test.collection`.
+
+Run an explained find on `collection`. The find will have the query predicate `{ name: 'john doe' }`. Specify a
+maxTimeMS value of 2000ms for the `explain`.
+
+Obtain the command started event for the explain. Confirm that the top-level explain command should has a `maxTimeMS`
+value of `2000`.

--- a/src/test/spec/json/crud/unified/aggregate-write-readPreference.json
+++ b/src/test/spec/json/crud/unified/aggregate-write-readPreference.json
@@ -78,11 +78,6 @@
           "x": 33
         }
       ]
-    },
-    {
-      "collectionName": "coll1",
-      "databaseName": "db0",
-      "documents": []
     }
   ],
   "tests": [
@@ -159,22 +154,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
       ]
     },
     {
@@ -247,22 +226,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
             }
           ]
         }
@@ -344,22 +307,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
-            }
-          ]
-        }
       ]
     },
     {
@@ -435,22 +382,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll1",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 2,
-              "x": 22
-            },
-            {
-              "_id": 3,
-              "x": 33
             }
           ]
         }

--- a/src/test/spec/json/crud/unified/aggregate-write-readPreference.yml
+++ b/src/test/spec/json/crud/unified/aggregate-write-readPreference.yml
@@ -51,9 +51,6 @@ initialData:
       - { _id: 1, x: 11 }
       - { _id: 2, x: 22 }
       - { _id: 3, x: 33 }
-  - collectionName: *collection1Name
-    databaseName: *database0Name
-    documents: []
 
 tests:
   - description: "Aggregate with $out includes read preference for 5.0+ server"
@@ -78,12 +75,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: &outcome
-      - collectionName: *collection1Name
-        databaseName: *database0Name
-        documents:
-          - { _id: 2, x: 22 }
-          - { _id: 3, x: 33 }
 
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -108,7 +99,6 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Aggregate with $merge includes read preference for 5.0+ server"
     runOnRequirements:
@@ -131,7 +121,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Aggregate with $merge omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -152,4 +141,3 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome

--- a/src/test/spec/json/crud/unified/client-bulkWrite-partialResults.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-partialResults.json
@@ -1,0 +1,540 @@
+{
+  "description": "client bulkWrite partial results",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "namespace": "crud-tests.coll0",
+    "newDocument": {
+      "_id": 2,
+      "x": 22
+    }
+  },
+  "tests": [
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when all operations fail during an unordered bulk write",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "1": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/crud/unified/client-bulkWrite-partialResults.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-partialResults.yml
@@ -1,0 +1,262 @@
+description: "client bulkWrite partial results"
+schemaVersion: "1.4" # To support `serverless: forbid`
+runOnRequirements:
+  - minServerVersion: "8.0"
+    serverless: forbid
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - &existingDocument { _id: 1, x: 11 }
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+  newDocument: &newDocument { _id: 2, x: 22 }
+
+tests:
+  - description: "partialResult is unset when first operation fails during an ordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: true
+          verboseResults: true
+        expectError:
+          expectResult:
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
+  - description: "partialResult is unset when first operation fails during an ordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: true
+          verboseResults: false
+        expectError:
+          expectResult:
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
+  - description: "partialResult is set when second operation fails during an ordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: true
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              0:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when second operation fails during an ordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: true
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}
+  - description: "partialResult is unset when all operations fail during an unordered bulk write"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+        expectError:
+          expectResult:
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
+  - description: "partialResult is set when first operation fails during an unordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: false
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              1:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when first operation fails during an unordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: false
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}
+  - description: "partialResult is set when second operation fails during an unordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              0:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when first operation fails during an unordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}

--- a/src/test/spec/json/crud/unified/db-aggregate-write-readPreference.json
+++ b/src/test/spec/json/crud/unified/db-aggregate-write-readPreference.json
@@ -52,13 +52,6 @@
       }
     }
   ],
-  "initialData": [
-    {
-      "collectionName": "coll0",
-      "databaseName": "db0",
-      "documents": []
-    }
-  ],
   "tests": [
     {
       "description": "Database-level aggregate with $out includes read preference for 5.0+ server",
@@ -138,17 +131,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -232,17 +214,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -332,17 +303,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
-            }
-          ]
-        }
       ]
     },
     {
@@ -426,17 +386,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }

--- a/src/test/spec/json/crud/unified/db-aggregate-write-readPreference.yml
+++ b/src/test/spec/json/crud/unified/db-aggregate-write-readPreference.yml
@@ -43,11 +43,6 @@ createEntities:
       database: *database0
       collectionName: &collection0Name coll0
 
-initialData:
-  - collectionName: *collection0Name
-    databaseName: *database0Name
-    documents: []
-
 tests:
   - description: "Database-level aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:
@@ -73,11 +68,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: &outcome
-      - collectionName: *collection0Name
-        databaseName: *database0Name
-        documents:
-          - { _id: 1 }
 
   - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -102,7 +92,6 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Database-level aggregate with $merge includes read preference for 5.0+ server"
     runOnRequirements:
@@ -127,7 +116,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Database-level aggregate with $merge omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -148,4 +136,3 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome

--- a/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.yml
+++ b/src/test/spec/json/crud/unified/insertOne-dots_and_dollars.yml
@@ -198,7 +198,7 @@ tests:
           # Using "$db" here works for libmongoc so long as it's a string type;
           # however, neither $ref nor $id would be accepted on their own.
           #
-          # See https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#parsers
+          # See https://github.com/mongodb/specifications/blob/master/source/extended-json.md#parsers
           document: &dbrefLikeKey { _id: 1, a: { $db: "foo" } }
         expectResult: *insertResult
     expectEvents:


### PR DESCRIPTION
`src/operation/bulk_write.rs` and `src/test/spec/json/crud/unified/client-bulkWrite-partialResults.[json|yml]` are the only relevant changes here; the rest got pulled in via a CRUD spec test sync