### PR TITLE
HELP-68823 Fix invalid_me comparison and normalize host strings

### DIFF
--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -11,7 +11,7 @@ use std::{
     convert::TryFrom,
     fmt::{self, Display, Formatter, Write},
     hash::{Hash, Hasher},
-    net::Ipv6Addr,
+    net::{Ipv4Addr, Ipv6Addr},
     path::PathBuf,
     str::FromStr,
     time::Duration,
@@ -277,6 +277,14 @@ impl ServerAddress {
             .into());
         }
 
+        let normalized_hostname = if let Ok(v4) = hostname.parse::<Ipv4Addr>() {
+            v4.to_string()
+        } else if let Ok(v6) = hostname.parse::<Ipv6Addr>() {
+            v6.to_string()
+        } else {
+            hostname.to_lowercase()
+        };
+
         let port = if let Some(port) = port {
             match u16::from_str(port) {
                 Ok(0) | Err(_) => {
@@ -296,7 +304,7 @@ impl ServerAddress {
         };
 
         Ok(Self::Tcp {
-            host: hostname.to_lowercase(),
+            host: normalized_hostname,
             port,
         })
     }

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -338,7 +338,7 @@ impl ServerDescription {
     pub(crate) fn invalid_me(&self) -> Result<bool> {
         if let Some(ref reply) = self.reply.as_ref().map_err(Clone::clone)? {
             if let Some(ref me) = reply.command_response.me {
-                return Ok(&self.address.to_string() != me);
+                return Ok(self.address != ServerAddress::parse(me)?);
             }
         }
 

--- a/src/sdam/test.rs
+++ b/src/sdam/test.rs
@@ -335,3 +335,27 @@ async fn removed_server_monitor_stops() -> crate::error::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn ipv6_invalid_me() {
+    let addr = ServerAddress::Tcp {
+        host: "::1".to_string(),
+        port: Some(8191),
+    };
+    let desc = ServerDescription {
+        address: addr.clone(),
+        server_type: super::ServerType::RsSecondary,
+        last_update_time: None,
+        average_round_trip_time: None,
+        reply: Ok(Some(crate::hello::HelloReply {
+            server_address: addr.clone(),
+            command_response: crate::hello::HelloCommandResponse {
+                me: Some("[::1]:8191".to_string()),
+                ..Default::default()
+            },
+            raw_command_response: bson::RawDocumentBuf::new(),
+            cluster_time: None,
+        })),
+    };
+    assert!(!desc.invalid_me().unwrap());
+}


### PR DESCRIPTION
HELP-68823

This wasn't the fix that I was intending to put into mainline, but that turns out to have a lot more in the way of wrinkles than I expected.  In particular, we have some public APIs (e.g. [`ToplogyDescription::servers`](https://docs.rs/mongodb/latest/mongodb/event/sdam/struct.TopologyDescription.html#method.servers)) that hand out `&ServerDescription` values, which locks us into having the underlying data structure storing that type either as the primary (how it's currently done) or as some kind of internally-mutable cache (ew).

There may be some clever path forward for split types that maintains API compatibility that I didn't see, but for the moment I think it's best to get the simple fix in and unblock downstream users.  This PR, while minimal, fixes the core issue and explicitly normalizes anything that parses as an IP address, so it should be reasonably robust, and I've gone through and audited all the other uses of `ServerAddress`'s `Display` impl and they're all test code or error messages so I think the chance of another recurrence of this problem is low.