### PR TITLE
RUST-2125 Run tests using LB URI when present

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1510,6 +1510,8 @@ functions:
         include_expansions_in_env:
           - PROJECT_DIRECTORY
           - OPENSSL
+          - SINGLE_MONGOS_LB_URI
+          - MULTI_MONGOS_LB_URI
           - MONGODB_URI
           - MONGODB_API_VERSION
           - PATH


### PR DESCRIPTION
RUST-2125

Turns out we were, in fact, not running the driver test suite in loadbalanced mode.  [This run](https://spruce.mongodb.com/version/677eab6d0a5b3c00075cbda7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) shows a test properly failing with a pinning error with this fix in place and the earlier bugfix to the pinning logic reverted.