### PR TITLE
make from_raw publicly accessible

### DIFF
--- a/src/change_stream/event.rs
+++ b/src/change_stream/event.rs
@@ -38,7 +38,8 @@ impl ResumeToken {
         }
     }
 
-    pub(crate) fn from_raw(doc: Option<RawDocumentBuf>) -> Option<ResumeToken> {
+    /// A utility method to create a `ResumeToken` from a raw BSON document.
+    pub fn from_raw(doc: Option<RawDocumentBuf>) -> Option<ResumeToken> {
         doc.map(|doc| ResumeToken(RawBson::Document(doc)))
     }
 


### PR DESCRIPTION
This allows the client to persist and re-construct a ResumeToken, which is particularly useful when the change stream consumption is interrupted and the client is able to restart from a persisted ResumeToken without losing any changes.