### PR TITLE
minor: refactor faas tests to validate metadata

### DIFF
--- a/src/cmap/establish.rs
+++ b/src/cmap/establish.rs
@@ -1,4 +1,4 @@
-pub(super) mod handshake;
+pub(crate) mod handshake;
 
 use std::time::Duration;
 

--- a/src/cmap/establish/handshake.rs
+++ b/src/cmap/establish/handshake.rs
@@ -336,7 +336,8 @@ pub(crate) struct Handshaker {
 }
 
 #[cfg(test)]
-pub(crate) static METADATA: std::sync::OnceLock<ClientMetadata> = std::sync::OnceLock::new();
+#[allow(clippy::incompatible_msrv)]
+pub(crate) static TEST_METADATA: std::sync::OnceLock<ClientMetadata> = std::sync::OnceLock::new();
 
 impl Handshaker {
     /// Creates a new Handshaker.
@@ -431,7 +432,8 @@ impl Handshaker {
             meta_doc = (&metadata).into();
         }
         #[cfg(test)]
-        let _ = METADATA.set(metadata);
+        #[allow(clippy::incompatible_msrv)]
+        let _ = TEST_METADATA.set(metadata);
         body.append("client", meta_doc);
 
         Ok((command, client_first))

--- a/src/test/spec/faas.rs
+++ b/src/test/spec/faas.rs
@@ -1,6 +1,14 @@
 use std::env;
 
-use crate::Client;
+use crate::{
+    cmap::establish::handshake::{
+        ClientMetadata,
+        FaasEnvironmentName,
+        RuntimeEnvironment,
+        BASE_CLIENT_METADATA,
+    },
+    Client,
+};
 
 type Result<T> = anyhow::Result<T>;
 
@@ -33,79 +41,151 @@ impl Drop for TempVars {
     }
 }
 
-async fn check_faas_handshake(vars: &[(&'static str, &str)]) -> Result<()> {
+async fn check_faas_handshake(
+    vars: &[(&'static str, &str)],
+    expected: &ClientMetadata,
+) -> Result<()> {
     let _tv = TempVars::set(vars);
 
     let client = Client::for_test().await;
     client.list_database_names().await?;
+    let metadata = crate::cmap::establish::handshake::METADATA.get().unwrap();
+    assert_eq!(expected, metadata);
 
     Ok(())
 }
 
 #[tokio::test]
 async fn valid_aws() -> Result<()> {
-    check_faas_handshake(&[
-        ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
-        ("AWS_REGION", "us-east-2"),
-        ("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "1024"),
-    ])
+    check_faas_handshake(
+        &[
+            ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
+            ("AWS_REGION", "us-east-2"),
+            ("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "1024"),
+        ],
+        &ClientMetadata {
+            env: Some(RuntimeEnvironment {
+                name: Some(FaasEnvironmentName::AwsLambda),
+                runtime: Some("AWS_Lambda_java8".to_string()),
+                memory_mb: Some(1024),
+                region: Some("us-east-2".to_string()),
+                ..RuntimeEnvironment::UNSET
+            }),
+            ..BASE_CLIENT_METADATA.clone()
+        },
+    )
     .await
 }
 
 #[tokio::test]
 async fn valid_azure() -> Result<()> {
-    check_faas_handshake(&[("FUNCTIONS_WORKER_RUNTIME", "node")]).await
+    check_faas_handshake(
+        &[("FUNCTIONS_WORKER_RUNTIME", "node")],
+        &ClientMetadata {
+            env: Some(RuntimeEnvironment {
+                name: Some(FaasEnvironmentName::AzureFunc),
+                runtime: Some("node".to_string()),
+                ..RuntimeEnvironment::UNSET
+            }),
+            ..BASE_CLIENT_METADATA.clone()
+        },
+    )
+    .await
 }
 
 #[tokio::test]
 async fn valid_gcp() -> Result<()> {
-    check_faas_handshake(&[
-        ("K_SERVICE", "servicename"),
-        ("FUNCTION_MEMORY_MB", "1024"),
-        ("FUNCTION_TIMEOUT_SEC", "60"),
-        ("FUNCTION_REGION", "us-central1"),
-    ])
+    check_faas_handshake(
+        &[
+            ("K_SERVICE", "servicename"),
+            ("FUNCTION_MEMORY_MB", "1024"),
+            ("FUNCTION_TIMEOUT_SEC", "60"),
+            ("FUNCTION_REGION", "us-central1"),
+        ],
+        &ClientMetadata {
+            env: Some(RuntimeEnvironment {
+                name: Some(FaasEnvironmentName::GcpFunc),
+                memory_mb: Some(1024),
+                timeout_sec: Some(60),
+                region: Some("us-central1".to_string()),
+                ..RuntimeEnvironment::UNSET
+            }),
+            ..BASE_CLIENT_METADATA.clone()
+        },
+    )
     .await
 }
 
 #[tokio::test]
 async fn valid_vercel() -> Result<()> {
-    check_faas_handshake(&[
-        ("VERCEL", "1"),
-        ("VERCEL_URL", "*.vercel.app"),
-        ("VERCEL_REGION", "cdg1"),
-    ])
+    check_faas_handshake(
+        &[
+            ("VERCEL", "1"),
+            ("VERCEL_URL", "*.vercel.app"),
+            ("VERCEL_REGION", "cdg1"),
+        ],
+        &ClientMetadata {
+            env: Some(RuntimeEnvironment {
+                name: Some(FaasEnvironmentName::Vercel),
+                region: Some("cdg1".to_string()),
+                ..RuntimeEnvironment::UNSET
+            }),
+            ..BASE_CLIENT_METADATA.clone()
+        },
+    )
     .await
 }
 
 #[tokio::test]
 async fn invalid_multiple_providers() -> Result<()> {
-    check_faas_handshake(&[
-        ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
-        ("FUNCTIONS_WORKER_RUNTIME", "node"),
-    ])
+    check_faas_handshake(
+        &[
+            ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
+            ("FUNCTIONS_WORKER_RUNTIME", "node"),
+        ],
+        &BASE_CLIENT_METADATA,
+    )
     .await
 }
 
 #[tokio::test]
 async fn invalid_long_string() -> Result<()> {
-    check_faas_handshake(&[
-        ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
-        ("AWS_REGION", &"a".repeat(512)),
-    ])
+    check_faas_handshake(
+        &[
+            ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
+            ("AWS_REGION", &"a".repeat(512)),
+        ],
+        &ClientMetadata {
+            env: Some(RuntimeEnvironment {
+                name: Some(FaasEnvironmentName::AwsLambda),
+                ..RuntimeEnvironment::UNSET
+            }),
+            ..BASE_CLIENT_METADATA.clone()
+        },
+    )
     .await
 }
 
 #[tokio::test]
 async fn invalid_wrong_type() -> Result<()> {
-    check_faas_handshake(&[
-        ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
-        ("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "big"),
-    ])
+    check_faas_handshake(
+        &[
+            ("AWS_EXECUTION_ENV", "AWS_Lambda_java8"),
+            ("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "big"),
+        ],
+        &ClientMetadata {
+            env: Some(RuntimeEnvironment {
+                name: Some(FaasEnvironmentName::AwsLambda),
+                runtime: Some("AWS_Lambda_java8".to_string()),
+                ..RuntimeEnvironment::UNSET
+            }),
+            ..BASE_CLIENT_METADATA.clone()
+        },
+    )
     .await
 }
 
 #[tokio::test]
 async fn invalid_aws_not_lambda() -> Result<()> {
-    check_faas_handshake(&[("AWS_EXECUTION_ENV", "EC2")]).await
+    check_faas_handshake(&[("AWS_EXECUTION_ENV", "EC2")], &BASE_CLIENT_METADATA).await
 }

--- a/src/test/spec/faas.rs
+++ b/src/test/spec/faas.rs
@@ -49,7 +49,10 @@ async fn check_faas_handshake(
 
     let client = Client::for_test().await;
     client.list_database_names().await?;
-    let metadata = crate::cmap::establish::handshake::METADATA.get().unwrap();
+    #[allow(clippy::incompatible_msrv)]
+    let metadata = crate::cmap::establish::handshake::TEST_METADATA
+        .get()
+        .unwrap();
     assert_eq!(expected, metadata);
 
     Ok(())


### PR DESCRIPTION
This is preliminary to RUST-2000, which will need this kind of observability.  (And we probably should have been doing it from the start anyway.)