### PR TITLE
Disallow setting `query_type` for `encrypt_expression`

### DIFF
--- a/src/action/csfle/encrypt.rs
+++ b/src/action/csfle/encrypt.rs
@@ -40,13 +40,15 @@ impl ClientEncryption {
     /// Encrypts a Match Expression or Aggregate Expression to query a range index.
     /// `expression` is expected to be a BSON document of one of the following forms:
     /// 1. A Match Expression of this form:
-    ///   {$and: [{<field>: {$gt: <value1>}}, {<field>: {$lt: <value2> }}]}
+    ///   `{$and: [{<field>: {$gt: <value1>}}, {<field>: {$lt: <value2> }}]}`
     /// 2. An Aggregate Expression of this form:
-    ///   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
-    /// $gt may also be $gte. $lt may also be $lte.
+    ///   `{$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]`
+    ///
+    /// For either expression, `$gt` may also be `$gte`, and `$lt` may also be `$lte`.
     ///
     /// The expression will be encrypted using the [`Algorithm::Range`] algorithm and the
-    /// "range" query type.
+    /// "range" query type. It is not valid to set a query type in [`EncryptOptions`] when calling
+    /// this method.
     ///
     /// `await` will return a d[`Result<Document>`] containing the encrypted expression.
     #[deeplink]
@@ -61,10 +63,7 @@ impl ClientEncryption {
             mode: Expression { value: expression },
             key: key.into(),
             algorithm: Algorithm::Range,
-            options: Some(EncryptOptions {
-                query_type: Some("range".into()),
-                ..Default::default()
-            }),
+            options: None,
         }
     }
 }
@@ -110,14 +109,17 @@ pub struct Expression {
 }
 
 /// Options for encrypting a value.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, TypedBuilder)]
+#[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
 #[export_tokens]
 pub struct EncryptOptions {
     /// The contention factor.
     pub contention_factor: Option<i64>,
+
     /// The query type.
     pub query_type: Option<String>,
+
     /// Set the range options. This should only be set when the algorithm is
     /// [`Algorithm::Range`].
     pub range_options: Option<RangeOptions>,

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -33,25 +33,17 @@ impl<'a> Action for Encrypt<'a, Expression> {
     type Future = EncryptExpressionFuture;
 
     async fn execute(mut self) -> Result<Document> {
-        match self.options.as_mut() {
-            Some(options) => match options.query_type {
-                Some(ref query_type) => {
-                    if query_type != "range" {
-                        return Err(Error::invalid_argument(format!(
-                            "query_type cannot be set for encrypt_expression, got {}",
-                            query_type
-                        )));
-                    }
+        let options = self.options.get_or_insert_with(Default::default);
+        match options.query_type {
+            Some(ref query_type) => {
+                if query_type != "range" {
+                    return Err(Error::invalid_argument(format!(
+                        "query_type cannot be set for encrypt_expression, got {}",
+                        query_type
+                    )));
                 }
-                None => options.query_type = Some("range".to_string()),
-            },
-            None => {
-                self.options = Some(
-                    EncryptOptions::builder()
-                        .query_type("range".to_string())
-                        .build(),
-                );
             }
+            None => options.query_type = Some("range".to_string()),
         }
 
         let ctx = self

--- a/src/client/csfle/client_encryption/encrypt.rs
+++ b/src/client/csfle/client_encryption/encrypt.rs
@@ -32,7 +32,28 @@ impl<'a> Action for Encrypt<'a, Value> {
 impl<'a> Action for Encrypt<'a, Expression> {
     type Future = EncryptExpressionFuture;
 
-    async fn execute(self) -> Result<Document> {
+    async fn execute(mut self) -> Result<Document> {
+        match self.options.as_mut() {
+            Some(options) => match options.query_type {
+                Some(ref query_type) => {
+                    if query_type != "range" {
+                        return Err(Error::invalid_argument(format!(
+                            "query_type cannot be set for encrypt_expression, got {}",
+                            query_type
+                        )));
+                    }
+                }
+                None => options.query_type = Some("range".to_string()),
+            },
+            None => {
+                self.options = Some(
+                    EncryptOptions::builder()
+                        .query_type("range".to_string())
+                        .build(),
+                );
+            }
+        }
+
         let ctx = self
             .client_enc
             .get_ctx_builder(self.key, self.algorithm, self.options.unwrap_or_default())?

--- a/src/options.rs
+++ b/src/options.rs
@@ -15,6 +15,8 @@
 //!                   .build();
 //! ```
 
+#[cfg(feature = "in-use-encryption")]
+pub use crate::action::csfle::{DataKeyOptions, EncryptOptions};
 #[cfg(any(
     feature = "zstd-compression",
     feature = "zlib-compression",


### PR DESCRIPTION
Addresses the bug described in [this comment](https://github.com/mongodb/mongo-rust-driver/pull/1272#discussion_r1900275603)