### PR TITLE
RUST-2103 Better documentation for action options, batch 2

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate proc_macro;
 
 use macro_magic::{import_tokens_attr, mm_core::ForeignPath};
-use proc_macro2::extra;
 use quote::{quote, ToTokens};
 use syn::{
     braced,
@@ -559,9 +558,7 @@ pub fn option_setters_2(
     let mut doc_impl = impl_in.clone();
     // Synthesize a fn entry for each extra listed so it'll get a rustdoc entry
     if let Some((_, extra)) = args.extra {
-        dbg!("extra");
         for name in &extra.names {
-            dbg!(name);
             doc_impl.items.push(parse_quote! {
                 pub fn #name(&self) {}
             });

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -705,8 +705,8 @@ pub fn options_doc(
         #[doc = ""]
     });
     let preamble = format!(
-        "These methods can be chained before calling `.{}` to set options:",
-        if args.is_async() { "await" } else { "run()" }
+        "These methods can be chained before `{}` to set options:",
+        if args.is_async() { ".await" } else { "run" }
     );
     impl_fn.attrs.push(parse_quote! {
         #[doc = #preamble]

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -55,6 +55,7 @@ where
     /// returned cursor will be a [`SessionCursor`]. If [`with_type`](Aggregate::with_type) was
     /// called, the returned cursor will be generic over the `T` specified.
     #[deeplink]
+    #[options_doc(aggregate_setters)]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         Aggregate {
             target: AggregateTargetRef::Collection(CollRef::new(self)),
@@ -78,6 +79,7 @@ impl crate::sync::Database {
     /// [`crate::sync::SessionCursor`]. If [`with_type`](Aggregate::with_type) was called, the
     /// returned cursor will be generic over the `T` specified.
     #[deeplink]
+    #[options_doc(aggregate_setters, sync)]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         self.async_database.aggregate(pipeline)
     }
@@ -98,6 +100,7 @@ where
     /// `crate::sync::SessionCursor`. If [`with_type`](Aggregate::with_type) was called, the
     /// returned cursor will be generic over the `T` specified.
     #[deeplink]
+    #[options_doc(aggregate_setters, sync)]
     pub fn aggregate(&self, pipeline: impl IntoIterator<Item = Document>) -> Aggregate {
         self.async_collection.aggregate(pipeline)
     }
@@ -117,26 +120,8 @@ pub struct Aggregate<'a, Session = ImplicitSession, T = Document> {
 #[option_setters_2(
     source = crate::coll::options::AggregateOptions,
     doc_name = aggregate_setters,
-    extra = [session, with_type]
+    extra = [session]
 )]
-impl<Session, T> Aggregate<'_, Session, T> {}
-
-impl<'a, T> Aggregate<'a, ImplicitSession, T> {
-    /// Use the provided session when running the operation.
-    pub fn session(
-        self,
-        value: impl Into<&'a mut ClientSession>,
-    ) -> Aggregate<'a, ExplicitSession<'a>> {
-        Aggregate {
-            target: self.target,
-            pipeline: self.pipeline,
-            options: self.options,
-            session: ExplicitSession(value.into()),
-            _phantom: PhantomData,
-        }
-    }
-}
-
 impl<'a, Session, T> Aggregate<'a, Session, T> {
     /// Use the provided type for the returned cursor.
     ///
@@ -166,6 +151,22 @@ impl<'a, Session, T> Aggregate<'a, Session, T> {
             pipeline: self.pipeline,
             options: self.options,
             session: self.session,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Aggregate<'a, ImplicitSession, T> {
+    /// Use the provided session when running the operation.
+    pub fn session(
+        self,
+        value: impl Into<&'a mut ClientSession>,
+    ) -> Aggregate<'a, ExplicitSession<'a>> {
+        Aggregate {
+            target: self.target,
+            pipeline: self.pipeline,
+            options: self.options,
+            session: ExplicitSession(value.into()),
             _phantom: PhantomData,
         }
     }

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -114,7 +114,11 @@ pub struct Aggregate<'a, Session = ImplicitSession, T = Document> {
     _phantom: PhantomData<T>,
 }
 
-#[option_setters_2(source = crate::coll::options::AggregateOptions, doc_name = aggregate_setters)]
+#[option_setters_2(
+    source = crate::coll::options::AggregateOptions,
+    doc_name = aggregate_setters,
+    extra = [session, with_type]
+)]
 impl<Session, T> Aggregate<'_, Session, T> {}
 
 impl<'a, T> Aggregate<'a, ImplicitSession, T> {

--- a/src/action/aggregate.rs
+++ b/src/action/aggregate.rs
@@ -1,7 +1,6 @@
 use std::{marker::PhantomData, time::Duration};
 
 use bson::{Bson, Document};
-use macro_magic::export_tokens;
 use mongodb_internal_macros::{option_setters_2, options_doc};
 
 use crate::{
@@ -115,8 +114,7 @@ pub struct Aggregate<'a, Session = ImplicitSession, T = Document> {
     _phantom: PhantomData<T>,
 }
 
-#[option_setters_2(crate::coll::options::AggregateOptions)]
-#[export_tokens(aggregate_setters)]
+#[option_setters_2(source = crate::coll::options::AggregateOptions, doc_name = aggregate_setters)]
 impl<Session, T> Aggregate<'_, Session, T> {}
 
 impl<'a, T> Aggregate<'a, ImplicitSession, T> {

--- a/src/action/bulk_write.rs
+++ b/src/action/bulk_write.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, marker::PhantomData};
 
+use mongodb_internal_macros::{option_setters_2, options_doc};
+
 use crate::{
     bson::{Bson, Document},
     error::{BulkWriteError, Error, ErrorKind, Result},
@@ -10,7 +12,7 @@ use crate::{
     ClientSession,
 };
 
-use super::{action_impl, deeplink, option_setters};
+use super::{action_impl, deeplink};
 
 impl Client {
     /// Executes the provided list of write operations.
@@ -26,6 +28,7 @@ impl Client {
     ///
     /// Bulk write is only available on MongoDB 8.0+.
     #[deeplink]
+    #[options_doc(bulk_write_setters)]
     pub fn bulk_write(
         &self,
         models: impl IntoIterator<Item = impl Into<WriteModel>>,
@@ -53,6 +56,7 @@ impl crate::sync::Client {
     ///
     /// Bulk write is only available on MongoDB 8.0+.
     #[deeplink]
+    #[options_doc(bulk_write_setters, sync)]
     pub fn bulk_write(
         &self,
         models: impl IntoIterator<Item = impl Into<WriteModel>>,
@@ -85,18 +89,15 @@ impl<'a> BulkWrite<'a, SummaryBulkWriteResult> {
     }
 }
 
+#[option_setters_2(
+    source = crate::client::options::BulkWriteOptions,
+    doc_name = bulk_write_setters,
+    extra = [verbose_results]
+)]
 impl<'a, R> BulkWrite<'a, R>
 where
     R: BulkWriteResult,
 {
-    option_setters!(options: BulkWriteOptions;
-        ordered: bool,
-        bypass_document_validation: bool,
-        comment: Bson,
-        let_vars: Document,
-        write_concern: WriteConcern,
-    );
-
     /// Use the provided session when running the operation.
     pub fn session(mut self, session: impl Into<&'a mut ClientSession>) -> Self {
         self.session = Some(session.into());

--- a/src/action/client_options.rs
+++ b/src/action/client_options.rs
@@ -1,3 +1,6 @@
+use macro_magic::export_tokens;
+use mongodb_internal_macros::options_doc;
+
 use crate::{
     client::options::{ClientOptions, ConnectionString, ResolverConfig},
     error::{Error, Result},
@@ -62,6 +65,7 @@ impl ClientOptions {
     ///     [`Compressor`](crate::compression::compressors::Compressor) enum
     ///
     /// `await` will return `Result<ClientOptions>`.
+    #[options_doc(parse_conn_str_setters)]
     pub fn parse<C, E>(conn_str: C) -> ParseConnectionString
     where
         C: TryInto<ConnectionString, Error = E>,
@@ -92,6 +96,7 @@ pub struct ParseConnectionString {
     pub(crate) resolver_config: Option<ResolverConfig>,
 }
 
+#[export_tokens(parse_conn_str_setters)]
 impl ParseConnectionString {
     /// In the case that "mongodb+srv" is used, SRV and TXT record lookups will be done using the
     /// provided `ResolverConfig` as part of this method.

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -70,8 +70,9 @@ impl<T: Send + Sync> crate::sync::Collection<T> {
 impl<T: DeserializeOwned + Send + Sync> crate::sync::Collection<T> {
     /// Finds a single document in the collection matching `filter`.
     ///
-    /// [`run`](Find::run) will return d[`Result<Option<T>>`].
+    /// [`run`](FindOne::run) will return d[`Result<Option<T>>`].
     #[deeplink]
+    #[options_doc(find_one_setters, sync)]
     pub fn find_one(&self, filter: Document) -> FindOne<'_, T> {
         self.async_collection.find_one(filter)
     }

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -18,7 +18,7 @@ use crate::{
     SessionCursor,
 };
 
-use super::{action_impl, deeplink, option_setters, ExplicitSession, ImplicitSession};
+use super::{action_impl, deeplink, ExplicitSession, ImplicitSession};
 
 impl<T: Send + Sync> Collection<T> {
     /// Finds the documents in the collection matching `filter`.
@@ -42,6 +42,7 @@ impl<T: DeserializeOwned + Send + Sync> Collection<T> {
     ///
     /// `await` will return d[`Result<Option<T>>`].
     #[deeplink]
+    #[options_doc(find_one_setters)]
     pub fn find_one(&self, filter: Document) -> FindOne<'_, T> {
         FindOne {
             coll: self,
@@ -59,6 +60,7 @@ impl<T: Send + Sync> crate::sync::Collection<T> {
     /// [`run`](Find::run) will return d[`Result<crate::sync::Cursor<T>>`] (or
     /// d[`Result<crate::sync::SessionCursor<T>>`] if a session is provided).
     #[deeplink]
+    #[options_doc(find_setters, sync)]
     pub fn find(&self, filter: Document) -> Find<'_, T> {
         self.async_collection.find(filter)
     }
@@ -143,26 +145,9 @@ pub struct FindOne<'a, T: Send + Sync> {
     session: Option<&'a mut ClientSession>,
 }
 
+#[option_setters_2(crate::coll::options::FindOneOptions)]
+#[export_tokens(find_one_setters)]
 impl<'a, T: Send + Sync> FindOne<'a, T> {
-    option_setters! { options: FindOneOptions;
-        allow_partial_results: bool,
-        collation: Collation,
-        comment: Bson,
-        hint: Hint,
-        max: Document,
-        max_scan: u64,
-        max_time: Duration,
-        min: Document,
-        projection: Document,
-        read_concern: ReadConcern,
-        return_key: bool,
-        selection_criteria: SelectionCriteria,
-        show_record_id: bool,
-        skip: u64,
-        sort: Document,
-        let_vars: Document,
-    }
-
     /// Use the provided session when running the operation.
     pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {
         self.session = Some(value.into());

--- a/src/action/find.rs
+++ b/src/action/find.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use bson::{Bson, Document};
-use macro_magic::export_tokens;
 use mongodb_internal_macros::{option_setters_2, options_doc};
 use serde::de::DeserializeOwned;
 
@@ -87,8 +86,7 @@ pub struct Find<'a, T: Send + Sync, Session = ImplicitSession> {
     session: Session,
 }
 
-#[option_setters_2(crate::coll::options::FindOptions)]
-#[export_tokens(find_setters)]
+#[option_setters_2(source = crate::coll::options::FindOptions, doc_name = find_setters)]
 impl<'a, T: Send + Sync, Session> Find<'a, T, Session> {
     /// Use the provided session when running the operation.
     pub fn session<'s>(
@@ -146,8 +144,7 @@ pub struct FindOne<'a, T: Send + Sync> {
     session: Option<&'a mut ClientSession>,
 }
 
-#[option_setters_2(crate::coll::options::FindOneOptions)]
-#[export_tokens(find_one_setters)]
+#[option_setters_2(source = crate::coll::options::FindOneOptions, doc_name = find_one_setters)]
 impl<'a, T: Send + Sync> FindOne<'a, T> {
     /// Use the provided session when running the operation.
     pub fn session(mut self, value: impl Into<&'a mut ClientSession>) -> Self {

--- a/src/client/options/bulk_write.rs
+++ b/src/client/options/bulk_write.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 
+use macro_magic::export_tokens;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
@@ -19,6 +20,7 @@ use crate::{
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
+#[export_tokens]
 pub struct BulkWriteOptions {
     /// Whether the operations should be performed in the order in which they were specified. If
     /// true, no more writes will be performed if a single write fails. If false, writes will

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -626,6 +626,7 @@ pub struct AggregateOptions {
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
+#[export_tokens]
 pub struct CountOptions {
     /// The index to use for the operation.
     pub hint: Option<Hint>,
@@ -680,6 +681,7 @@ pub struct CountOptions {
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
+#[export_tokens]
 pub struct EstimatedDocumentCountOptions {
     /// The maximum amount of time to allow the query to run.
     ///

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -932,6 +932,7 @@ where
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
+#[export_tokens]
 pub struct FindOneOptions {
     /// If true, partial results will be returned from a mongos rather than an error being
     /// returned if one or more shards is down.

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -529,6 +529,7 @@ pub struct FindOneAndUpdateOptions {
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
+#[export_tokens]
 pub struct AggregateOptions {
     /// Enables writing to temporary files. When set to true, aggregation stages can write data to
     /// the _tmp subdirectory in the dbPath directory.

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use bson::doc;
+use macro_magic::export_tokens;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
@@ -36,6 +37,7 @@ pub struct DatabaseOptions {
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
+#[export_tokens]
 pub struct CreateCollectionOptions {
     /// Whether the collection should be capped. If true, `size` must also be set.
     pub capped: Option<bool>,


### PR DESCRIPTION
RUST-2103

This updates more actions to use the doc generation macros for option setters.  Some of these (notably `aggregate`) have setters split across multiple `impl` blocks with different type constraints that we want to show as a merged list in the documentation, so this required some changes to the machinery.

In particular, `option_setters_2` now accepts the name to export tokens for doc use under, and an optional list of extra setter names to include in those exported tokens.  This could be done at least two other ways:
* the extra names could be passed in to the `options_doc` macro; I didn't go with that because that would mean repeating them for each use of the macro, which is always at least twice (async/sync) and sometimes more if an action type is shared.
* the impls could be pairwise-merged via another macro ('option_setters_merge_export'?) for doc consumption; that seems like it'd get messy fast.

Since this required introducing custom argument parsing for `option_setters_2`, I made it use named `key = value` arguments for readability.

Unrelated to any of the above, I also introduced an optional `sync` arg to `options_doc` which just changes its wording slightly to be appropriate.