### PR TITLE
remove "not supported" note for `MongoDbOidc`

### DIFF
--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -94,8 +94,7 @@ pub enum AuthMechanism {
     #[cfg(feature = "aws-auth")]
     MongoDbAws,
 
-    /// MONGODB-OIDC authenticates using [OpenID Connect](https://openid.net/developers/specs/) access tokens.  NOTE: this is not supported by the Rust driver.
-    // TODO RUST-1497: remove the NOTE.
+    /// MONGODB-OIDC authenticates using [OpenID Connect](https://openid.net/developers/specs/) access tokens.
     MongoDbOidc,
 }
 


### PR DESCRIPTION
Though there is pending work for OIDC (see RUST-1497), I expect this note is outdated.

The [3.0.0 release notes](https://github.com/mongodb/mongo-rust-driver/releases/tag/v3.0.0) document support for OIDC.

Change was motivated by [this slack thread](https://mongodb.slack.com/archives/CP893U9MX/p1730981781044979).