### PR TITLE
RUST-2042 and RUST-2076 sync tests to fix serverless task

### DIFF
--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.json
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.json
@@ -6,8 +6,7 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ],
-      "serverless": "forbid"
+      ]
     }
   ],
   "database_name": "default",

--- a/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.yml
+++ b/src/test/spec/json/client-side-encryption/legacy/fle2v2-Rangev2-Compact.yml
@@ -3,7 +3,6 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
-    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []

--- a/src/test/spec/json/crud/unified/client-bulkWrite-replaceOne-sort.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-replaceOne-sort.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-replaceOne-sort.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-replaceOne-sort.yml
@@ -4,7 +4,7 @@ schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "8.0"
-    serverless: forbid # Serverless does not support bulkWrite. See 
+    serverless: forbid # Serverless does not support bulkWrite: CLOUDP-256344.
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-replaceOne-sort.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-replaceOne-sort.yml
@@ -4,6 +4,7 @@ schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid # Serverless does not support bulkWrite. See 
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-updateOne-sort.json
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-updateOne-sort.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/src/test/spec/json/crud/unified/client-bulkWrite-updateOne-sort.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-updateOne-sort.yml
@@ -4,7 +4,7 @@ schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "8.0"
-    serverless: forbid # Serverless does not support bulkWrite. See 
+    serverless: forbid # Serverless does not support bulkWrite: CLOUDP-256344.
 
 createEntities:
   - client:

--- a/src/test/spec/json/crud/unified/client-bulkWrite-updateOne-sort.yml
+++ b/src/test/spec/json/crud/unified/client-bulkWrite-updateOne-sort.yml
@@ -4,6 +4,7 @@ schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid # Serverless does not support bulkWrite. See 
 
 createEntities:
   - client:

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-retry.json
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-retry.json
@@ -422,6 +422,11 @@
     },
     {
       "description": "commit is not retried after MaxTimeMSExpired error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-retry.yml
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-retry.yml
@@ -212,6 +212,9 @@ tests:
           - { _id: 1 }
   -
     description: commit is not retried after MaxTimeMSExpired error
+    runOnRequirements:
+      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.json
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.json
@@ -414,6 +414,11 @@
     },
     {
       "description": "commitTransaction is not retried after UnknownReplWriteConcern error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -546,6 +551,11 @@
     },
     {
       "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -678,6 +688,11 @@
     },
     {
       "description": "commitTransaction is not retried after MaxTimeMSExpired error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.yml
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.yml
@@ -151,6 +151,9 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnknownReplWriteConcern error
+    runOnRequirements:
+      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -203,6 +206,9 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnsatisfiableWriteConcern error
+    runOnRequirements:
+      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -226,6 +232,9 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after MaxTimeMSExpired error
+    runOnRequirements:
+      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/src/test/spec/json/transactions/unified/retryable-commit.json
+++ b/src/test/spec/json/transactions/unified/retryable-commit.json
@@ -89,6 +89,11 @@
   "tests": [
     {
       "description": "commitTransaction fails after Interrupted",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "object": "testRunner",

--- a/src/test/spec/json/transactions/unified/retryable-commit.yml
+++ b/src/test/spec/json/transactions/unified/retryable-commit.yml
@@ -67,6 +67,9 @@ initialData:
 tests:
   -
     description: 'commitTransaction fails after Interrupted'
+    runOnRequirements:
+      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
+      - serverless: forbid
     operations:
       -
         object: testRunner


### PR DESCRIPTION
Sync spec tests. Resolves RUST-2042 and RUST-2076.

Fixes the `test-serverless` task: [patch build](https://spruce.mongodb.com/version/672297118bfe2800075e0309).
