### PR TITLE
DRIVERS-2949 Test happy eyeballs behavior

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,7 +6,7 @@ default-filter = 'not test(test::happy_eyeballs)'
 failure-output = "final"
 test-threads = 1
 fail-fast = false
-default-filter = 'all()'
+default-filter = 'not test(test::happy_eyeballs)'
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,10 +1,12 @@
 [profile.default]
 test-threads = 1
+default-filter = 'not test(test::happy_eyeballs)'
 
 [profile.ci]
 failure-output = "final"
 test-threads = 1
 fail-fast = false
+default-filter = 'all()'
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -30,7 +30,6 @@ pre:
 
 # Functions to run after all tasks (except those in task groups).
 post:
-  - func: "stop happy eyeballs server"
   - func: "stop csfle servers"
   - func: "stop load balancer"
   - func: "stop mongo orchestration"
@@ -381,6 +380,20 @@ buildvariants:
     tasks:
       - name: test-aws-lambda-task-group
 
+  - name: happy-eyeballs-macos
+    display_name: "Happy Eyeballs (MacOS)"
+    run_on:
+      - macos-1100
+    tasks:
+      - happy-eyeballs-task-group
+
+  - name: happy-eyeballs-windows
+    display_name: "Happy Eyeballs (Windows)"
+    run_on:
+      - windows-64-vs2017-small
+    tasks:
+      - happy-eyeballs-task-group
+
 ###############
 # Task Groups #
 ###############
@@ -711,6 +724,26 @@ task_groups:
     setup_group_timeout_secs: 1800
     tasks:
       - oidc-auth-test-gcp-latest
+
+  - name: happy-eyeballs-task-group
+    setup_group_can_fail_task: true
+    setup_group_timeout_secs: 1800
+    setup_group:
+      - func: "fetch source"
+      - func: "create expansions"
+      - func: "prepare resources"
+      - func: "windows fix"
+      - func: "fix absolute paths"
+      - func: "init test-results"
+      - func: "make files executable"
+      - func: "install rust"
+      - func: "install junit dependencies"
+      - func: "start happy eyeballs server"
+    tasks:
+      - test-happy-eyeballs
+    teardown_task:
+      - func: "stop happy eyeballs server"
+      - func: "upload test results"
 
 #########
 # Tasks #
@@ -1185,6 +1218,18 @@ tasks:
           export GCPOIDC_TEST_CMD="ls -la && PROJECT_DIRECTORY='.' OIDC_ENV=gcp OIDC=oidc TEST_FILE=./$TEST_FILE ./.evergreen/run-mongodb-oidc-test.sh"
           bash $DRIVERS_TOOLS/.evergreen/auth_oidc/gcp/run-driver-test.sh
 
+  - name: "test-happy-eyeballs"
+    commands:
+    - command: subprocess.exec
+      type: test
+      params:
+        working_dir: src
+        binary: bash
+        args:
+          - .evergreen/run-happy-eyeballs-tests.sh
+        include_expansions_in_env:
+          - PROJECT_DIRECTORY
+
 #############
 # Functions #
 #############
@@ -1464,20 +1509,6 @@ functions:
 
   "run driver test suite":
     - command: subprocess.exec
-      params:
-        working_dir: src
-        background: true
-        binary: ${PYTHON3}
-        args:
-          - .evergreen/happy-eyeballs-server.py
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: ${PYTHON3}
-        args:
-          - .evergreen/happy-eyeballs-server.py
-          - --wait
-    - command: subprocess.exec
       type: test
       params:
         working_dir: src
@@ -1493,15 +1524,6 @@ functions:
           - ZSTD
           - ZLIB
           - SNAPPY
-
-  "stop happy eyeballs server":
-    - command: subprocess.exec
-      params:
-        working_dir: src
-        binary: ${PYTHON3}
-        args:
-          - .evergreen/happy-eyeballs-server.py
-          - --stop
 
   "run sync tests":
     - command: subprocess.exec
@@ -1706,6 +1728,31 @@ functions:
           ${PREPARE_SHELL}
           export OIDC="oidc"
           .evergreen/run-mongodb-oidc-test.sh
+
+  "start happy eyeballs server":
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        background: true
+        binary: ${PYTHON3}
+        args:
+          - .evergreen/happy-eyeballs-server.py
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: ${PYTHON3}
+        args:
+          - .evergreen/happy-eyeballs-server.py
+          - --wait
+
+  "stop happy eyeballs server":
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: ${PYTHON3}
+        args:
+          - .evergreen/happy-eyeballs-server.py
+          - --stop
 
   "compile only":
     - command: shell.exec

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1390,7 +1390,6 @@ functions:
     - command: expansions.update
       params:
         file: src/python3.yml
-
     - command: shell.exec
       params:
         script: |
@@ -1471,6 +1470,13 @@ functions:
         binary: ${PYTHON3}
         args:
           - .evergreen/happy-eyeballs-server.py
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: ${PYTHON3}
+        args:
+          - .evergreen/happy-eyeballs-server.py
+          - --wait
     - command: subprocess.exec
       type: test
       params:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -30,6 +30,7 @@ pre:
 
 # Functions to run after all tasks (except those in task groups).
 post:
+  - func: "stop happy eyeballs server"
   - func: "stop csfle servers"
   - func: "stop load balancer"
   - func: "stop mongo orchestration"
@@ -1378,6 +1379,17 @@ functions:
         binary: bash
         args:
           - .evergreen/fetch-drivers-tools.sh
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+        binary: bash
+        args:
+          - .evergreen/find-python3.sh
+    - command: expansions.update
+      params:
+        file: src/python3.yml
 
     - command: shell.exec
       params:
@@ -1453,6 +1465,13 @@ functions:
 
   "run driver test suite":
     - command: subprocess.exec
+      params:
+        working_dir: src
+        background: true
+        binary: ${PYTHON3}
+        args:
+          - .evergreen/happy-eyeballs-server.py
+    - command: subprocess.exec
       type: test
       params:
         working_dir: src
@@ -1468,6 +1487,15 @@ functions:
           - ZSTD
           - ZLIB
           - SNAPPY
+
+  "stop happy eyeballs server":
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: ${PYTHON3}
+        args:
+          - .evergreen/happy-eyeballs-server.py
+          - --stop
 
   "run sync tests":
     - command: subprocess.exec

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -1,9 +1,6 @@
-#!/bin/bash
-
-source ./.evergreen/env.sh
 source ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
 PYTHON3=$(find_python3)
 
 cat <<EOT >python3.yml
-PYTHON3: "${PYTHON3}
+PYTHON3: "${PYTHON3}"
 EOT

--- a/.evergreen/find-python3.sh
+++ b/.evergreen/find-python3.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source ./.evergreen/env.sh
+source ${DRIVERS_TOOLS}/.evergreen/find-python3.sh
+PYTHON3=$(find_python3)
+
+cat <<EOT >python3.yml
+PYTHON3: "${PYTHON3}
+EOT

--- a/.evergreen/happy-eyeballs-client.py
+++ b/.evergreen/happy-eyeballs-client.py
@@ -7,8 +7,6 @@ parser = argparse.ArgumentParser(
     description='client for testing the happy eyeballs test server',
 )
 parser.add_argument('-c', '--control', default=10036, type=int, metavar='PORT', help='control port')
-parser.add_argument('-v4', '--ipv4', default=10037, type=int, metavar='PORT', help='IPv4 port')
-parser.add_argument('-v6', '--ipv6', default=10038, type=int, metavar='PORT', help='IPv6 port')
 parser.add_argument('-d', '--delay', default=4, type=int)
 args = parser.parse_args()
 
@@ -20,9 +18,11 @@ async def main():
     data = await control_r.read(1)
     if data != b'\x01':
         raise Exception(f'Expected byte 1, got {data}')
+    ipv4_port = int.from_bytes(await control_r.read(2))
+    ipv6_port = int.from_bytes(await control_r.read(2))
     async with asyncio.TaskGroup() as tg:
-        tg.create_task(connect('IPv4', args.ipv4, socket.AF_INET, b'\x04'))
-        tg.create_task(connect('IPv6', args.ipv6, socket.AF_INET6, b'\x06'))
+        tg.create_task(connect('IPv4', ipv4_port, socket.AF_INET, b'\x04'))
+        tg.create_task(connect('IPv6', ipv6_port, socket.AF_INET6, b'\x06'))
 
 async def connect(name: str, port: int, family: socket.AddressFamily, payload: bytes):
     print(f'{name}: connecting')

--- a/.evergreen/happy-eyeballs-client.py
+++ b/.evergreen/happy-eyeballs-client.py
@@ -1,0 +1,49 @@
+import argparse
+import asyncio
+import socket
+
+parser = argparse.ArgumentParser(
+    prog='happy-eyeballs-client',
+    description='client for testing the happy eyeballs test server',
+)
+parser.add_argument('-c', '--control', default=10036, type=int, metavar='PORT', help='control port')
+parser.add_argument('-v4', '--ipv4', default=10037, type=int, metavar='PORT', help='IPv4 port')
+parser.add_argument('-v6', '--ipv6', default=10038, type=int, metavar='PORT', help='IPv6 port')
+parser.add_argument('-d', '--delay', default=4, type=int)
+args = parser.parse_args()
+
+async def main():
+    print('connecting to control')
+    control_r, control_w = await asyncio.open_connection('localhost', args.control)
+    control_w.write(args.delay.to_bytes())
+    await control_w.drain()
+    data = await control_r.read(1)
+    if data != b'\x01':
+        raise Exception(f'Expected byte 1, got {data}')
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(connect_4())
+        tg.create_task(connect_6())
+
+async def connect_4():
+    print('ipv4: connecting')
+    reader, writer = await asyncio.open_connection('localhost', args.ipv4, family=socket.AF_INET)
+    print('ipv4: connected')
+    data = await reader.readexactly(1)
+    if data != b'\x04':
+        raise Exception(f'Expected byte 4, got {data}')
+    writer.close()
+    await writer.wait_closed()
+    print('ipv4: done')
+
+async def connect_6():
+    print('ipv6: connecting')
+    reader, writer = await asyncio.open_connection('localhost', args.ipv6, family=socket.AF_INET6)
+    print('ipv6: connected')
+    data = await reader.readexactly(1)
+    if data != b'\x06':
+        raise Exception(f'Expected byte 6, got {data}')
+    writer.close()
+    await writer.wait_closed()
+    print('ipv6: done')
+
+asyncio.run(main())

--- a/.evergreen/happy-eyeballs-client.py
+++ b/.evergreen/happy-eyeballs-client.py
@@ -20,10 +20,11 @@ async def main():
         raise Exception(f'Expected byte 1, got {data}')
     ipv4_port = int.from_bytes(await control_r.read(2), 'big')
     ipv6_port = int.from_bytes(await control_r.read(2), 'big')
-    await asyncio.wait([
+    connect_tasks = [
         asyncio.create_task(connect('IPv4', ipv4_port, socket.AF_INET, b'\x04')),
         asyncio.create_task(connect('IPv6', ipv6_port, socket.AF_INET6, b'\x06')),
-    ])
+    ]
+    await asyncio.wait(connect_tasks)
 
 async def connect(name: str, port: int, family: socket.AddressFamily, payload: bytes):
     print(f'{name}: connecting')

--- a/.evergreen/happy-eyeballs-server.py
+++ b/.evergreen/happy-eyeballs-server.py
@@ -20,45 +20,56 @@ async def main():
     async with srv:
         await srv.serve_forever()
 
-async def on_control_connected(reader, writer):
-    print(f'{PREFIX}: accepted control connection', file=sys.stderr)
+async def on_control_connected(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
     data = await reader.readexactly(1)
-    if data != b'\x04' and data != b'\x06':
+    if data == b'\x04':
+        print(f'{PREFIX}: ========================', file=sys.stderr)
+        print(f'{PREFIX}: request for delayed IPv4', file=sys.stderr)
+    elif data == b'\x06':
+        print(f'{PREFIX}: ========================', file=sys.stderr)
+        print(f'{PREFIX}: request for delayed IPv6', file=sys.stderr)
+    else:
         raise Exception(f'Expecting 4 or 6 for control byte, got {data}')
+    
+    connected = asyncio.Event()
+    on_ipv4_connected = lambda reader, writer: on_connected('IPv4', writer, b'\x04', connected)
+    on_ipv6_connected = lambda reader, writer: on_connected('IPv6', writer, b'\x06', connected)
     srv4 = await asyncio.start_server(on_ipv4_connected, 'localhost', args.ipv4, family=socket.AF_INET, start_serving=False)
     srv6 = await asyncio.start_server(on_ipv6_connected, 'localhost', args.ipv6, family=socket.AF_INET6, start_serving=False)
+    print(f'{PREFIX}: open for IPv4 on {args.ipv4}', file=sys.stderr)
+    print(f'{PREFIX}: open for IPv6 on {args.ipv6}', file=sys.stderr)
+
     writer.write(b'\x01')
     await writer.drain()
+
     async with asyncio.TaskGroup() as tg:
-        tg.create_task(listen_4(srv4, data == b'\x04'))
-        tg.create_task(listen_6(srv6, data == b'\x06'))
+        tg.create_task(listen('IPv4', srv4, data == b'\x04', connected))
+        tg.create_task(listen('IPv6', srv6, data == b'\x06', connected))
 
-async def listen_4(srv, delay):
+    srv4.close()
+    srv6.close()
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(srv4.wait_closed())
+        tg.create_task(srv6.wait_closed())
+    
+    print(f'{PREFIX}: connection complete, test ports closed', file=sys.stderr)
+    print(f'{PREFIX}: ========================', file=sys.stderr)
+
+async def listen(name: str, srv: asyncio.Server, delay: bool, connected: asyncio.Event):
     if delay:
-        print(f'{PREFIX}: delaying IPv4 binding', file=sys.stderr)
+        print(f'{PREFIX}: delaying {name} connections', file=sys.stderr)
         await asyncio.sleep(1.0)
-    print(f'{PREFIX}: listening for IPv4 connections on {args.ipv4}', file=sys.stderr)
+    print(f'{PREFIX}: accepting {name} connections', file=sys.stderr)
     async with srv:
-        await srv.serve_forever()
+        await srv.start_serving()
+        await connected.wait()
 
-async def listen_6(srv, delay):
-    if delay:
-        print(f'{PREFIX}: delaying IPv6 binding', file=sys.stderr)
-        await asyncio.sleep(1.0)
-    print(f'{PREFIX}: listening for IPv6 connections on {args.ipv6}', file=sys.stderr)
-    async with srv:
-        await srv.serve_forever()
-
-async def on_ipv4_connected(reader, writer):
-    writer.write(b'\x04')
+async def on_connected(name: str, writer: asyncio.StreamWriter, payload: bytes, connected: asyncio.Event):
+    print(f'{PREFIX}: connected on {name}')
+    writer.write(payload)
     await writer.drain()
     writer.close()
     await writer.wait_closed()
-
-async def on_ipv6_connected(reader, writer):
-    writer.write(b'\x06')
-    await writer.drain()
-    writer.close()
-    await writer.wait_closed()
+    connected.set()
 
 asyncio.run(main())

--- a/.evergreen/happy-eyeballs-server.py
+++ b/.evergreen/happy-eyeballs-server.py
@@ -1,0 +1,64 @@
+import argparse
+import asyncio
+import socket
+import sys
+
+parser = argparse.ArgumentParser(
+    prog='happy-eyeballs-server',
+    description='Fake server for testing happy eyeballs',
+)
+parser.add_argument('-c', '--control', default=10036, type=int, metavar='PORT', help='control port')
+parser.add_argument('-v4', '--ipv4', default=10037, type=int, metavar='PORT', help='IPv4 port')
+parser.add_argument('-v6', '--ipv6', default=10038, type=int, metavar='PORT', help='IPv6 port')
+args = parser.parse_args()
+
+PREFIX='happy eyeballs server'
+
+async def main():
+    srv = await asyncio.start_server(on_control_connected, 'localhost', args.control)
+    print(f'{PREFIX}: listening for control connections on {args.control}', file=sys.stderr)
+    async with srv:
+        await srv.serve_forever()
+
+async def on_control_connected(reader, writer):
+    print(f'{PREFIX}: accepted control connection', file=sys.stderr)
+    data = await reader.readexactly(1)
+    if data != b'\x04' and data != b'\x06':
+        raise Exception(f'Expecting 4 or 6 for control byte, got {data}')
+    srv4 = await asyncio.start_server(on_ipv4_connected, 'localhost', args.ipv4, family=socket.AF_INET, start_serving=False)
+    srv6 = await asyncio.start_server(on_ipv6_connected, 'localhost', args.ipv6, family=socket.AF_INET6, start_serving=False)
+    writer.write(b'\x01')
+    await writer.drain()
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(listen_4(srv4, data == b'\x04'))
+        tg.create_task(listen_6(srv6, data == b'\x06'))
+
+async def listen_4(srv, delay):
+    if delay:
+        print(f'{PREFIX}: delaying IPv4 binding', file=sys.stderr)
+        await asyncio.sleep(1.0)
+    print(f'{PREFIX}: listening for IPv4 connections on {args.ipv4}', file=sys.stderr)
+    async with srv:
+        await srv.serve_forever()
+
+async def listen_6(srv, delay):
+    if delay:
+        print(f'{PREFIX}: delaying IPv6 binding', file=sys.stderr)
+        await asyncio.sleep(1.0)
+    print(f'{PREFIX}: listening for IPv6 connections on {args.ipv6}', file=sys.stderr)
+    async with srv:
+        await srv.serve_forever()
+
+async def on_ipv4_connected(reader, writer):
+    writer.write(b'\x04')
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+async def on_ipv6_connected(reader, writer):
+    writer.write(b'\x06')
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
+
+asyncio.run(main())

--- a/.evergreen/happy-eyeballs-server.py
+++ b/.evergreen/happy-eyeballs-server.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import os
 import socket
 import sys
 
@@ -50,19 +49,17 @@ async def on_control_connected(reader: asyncio.StreamReader, writer: asyncio.Str
         print(f'Unexpected control byte: {data}', file=sys.stderr)
         exit(1)
     
-    # Create the test servers but do not yet start accepting connections
+    # Bind the test ports but do not yet start accepting connections
     connected = asyncio.Event()
     on_ipv4_connected = lambda reader, writer: on_test_connected('IPv4', writer, b'\x04', connected, slow)
     on_ipv6_connected = lambda reader, writer: on_test_connected('IPv6', writer, b'\x06', connected, slow)
-    srv4 = await asyncio.start_server(on_ipv4_connected, 'localhost', family=socket.AF_INET, start_serving=False)
-    srv6 = await asyncio.start_server(on_ipv6_connected, 'localhost', family=socket.AF_INET6, start_serving=False)
+    # port 0: pick random unused port
+    srv4 = await asyncio.start_server(on_ipv4_connected, 'localhost', 0, family=socket.AF_INET, start_serving=False)
+    srv6 = await asyncio.start_server(on_ipv6_connected, 'localhost', 0, family=socket.AF_INET6, start_serving=False)
     ipv4_port = srv4.sockets[0].getsockname()[1]
     ipv6_port = srv6.sockets[0].getsockname()[1]
     print(f'{PREFIX}: [slow {slow}] open for IPv4 on {ipv4_port}', file=sys.stderr)
     print(f'{PREFIX}: [slow {slow}] open for IPv6 on {ipv6_port}', file=sys.stderr)
-
-    # Sleep before replying to give the test server ports time to *actually* be open
-    await asyncio.sleep(0.5)
 
     # Reply to control request with success byte and test server ports
     writer.write(b'\x01')
@@ -93,12 +90,17 @@ async def on_control_connected(reader: asyncio.StreamReader, writer: asyncio.Str
     print(f'{PREFIX}: ========================', file=sys.stderr)
 
 async def test_listen(name: str, srv, delay: bool, connected: asyncio.Event, slow: str):
+    # Both connections are delayed; the slow one is delayed by more than the fast one; this
+    # ensures that the client is comparing timing and not simply choosing an immediate success
+    # over a connection denied.
     if delay:
         print(f'{PREFIX}: [slow {slow}] delaying {name} connections', file=sys.stderr)
+        await asyncio.sleep(2.0)
+    else:
         await asyncio.sleep(1.0)
-    print(f'{PREFIX}: [slow {slow}] accepting {name} connections', file=sys.stderr)
     async with srv:
         await srv.start_serving()
+        print(f'{PREFIX}: [slow {slow}] accepting {name} connections', file=sys.stderr)
         # Terminate this test server when either test server has handled a request
         await connected.wait()
 

--- a/.evergreen/run-happy-eyeballs-tests.sh
+++ b/.evergreen/run-happy-eyeballs-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+source .evergreen/env.sh
+source .evergreen/cargo-test.sh
+
+CARGO_OPTIONS+=("--ignore-default-filter")
+
+set +o errexit
+
+cargo_test "test::happy_eyeballs"
+exit $CARGO_RESULT

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,6 +21,7 @@ pub(crate) mod csfle;
 mod cursor;
 mod db;
 mod documentation_examples;
+mod happy_eyeballs;
 mod index_management;
 mod lambda_examples;
 pub(crate) mod spec;

--- a/src/test/happy_eyeballs.rs
+++ b/src/test/happy_eyeballs.rs
@@ -1,0 +1,25 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use crate::runtime::stream::tcp_connect;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+type Result<T> = anyhow::Result<T>;
+
+static CONTROL: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 10036);
+static IPV4: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 10037);
+static IPV6: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 10038);
+
+#[tokio::test]
+async fn slow_ipv4() -> Result<()> {
+    let mut control = tcp_connect(vec![CONTROL.clone()]).await?;
+    control.write_u8(4).await?;
+    let resp = control.read_u8().await?;
+    assert_eq!(resp, 1);
+
+    let mut conn = tcp_connect(vec![IPV4.clone(), IPV6.clone()]).await?;
+    assert!(conn.peer_addr()?.is_ipv6());
+    let data = conn.read_u8().await?;
+    assert_eq!(data, 6);
+
+    Ok(())
+}

--- a/src/test/happy_eyeballs.rs
+++ b/src/test/happy_eyeballs.rs
@@ -10,7 +10,7 @@ const SLOW_V4: u8 = 4;
 const SLOW_V6: u8 = 6;
 
 async fn happy_request(payload: u8) -> Result<(SocketAddr, SocketAddr)> {
-    let mut control = tcp_connect(vec![CONTROL.clone()]).await?;
+    let mut control = tcp_connect(vec![CONTROL]).await?;
     control.write_u8(payload).await?;
     let resp = control.read_u8().await?;
     assert_eq!(resp, 1);

--- a/src/test/happy_eyeballs.rs
+++ b/src/test/happy_eyeballs.rs
@@ -6,20 +6,40 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 type Result<T> = anyhow::Result<T>;
 
 static CONTROL: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 10036);
-static IPV4: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 10037);
-static IPV6: SocketAddr = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 10038);
+const SLOW_V4: u8 = 4;
+const SLOW_V6: u8 = 6;
+
+async fn happy_request(payload: u8) -> Result<(SocketAddr, SocketAddr)> {
+    let mut control = tcp_connect(vec![CONTROL.clone()]).await?;
+    control.write_u8(payload).await?;
+    let resp = control.read_u8().await?;
+    assert_eq!(resp, 1);
+    let v4_port = control.read_u16().await?;
+    let v6_port = control.read_u16().await?;
+    Ok((
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), v4_port),
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), v6_port),
+    ))
+}
 
 #[tokio::test]
 async fn slow_ipv4() -> Result<()> {
-    let mut control = tcp_connect(vec![CONTROL.clone()]).await?;
-    control.write_u8(4).await?;
-    let resp = control.read_u8().await?;
-    assert_eq!(resp, 1);
-
-    let mut conn = tcp_connect(vec![IPV4.clone(), IPV6.clone()]).await?;
+    let (v4_addr, v6_addr) = happy_request(SLOW_V4).await?;
+    let mut conn = tcp_connect(vec![v4_addr, v6_addr]).await?;
     assert!(conn.peer_addr()?.is_ipv6());
     let data = conn.read_u8().await?;
     assert_eq!(data, 6);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn slow_ipv6() -> Result<()> {
+    let (v4_addr, v6_addr) = happy_request(SLOW_V6).await?;
+    let mut conn = tcp_connect(vec![v4_addr, v6_addr]).await?;
+    assert!(conn.peer_addr()?.is_ipv4());
+    let data = conn.read_u8().await?;
+    assert_eq!(data, 4);
 
     Ok(())
 }

--- a/src/test/happy_eyeballs.rs
+++ b/src/test/happy_eyeballs.rs
@@ -3,43 +3,37 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use crate::runtime::stream::tcp_connect;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-type Result<T> = anyhow::Result<T>;
-
 static CONTROL: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 10036);
 const SLOW_V4: u8 = 4;
 const SLOW_V6: u8 = 6;
 
-async fn happy_request(payload: u8) -> Result<(SocketAddr, SocketAddr)> {
-    let mut control = tcp_connect(vec![CONTROL]).await?;
-    control.write_u8(payload).await?;
-    let resp = control.read_u8().await?;
+async fn happy_request(payload: u8) -> (SocketAddr, SocketAddr) {
+    let mut control = tcp_connect(vec![CONTROL]).await.unwrap();
+    control.write_u8(payload).await.unwrap();
+    let resp = control.read_u8().await.unwrap();
     assert_eq!(resp, 1);
-    let v4_port = control.read_u16().await?;
-    let v6_port = control.read_u16().await?;
-    Ok((
+    let v4_port = control.read_u16().await.unwrap();
+    let v6_port = control.read_u16().await.unwrap();
+    (
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), v4_port),
         SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), v6_port),
-    ))
+    )
 }
 
 #[tokio::test]
-async fn slow_ipv4() -> Result<()> {
-    let (v4_addr, v6_addr) = happy_request(SLOW_V4).await?;
-    let mut conn = tcp_connect(vec![v4_addr, v6_addr]).await?;
-    assert!(conn.peer_addr()?.is_ipv6());
-    let data = conn.read_u8().await?;
+async fn slow_ipv4() {
+    let (v4_addr, v6_addr) = happy_request(SLOW_V4).await;
+    let mut conn = tcp_connect(vec![v4_addr, v6_addr]).await.unwrap();
+    assert!(conn.peer_addr().unwrap().is_ipv6());
+    let data = conn.read_u8().await.unwrap();
     assert_eq!(data, 6);
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn slow_ipv6() -> Result<()> {
-    let (v4_addr, v6_addr) = happy_request(SLOW_V6).await?;
-    let mut conn = tcp_connect(vec![v4_addr, v6_addr]).await?;
-    assert!(conn.peer_addr()?.is_ipv4());
-    let data = conn.read_u8().await?;
+async fn slow_ipv6() {
+    let (v4_addr, v6_addr) = happy_request(SLOW_V6).await;
+    let mut conn = tcp_connect(vec![v4_addr, v6_addr]).await.unwrap();
+    assert!(conn.peer_addr().unwrap().is_ipv4());
+    let data = conn.read_u8().await.unwrap();
     assert_eq!(data, 4);
-
-    Ok(())
 }


### PR DESCRIPTION
DRIVERS-2949

With happy eyeballs on its way to being a driver spec, it needs a way for the behavior to be tested.  This PR implements a (relatively) simple python server that provides pairs of IPv4 and IPv6 ports on demand, with one of the pair being slow to start accepting incoming connections, and the corresponding Rust driver test using that server.

Originally I was hoping to have a static set of ports exposed by the test server (slow v4, fast v4, slow v6, fast v6), but it turns out that once you start accepting connections there's no way to delay the TCP handshake.  Instead, each test gets its own ephemeral pair of ports and the delay happens between binding to the port and accepting connections.

This also demonstrates the use of cargo nextest's `default-filter` to prevent these tests from running during normal interactive usage.