### PR TITLE
RUST-2195 add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Listing code owners is required by DRIVERS-3098
+* @mongodb/dbx-rust


### PR DESCRIPTION
To meet requirement of DRIVERS-3098. Follows pattern from other drivers: [PHP](https://github.com/mongodb/mongo-php-library/blob/a4ccccd9011bad978e6f0d52efd1a512ef64d35a/.github/CODEOWNERS), [C#](https://github.com/mongodb/mongo-csharp-driver/blob/main/CODEOWNERS).