### PR TITLE
RUST-2050 Fix Azure KMS test binary

### DIFF
--- a/.evergreen/azure-kms-test/src/main.rs
+++ b/.evergreen/azure-kms-test/src/main.rs
@@ -1,6 +1,6 @@
 use mongodb::{
     bson::doc,
-    client_encryption::{ClientEncryption, MasterKey},
+    client_encryption::{AzureMasterKey, ClientEncryption, MasterKey},
     error::Result,
     mongocrypt::ctx::KmsProvider,
     Client,
@@ -14,18 +14,19 @@ async fn main() -> Result<()> {
     let c = ClientEncryption::new(
         Client::with_uri_str("mongodb://localhost:27017").await?,
         Namespace::new("keyvault", "datakeys"),
-        [(KmsProvider::Azure, doc! {}, None)],
+        [(KmsProvider::azure(), doc! {}, None)],
     )?;
 
     let key_name = env::var("KEY_NAME").expect("KEY_NAME environment variable should be set");
     let key_vault_endpoint = env::var("KEY_VAULT_ENDPOINT")
         .expect("KEY_VAULT_ENDPOINT environment variable should be set");
 
-    c.create_data_key(MasterKey::Azure {
-        key_vault_endpoint,
-        key_name,
-        key_version: None,
-    })
+    c.create_data_key(MasterKey::Azure(
+        AzureMasterKey::builder()
+            .key_vault_endpoint(key_vault_endpoint)
+            .key_name(key_name)
+            .build(),
+    ))
     .await?;
 
     println!("Azure KMS integration test passed!");


### PR DESCRIPTION
RUST-2050

[Passing run](https://spruce.mongodb.com/version/6703ed3c99f9f30007997628/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

We just hadn't updated this for the recent API changes here.