### PR TITLE
RUST-2010 Work around evergreen agent bug(?)

### DIFF
--- a/.evergreen/run-driver-benchmark-unresponsive.sh
+++ b/.evergreen/run-driver-benchmark-unresponsive.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+
+source ./.evergreen/env.sh
+
+cd benchmarks
+cargo run \
+  --release \
+  -- --output="../benchmark-results.json" -i 21
+
+cat ../benchmark-results.json

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -563,7 +563,8 @@ fn parse_ids(matches: ArgMatches) -> HashSet<BenchmarkId> {
         ids.insert(BenchmarkId::LdJsonMultiFileImport);
         ids.insert(BenchmarkId::LdJsonMultiFileExport);
         ids.insert(BenchmarkId::GridFsMultiDownload);
-        ids.insert(BenchmarkId::GridFsMultiUpload);
+        // TODO RUST-2010 Re-enable this benchmark
+        //ids.insert(BenchmarkId::GridFsMultiUpload);
     }
     if matches.is_present("bson") {
         ids.insert(BenchmarkId::BsonFlatDocumentDecode);
@@ -589,13 +590,16 @@ fn parse_ids(matches: ArgMatches) -> HashSet<BenchmarkId> {
         ids.insert(BenchmarkId::GridFsDownload);
         ids.insert(BenchmarkId::GridFsUpload);
         ids.insert(BenchmarkId::GridFsMultiDownload);
-        ids.insert(BenchmarkId::GridFsMultiUpload);
+        // TODO RUST-2010 Re-enable this benchmark
+        //ids.insert(BenchmarkId::GridFsMultiUpload);
     }
 
     // if none were enabled, that means no arguments were provided and all should be enabled.
     if ids.is_empty() {
         ids = (1..=MAX_ID)
             .map(|id| BenchmarkId::try_from(id as u8).unwrap())
+            // TODO RUST-2010 Re-enable this benchmark
+            .filter(|id| *id != BenchmarkId::GridFsMultiUpload)
             .collect()
     }
 


### PR DESCRIPTION
RUST-2010

This disables the gridfs multi upload benchmark for now ([passing run](https://spruce.mongodb.com/version/6707e544bb7df200076311b8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)); I'll be filing an evergreen bug to follow up.

I've verified that it's specifically that benchmark - running that one alone is enough to trigger the "system unresponsive" status, and disabling it causes the suite to complete successfully.  Running the suite manually on a host with the same distro as the evergreen run works fine and the host remains responsive throughout, so there's definitely some weird interaction happening with the evergreen agent heartbeat.  Unfortunately, I could find very little documentation on how that works :(