### PR TITLE
RUST-1375 Update MSRV policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,7 @@ Commits to main are run automatically on [evergreen](https://evergreen.mongodb.c
 
 ## Minimum supported Rust version (MSRV) policy
 
-The MSRV for this crate is currently 1.71.1. This will rarely be increased, and if it ever is,
-it will only happen in a minor or major version release.
+The MSRV for this crate is currently 1.71.1. Increases to the MSRV will only happen in a minor or major version release, and will be to a Rust version at least six months old.
 
 ## License
 


### PR DESCRIPTION
RUST-1375

This:
* gets rid of the "will rarely be increased" phrase; we tried to hew to this by jumping through hoops to do it as little as possible but literally no other crates I could find make this promise.   Likewise "if it ever is" was long since dead verbiage 🙂.
* Sets the six month rolling window.  Of those crates that do provide a written policy, this seems to be a little on the conservative side of normal; only `rustls` sets a longer window and most do a shorter one.

I considered defining the window in terms of a set number of releases instead of a time period (both are common in the crate ecosystem) and went with time period because I find that a little easier to personally reason about.