### PR TITLE
RUST-2168 Revert skip to `non-lb-connection-establishment`

### DIFF
--- a/src/test/spec/json/load-balancers/non-lb-connection-establishment.json
+++ b/src/test/spec/json/load-balancers/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",

--- a/src/test/spec/json/load-balancers/non-lb-connection-establishment.yml
+++ b/src/test/spec/json/load-balancers/non-lb-connection-establishment.yml
@@ -42,11 +42,6 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
-    runOnRequirements:
-      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
-        topologies: [ single ]
-      - topologies: [ sharded ]
-
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
Reverts commit f09370980410e86e6f25c6a1c2471f1c3d86187a.

[SERVER-101078](https://jira.mongodb.org/browse/SERVER-101078) is fixed on 8.1.0-rc0 and enables running this test again.
