### PR TITLE
Skip KMS retry test on serverless

### DIFF
--- a/src/cmap/conn.rs
+++ b/src/cmap/conn.rs
@@ -327,8 +327,8 @@ impl PinnedConnectionHandle {
         }
     }
 
-    /// Retrieve the pinned connection.  Will fail if the connection has been unpinned or is still in
-    /// use.
+    /// Retrieve the pinned connection.  Will fail if the connection has been unpinned or is still
+    /// in use.
     pub(crate) async fn take_connection(&self) -> Result<PooledConnection> {
         use tokio::sync::mpsc::error::TryRecvError;
         let mut receiver = self.receiver.lock().await;

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -3498,6 +3498,11 @@ async fn range_explicit_encryption_defaults() -> Result<()> {
 // using openssl causes errors after configuring a network failpoint
 #[cfg(not(feature = "openssl-tls"))]
 async fn kms_retry() {
+    if *super::SERVERLESS {
+        log_uncaptured("skipping kms_retry on serverless");
+        return;
+    }
+
     use reqwest::{Certificate, Client as HttpClient};
 
     let endpoint = "127.0.0.1:9003";


### PR DESCRIPTION
The certs used in `kms_retry` are not valid for connecting with serverless