### PR TITLE
RUST-2054 Fix quoting when constructing index names

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -32,11 +32,14 @@ impl IndexModel {
             .and_then(|o| o.name.as_ref())
             .is_none()
         {
-            let key_names: Vec<String> = self
-                .keys
-                .iter()
-                .map(|(k, v)| format!("{}_{}", k, v))
-                .collect();
+            fn format_kv(kv: (&String, &bson::Bson)) -> String {
+                if let bson::Bson::String(s) = kv.1 {
+                    format!("{}_{}", kv.0, s)
+                } else {
+                    format!("{}_{}", kv.0, kv.1)
+                }
+            }
+            let key_names: Vec<String> = self.keys.iter().map(format_kv).collect();
             self.options.get_or_insert(IndexOptions::default()).name = Some(key_names.join("_"));
         }
     }

--- a/src/test/index_management.rs
+++ b/src/test/index_management.rs
@@ -55,6 +55,20 @@ async fn index_management_creates() {
     assert_eq!(names, vec!["_id_", "a_1_b_-1", "c_1", "customname"]);
 }
 
+// Test that creating indexes with string field types produces correct names.
+#[tokio::test]
+async fn index_management_string_names() {
+    let client = Client::for_test().await;
+    let coll = client
+        .init_db_and_coll("index_management", "string_names")
+        .await;
+    let result = coll
+        .create_index(IndexModel::builder().keys(doc! { "field": "2d" }).build())
+        .await
+        .expect("Test failed to create index");
+    assert_eq!(result.index_name, "field_2d");
+}
+
 // Test that creating a duplicate index works as expected.
 #[tokio::test]
 #[function_name::named]


### PR DESCRIPTION
RUST-2054

We didn't catch this before because the other tests checking index names all have integer values.