### PR TITLE
Make `EncryptedClientBuilder` publicly accessible

### DIFF
--- a/src/client/csfle/client_encryption.rs
+++ b/src/client/csfle/client_encryption.rs
@@ -22,6 +22,7 @@ use crate::{
 
 use super::{options::KmsProviders, state_machine::CryptExecutor};
 
+pub use super::client_builder::EncryptedClientBuilder;
 pub use crate::action::csfle::encrypt::{EncryptKey, RangeOptions};
 
 /// A handle to the key vault.  Used to create data encryption keys, and to explicitly encrypt and


### PR DESCRIPTION
`EncryptedClientBuilder` isn't currently part of the public API, which means its docs aren't loaded on our documentation page (see lack of link on the return type [here](https://docs.rs/mongodb/latest/mongodb/struct.Client.html#method.encrypted_builder)). This exports it in the `client_encryption` module to make the docs visible.