### PR TITLE
RUST-2049 Fix search index helpers and AWS Lambda tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -364,7 +364,7 @@ buildvariants:
 
   - name: search-index
     display_name: "Search Index Helpers"
-    #patchable: false
+    patchable: false
     run_on:
       - rhel87-small
     tasks:
@@ -591,19 +591,23 @@ task_groups:
       - func: "make files executable"
       - func: "install rust"
       - func: "install cargo-lambda"
+      - command: ec2.assume_role
+        params:
+          role_arn: ${aws_test_secrets_role}
       - command: subprocess.exec
         params:
           working_dir: src
           binary: bash
           include_expansions_in_env:
-            - DRIVERS_ATLAS_PUBLIC_API_KEY
-            - DRIVERS_ATLAS_PRIVATE_API_KEY
-            - DRIVERS_ATLAS_GROUP_ID
-            - DRIVERS_ATLAS_LAMBDA_USER
-            - DRIVERS_ATLAS_LAMBDA_PASSWORD
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+            - DRIVERS_TOOLS
             - LAMBDA_STACK_NAME
             - MONGODB_VERSION
           args:
+            - .evergreen/with-secrets.sh
+            - drivers/atlas-dev
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
@@ -614,11 +618,10 @@ task_groups:
           working_dir: src
           binary: bash
           include_expansions_in_env:
-            - DRIVERS_ATLAS_PUBLIC_API_KEY
-            - DRIVERS_ATLAS_PRIVATE_API_KEY
-            - DRIVERS_ATLAS_GROUP_ID
             - CLUSTER_NAME
           args:
+            - .evergreen/with-secrets.sh
+            - drivers/atlas-dev
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
     setup_group_can_fail_task: true
     setup_group_timeout_secs: 1800

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -364,7 +364,7 @@ buildvariants:
 
   - name: search-index
     display_name: "Search Index Helpers"
-    patchable: false
+    #patchable: false
     run_on:
       - rhel87-small
     tasks:
@@ -543,21 +543,25 @@ task_groups:
       - func: "make files executable"
       - func: "install rust"
       - func: "install junit dependencies"
+      - command: ec2.assume_role
+        params:
+          role_arn: ${aws_test_secrets_role}
       - command: subprocess.exec
         params:
           working_dir: src
           binary: bash
           include_expansions_in_env:
-            - DRIVERS_ATLAS_PUBLIC_API_KEY
-            - DRIVERS_ATLAS_PRIVATE_API_KEY
-            - DRIVERS_ATLAS_GROUP_ID
-            - DRIVERS_ATLAS_LAMBDA_USER
-            - DRIVERS_ATLAS_LAMBDA_PASSWORD
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
+            - DRIVERS_TOOLS
             - LAMBDA_STACK_NAME
             - MONGODB_VERSION
           env:
             MONGODB_VERSION: "7.0"
           args:
+            - .evergreen/with-secrets.sh
+            - drivers/atlas-dev
             - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
@@ -568,11 +572,10 @@ task_groups:
           working_dir: src
           binary: bash
           include_expansions_in_env:
-            - DRIVERS_ATLAS_PUBLIC_API_KEY
-            - DRIVERS_ATLAS_PRIVATE_API_KEY
-            - DRIVERS_ATLAS_GROUP_ID
             - CLUSTER_NAME
           args:
+            - .evergreen/with-secrets.sh
+            - drivers/atlas-dev
             - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
       - func: "upload test results"
     tasks:

--- a/.evergreen/with-secrets.sh
+++ b/.evergreen/with-secrets.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script takes an AWS Secrets Manager vault name and a command line
+# to execute, e.g.
+#
+# ./with-secrets drivers/atlas-dev setup-atlas-cluster.sh
+#
+# It fetches the secrets from the vault, populates the local environment
+# variables with those secrets, and then executes the command line.
+#
+# Secrets are cached based on the name of the vault, so if an earlier
+# task has fetched the same vault those secrets will be reused.
+
+vault=$1
+shift
+
+if [ -z "${vault}" ] || [ -z "$@" ]; then
+    echo "At least two arguments (vault name and command) are required."
+    exit 1
+fi
+
+vault_cache_key=$(echo "${vault}" | sed -e s/\\\//_/)
+vault_cache_file="secrets-${vault_cache_key}.sh"
+
+if [ -f "${vault_cache_file}" ]; then
+    # Cached, hooray
+    . "${vault_cache_file}"
+else
+    # Need to actually fetch from the vault
+    if [ -z "${DRIVERS_TOOLS}" ]; then
+        echo "\$DRIVERS_TOOLS must be set."
+        exit 1
+    fi
+    . "${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh" "${vault}"
+    mv secrets-export.sh "${vault_cache_file}"
+fi
+
+exec "$@"


### PR DESCRIPTION
RUST-2049

Passing runs for [search index helpers](https://spruce.mongodb.com/version/66fec5fd6481480007581911/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and [AWS Lambda](https://spruce.mongodb.com/version/66fed0f033b96200077e1751/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

Both of these just had stale credentials that weren't using the secrets manager; I updated them and introduced a helper script that makes it easier to run tests using managed credentials.