### PR TITLE
HELP-70689 Use openssl cert parsing when openssl-tls is enabled

### DIFF
--- a/src/runtime/tls_openssl.rs
+++ b/src/runtime/tls_openssl.rs
@@ -98,9 +98,15 @@ fn make_openssl_connector(cfg: TlsOptions) -> Result<SslConnector> {
             #[cfg(feature = "cert-key-password")]
             if let Some(key_pw) = tls_certificate_key_file_password {
                 let contents = std::fs::read(&path)?;
+
+                /*
                 let key_bytes = super::pem::decrypt_private_key(&contents, &key_pw)?;
                 let key =
                     openssl::pkey::PKey::private_key_from_der(&key_bytes).map_err(openssl_err)?;
+                    */
+
+                let key = openssl::pkey::PKey::private_key_from_pem_passphrase(&contents, &key_pw)
+                    .map_err(openssl_err)?;
                 builder.set_private_key(&key).map_err(openssl_err)?;
                 return Ok(());
             }


### PR DESCRIPTION
HELP-70689

I left the old lines present but commented out just as a reference.  Once this is merged, I'll cherrypick it to the `ipv6-backport` branch.