### PR TITLE
RUST-2209 Assert `InvalidArgument` errors are returned for too-large bulk write inputs

### DIFF
--- a/src/test/bulk_write.rs
+++ b/src/test/bulk_write.rs
@@ -514,7 +514,7 @@ async fn too_large_client_error() {
         .build();
 
     let error = client.bulk_write(vec![model]).await.unwrap_err();
-    assert!(!error.is_server_error());
+    assert!(error.is_invalid_argument());
 
     // Case 2: namespace too large
     let model = InsertOneModel::builder()
@@ -523,7 +523,7 @@ async fn too_large_client_error() {
         .build();
 
     let error = client.bulk_write(vec![model]).await.unwrap_err();
-    assert!(!error.is_server_error());
+    assert!(error.is_invalid_argument());
 }
 
 // CRUD prose test 13


### PR DESCRIPTION
changes for https://github.com/mongodb/specifications/pull/1785