### PR TITLE
minor: remove call to deprecated function

### DIFF
--- a/src/runtime/tls_openssl.rs
+++ b/src/runtime/tls_openssl.rs
@@ -113,7 +113,7 @@ fn make_openssl_connector(cfg: TlsOptions) -> Result<SslConnector> {
 
 fn init_trust() {
     static ONCE: Once = Once::new();
-    ONCE.call_once(openssl_probe::init_ssl_cert_env_vars);
+    ONCE.call_once(|| unsafe { openssl_probe::init_openssl_env_vars() });
 }
 
 fn make_ssl_stream(


### PR DESCRIPTION
`openssl::init_ssl_cert_env_vars` was deprecated in the most recent `openssl-probe` release.