### PR TITLE
RUST-2103 Preliminary improvement for action rustdocs: `find`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ tracing = { version = "0.1.36", optional = true }
 typed-builder = "0.10.0"
 webpki-roots = "0.25.2"
 zstd = { version = "0.11.2", optional = true }
+macro_magic = "0.5.1"
 
 [dependencies.pbkdf2]
 version = "0.11.0"

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ allow = [
     "MIT",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    "CC0-1.0",
     "ISC",
     "OpenSSL",
     "BSD-2-Clause",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+macro_magic = { version = "0.5.1", features = ["proc_support"] }
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
 syn = { version = "2.0.52", features = ["full", "parsing", "proc-macro", "extra-traits"] }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -590,7 +590,7 @@ pub fn options_doc(
         #[doc = "These methods can be chained before calling `.await` to set options:"]
     });
     for name in setter_names {
-        let docstr = format!("  * [{0}]({1}::{0})", name, doc_path);
+        let docstr = format!("  * [`{0}`]({1}::{0})", name, doc_path);
         impl_fn.attrs.push(parse_quote! {
             #[doc = #docstr]
         });

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use bson::{Bson, Document};
 use macro_magic::export_tokens;
-use mongodb_internal_macros::options_doc;
+use mongodb_internal_macros::{option_setters_2, options_doc};
 use serde::de::DeserializeOwned;
 
 use crate::{
@@ -84,6 +84,7 @@ pub struct Find<'a, T: Send + Sync, Session = ImplicitSession> {
     session: Session,
 }
 
+#[option_setters_2]
 #[export_tokens(find_setters)]
 impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     option_setters!(options: FindOptions;

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -87,31 +87,6 @@ pub struct Find<'a, T: Send + Sync, Session = ImplicitSession> {
 #[option_setters_2(crate::coll::options::FindOptions)]
 #[export_tokens(find_setters)]
 impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
-    option_setters!(options: FindOptions;
-        allow_disk_use: bool,
-        allow_partial_results: bool,
-        batch_size: u32,
-        comment: Bson,
-        cursor_type: CursorType,
-        hint: Hint,
-        limit: i64,
-        max: Document,
-        max_await_time: Duration,
-        max_scan: u64,
-        max_time: Duration,
-        min: Document,
-        no_cursor_timeout: bool,
-        projection: Document,
-        read_concern: ReadConcern,
-        return_key: bool,
-        selection_criteria: SelectionCriteria,
-        show_record_id: bool,
-        skip: u64,
-        sort: Document,
-        collation: Collation,
-        let_vars: Document,
-    );
-
     /// Use the provided session when running the operation.
     pub fn session<'s>(
         self,

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
 use bson::{Bson, Document};
+use macro_magic::export_tokens;
+use mongodb_internal_macros::options_doc;
 use serde::de::DeserializeOwned;
 
 use crate::{
@@ -24,6 +26,7 @@ impl<T: Send + Sync> Collection<T> {
     /// `await` will return d[`Result<Cursor<T>>`] (or d[`Result<SessionCursor<T>>`] if a session is
     /// provided).
     #[deeplink]
+    #[options_doc(find_setters)]
     pub fn find(&self, filter: Document) -> Find<'_, T> {
         Find {
             coll: self,
@@ -81,6 +84,7 @@ pub struct Find<'a, T: Send + Sync, Session = ImplicitSession> {
     session: Session,
 }
 
+#[export_tokens(find_setters)]
 impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     option_setters!(options: FindOptions;
         allow_disk_use: bool,

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -84,7 +84,7 @@ pub struct Find<'a, T: Send + Sync, Session = ImplicitSession> {
     session: Session,
 }
 
-#[option_setters_2]
+#[option_setters_2(crate::coll::options::FindOptions)]
 #[export_tokens(find_setters)]
 impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     option_setters!(options: FindOptions;

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use macro_magic::export_tokens;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
@@ -760,6 +761,7 @@ pub struct DistinctOptions {
 #[builder(field_defaults(default, setter(into)))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
+#[export_tokens]
 pub struct FindOptions {
     /// Enables writing to temporary files by the server. When set to true, the find operation can
     /// write data to the _tmp subdirectory in the dbPath directory. Only supported in server


### PR DESCRIPTION
RUST-2103

There's enough machinery here that I thought it would be better to do it across multiple PRs - this one has the core added functionality and a single action converted to use it.  I'll follow up with PRs implementing conversions for the rest of the actions and the (hopefully minor) functionality updates those will likely need.

This is what the rustdocs for `find` look like with these changes ([old](https://docs.rs/mongodb/latest/mongodb/struct.Collection.html#method.find) for comparison):

<img width="991" alt="Screenshot 2024-11-22 at 11 28 20 AM" src="https://github.com/user-attachments/assets/94713b03-2905-4f0d-a0a2-3c7e19106016">

And the new rustdocs for the setters ([old](https://docs.rs/mongodb/latest/mongodb/action/struct.Find.html#method.max_await_time)):

<img width="1001" alt="Screenshot 2024-11-20 at 2 27 27 PM" src="https://github.com/user-attachments/assets/ff1405a2-8194-4eb0-ad55-6ff5b5acbe48">