### PR TITLE
DRIVERS-2949 Disable flaky Windows happy eyeballs test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -387,16 +387,6 @@ buildvariants:
     tasks:
       - happy-eyeballs-task-group
 
-#  Windows has a very short grace window before it starts refusing TCP handshakes, leading to flaky
-#  tests.
-#
-#  - name: happy-eyeballs-windows
-#    display_name: "Happy Eyeballs (Windows)"
-#    run_on:
-#      - windows-64-vs2017-small
-#    tasks:
-#      - happy-eyeballs-task-group
-
 ###############
 # Task Groups #
 ###############

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -387,12 +387,15 @@ buildvariants:
     tasks:
       - happy-eyeballs-task-group
 
-  - name: happy-eyeballs-windows
-    display_name: "Happy Eyeballs (Windows)"
-    run_on:
-      - windows-64-vs2017-small
-    tasks:
-      - happy-eyeballs-task-group
+#  Windows has a very short grace window before it starts refusing TCP handshakes, leading to flaky
+#  tests.
+#
+#  - name: happy-eyeballs-windows
+#    display_name: "Happy Eyeballs (Windows)"
+#    run_on:
+#      - windows-64-vs2017-small
+#    tasks:
+#      - happy-eyeballs-task-group
 
 ###############
 # Task Groups #


### PR DESCRIPTION
DRIVERS-2949

This is well into the murky realm of unspecified and undocumented OS-specific behavior here.

As far as I can tell from experimentation, MacOS will let a port sit in the `bound`-but-not-`listen`ing limbo state that the test relies on and let TCP handshakes queue up to the normal TCP handshake timeout (~30s), Windows will only maintain a port in that state for a very short window (~1s) before treating it the same as Linux does (deny by default until `listen` is called).

That short window meant that the test on Windows would pass with ~70% success rate, which can be dialed up or down based on how much of a delay the test server used, but never enough to avoid normal delays from external variation making the test flaky.  Because of that, I've disabled the test on Windows.

If this ever gets revisited as a cross-driver project, I think testing will need a serious look - I happened to stumble into something that worked because I'm developing on a Macbook, but it's clearly relying on deeply magical behavior that ought not be relied on.