### PR TITLE
RUST-2172 Test on Graviton processor

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -376,6 +376,26 @@ buildvariants:
     tasks:
       - happy-eyeballs-task-group
 
+  #- name: graviton-legacy
+  #  display_name: "Graviton (legacy versions)"
+  #  run_on:
+  #    - amazon2-arm64-latest-large-m8g
+  #  tasks:
+  #    - name: .6.0
+  #    - name: .5.0
+  #    - name: .4.4
+  #    - name: .4.4
+  #    - name: .4.2
+
+  - name: graviton
+    display_name: "Graviton"
+    run_on:
+      - amazon2023-arm64-latest-large-m8g
+    tasks:
+      - name: .latest
+      #- name: .8.0
+      #- name: .7.0
+
 ###############
 # Task Groups #
 ###############


### PR DESCRIPTION
RUST-2172

Happily, no changes were needed.  Full test against older versions is [here](https://spruce.mongodb.com/version/67dc3757e942f7000766eea2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) - I left those evergreen configs present but commented out to make it easy to re-run in the future if needed.