### PR TITLE
RUST-2095 Test that driver-generated `_id` fields are prepended

### DIFF
--- a/src/test/spec/crud.rs
+++ b/src/test/spec/crud.rs
@@ -1,4 +1,13 @@
-use crate::test::{spec::unified_runner::run_unified_tests, SERVERLESS};
+use crate::{
+    bson::doc,
+    test::{
+        log_uncaptured,
+        server_version_lt,
+        spec::unified_runner::run_unified_tests,
+        SERVERLESS,
+    },
+    Client,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn run_unified() {
@@ -51,4 +60,44 @@ async fn run_unified() {
         .skip_files(&skipped_files)
         .skip_tests(&skipped_tests)
         .await;
+}
+
+#[tokio::test]
+async fn generated_id_first_field() {
+    let client = Client::for_test().monitor_events().await;
+    let events = &client.events;
+    let collection = client.database("db").collection("coll");
+
+    collection.insert_one(doc! { "x": 1 }).await.unwrap();
+    let insert_events = events.get_command_started_events(&["insert"]);
+    let insert_document = insert_events[0]
+        .command
+        .get_array("documents")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_document()
+        .unwrap();
+    let (key, _) = insert_document.iter().next().unwrap();
+    assert_eq!(key, "_id");
+
+    if server_version_lt(8, 0).await || *SERVERLESS {
+        log_uncaptured("skipping bulk write test in generated_id_first_field");
+    }
+
+    let insert_one_model = collection.insert_one_model(doc! { "y": 2 }).unwrap();
+    client.bulk_write(vec![insert_one_model]).await.unwrap();
+    let bulk_write_events = events.get_command_started_events(&["bulkWrite"]);
+    let insert_operation = bulk_write_events[0]
+        .command
+        .get_array("ops")
+        .unwrap()
+        .first()
+        .unwrap()
+        .as_document()
+        .unwrap();
+    assert!(insert_operation.contains_key("insert"));
+    let insert_document = insert_operation.get_document("document").unwrap();
+    let (key, _) = insert_document.iter().next().unwrap();
+    assert_eq!(key, "_id");
 }


### PR DESCRIPTION
RUST-2095