### PR TITLE
RUST-2181 Fix rustup installation on windows

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -21,6 +21,15 @@ for arg; do
   if [ $arg == "rust" ]; then
     curl https://sh.rustup.rs -sSf | sh -s -- -y --no-modify-path $DEFAULT_HOST_OPTIONS
 
+    # Cygwin has a bug with reporting symlink paths that breaks rustup; see 
+    # https://github.com/rust-lang/rustup/issues/4239.  This works around it by replacing the
+    # symlinks with copies.
+    if [ "Windows_NT" == "$OS" ]; then
+      pushd ${CARGO_HOME}/bin
+      python3 ../../.evergreen/unsymlink.py
+      popd
+    fi
+
     # This file is not created by default on Windows
     echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >>${CARGO_HOME}/env
     echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >>${CARGO_HOME}/env

--- a/.evergreen/unsymlink.py
+++ b/.evergreen/unsymlink.py
@@ -1,0 +1,19 @@
+import os
+import shutil
+
+found = []
+for entry in os.scandir():
+    if not entry.is_symlink():
+        print(f"Skipping {entry.name}: not a symlink")
+        continue
+    target = os.readlink(entry.name)
+    if target != "rustup.exe":
+        print(f"Skipping {entry.name}: not rustup.exe")
+        continue
+    print(f"Found {entry.name}")
+    found.append(entry.name)
+
+for name in found:
+    print(f"Replacing {name} symlink with copy")
+    os.remove(name)
+    shutil.copy2("rustup.exe", name)


### PR DESCRIPTION
RUST-2181

This works around the cygwin symlink bug (https://github.com/rust-lang/rustup/issues/4239) with a small script that replaces the symlinks with actual copies.  This wouldn't be a good workaround for a long-lived installation because it'd mess with the rustup upgrade process, but because we're doing a clean install every time and then discarding it once tests are done it's fine here.

I went with python for the script rather than bash because I think it ends up being substantially more readable.