### PR TITLE
RUST-2090/gridfs helpers

### DIFF
--- a/src/action/gridfs.rs
+++ b/src/action/gridfs.rs
@@ -7,9 +7,9 @@ mod find;
 mod rename;
 mod upload;
 
-pub use delete::Delete;
+pub use delete::{Delete, DeleteByName};
 pub use download::{OpenDownloadStream, OpenDownloadStreamByName};
 pub use drop::Drop;
 pub use find::{Find, FindOne};
-pub use rename::Rename;
+pub use rename::{Rename, RenameByName};
 pub use upload::OpenUploadStream;

--- a/src/action/gridfs/delete.rs
+++ b/src/action/gridfs/delete.rs
@@ -17,6 +17,18 @@ impl GridFsBucket {
     pub fn delete(&self, id: Bson) -> Delete {
         Delete { bucket: self, id }
     }
+
+    /// Deletes the [`FilesCollectionDocument`] with the given name and its associated chunks from
+    /// this bucket. This method returns an error if the name does not match any files in the
+    /// bucket.
+    ///
+    /// `await` will return [`Result<()>`].
+    pub fn delete_by_name(&self, filename: impl Into<String>) -> DeleteByName {
+        DeleteByName {
+            bucket: self,
+            filename: filename.into(),
+        }
+    }
 }
 
 #[cfg(feature = "sync")]
@@ -28,6 +40,15 @@ impl crate::sync::gridfs::GridFsBucket {
     /// [`run`](Delete::run) will return [`Result<()>`].
     pub fn delete(&self, id: Bson) -> Delete {
         self.async_bucket.delete(id)
+    }
+
+    /// Deletes the [`FilesCollectionDocument`] with the given name and its associated chunks from
+    /// this bucket. This method returns an error if the name does not match any files in the
+    /// bucket.
+    ///
+    /// [`run`](DeleteByName::run) will return [`Result<()>`].
+    pub fn delete_by_name(&self, filename: impl Into<String>) -> DeleteByName {
+        self.async_bucket.delete_by_name(filename)
     }
 }
 
@@ -59,6 +80,58 @@ impl<'a> Action for Delete<'a> {
         if delete_result.deleted_count == 0 {
             return Err(ErrorKind::GridFs(GridFsErrorKind::FileNotFound {
                 identifier: GridFsFileIdentifier::Id(self.id),
+            })
+            .into());
+        }
+
+        Ok(())
+    }
+}
+
+/// Deletes a named [`FilesCollectionDocument`] and its associated chunks.  Construct with
+/// [`GridFsBucket::delete_by_name`].
+#[must_use]
+pub struct DeleteByName<'a> {
+    bucket: &'a GridFsBucket,
+    filename: String,
+}
+
+#[action_impl]
+impl<'a> Action for DeleteByName<'a> {
+    type Future = DeleteByNameFuture;
+
+    async fn execute(self) -> Result<()> {
+        use futures_util::stream::{StreamExt, TryStreamExt};
+        let ids: Vec<_> = self
+            .bucket
+            .files()
+            .find(doc! { "filename": self.filename.clone() })
+            .projection(doc! { "_id": 1 })
+            .await?
+            .with_type::<bson::Document>()
+            .map(|r| match r {
+                Ok(mut d) => d
+                    .remove("_id")
+                    .ok_or_else(|| crate::error::Error::internal("_id field expected")),
+                Err(e) => Err(e),
+            })
+            .try_collect()
+            .await?;
+
+        let count = self
+            .bucket
+            .files()
+            .delete_many(doc! { "_id": { "$in": ids.clone() } })
+            .await?
+            .deleted_count;
+        self.bucket
+            .chunks()
+            .delete_many(doc! { "files_id": { "$in": ids } })
+            .await?;
+
+        if count == 0 {
+            return Err(ErrorKind::GridFs(GridFsErrorKind::FileNotFound {
+                identifier: GridFsFileIdentifier::Filename(self.filename),
             })
             .into());
         }

--- a/src/action/gridfs/rename.rs
+++ b/src/action/gridfs/rename.rs
@@ -84,7 +84,7 @@ impl<'a> Action for Rename<'a> {
     }
 }
 
-// Renames a file selected by name.  Construct with [`GridFsBucket::rename_by_name`].
+/// Renames a file selected by name.  Construct with [`GridFsBucket::rename_by_name`].
 #[must_use]
 pub struct RenameByName<'a> {
     bucket: &'a GridFsBucket,

--- a/src/action/gridfs/rename.rs
+++ b/src/action/gridfs/rename.rs
@@ -1,6 +1,10 @@
 use bson::{doc, Bson};
 
-use crate::{action::action_impl, error::Result, gridfs::GridFsBucket};
+use crate::{
+    action::action_impl,
+    error::{ErrorKind, GridFsErrorKind, GridFsFileIdentifier, Result},
+    gridfs::GridFsBucket,
+};
 
 impl GridFsBucket {
     /// Renames the file with the given 'id' to the provided `new_filename`. This method returns an
@@ -14,6 +18,22 @@ impl GridFsBucket {
             new_filename: new_filename.into(),
         }
     }
+
+    /// Renames all revisions of the file with the given name to the provided `new_filename`. This
+    /// method returns an error if the name does not match any files in the bucket.
+    ///
+    /// `await` will return [`Result<()>`].
+    pub fn rename_by_name(
+        &self,
+        filename: impl Into<String>,
+        new_filename: impl Into<String>,
+    ) -> RenameByName {
+        RenameByName {
+            bucket: self,
+            filename: filename.into(),
+            new_filename: new_filename.into(),
+        }
+    }
 }
 
 #[cfg(feature = "sync")]
@@ -24,6 +44,18 @@ impl crate::sync::gridfs::GridFsBucket {
     /// [`run`](Rename::run) will return [`Result<()>`].
     pub fn rename(&self, id: Bson, new_filename: impl Into<String>) -> Rename {
         self.async_bucket.rename(id, new_filename)
+    }
+
+    /// Renames all revisions of the file with the given name to the provided `new_filename`. This
+    /// method returns an error if the name does not match any files in the bucket.
+    ///
+    /// [`run`](RenameByName::run) will return [`Result<()>`].
+    pub fn rename_by_name(
+        &self,
+        filename: impl Into<String>,
+        new_filename: impl Into<String>,
+    ) -> RenameByName {
+        self.async_bucket.rename_by_name(filename, new_filename)
     }
 }
 
@@ -47,6 +79,39 @@ impl<'a> Action for Rename<'a> {
                 doc! { "$set": { "filename": self.new_filename } },
             )
             .await?;
+
+        Ok(())
+    }
+}
+
+// Renames a file selected by name.  Construct with [`GridFsBucket::rename_by_name`].
+#[must_use]
+pub struct RenameByName<'a> {
+    bucket: &'a GridFsBucket,
+    filename: String,
+    new_filename: String,
+}
+
+#[action_impl]
+impl<'a> Action for RenameByName<'a> {
+    type Future = RenameByNameFuture;
+
+    async fn execute(self) -> Result<()> {
+        let count = self
+            .bucket
+            .files()
+            .update_many(
+                doc! { "filename": self.filename.clone() },
+                doc! { "$set": { "filename": self.new_filename } },
+            )
+            .await?
+            .matched_count;
+        if count == 0 {
+            return Err(ErrorKind::GridFs(GridFsErrorKind::FileNotFound {
+                identifier: GridFsFileIdentifier::Filename(self.filename),
+            })
+            .into());
+        }
 
         Ok(())
     }

--- a/src/test/spec/json/gridfs/delete.json
+++ b/src/test/spec/json/gridfs/delete.json
@@ -497,7 +497,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -650,7 +650,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],

--- a/src/test/spec/json/gridfs/delete.yml
+++ b/src/test/spec/json/gridfs/delete.yml
@@ -141,7 +141,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000000" }
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
     outcome:
       - collectionName: *bucket0_files_collectionName
         databaseName: *database0Name
@@ -170,7 +170,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000004" }
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
     outcome:
       - collectionName: *bucket0_files_collectionName
         databaseName: *database0Name

--- a/src/test/spec/json/gridfs/deleteByName.json
+++ b/src/test/spec/json/gridfs/deleteByName.json
@@ -1,0 +1,230 @@
+{
+  "description": "gridfs-deleteByName",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "length": 2,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "length": 8,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "otherfilename",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "delete when multiple revisions of the file exist",
+      "operations": [
+        {
+          "name": "deleteByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename"
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "length": 8,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "otherfilename",
+              "metadata": {}
+            }
+          ]
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "delete when file name does not exist",
+      "operations": [
+        {
+          "name": "deleteByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "missing-file"
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/gridfs/deleteByName.yml
+++ b/src/test/spec/json/gridfs/deleteByName.yml
@@ -1,0 +1,102 @@
+description: "gridfs-deleteByName"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file1
+        _id: { "$oid": "000000000000000000000001" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file2
+        _id: { "$oid": "000000000000000000000002" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file3
+        _id: { "$oid": "000000000000000000000003" }
+        length: 2
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file4
+        _id: { "$oid": "000000000000000000000004" }
+        length: 8
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "otherfilename"
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file2_chunk0
+        _id: { "$oid": "000000000000000000000001" }
+        files_id: { "$oid": "000000000000000000000002" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file3_chunk0
+        _id: { "$oid": "000000000000000000000002" }
+        files_id: { "$oid": "000000000000000000000003" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file3_chunk1
+        _id: { "$oid": "000000000000000000000003" }
+        files_id: { "$oid": "000000000000000000000003" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file4_chunk0
+        _id: { "$oid": "000000000000000000000004" }
+        files_id: { "$oid": "000000000000000000000004" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+
+tests:
+  - description: "delete when multiple revisions of the file exist"
+    operations:
+      - name: deleteByName
+        object: *bucket0
+        arguments:
+          filename: filename
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents:
+          - <<: *file4
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents:
+          - *file4_chunk0
+  - description: "delete when file name does not exist"
+    operations:
+      - name: deleteByName
+        object: *bucket0
+        arguments:
+          filename: missing-file
+        expectError: { isClientError: true } # FileNotFound

--- a/src/test/spec/json/gridfs/download.json
+++ b/src/test/spec/json/gridfs/download.json
@@ -338,7 +338,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -370,7 +370,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -402,7 +402,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -471,7 +471,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -514,7 +514,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/src/test/spec/json/gridfs/download.yml
+++ b/src/test/spec/json/gridfs/download.yml
@@ -139,7 +139,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000000" }
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
   - description: "download when an intermediate chunk is missing"
     operations:
       - name: deleteOne
@@ -154,7 +154,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsMissing
+        expectError: { isClientError: true } # ChunkIsMissing
   - description: "download when final chunk is missing"
     operations:
       - name: deleteOne
@@ -169,7 +169,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsMissing
+        expectError: { isClientError: true } # ChunkIsMissing
   - description: "download when an intermediate chunk is the wrong size"
     operations:
       - name: bulkWrite
@@ -195,7 +195,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsWrongSize
+        expectError: { isClientError: true } # ChunkIsWrongSize
   - description: "download when final chunk is the wrong size"
     operations:
       - name: updateOne
@@ -213,7 +213,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsWrongSize
+        expectError: { isClientError: true } # ChunkIsWrongSize
   - description: "download legacy file with no name"
     operations:
       - name: download

--- a/src/test/spec/json/gridfs/downloadByName.json
+++ b/src/test/spec/json/gridfs/downloadByName.json
@@ -290,7 +290,7 @@
             "filename": "xyz"
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -306,7 +306,7 @@
             "revision": 999
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/src/test/spec/json/gridfs/downloadByName.yml
+++ b/src/test/spec/json/gridfs/downloadByName.yml
@@ -133,7 +133,7 @@ tests:
         object: *bucket0
         arguments:
           filename: "xyz"
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
   - description: "downloadByName when revision does not exist"
     operations:
       - name: downloadByName
@@ -141,4 +141,4 @@ tests:
         arguments:
           filename: "abc"
           revision: 999
-        expectError: { isError: true } # RevisionNotFound
+        expectError: { isClientError: true } # RevisionNotFound

--- a/src/test/spec/json/gridfs/renameByName.json
+++ b/src/test/spec/json/gridfs/renameByName.json
@@ -1,0 +1,313 @@
+{
+  "description": "gridfs-renameByName",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "length": 2,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "length": 8,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "otherfilename",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "n": 1,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "rename when multiple revisions of the file exist",
+      "operations": [
+        {
+          "name": "renameByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename",
+            "newFilename": "newfilename"
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000003"
+              },
+              "length": 2,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "length": 8,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "otherfilename",
+              "metadata": {}
+            }
+          ]
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000003"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000003"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "n": 1,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rename when file name does not exist",
+      "operations": [
+        {
+          "name": "renameByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "missing-file",
+            "newFilename": "newfilename"
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/gridfs/renameByName.yml
+++ b/src/test/spec/json/gridfs/renameByName.yml
@@ -1,0 +1,113 @@
+description: "gridfs-renameByName"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file1
+        _id: { "$oid": "000000000000000000000001" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file2
+        _id: { "$oid": "000000000000000000000002" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file3
+        _id: { "$oid": "000000000000000000000003" }
+        length: 2
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file4
+        _id: { "$oid": "000000000000000000000004" }
+        length: 8
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "otherfilename"
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file2_chunk0
+        _id: { "$oid": "000000000000000000000001" }
+        files_id: { "$oid": "000000000000000000000002" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file3_chunk0
+        _id: { "$oid": "000000000000000000000002" }
+        files_id: { "$oid": "000000000000000000000003" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file4_chunk0
+        _id: { "$oid": "000000000000000000000003" }
+        files_id: { "$oid": "000000000000000000000004" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file4_chunk1
+        _id: { "$oid": "000000000000000000000004" }
+        files_id: { "$oid": "000000000000000000000004" }
+        n: 1
+        data: { "$binary": { "base64": "", "subType": "00" } }
+
+tests:
+  - description: "rename when multiple revisions of the file exist"
+    operations:
+      - name: renameByName
+        object: *bucket0
+        arguments:
+          filename: filename
+          newFilename: newfilename
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents:
+          - <<: *file1
+            filename: newfilename
+          - <<: *file2
+            filename: newfilename
+          - <<: *file3
+            filename: newfilename
+          - <<: *file4
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents:
+          - *file2_chunk0
+          - *file3_chunk0
+          - *file4_chunk0
+          - *file4_chunk1
+  - description: "rename when file name does not exist"
+    operations:
+      - name: renameByName
+        object: *bucket0
+        arguments:
+          filename: missing-file
+          newFilename: newfilename
+        expectError: { isClientError: true } # FileNotFound

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -53,7 +53,7 @@ use find::{
     FindOneAndUpdate,
 };
 use futures::{future::BoxFuture, FutureExt};
-use gridfs::{Delete, Download, DownloadByName, Upload};
+use gridfs::{Delete, DeleteByName, Download, DownloadByName, RenameByName, Upload};
 use index::{
     AssertIndexExists,
     AssertIndexNotExists,
@@ -424,7 +424,9 @@ impl<'de> Deserialize<'de> for Operation {
             "download" => deserialize_op::<Download>(definition.arguments),
             "downloadByName" => deserialize_op::<DownloadByName>(definition.arguments),
             "delete" => deserialize_op::<Delete>(definition.arguments),
+            "deleteByName" => deserialize_op::<DeleteByName>(definition.arguments),
             "upload" => deserialize_op::<Upload>(definition.arguments),
+            "renameByName" => deserialize_op::<RenameByName>(definition.arguments),
             #[cfg(feature = "in-use-encryption")]
             "getKeyByAltName" => deserialize_op::<GetKeyByAltName>(definition.arguments),
             #[cfg(feature = "in-use-encryption")]

--- a/src/test/spec/unified_runner/operation/gridfs.rs
+++ b/src/test/spec/unified_runner/operation/gridfs.rs
@@ -89,6 +89,28 @@ impl TestOperation for Delete {
         .boxed()
     }
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct DeleteByName {
+    filename: String,
+}
+
+impl TestOperation for DeleteByName {
+    fn execute_entity_operation<'a>(
+        &'a self,
+        id: &'a str,
+        test_runner: &'a TestRunner,
+    ) -> BoxFuture<'a, Result<Option<Entity>>> {
+        async move {
+            let bucket = test_runner.get_bucket(id).await;
+            bucket.delete_by_name(&self.filename).await?;
+            Ok(None)
+        }
+        .boxed()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct Upload {

--- a/src/test/spec/unified_runner/operation/gridfs.rs
+++ b/src/test/spec/unified_runner/operation/gridfs.rs
@@ -146,3 +146,27 @@ impl TestOperation for Upload {
         .boxed()
     }
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct RenameByName {
+    filename: String,
+    new_filename: String,
+}
+
+impl TestOperation for RenameByName {
+    fn execute_entity_operation<'a>(
+        &'a self,
+        id: &'a str,
+        test_runner: &'a TestRunner,
+    ) -> BoxFuture<'a, Result<Option<Entity>>> {
+        async move {
+            let bucket = test_runner.get_bucket(id).await;
+            bucket
+                .rename_by_name(&self.filename, &self.new_filename)
+                .await?;
+            Ok(None)
+        }
+        .boxed()
+    }
+}


### PR DESCRIPTION
RUST-2090

This adds the helpers for RUST-2090 and RUST-2091; it also syncs _some_ of the changes from RUST-2080 but there are wrinkles with the added tests for gridfs rename (see comments in DRIVERS-3023) so those aren't in here.  With the exception of the `rename.yaml`/`.json` that adds, this brings the `gridfs` test path fully up to sync.