### PR TITLE
RUST-2165 Pin transitive deps for MSRV

### DIFF
--- a/.evergreen/MSRV-Cargo.toml.diff
+++ b/.evergreen/MSRV-Cargo.toml.diff
@@ -1,0 +1,13 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index be6e3f80..2edd8b1b 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -118,6 +118,8 @@ typed-builder = "0.10.0"
+ webpki-roots = "0.25.2"
+ zstd = { version = "0.11.2", optional = true }
+ macro_magic = "0.5.1"
++zerofrom = "=0.1.5"
++litemap = "=0.7.4"
+ 
+ [dependencies.pbkdf2]
+ version = "0.11.0"


### PR DESCRIPTION
RUST-2165

The original dependency that necessitated the ticket yanked its version, but a couple others showed up since then.