### PR TITLE
Fix compilation when `dns-resolver` is disabled

### DIFF
--- a/src/runtime/tls_openssl.rs
+++ b/src/runtime/tls_openssl.rs
@@ -113,7 +113,7 @@ fn make_openssl_connector(cfg: TlsOptions) -> Result<SslConnector> {
 
 fn init_trust() {
     static ONCE: Once = Once::new();
-    ONCE.call_once(openssl_probe::init_ssl_cert_env_vars);
+    ONCE.call_once(|| unsafe { openssl_probe::init_openssl_env_vars() });
 }
 
 fn make_ssl_stream(

--- a/src/runtime/tls_openssl.rs
+++ b/src/runtime/tls_openssl.rs
@@ -113,7 +113,7 @@ fn make_openssl_connector(cfg: TlsOptions) -> Result<SslConnector> {
 
 fn init_trust() {
     static ONCE: Once = Once::new();
-    ONCE.call_once(|| unsafe { openssl_probe::init_openssl_env_vars() });
+    ONCE.call_once(openssl_probe::init_ssl_cert_env_vars);
 }
 
 fn make_ssl_stream(

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -20,6 +20,7 @@ pub(crate) struct LookupHosts {
 }
 
 impl LookupHosts {
+    #[cfg(feature = "dns-resolver")]
     pub(crate) fn validate(mut self, original_hostname: &str, dm: DomainMismatch) -> Result<Self> {
         let original_hostname_parts: Vec<_> = original_hostname.split('.').collect();
         let original_domain_name = if original_hostname_parts.len() >= 3 {
@@ -261,7 +262,10 @@ pub(crate) struct SrvResolver {}
 
 #[cfg(not(feature = "dns-resolver"))]
 impl SrvResolver {
-    pub(crate) async fn new(_config: Option<ResolverConfig>) -> Result<Self> {
+    pub(crate) async fn new(
+        _config: Option<ResolverConfig>,
+        _srv_service_name: Option<String>,
+    ) -> Result<Self> {
         Ok(Self {})
     }
 


### PR DESCRIPTION
Fixes #1291. I've tested this locally, but I also filed RUST-2143 to test all feature flag combinations in CI so that we can catch these kinds of errors.