### PR TITLE
RUST-2099 sync spec tests

### DIFF
--- a/src/test/spec/json/transactions-convenient-api/unified/commit-retry.json
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-retry.json
@@ -422,11 +422,6 @@
     },
     {
       "description": "commit is not retried after MaxTimeMSExpired error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-retry.yml
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-retry.yml
@@ -212,9 +212,6 @@ tests:
           - { _id: 1 }
   -
     description: commit is not retried after MaxTimeMSExpired error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.json
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.json
@@ -414,11 +414,6 @@
     },
     {
       "description": "commitTransaction is not retried after UnknownReplWriteConcern error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",
@@ -551,11 +546,6 @@
     },
     {
       "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",
@@ -688,11 +678,6 @@
     },
     {
       "description": "commitTransaction is not retried after MaxTimeMSExpired error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.yml
+++ b/src/test/spec/json/transactions-convenient-api/unified/commit-writeconcernerror.yml
@@ -151,9 +151,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnknownReplWriteConcern error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -206,9 +203,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnsatisfiableWriteConcern error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -232,9 +226,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after MaxTimeMSExpired error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/src/test/spec/json/transactions/unified/retryable-commit.json
+++ b/src/test/spec/json/transactions/unified/retryable-commit.json
@@ -89,11 +89,6 @@
   "tests": [
     {
       "description": "commitTransaction fails after Interrupted",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "object": "testRunner",

--- a/src/test/spec/json/transactions/unified/retryable-commit.yml
+++ b/src/test/spec/json/transactions/unified/retryable-commit.yml
@@ -67,9 +67,6 @@ initialData:
 tests:
   -
     description: 'commitTransaction fails after Interrupted'
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       -
         object: testRunner


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/mongo-rust-driver/pull/1236. Sync spec tests from https://github.com/mongodb/specifications/commit/da04aff83cf4fb01d0fe9b811a513cd030137c19.

Verified with [this patch](https://spruce.mongodb.com/version/673e45c6b58c46000702bc03) of the `test-serverless` task. The patch is based on an older commit: 3bf5e977949f570c0af192a2b81a091603148d8f. `test-serverless` is failing on `main` from seemingly unrelated tests. Those failures are not addressed in this PR.

