### PR TITLE
Sync `valid-fail` and `invalid` unified format tests

### DIFF
--- a/src/test/spec/json/unified-test-format/invalid/clientEncryptionOpts-kmsProviders-invalidName.json
+++ b/src/test/spec/json/unified-test-format/invalid/clientEncryptionOpts-kmsProviders-invalidName.json
@@ -1,0 +1,29 @@
+{
+  "description": "clientEncryptionOpts-kmsProviders-invalidName",
+  "schemaVersion": "1.18",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "clientEncryption": {
+        "id": "clientEncryption0",
+        "clientEncryptionOpts": {
+          "keyVaultClient": "client0",
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "aws:name_with_invalid_character*": {}
+          }
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "",
+      "operations": []
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/clientEncryptionOpts-kmsProviders-invalidName.yml
+++ b/src/test/spec/json/unified-test-format/invalid/clientEncryptionOpts-kmsProviders-invalidName.yml
@@ -1,0 +1,19 @@
+description: clientEncryptionOpts-kmsProviders-invalidName
+
+schemaVersion: "1.18"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          # The `*` is an invalid character.
+          "aws:name_with_invalid_character*": {}
+
+tests:
+  - description: ""
+    operations: []

--- a/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.json
+++ b/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandFailedEvent-databaseName-type",
+  "schemaVersion": "1.15",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandFailedEvent": {
+                "databaseName": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.yml
+++ b/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.yml
@@ -1,0 +1,16 @@
+description: "expectedCommandEvent-commandFailedEvent-databaseName-type"
+
+schemaVersion: "1.15"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandFailedEvent:
+              databaseName: 0

--- a/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.json
+++ b/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandSucceededEvent-databaseName-type",
+  "schemaVersion": "1.15",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandSucceededEvent": {
+                "databaseName": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.yml
+++ b/src/test/spec/json/unified-test-format/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.yml
@@ -1,0 +1,16 @@
+description: "expectedCommandEvent-commandSucceededEvent-databaseName-type"
+
+schemaVersion: "1.15"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandSucceededEvent:
+              databaseName: 0

--- a/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreExtraMessages-type.json
+++ b/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreExtraMessages-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "expectedLogMessagesForClient-ignoreExtraMessages-type",
+  "schemaVersion": "1.16",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectLogMessages": [
+        {
+          "client": "client0",
+          "ignoreExtraMessages": "true",
+          "messages": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreExtraMessages-type.yml
+++ b/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreExtraMessages-type.yml
@@ -1,0 +1,15 @@
+description: "expectedLogMessagesForClient-ignoreExtraMessages-type"
+
+schemaVersion: "1.16"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectLogMessages:
+      - client: *client0
+        ignoreExtraMessages: "true"
+        messages: []

--- a/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-items.json
+++ b/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-items.json
@@ -1,0 +1,26 @@
+{
+  "description": "expectedLogMessagesForClient-ignoreMessages-items",
+  "schemaVersion": "1.16",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectLogMessages": [
+        {
+          "client": "client0",
+          "messages": [],
+          "ignoreMessages": [
+            0
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-items.yml
+++ b/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-items.yml
@@ -1,0 +1,15 @@
+description: "expectedLogMessagesForClient-ignoreMessages-items"
+
+schemaVersion: "1.16"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectLogMessages:
+      - client: *client0
+        messages: []
+        ignoreMessages: [0]

--- a/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-type.json
+++ b/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-type.json
@@ -1,0 +1,24 @@
+{
+  "description": "expectedLogMessagesForClient-ignoreMessages-type",
+  "schemaVersion": "1.16",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectLogMessages": [
+        {
+          "client": "client0",
+          "messages": [],
+          "ignoreMessages": 0
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-type.yml
+++ b/src/test/spec/json/unified-test-format/invalid/expectedLogMessagesForClient-ignoreMessages-type.yml
@@ -1,0 +1,15 @@
+description: "expectedLogMessagesForClient-ignoreMessages-type"
+
+schemaVersion: "1.16"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectLogMessages:
+      - client: *client0
+        messages: []
+        ignoreMessages: 0

--- a/src/test/spec/json/unified-test-format/invalid/expectedSdamEvent-topologyDescriptionChangedEvent-additionalProperties.json
+++ b/src/test/spec/json/unified-test-format/invalid/expectedSdamEvent-topologyDescriptionChangedEvent-additionalProperties.json
@@ -1,0 +1,23 @@
+{
+  "description": "expectedSdamEvent-topologyDescriptionChangedEvent-additionalProperties",
+  "schemaVersion": "1.14",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "eventType": "sdam",
+          "events": [
+            {
+              "topologyDescriptionChangedEvent": {
+                "foo": "bar"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/expectedSdamEvent-topologyDescriptionChangedEvent-additionalProperties.yml
+++ b/src/test/spec/json/unified-test-format/invalid/expectedSdamEvent-topologyDescriptionChangedEvent-additionalProperties.yml
@@ -1,0 +1,13 @@
+description: expectedSdamEvent-topologyDescriptionChangedEvent-additionalProperties
+
+schemaVersion: '1.14'
+
+tests:
+  - description: foo
+    operations: []
+    expectEvents:
+      - client: client0
+        eventType: sdam
+        events:
+          - topologyDescriptionChangedEvent:
+              foo: bar

--- a/src/test/spec/json/unified-test-format/invalid/runOnRequirement-authMechanism-type.json
+++ b/src/test/spec/json/unified-test-format/invalid/runOnRequirement-authMechanism-type.json
@@ -1,0 +1,15 @@
+{
+  "description": "runOnRequirement-authMechanism-type",
+  "schemaVersion": "1.19",
+  "runOnRequirements": [
+    {
+      "authMechanism": 0
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/invalid/runOnRequirement-authMechanism-type.yml
+++ b/src/test/spec/json/unified-test-format/invalid/runOnRequirement-authMechanism-type.yml
@@ -1,0 +1,10 @@
+description: runOnRequirement-authMechanism-type
+
+schemaVersion: '1.19'
+
+runOnRequirements:
+  - authMechanism: 0
+
+tests:
+  - description: foo
+    operations: []

--- a/src/test/spec/json/unified-test-format/valid-fail/entity-findCursor-malformed.yml
+++ b/src/test/spec/json/unified-test-format/valid-fail/entity-findCursor-malformed.yml
@@ -1,4 +1,4 @@
-# This test is split out into a separate file to accomodate drivers that validate operation structure while decoding
+# This test is split out into a separate file to accommodate drivers that validate operation structure while decoding
 # from JSON/YML. Such drivers fail to decode any files containing invalid operations. Combining this test in a file
 # with other entity-findCursor valid-fail tests, which test failures that occur during test execution, would prevent
 # such drivers from decoding the file and running any of the tests.

--- a/src/test/spec/json/unified-test-format/valid-fail/ignoreResultAndError-malformed.yml
+++ b/src/test/spec/json/unified-test-format/valid-fail/ignoreResultAndError-malformed.yml
@@ -1,4 +1,4 @@
-# This test is split out into a separate file to accomodate drivers that validate operation structure while decoding
+# This test is split out into a separate file to accommodate drivers that validate operation structure while decoding
 # from JSON/YML. Such drivers fail to decode any files containing invalid operations. Combining this test in a file
 # with other ignoreResultAndError valid-fail tests, which test failures that occur during test execution, would prevent
 # such drivers from decoding the file and running any of the tests.

--- a/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsDocument.json
+++ b/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsDocument.json
@@ -1,0 +1,205 @@
+{
+  "description": "operator-matchAsDocument",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "json": "{ \"x\": 1, \"y\": 2 }"
+        },
+        {
+          "_id": 2,
+          "json": "1"
+        },
+        {
+          "_id": 3,
+          "json": "[ \"foo\" ]"
+        },
+        {
+          "_id": 4,
+          "json": "{ \"x\" }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsDocument with non-matching filter",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": "two"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument does not permit extra fields",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument expects JSON object but given scalar",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument expects JSON object but given array",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 3,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument fails to decode Extended JSON",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 4
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 4,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsDocument.yml
+++ b/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsDocument.yml
@@ -1,0 +1,88 @@
+description: operator-matchAsDocument
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, json: '{ "x": 1, "y": 2 }' }
+      # Documents with non-objects or invalid JSON
+      - { _id: 2, json: '1' }
+      - { _id: 3, json: '[ "foo" ]' }
+      - { _id: 4, json: '{ "x" }' }
+
+tests:
+  - description: matchAsDocument with non-matching filter
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: "two" } } }
+  -
+    description: matchAsDocument evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: { $$exists: false } } } }
+  -
+    description: matchAsDocument does not permit extra fields
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1 } } }
+  -
+    description: matchAsDocument expects JSON object but given scalar
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          # The following $$matchAsRoot expression would match any document, so
+          # this ensures the failure is due to the actual value.
+          - { _id: 2, json: &match_any_document { $$matchAsDocument: { $$matchAsRoot: { } } } }
+  -
+    description: matchAsDocument expects JSON object but given array
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 3 }
+          limit: 1
+        expectResult:
+          - { _id: 3, json: *match_any_document }
+  -
+    description: matchAsDocument fails to decode Extended JSON
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 4 }
+          limit: 1
+        expectResult:
+          - { _id: 4, json: *match_any_document }

--- a/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsRoot.json
+++ b/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsRoot.json
@@ -1,0 +1,67 @@
+{
+  "description": "operator-matchAsRoot",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": {
+            "y": 2,
+            "z": 3
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsRoot with nested document does not match",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 3
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsRoot.yml
+++ b/src/test/spec/json/unified-test-format/valid-fail/operator-matchAsRoot.yml
@@ -1,0 +1,33 @@
+description: operator-matchAsRoot
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: { y: 2, z: 3 } }
+
+tests:
+  -
+    description: matchAsRoot with nested document does not match
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 3 } } }


### PR DESCRIPTION
This in tandem with #1342 resolves RUST-2075. The rest of the synced files are tests we missed when implementing larger pieces of work that added new unified test runner functionality.