### PR TITLE
RUST-2020 Ignore speculative authentication on reauthentication

### DIFF
--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -522,8 +522,9 @@ mod basic {
         collection.insert_one(doc! { "y": 2 }).await?;
 
         assert_eq!(*call_count.lock().await, 1);
-        let sasl_start_events = event_buffer.get_command_started_events(&["saslStart"]);
-        assert!(!sasl_start_events.is_empty());
+        let _sasl_start_events = event_buffer.get_command_started_events(&["saslStart"]);
+        // TODO RUST-2176: unskip this assertion when saslStart events are emitted
+        // assert!(!sasl_start_events.is_empty());
 
         Ok(())
     }

--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -410,11 +410,9 @@ mod basic {
                     } else {
                         "bad token".to_string()
                     };
-                    Ok(oidc::IdpServerResponse {
-                        access_token,
-                        expires: None,
-                        refresh_token: None,
-                    })
+                    Ok(oidc::IdpServerResponse::builder()
+                        .access_token(access_token)
+                        .build())
                 }
                 .boxed()
             }))
@@ -453,11 +451,9 @@ mod basic {
                     } else {
                         "bad token".to_string()
                     };
-                    Ok(oidc::IdpServerResponse {
-                        access_token,
-                        expires: None,
-                        refresh_token: None,
-                    })
+                    Ok(oidc::IdpServerResponse::builder()
+                        .access_token(access_token)
+                        .build())
                 }
                 .boxed()
             }))
@@ -491,11 +487,9 @@ mod basic {
                 let call_count = cb_call_count.clone();
                 async move {
                     *call_count.lock().await += 1;
-                    Ok(oidc::IdpServerResponse {
-                        access_token: get_access_token_test_user_1().await,
-                        expires: None,
-                        refresh_token: None,
-                    })
+                    Ok(oidc::IdpServerResponse::builder()
+                        .access_token(get_access_token_test_user_1().await)
+                        .build())
                 }
                 .boxed()
             }))

--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -353,7 +353,7 @@ mod basic {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn machine_4_reauthentication() -> anyhow::Result<()> {
+    async fn machine_4_1_reauthentication() -> anyhow::Result<()> {
         let admin_client = Client::with_uri_str(&*MONGODB_URI).await?;
 
         // Now set a failpoint for find with 391 error code
@@ -394,6 +394,92 @@ mod basic {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn machine_4_2_read_command_fails_if_reauth_fails() -> anyhow::Result<()> {
+        let call_count = Arc::new(Mutex::new(0));
+        let cb_call_count = call_count.clone();
+
+        let mut options = ClientOptions::parse(&*MONGODB_URI_SINGLE).await?;
+        let credential = Credential::builder()
+            .mechanism(AuthMechanism::MongoDbOidc)
+            .oidc_callback(oidc::Callback::machine(move |_| {
+                let call_count = cb_call_count.clone();
+                async move {
+                    *call_count.lock().await += 1;
+                    let access_token = if *call_count.lock().await == 1 {
+                        get_access_token_test_user_1().await
+                    } else {
+                        "bad token".to_string()
+                    };
+                    Ok(oidc::IdpServerResponse {
+                        access_token,
+                        expires: None,
+                        refresh_token: None,
+                    })
+                }
+                .boxed()
+            }))
+            .build();
+        options.credential = Some(credential);
+        let client = Client::with_options(options)?;
+        let collection = client.database("test").collection::<Document>("test");
+
+        collection.find_one(doc! {}).await?;
+
+        let fail_point =
+            FailPoint::fail_command(&["find"], FailPointMode::Times(1)).error_code(391);
+        let _guard = client.enable_fail_point(fail_point).await?;
+
+        collection.find_one(doc! {}).await.unwrap_err();
+
+        assert_eq!(*call_count.lock().await, 2);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn machine_4_3_write_command_fails_if_reauth_fails() -> anyhow::Result<()> {
+        let call_count = Arc::new(Mutex::new(0));
+        let cb_call_count = call_count.clone();
+
+        let mut options = ClientOptions::parse(&*MONGODB_URI_SINGLE).await?;
+        let credential = Credential::builder()
+            .mechanism(AuthMechanism::MongoDbOidc)
+            .oidc_callback(oidc::Callback::machine(move |_| {
+                let call_count = cb_call_count.clone();
+                async move {
+                    *call_count.lock().await += 1;
+                    let access_token = if *call_count.lock().await == 1 {
+                        get_access_token_test_user_1().await
+                    } else {
+                        "bad token".to_string()
+                    };
+                    Ok(oidc::IdpServerResponse {
+                        access_token,
+                        expires: None,
+                        refresh_token: None,
+                    })
+                }
+                .boxed()
+            }))
+            .build();
+        options.credential = Some(credential);
+        let client = Client::with_options(options)?;
+        let collection = client.database("test").collection::<Document>("test");
+
+        collection.insert_one(doc! { "x": 1 }).await?;
+
+        let fail_point =
+            FailPoint::fail_command(&["insert"], FailPointMode::Times(1)).error_code(391);
+        let _guard = client.enable_fail_point(fail_point).await?;
+
+        collection.insert_one(doc! { "y": 2 }).await.unwrap_err();
+
+        assert_eq!(*call_count.lock().await, 2);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn machine_4_4_speculative_auth_ignored_on_reauth() -> anyhow::Result<()> {
         let call_count = Arc::new(Mutex::new(0));
         let cb_call_count = call_count.clone();
@@ -421,12 +507,9 @@ mod basic {
         options.credential = Some(credential);
         let client = Client::for_test().options(options).monitor_events().await;
         let event_buffer = &client.events;
+        let collection = client.database("test").collection::<Document>("test");
 
-        client
-            .database("test")
-            .collection("test")
-            .insert_one(doc! { "x": 1 })
-            .await?;
+        collection.insert_one(doc! { "x": 1 }).await?;
 
         assert_eq!(*call_count.lock().await, 0);
         let sasl_start_events = event_buffer.get_command_started_events(&["saslStart"]);
@@ -436,11 +519,7 @@ mod basic {
             FailPoint::fail_command(&["insert"], FailPointMode::Times(1)).error_code(391);
         let _guard = client.enable_fail_point(fail_point).await?;
 
-        client
-            .database("test")
-            .collection("test")
-            .insert_one(doc! { "y": 2 })
-            .await?;
+        collection.insert_one(doc! { "y": 2 }).await?;
 
         assert_eq!(*call_count.lock().await, 1);
         let sasl_start_events = event_buffer.get_command_started_events(&["saslStart"]);

--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -523,7 +523,7 @@ mod basic {
 
         assert_eq!(*call_count.lock().await, 1);
         let sasl_start_events = event_buffer.get_command_started_events(&["saslStart"]);
-        assert!(sasl_start_events.is_empty());
+        assert!(!sasl_start_events.is_empty());
 
         Ok(())
     }

--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -423,8 +423,8 @@ mod basic {
         let event_buffer = &client.events;
 
         client
-            .database("db")
-            .collection("coll")
+            .database("test")
+            .collection("test")
             .insert_one(doc! { "x": 1 })
             .await?;
 
@@ -437,8 +437,8 @@ mod basic {
         let _guard = client.enable_fail_point(fail_point).await.unwrap();
 
         client
-            .database("db")
-            .collection("coll")
+            .database("test")
+            .collection("test")
             .insert_one(doc! { "y": 2 })
             .await?;
 

--- a/src/test/spec/oidc.rs
+++ b/src/test/spec/oidc.rs
@@ -393,7 +393,7 @@ mod basic {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn machine_4_4_speculative_auth_ignored_on_reauth() -> anyhow::Result<()> {
         let call_count = Arc::new(Mutex::new(0));
         let cb_call_count = call_count.clone();
@@ -434,7 +434,7 @@ mod basic {
 
         let fail_point =
             FailPoint::fail_command(&["insert"], FailPointMode::Times(1)).error_code(391);
-        let _guard = client.enable_fail_point(fail_point).await.unwrap();
+        let _guard = client.enable_fail_point(fail_point).await?;
 
         client
             .database("test")


### PR DESCRIPTION
RUST-2020

The driver behavior was already correct, so this entailed adding a new prose test (4.4). Note that the assertions on `saslStart` events for this test will not run properly until RUST-2176 is implemented. I also added a few other reauth tests we were missing (4.2, 4.3).