### PR TITLE
RUST 2180 Update version numbers for 3.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://www.mongodb.com/docs/drivers/rust/"
 license = "Apache-2.0"
 readme = "README.md"
 name = "mongodb"
-version = "3.2.1"
+version = "3.2.3"
 
 exclude = [
     "etc/**",
@@ -72,7 +72,7 @@ tracing-unstable = ["dep:tracing", "dep:log"]
 async-trait = "0.1.42"
 base64 = "0.13.0"
 bitflags = "1.1.0"
-bson = { git = "https://github.com/mongodb/bson-rust", branch = "main", version = "2.13.0" }
+bson = { git = "https://github.com/mongodb/bson-rust", branch = "main", version = "2.14.0" }
 chrono = { version = "0.4.7", default-features = false, features = [
     "clock",
     "std",
@@ -92,7 +92,7 @@ once_cell = "1.19.0"
 log = { version = "0.4.17", optional = true }
 md-5 = "0.10.1"
 mongocrypt = { git = "https://github.com/mongodb/libmongocrypt-rust.git", branch = "main", optional = true, version = "0.2.1" }
-mongodb-internal-macros = { path = "macros", version = "3.2.1" }
+mongodb-internal-macros = { path = "macros", version = "3.2.3" }
 num_cpus = { version = "1.13.1", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The driver tests against Linux, MacOS, and Windows in CI.
 The driver is available on [crates.io](https://crates.io/crates/mongodb). To use the driver in your application, simply add it to your project's `Cargo.toml`.
 ```toml
 [dependencies]
-mongodb = "3.2.1"
+mongodb = "3.2.3"
 ```
 
 Version 1 of this crate has reached end of life and will no longer be receiving any updates or bug fixes, so all users are recommended to always depend on the latest 2.x release. See the [2.0.0 release notes](https://github.com/mongodb/mongo-rust-driver/releases/tag/v2.0.0) for migration information if upgrading from a 1.x version.
@@ -27,7 +27,7 @@ Version 1 of this crate has reached end of life and will no longer be receiving 
 The driver also provides a blocking sync API. To enable this, add the `"sync"` feature to your `Cargo.toml`:
 ```toml
 [dependencies.mongodb]
-version = "3.2.1"
+version = "3.2.3"
 features = ["sync"]
 ```
 **Note:** The sync-specific types can be imported from `mongodb::sync` (e.g. `mongodb::sync::Client`).

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodb-internal-macros"
-version = "3.2.1"
+version = "3.2.3"
 description = "Internal macros for the mongodb crate"
 edition = "2021"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(test, type_length_limit = "80000000")]
-#![doc(html_root_url = "https://docs.rs/mongodb/3.2.1")]
+#![doc(html_root_url = "https://docs.rs/mongodb/3.2.3")]
 
 #[macro_use]
 pub mod options;


### PR DESCRIPTION
My plan is to merge this into main first and then pick this commit and the bug fix onto 3.2.x so that we don't have to update the version numbers on main after the release.