### PR TITLE
RUST-2175 add IPv6 literal test

### DIFF
--- a/src/test/spec/json/server-discovery-and-monitoring/rs/secondary_ipv6_literal.json
+++ b/src/test/spec/json/server-discovery-and-monitoring/rs/secondary_ipv6_literal.json
@@ -1,0 +1,38 @@
+{
+  "description": "Secondary with IPv6 literal",
+  "uri": "mongodb://[::1]/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "[::1]:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": false,
+            "secondary": true,
+            "setName": "rs",
+            "me": "[::1]:27017",
+            "hosts": [
+              "[::1]:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 26
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "[::1]:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/src/test/spec/json/server-discovery-and-monitoring/rs/secondary_ipv6_literal.yml
+++ b/src/test/spec/json/server-discovery-and-monitoring/rs/secondary_ipv6_literal.yml
@@ -1,0 +1,25 @@
+# Regression test for bug discovered in HELP-68823.
+description: Secondary with IPv6 literal
+uri: mongodb://[::1]/?replicaSet=rs
+phases:
+- responses:
+  - - "[::1]:27017"
+    - ok: 1
+      helloOk: true
+      isWritablePrimary: false
+      secondary: true
+      setName: rs
+      me: "[::1]:27017"
+      hosts:
+      - "[::1]:27017"
+      minWireVersion: 0
+      maxWireVersion: 26
+  outcome:
+    servers:
+      "[::1]:27017":
+        type: RSSecondary
+        setName: rs
+    topologyType: ReplicaSetNoPrimary
+    setName: rs
+    logicalSessionTimeoutMinutes: null
+    compatible: true


### PR DESCRIPTION
Verified with this [patch build](https://spruce.mongodb.com/version/67cb381fab4bc8000769cd72/). The test is independent of the live server topology since it uses mock data.
