### PR TITLE
RUST-1447 Cache test client metadata

### DIFF
--- a/src/client/session/test/causal_consistency.rs
+++ b/src/client/session/test/causal_consistency.rs
@@ -489,8 +489,8 @@ async fn cluster_time_sent_in_commands() {
 
     let client = Client::for_test().monitor_events().await;
     let coll = client
-        .database("causal_consistency_12")
-        .collection::<Document>("causal_consistency_12");
+        .create_fresh_collection("causal_consistency_12", "causal_consistency_12", None)
+        .await;
 
     coll.find_one(doc! {}).await.unwrap();
 

--- a/src/sync/test.rs
+++ b/src/sync/test.rs
@@ -20,6 +20,7 @@ use crate::{
         WriteConcern,
     },
     sync::{Client, ClientSession, Collection},
+    test::transactions_supported,
     Client as AsyncClient,
 };
 
@@ -233,10 +234,7 @@ fn typed_collection() {
 #[test]
 #[function_name::named]
 fn transactions() {
-    let should_skip = crate::sync::TOKIO_RUNTIME.block_on(async {
-        let test_client = AsyncClient::for_test().await;
-        !test_client.supports_transactions()
-    });
+    let should_skip = crate::sync::TOKIO_RUNTIME.block_on(async { transactions_supported().await });
     if should_skip {
         return;
     }

--- a/src/test/client.rs
+++ b/src/test/client.rs
@@ -630,7 +630,7 @@ async fn retry_commit_txn_check_out() {
         );
         return;
     }
-    if !streaming_monitor_protocol_supported().await {
+    if streaming_monitor_protocol_supported().await {
         log_uncaptured("skipping retry_commit_txn_check_out due to streaming protocol support");
         return;
     }

--- a/src/test/csfle.rs
+++ b/src/test/csfle.rs
@@ -33,7 +33,7 @@ use crate::{
     Namespace,
 };
 
-use super::{log_uncaptured, EventClient};
+use super::{log_uncaptured, server_version_lt, topology_is_standalone, EventClient};
 
 type Result<T> = anyhow::Result<T>;
 pub(crate) type KmsInfo = (KmsProvider, Document, Option<TlsOptions>);
@@ -300,12 +300,11 @@ macro_rules! failure {
 use failure;
 
 async fn fle2v2_ok(name: &str) -> bool {
-    let setup_client = Client::for_test().await;
-    if setup_client.server_version_lt(7, 0) {
+    if server_version_lt(7, 0).await {
         log_uncaptured(format!("Skipping {}: not supported on server < 7.0", name));
         return false;
     }
-    if setup_client.is_standalone() {
+    if topology_is_standalone().await {
         log_uncaptured(format!("Skipping {}: not supported on standalone", name));
         return false;
     }

--- a/src/test/spec/connection_stepdown.rs
+++ b/src/test/spec/connection_stepdown.rs
@@ -7,7 +7,14 @@ use crate::{
     error::{CommandError, ErrorKind},
     options::{Acknowledgment, WriteConcern},
     selection_criteria::SelectionCriteria,
-    test::{get_client_options, log_uncaptured, EventClient},
+    test::{
+        get_client_options,
+        log_uncaptured,
+        server_version_eq,
+        server_version_lt,
+        topology_is_replica_set,
+        EventClient,
+    },
     Collection,
     Database,
 };
@@ -16,6 +23,14 @@ async fn run_test<F: Future>(
     name: &str,
     test: impl Fn(EventClient, Database, Collection<Document>) -> F,
 ) {
+    if !topology_is_replica_set().await {
+        log_uncaptured(format!(
+            "skipping test {:?} due to not running on a replica set",
+            name
+        ));
+        return;
+    }
+
     let mut options = get_client_options().await.clone();
     options.retry_writes = Some(false);
     let client = crate::Client::for_test()
@@ -23,14 +38,6 @@ async fn run_test<F: Future>(
         .use_single_mongos()
         .monitor_events()
         .await;
-
-    if !client.is_replica_set() {
-        log_uncaptured(format!(
-            "skipping test {:?} due to not running on a replica set",
-            name
-        ));
-        return;
-    }
 
     let name = format!("step-down-{}", name);
 
@@ -53,7 +60,7 @@ async fn run_test<F: Future>(
 async fn get_more() {
     async fn get_more_test(client: EventClient, _db: Database, coll: Collection<Document>) {
         // This test requires server version 4.2 or higher.
-        if client.server_version_lt(4, 2) {
+        if server_version_lt(4, 2).await {
             log_uncaptured("skipping get_more due to server version < 4.2");
             return;
         }
@@ -106,7 +113,7 @@ async fn notwritableprimary_keep_pool() {
         coll: Collection<Document>,
     ) {
         // This test requires server version 4.2 or higher.
-        if client.server_version_lt(4, 2) {
+        if server_version_lt(4, 2).await {
             log_uncaptured("skipping notwritableprimary_keep_pool due to server version < 4.2");
             return;
         }
@@ -156,7 +163,7 @@ async fn notwritableprimary_reset_pool() {
         coll: Collection<Document>,
     ) {
         // This test must only run on 4.0 servers.
-        if !client.server_version_eq(4, 0) {
+        if !server_version_eq(4, 0).await {
             log_uncaptured(
                 "skipping notwritableprimary_reset_pool due to unsupported server version",
             );
@@ -207,11 +214,6 @@ async fn shutdown_in_progress() {
         _db: Database,
         coll: Collection<Document>,
     ) {
-        if client.server_version_lt(4, 0) {
-            log_uncaptured("skipping shutdown_in_progress due to server version < 4.0");
-            return;
-        }
-
         client
             .database("admin")
             .run_command(doc! {
@@ -252,11 +254,6 @@ async fn interrupted_at_shutdown() {
         _db: Database,
         coll: Collection<Document>,
     ) {
-        if client.server_version_lt(4, 0) {
-            log_uncaptured("skipping interrupted_at_shutdown due to server version < 4.2");
-            return;
-        }
-
         client
             .database("admin")
             .run_command(doc! {

--- a/src/test/spec/sdam.rs
+++ b/src/test/spec/sdam.rs
@@ -7,9 +7,12 @@ use crate::{
     hello::LEGACY_HELLO_COMMAND_NAME,
     runtime,
     test::{
+        block_connection_supported,
         get_client_options,
         log_uncaptured,
         spec::unified_runner::run_unified_tests,
+        streaming_monitor_protocol_supported,
+        topology_is_load_balanced,
         util::{
             event_buffer::EventBuffer,
             fail_point::{FailPoint, FailPointMode},
@@ -45,8 +48,7 @@ async fn run_unified() {
 /// Streaming protocol prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn streaming_min_heartbeat_frequency() {
-    let test_client = Client::for_test().await;
-    if test_client.is_load_balanced() {
+    if topology_is_load_balanced().await {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
     }
@@ -96,8 +98,7 @@ async fn streaming_min_heartbeat_frequency() {
 /// Variant of the previous prose test that checks for a non-minHeartbeatFrequencyMS value.
 #[tokio::test(flavor = "multi_thread")]
 async fn heartbeat_frequency_is_respected() {
-    let test_client = Client::for_test().await;
-    if test_client.is_load_balanced() {
+    if topology_is_load_balanced().await {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;
     }
@@ -147,20 +148,17 @@ async fn heartbeat_frequency_is_respected() {
 /// RTT prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn rtt_is_updated() {
-    let test_client = Client::for_test().await;
-    if !test_client.supports_streaming_monitoring_protocol() {
+    if !streaming_monitor_protocol_supported().await {
         log_uncaptured(
             "skipping rtt_is_updated due to not supporting streaming monitoring protocol",
         );
         return;
     }
-
-    if test_client.is_load_balanced() {
+    if topology_is_load_balanced().await {
         log_uncaptured("skipping rtt_is_updated due to load balanced topology");
         return;
     }
-
-    if test_client.supports_block_connection() {
+    if !block_connection_supported().await {
         log_uncaptured("skipping rtt_is_updated due to not supporting block_connection");
         return;
     }

--- a/src/test/spec/sessions.rs
+++ b/src/test/spec/sessions.rs
@@ -13,15 +13,19 @@ use crate::{
     bson::{doc, Document},
     error::{ErrorKind, Result},
     event::command::{CommandEvent, CommandStartedEvent},
-    test::{get_client_options, spec::unified_runner::run_unified_tests},
+    test::{
+        get_client_options,
+        server_version_gte,
+        spec::unified_runner::run_unified_tests,
+        topology_is_sharded,
+    },
     Client,
 };
 
 #[tokio::test(flavor = "multi_thread")]
 async fn run_unified() {
     let mut skipped_files = vec![];
-    let client = Client::for_test().await;
-    if client.is_sharded() && client.server_version_gte(7, 0) {
+    if topology_is_sharded().await && server_version_gte(7, 0).await {
         // TODO RUST-1666: unskip this file
         skipped_files.push("snapshot-sessions.json");
     }

--- a/src/test/spec/write_error.rs
+++ b/src/test/spec/write_error.rs
@@ -1,20 +1,20 @@
 use crate::{
     bson::{doc, Document},
     error::{ErrorKind, WriteFailure},
-    test::log_uncaptured,
+    test::{log_uncaptured, server_version_lt},
     Client,
     Collection,
 };
 
 #[tokio::test]
 async fn details() {
-    let client = Client::for_test().monitor_events().await;
-
-    if client.server_version_lt(5, 0) {
+    if server_version_lt(5, 0).await {
         // SERVER-58399
         log_uncaptured("skipping write_error_details test due to server version");
         return;
     }
+
+    let client = Client::for_test().monitor_events().await;
 
     let db = client.database("write_error_details");
     db.drop().await.unwrap();

--- a/src/test/timeseries.rs
+++ b/src/test/timeseries.rs
@@ -1,17 +1,22 @@
 use bson::doc;
 use futures::TryStreamExt;
 
-use crate::{db::options::TimeseriesOptions, test::log_uncaptured, Client};
+use crate::{
+    db::options::TimeseriesOptions,
+    test::{log_uncaptured, server_version_lt},
+    Client,
+};
 
 type Result<T> = anyhow::Result<T>;
 
 #[tokio::test]
 async fn list_collections_timeseries() -> Result<()> {
-    let client = Client::for_test().await;
-    if client.server_version_lt(5, 0) {
+    if server_version_lt(5, 0).await {
         log_uncaptured("Skipping list_collections_timeseries: timeseries require server >= 5.0");
         return Ok(());
     }
+
+    let client = Client::for_test().await;
     let db = client.database("list_collections_timeseries");
     db.drop().await?;
     db.create_collection("test")


### PR DESCRIPTION
RUST-1447

Removes all server round-trips from test client creation and instead caches client metadata in a number of lazy static variables in `src/test.rs`. The changes outside of `src/test.rs` and `src/test/util.rs` are largely search-and-replace; I also removed some checks related to 4.0 now that we don't support/test any lower server versions.