### PR TITLE
RUST-2198 Add `run_raw_command` method

### DIFF
--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -51,7 +51,7 @@ impl Database {
     /// Note that no inspection is done on `doc`, so the command will not use the database's default
     /// read concern or write concern. If specific read concern or write concern is desired, it must
     /// be specified manually.
-    /// Please note that run_command doesn't validate WriteConcerns passed into the body of the
+    /// Please note that run_raw_command doesn't validate WriteConcerns passed into the body of the
     /// command document.
     ///
     /// `await` will return d[`Result<Document>`].
@@ -119,7 +119,7 @@ impl crate::sync::Database {
     /// Note that no inspection is done on `doc`, so the command will not use the database's default
     /// read concern or write concern. If specific read concern or write concern is desired, it must
     /// be specified manually.
-    /// Please note that run_command doesn't validate WriteConcerns passed into the body of the
+    /// Please note that run_raw_command doesn't validate WriteConcerns passed into the body of the
     /// command document.
     ///
     /// [`run`](RunCommand::run) will return d[`Result<Document>`].

--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -9,19 +9,11 @@ use crate::{
     error::{ErrorKind, Result},
     operation::{run_command, run_cursor_command},
     selection_criteria::SelectionCriteria,
-    ClientSession,
-    Cursor,
-    Database,
-    SessionCursor,
+    ClientSession, Cursor, Database, SessionCursor,
 };
 
 use super::{
-    action_impl,
-    deeplink,
-    export_doc,
-    option_setters,
-    options_doc,
-    ExplicitSession,
+    action_impl, deeplink, export_doc, option_setters, options_doc, ExplicitSession,
     ImplicitSession,
 };
 
@@ -179,7 +171,7 @@ impl<'a> Action for RunCommand<'a> {
         if let Some(session) = &self.session {
             match session.transaction.state {
                 TransactionState::Starting | TransactionState::InProgress => {
-                    if command.get("readConcern").ok().is_some() {
+                    if command.get("readConcern").is_ok_and(|rc| rc.is_some()) {
                         return Err(ErrorKind::InvalidArgument {
                             message: "Cannot set read concern after starting a transaction".into(),
                         }

--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -106,6 +106,21 @@ impl crate::sync::Database {
         self.async_database.run_command(command)
     }
 
+    /// Runs a database-level command.
+    ///
+    /// Note that no inspection is done on `doc`, so the command will not use the database's default
+    /// read concern or write concern. If specific read concern or write concern is desired, it must
+    /// be specified manually.
+    /// Please note that run_command doesn't validate WriteConcerns passed into the body of the
+    /// command document.
+    ///
+    /// [`run`](RunCommand::run) will return d[`Result<Document>`].
+    #[deeplink]
+    #[options_doc(run_command, sync)]
+    pub fn run_raw_command(&self, command: RawDocumentBuf) -> RunCommand {
+        self.async_database.run_raw_command(command)
+    }
+
     /// Runs a database-level command and returns a cursor to the response.
     ///
     /// [`run`](RunCursorCommand::run) will return d[`Result<crate::sync::Cursor<Document>>`] or a
@@ -114,6 +129,16 @@ impl crate::sync::Database {
     #[options_doc(run_cursor_command, sync)]
     pub fn run_cursor_command(&self, command: Document) -> RunCursorCommand {
         self.async_database.run_cursor_command(command)
+    }
+
+    /// Runs a database-level command and returns a cursor to the response.
+    ///
+    /// [`run`](RunCursorCommand::run) will return d[`Result<crate::sync::Cursor<Document>>`] or a
+    /// d[`Result<crate::sync::SessionCursor<Document>>`] if a [`ClientSession`] is provided.
+    #[deeplink]
+    #[options_doc(run_cursor_command, sync)]
+    pub fn run_raw_cursor_command(&self, command: RawDocumentBuf) -> RunCursorCommand {
+        self.async_database.run_raw_cursor_command(command)
     }
 }
 

--- a/src/action/run_command.rs
+++ b/src/action/run_command.rs
@@ -9,11 +9,19 @@ use crate::{
     error::{ErrorKind, Result},
     operation::{run_command, run_cursor_command},
     selection_criteria::SelectionCriteria,
-    ClientSession, Cursor, Database, SessionCursor,
+    ClientSession,
+    Cursor,
+    Database,
+    SessionCursor,
 };
 
 use super::{
-    action_impl, deeplink, export_doc, option_setters, options_doc, ExplicitSession,
+    action_impl,
+    deeplink,
+    export_doc,
+    option_setters,
+    options_doc,
+    ExplicitSession,
     ImplicitSession,
 };
 

--- a/src/client/csfle/state_machine.rs
+++ b/src/client/csfle/state_machine.rs
@@ -126,7 +126,7 @@ impl CryptExecutor {
                     let db = db.as_ref().ok_or_else(|| {
                         Error::internal("db required for NeedMongoMarkings state")
                     })?;
-                    let op = RawOutput(RunCommand::new_raw(db.to_string(), command, None, None)?);
+                    let op = RawOutput(RunCommand::new(db.to_string(), command, None, None));
                     let mongocryptd_client = self.mongocryptd_client.as_ref().ok_or_else(|| {
                         Error::invalid_argument("this operation requires mongocryptd")
                     })?;

--- a/src/coll.rs
+++ b/src/coll.rs
@@ -3,11 +3,11 @@ pub mod options;
 
 use std::{fmt, fmt::Debug, str::FromStr, sync::Arc};
 
+use bson::rawdoc;
 use serde::{de::Error as DeError, Deserialize, Deserializer, Serialize};
 
 use self::options::*;
 use crate::{
-    bson::doc,
     client::options::ServerAddress,
     cmap::conn::PinnedConnectionHandle,
     concern::{ReadConcern, WriteConcern},
@@ -199,13 +199,13 @@ where
 
         let op = crate::operation::run_command::RunCommand::new(
             ns.db,
-            doc! {
+            rawdoc! {
                 "killCursors": ns.coll.as_str(),
                 "cursors": [cursor_id]
             },
             drop_address.map(SelectionCriteria::from_address),
             pinned_connection,
-        )?;
+        );
         self.client().execute_operation(op, None).await?;
         Ok(())
     }

--- a/src/operation/run_command.rs
+++ b/src/operation/run_command.rs
@@ -21,30 +21,16 @@ pub(crate) struct RunCommand<'conn> {
 impl<'conn> RunCommand<'conn> {
     pub(crate) fn new(
         db: String,
-        command: Document,
-        selection_criteria: Option<SelectionCriteria>,
-        pinned_connection: Option<&'conn PinnedConnectionHandle>,
-    ) -> Result<Self> {
-        Ok(Self {
-            db,
-            command: RawDocumentBuf::from_document(&command)?,
-            selection_criteria,
-            pinned_connection,
-        })
-    }
-
-    pub(crate) fn new_raw(
-        db: String,
         command: RawDocumentBuf,
         selection_criteria: Option<SelectionCriteria>,
         pinned_connection: Option<&'conn PinnedConnectionHandle>,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             db,
             command,
             selection_criteria,
             pinned_connection,
-        })
+        }
     }
 
     fn command_name(&self) -> Option<&str> {

--- a/src/operation/run_command.rs
+++ b/src/operation/run_command.rs
@@ -33,7 +33,6 @@ impl<'conn> RunCommand<'conn> {
         })
     }
 
-    #[cfg(feature = "in-use-encryption")]
     pub(crate) fn new_raw(
         db: String,
         command: RawDocumentBuf,


### PR DESCRIPTION
The database `run_command` api only takes a Document, while internally it is later converted to a RawDocumentBuf before execution. In a situation where you already have the command as a RawDocumentBuf in the first place, an unneeded conversion RawDocumentBuf -> Document -> RawDocumentBuf is required to use this API.

I noticed that there was this `RunCommand::new_raw` method, which was feature gated behind "in-use-encryption". I'm not sure the reason for this gate, but it's trivial to remove it and use it with the additional `database.raw_run_command` method added here.

I only added `raw_run_command`, but a similar `raw_run_cursor_command` could also be added which takes RawDocumentBuf as well.