### PR TITLE
minor: skip sessions not supported tests on 8.1+

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -238,7 +238,7 @@ buildvariants:
 
   - name: gcp-kms
     display_name: "GCP KMS"
-    # patchable: false
+    patchable: false
     run_on:
       # The GCP CLI is not available on RHEL/Ubuntu machines.
       - debian11-small

--- a/src/test/spec/sessions/sessions_not_supported.rs
+++ b/src/test/spec/sessions/sessions_not_supported.rs
@@ -12,9 +12,11 @@ use crate::{
 
 async fn spawn_mongocryptd(name: &str) -> Option<(EventClient, Process)> {
     let util_client = Client::for_test().await;
-    if util_client.server_version_lt(4, 2) {
+    // TODO RUST-1447: unskip on 8.1+
+    if util_client.server_version_lt(4, 2) || util_client.server_version_gte(8, 1) {
         log_uncaptured(format!(
-            "Skipping {name}: cannot spawn mongocryptd due to server version < 4.2"
+            "Skipping {name}: cannot spawn mongocryptd due to server version < 4.2 or server \
+             version >= 8.1"
         ));
         return None;
     }


### PR DESCRIPTION
Running `buildInfo` on `mongocryptd` 8.1+ causes errors (perhaps related to [SERVER-87874](https://jira.mongodb.org/browse/SERVER-87874)?) for the sessions-not-supported tests. I skipped the tests on 8.1+ for now, but we should do RUST-1447 so that we don't need to call `buildInfo` and other metadata-retrieving commands for each test client we create.