### PR TITLE
RUST-2048 Update specification links

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Rust Driver Benchmark Suite
 
-This suite implements the benchmarks described in this (spec)[https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.rst].
+This suite implements the benchmarks described in this (spec)[https://github.com/mongodb/specifications/blob/master/source/benchmarking/benchmarking.md].
 
 In order to run the microbenchmarks, first run `./download-data.sh`. (NOTE: the data for the deeply nested BSON encoding and decoding is
 currently broken, so these benchmarks will not be runnable until that's fixed).

--- a/src/change_stream.rs
+++ b/src/change_stream.rs
@@ -35,7 +35,7 @@ use crate::{
 ///
 /// `ChangeStream`s are "resumable", meaning that they can be restarted at a given place in the
 /// stream of events. This is done automatically when the `ChangeStream` encounters certain
-/// ["resumable"](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error)
+/// ["resumable"](https://specifications.readthedocs.io/en/latest/change-streams/change-streams/#resumable-error)
 /// errors, such as transient network failures. It can also be done manually by passing
 /// a [`ResumeToken`] retrieved from a past event into either the
 /// [`resume_after`](crate::action::Watch::resume_after) or

--- a/src/client/csfle/options.rs
+++ b/src/client/csfle/options.rs
@@ -17,7 +17,7 @@ use crate::{
 /// collection. Automatic encryption is not supported for operations on a database or view, and
 /// operations that are not bypassed will result in error (see [libmongocrypt: Auto Encryption
 /// Allow-List](
-/// https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-allow-list
+/// https://specifications.readthedocs.io/en/latest/client-side-encryption/client-side-encryption/#libmongocrypt-auto-encryption-allow-list
 /// )). To bypass automatic encryption for all operations, set bypassAutoEncryption=true in
 /// AutoEncryptionOpts.
 #[derive(Debug, Clone, Deserialize)]

--- a/src/event/sdam.rs
+++ b/src/event/sdam.rs
@@ -17,7 +17,7 @@ pub use crate::sdam::public::TopologyType;
 pub use topology_description::TopologyDescription;
 
 /// A description of the most up-to-date information known about a server. Further details can be
-/// found in the [Server Discovery and Monitoring specification](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst).
+/// found in the [Server Discovery and Monitoring specification](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring/).
 pub type ServerDescription = crate::sdam::public::ServerInfo<'static>;
 
 /// Published when a server description changes.

--- a/src/event/sdam/topology_description.rs
+++ b/src/event/sdam/topology_description.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// A description of the most up-to-date information known about a topology. Further details can
-/// be found in the [Server Discovery and Monitoring specification](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst).
+/// be found in the [Server Discovery and Monitoring specification](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring/).
 #[derive(Clone, derive_more::Display)]
 #[display(fmt = "{}", description)]
 pub struct TopologyDescription {

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -142,7 +142,7 @@ pub(crate) struct ServerDescription {
 }
 
 // Server description equality has a specific notion of what fields in a hello command response
-// should be compared (https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#serverdescription).
+// should be compared (https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring/#server-description-equality).
 fn hello_command_eq(a: &HelloCommandResponse, b: &HelloCommandResponse) -> bool {
     a.server_type() == b.server_type()
         && a.min_wire_version == b.min_wire_version

--- a/src/sdam/public.rs
+++ b/src/sdam/public.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// A description of the most up-to-date information known about a server. Further details can be
-/// found in the [Server Discovery and Monitoring specification](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst).
+/// found in the [Server Discovery and Monitoring specification](https://specifications.readthedocs.io/en/latest/server-discovery-and-monitoring/server-discovery-and-monitoring/).
 #[derive(Clone)]
 pub struct ServerInfo<'a> {
     pub(crate) description: Cow<'a, ServerDescription>,

--- a/src/sdam/srv_polling/test.rs
+++ b/src/sdam/srv_polling/test.rs
@@ -121,7 +121,7 @@ async fn no_results() {
 }
 
 // SRV polling is not done for load-balanced clusters (as per spec at
-// https://github.com/mongodb/specifications/blob/master/source/polling-srv-records-for-mongos-discovery/tests/README.rst#test-that-srv-polling-is-not-done-for-load-balalanced-clusters).
+// https://github.com/mongodb/specifications/tree/master/source/polling-srv-records-for-mongos-discovery/tests#9-test-that-srv-polling-is-not-done-for-load-balalanced-clusters).
 #[tokio::test]
 async fn load_balanced_no_srv_polling() {
     if get_client_options().await.load_balanced != Some(true) {

--- a/src/sync/change_stream.rs
+++ b/src/sync/change_stream.rs
@@ -18,7 +18,7 @@ use super::ClientSession;
 ///
 /// `ChangeStream`s are "resumable", meaning that they can be restarted at a given place in the
 /// stream of events. This is done automatically when the `ChangeStream` encounters certain
-/// ["resumable"](https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resumable-error)
+/// ["resumable"](https://specifications.readthedocs.io/en/latest/change-streams/change-streams/#resumable-error)
 /// errors, such as transient network failures. It can also be done manually by passing
 /// a [`ResumeToken`] retrieved from a past event into either the
 /// [`resume_after`](crate::action::Watch::resume_after) or


### PR DESCRIPTION
Updates spec links to point to readthedocs or markdown files. I didn't bother with links in `src/test/spec/json` as I assume we'll pull in updated links there as we sync the tests.