### PR TITLE
RUST-663 Support $merge and $out executing on secondaries

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -33,13 +33,10 @@ if [ "Windows_NT" == "$OS" ]; then
   export SSL_CERT_DIR=$(cygpath /etc/ssl/certs --windows)
 fi
 
-CARGO_OPTIONS+=("--nocapture")
-export TEST_FILE=aggregate-write-readPreference.json
-cargo_test "test::spec::crud::run_unified"
-#cargo_test ""
+cargo_test ""
 
 # cargo-nextest doesn't support doc tests
-#RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)
-#((CARGO_RESULT = ${CARGO_RESULT} || $?))
+RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)
+((CARGO_RESULT = ${CARGO_RESULT} || $?))
 
 exit $CARGO_RESULT

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -33,10 +33,13 @@ if [ "Windows_NT" == "$OS" ]; then
   export SSL_CERT_DIR=$(cygpath /etc/ssl/certs --windows)
 fi
 
-cargo_test ""
+CARGO_OPTIONS+=("--nocapture")
+export TEST_FILE=aggregate-write-readPreference.json
+cargo_test "test::spec::crud::run_unified"
+#cargo_test ""
 
 # cargo-nextest doesn't support doc tests
-RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)
-((CARGO_RESULT = ${CARGO_RESULT} || $?))
+#RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)
+#((CARGO_RESULT = ${CARGO_RESULT} || $?))
 
 exit $CARGO_RESULT

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -309,6 +309,8 @@ impl Client {
         let mut retry: Option<ExecutionRetry> = None;
         let mut implicit_session: Option<ClientSession> = None;
         loop {
+            op.update_for_topology(&self.inner.topology.description());
+
             if retry.is_some() {
                 op.update_for_retry();
             }

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -498,7 +498,7 @@ impl Client {
         self.inner.topology.update_command_with_read_pref(
             connection.address(),
             &mut cmd,
-            Some(&effective_criteria),
+            &effective_criteria,
         );
 
         match session {

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -29,6 +29,7 @@ use crate::{
             wire::{next_request_id, Message},
             PinnedConnectionHandle,
         },
+        Command,
         ConnectionPool,
         RawCommandResponse,
     },
@@ -58,7 +59,7 @@ use crate::{
         Retryability,
     },
     options::{ChangeStreamOptions, SelectionCriteria},
-    sdam::{HandshakePhase, SelectedServer, ServerType, TopologyType, TransactionSupportStatus},
+    sdam::{HandshakePhase, ServerType, TopologyType, TransactionSupportStatus},
     selection_criteria::ReadPreference,
     tracking_arc::TrackingArc,
     ClusterTime,
@@ -309,7 +310,7 @@ impl Client {
         let mut retry: Option<ExecutionRetry> = None;
         let mut implicit_session: Option<ClientSession> = None;
         loop {
-            op.update_for_topology(&self.inner.topology.description());
+            //op.update_for_topology(&self.inner.topology.description());
 
             if retry.is_some() {
                 op.update_for_retry();
@@ -320,7 +321,7 @@ impl Client {
                 .and_then(|s| s.transaction.pinned_mongos())
                 .or_else(|| op.selection_criteria());
 
-            let server = match self
+            let (server, effective_criteria) = match self
                 .select_server(
                     selection_criteria,
                     op.name(),
@@ -328,7 +329,7 @@ impl Client {
                 )
                 .await
             {
-                Ok(server) => server,
+                Ok(out) => out,
                 Err(mut err) => {
                     retry.first_error()?;
 
@@ -389,14 +390,11 @@ impl Client {
                 .and_then(|r| r.prior_txn_number)
                 .or_else(|| get_txn_number(&mut session, retryability));
 
+            let cmd =
+                self.build_command(op, &mut conn, &mut session, txn_number, effective_criteria)?;
+
             let details = match self
-                .execute_operation_on_connection(
-                    op,
-                    &mut conn,
-                    &mut session,
-                    txn_number,
-                    retryability,
-                )
+                .execute_command_on_connection(cmd, op, &mut conn, &mut session, retryability)
                 .await
             {
                 Ok(output) => ExecutionDetails {
@@ -485,19 +483,14 @@ impl Client {
         }
     }
 
-    /// Executes an operation on a given connection, optionally using a provided session.
-    async fn execute_operation_on_connection<T: Operation>(
+    fn build_command<T: Operation>(
         &self,
         op: &mut T,
         connection: &mut PooledConnection,
         session: &mut Option<&mut ClientSession>,
         txn_number: Option<i64>,
-        retryability: Retryability,
-    ) -> Result<T::O> {
-        if let Some(wc) = op.write_concern() {
-            wc.validate()?;
-        }
-
+        _effective_critera: SelectionCriteria,
+    ) -> Result<Command> {
         let stream_description = connection.stream_description()?;
         let is_sharded = stream_description.initial_server_type == ServerType::Mongos;
         let mut cmd = op.build(stream_description)?;
@@ -605,16 +598,30 @@ impl Client {
             cmd.set_cluster_time(cluster_time);
         }
 
-        let connection_info = connection.info();
-        let service_id = connection.service_id();
-        let request_id = next_request_id();
-
         if let Some(ref server_api) = self.inner.options.server_api {
             cmd.set_server_api(server_api);
         }
 
-        let should_redact = cmd.should_redact();
+        Ok(cmd)
+    }
 
+    /// Executes a command on a given connection, optionally using a provided session.
+    async fn execute_command_on_connection<T: Operation>(
+        &self,
+        cmd: Command,
+        op: &mut T,
+        connection: &mut PooledConnection,
+        session: &mut Option<&mut ClientSession>,
+        retryability: Retryability,
+    ) -> Result<T::O> {
+        if let Some(wc) = op.write_concern() {
+            wc.validate()?;
+        }
+
+        let connection_info = connection.info();
+        let service_id = connection.service_id();
+        let request_id = next_request_id();
+        let should_redact = cmd.should_redact();
         let cmd_name = cmd.name.clone();
         let target_db = cmd.target_db.clone();
 
@@ -653,78 +660,9 @@ impl Client {
         let start_time = Instant::now();
         let command_result = match connection.send_message(message).await {
             Ok(response) => {
-                async fn handle_response<T: Operation>(
-                    client: &Client,
-                    op: &T,
-                    session: &mut Option<&mut ClientSession>,
-                    is_sharded: bool,
-                    response: RawCommandResponse,
-                ) -> Result<RawCommandResponse> {
-                    let raw_doc = RawDocument::from_bytes(response.as_bytes())?;
-
-                    let ok = match raw_doc.get("ok")? {
-                        Some(b) => crate::bson_util::get_int_raw(b).ok_or_else(|| {
-                            ErrorKind::InvalidResponse {
-                                message: format!(
-                                    "expected ok value to be a number, instead got {:?}",
-                                    b
-                                ),
-                            }
-                        })?,
-                        None => {
-                            return Err(ErrorKind::InvalidResponse {
-                                message: "missing 'ok' value in response".to_string(),
-                            }
-                            .into())
-                        }
-                    };
-
-                    let cluster_time: Option<ClusterTime> = raw_doc
-                        .get("$clusterTime")?
-                        .and_then(RawBsonRef::as_document)
-                        .map(|d| bson::from_slice(d.as_bytes()))
-                        .transpose()?;
-
-                    let at_cluster_time = op.extract_at_cluster_time(raw_doc)?;
-
-                    client
-                        .update_cluster_time(cluster_time, at_cluster_time, session)
-                        .await;
-
-                    if let (Some(session), Some(ts)) = (
-                        session.as_mut(),
-                        raw_doc
-                            .get("operationTime")?
-                            .and_then(RawBsonRef::as_timestamp),
-                    ) {
-                        session.advance_operation_time(ts);
-                    }
-
-                    if ok == 1 {
-                        if let Some(ref mut session) = session {
-                            if is_sharded && session.in_transaction() {
-                                let recovery_token = raw_doc
-                                    .get("recoveryToken")?
-                                    .and_then(RawBsonRef::as_document)
-                                    .map(|d| bson::from_slice(d.as_bytes()))
-                                    .transpose()?;
-                                session.transaction.recovery_token = recovery_token;
-                            }
-                        }
-
-                        Ok(response)
-                    } else {
-                        Err(response
-                            .body::<CommandErrorBody>()
-                            .map(|error_response| error_response.into())
-                            .unwrap_or_else(|e| {
-                                Error::from(ErrorKind::InvalidResponse {
-                                    message: format!("error deserializing command error: {}", e),
-                                })
-                            }))
-                    }
-                }
-                handle_response(self, op, session, is_sharded, response).await
+                let is_sharded =
+                    connection.stream_description()?.initial_server_type == ServerType::Mongos;
+                Self::parse_response(self, op, session, is_sharded, response).await
             }
             Err(err) => Err(err),
         };
@@ -811,6 +749,75 @@ impl Client {
         }
     }
 
+    async fn parse_response<T: Operation>(
+        client: &Client,
+        op: &T,
+        session: &mut Option<&mut ClientSession>,
+        is_sharded: bool,
+        response: RawCommandResponse,
+    ) -> Result<RawCommandResponse> {
+        let raw_doc = RawDocument::from_bytes(response.as_bytes())?;
+
+        let ok = match raw_doc.get("ok")? {
+            Some(b) => {
+                crate::bson_util::get_int_raw(b).ok_or_else(|| ErrorKind::InvalidResponse {
+                    message: format!("expected ok value to be a number, instead got {:?}", b),
+                })?
+            }
+            None => {
+                return Err(ErrorKind::InvalidResponse {
+                    message: "missing 'ok' value in response".to_string(),
+                }
+                .into())
+            }
+        };
+
+        let cluster_time: Option<ClusterTime> = raw_doc
+            .get("$clusterTime")?
+            .and_then(RawBsonRef::as_document)
+            .map(|d| bson::from_slice(d.as_bytes()))
+            .transpose()?;
+
+        let at_cluster_time = op.extract_at_cluster_time(raw_doc)?;
+
+        client
+            .update_cluster_time(cluster_time, at_cluster_time, session)
+            .await;
+
+        if let (Some(session), Some(ts)) = (
+            session.as_mut(),
+            raw_doc
+                .get("operationTime")?
+                .and_then(RawBsonRef::as_timestamp),
+        ) {
+            session.advance_operation_time(ts);
+        }
+
+        if ok == 1 {
+            if let Some(ref mut session) = session {
+                if is_sharded && session.in_transaction() {
+                    let recovery_token = raw_doc
+                        .get("recoveryToken")?
+                        .and_then(RawBsonRef::as_document)
+                        .map(|d| bson::from_slice(d.as_bytes()))
+                        .transpose()?;
+                    session.transaction.recovery_token = recovery_token;
+                }
+            }
+
+            Ok(response)
+        } else {
+            Err(response
+                .body::<CommandErrorBody>()
+                .map(|error_response| error_response.into())
+                .unwrap_or_else(|e| {
+                    Error::from(ErrorKind::InvalidResponse {
+                        message: format!("error deserializing command error: {}", e),
+                    })
+                }))
+        }
+    }
+
     #[cfg(feature = "in-use-encryption")]
     fn auto_encrypt<'a>(
         &'a self,
@@ -846,7 +853,7 @@ impl Client {
             (matches!(topology_type, TopologyType::Single) && server_type.is_available())
                 || server_type.is_data_bearing()
         }));
-        let _: SelectedServer = self
+        let _ = self
             .select_server(Some(&criteria), operation_name, None)
             .await?;
         Ok(())

--- a/src/client/executor.rs
+++ b/src/client/executor.rs
@@ -326,6 +326,7 @@ impl Client {
                     selection_criteria,
                     op.name(),
                     retry.as_ref().map(|r| &r.first_server),
+                    op.is_out_or_merge(),
                 )
                 .await
             {
@@ -489,7 +490,7 @@ impl Client {
         connection: &mut PooledConnection,
         session: &mut Option<&mut ClientSession>,
         txn_number: Option<i64>,
-        _effective_critera: SelectionCriteria,
+        effective_criteria: SelectionCriteria,
     ) -> Result<Command> {
         let stream_description = connection.stream_description()?;
         let is_sharded = stream_description.initial_server_type == ServerType::Mongos;
@@ -497,7 +498,7 @@ impl Client {
         self.inner.topology.update_command_with_read_pref(
             connection.address(),
             &mut cmd,
-            op.selection_criteria(),
+            Some(&effective_criteria),
         );
 
         match session {
@@ -854,7 +855,7 @@ impl Client {
                 || server_type.is_data_bearing()
         }));
         let _ = self
-            .select_server(Some(&criteria), operation_name, None)
+            .select_server(Some(&criteria), operation_name, None, false)
             .await?;
         Ok(())
     }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -76,7 +76,6 @@ pub(crate) use update::{Update, UpdateOrReplace};
 
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
 const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
-const _SERVER_5_0_0_WIRE_VERSION: i32 = 13;
 const SERVER_8_0_0_WIRE_VERSION: i32 = 25;
 // The maximum number of bytes that may be included in a write payload when auto-encryption is
 // enabled.
@@ -148,6 +147,9 @@ pub(crate) trait Operation {
 
     /// Updates this operation as needed for a retry.
     fn update_for_retry(&mut self);
+
+    /// Returns whether this is a $out or $merge aggregation operation.
+    fn is_out_or_merge(&self) -> bool;
 
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle>;
 
@@ -236,6 +238,11 @@ pub(crate) trait OperationWithDefaults: Send + Sync {
     /// Updates this operation as needed for a retry.
     fn update_for_retry(&mut self) {}
 
+    /// Returns whether this is a $out or $merge aggregation operation.
+    fn is_out_or_merge(&self) -> bool {
+        false
+    }
+
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         None
     }
@@ -287,6 +294,9 @@ where
     }
     fn update_for_retry(&mut self) {
         self.update_for_retry()
+    }
+    fn is_out_or_merge(&self) -> bool {
+        self.is_out_or_merge()
     }
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.pinned_connection()

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -52,6 +52,7 @@ use crate::{
         WriteFailure,
     },
     options::WriteConcern,
+    sdam::TopologyDescription,
     selection_criteria::SelectionCriteria,
     BoxFuture,
     ClientSession,
@@ -148,6 +149,9 @@ pub(crate) trait Operation {
     /// Updates this operation as needed for a retry.
     fn update_for_retry(&mut self);
 
+    /// Updates this operation based on server topology.
+    fn update_for_topology(&mut self, _topology: &TopologyDescription);
+
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle>;
 
     fn name(&self) -> &str;
@@ -235,6 +239,9 @@ pub(crate) trait OperationWithDefaults: Send + Sync {
     /// Updates this operation as needed for a retry.
     fn update_for_retry(&mut self) {}
 
+    /// Updates this operation based on server topology.
+    fn update_for_topology(&mut self, _topology: &TopologyDescription) {}
+
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         None
     }
@@ -286,6 +293,9 @@ where
     }
     fn update_for_retry(&mut self) {
         self.update_for_retry()
+    }
+    fn update_for_topology(&mut self, topology: &TopologyDescription) {
+        self.update_for_topology(topology)
     }
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.pinned_connection()

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -52,7 +52,6 @@ use crate::{
         WriteFailure,
     },
     options::WriteConcern,
-    sdam::TopologyDescription,
     selection_criteria::SelectionCriteria,
     BoxFuture,
     ClientSession,
@@ -77,6 +76,7 @@ pub(crate) use update::{Update, UpdateOrReplace};
 
 const SERVER_4_2_0_WIRE_VERSION: i32 = 8;
 const SERVER_4_4_0_WIRE_VERSION: i32 = 9;
+const _SERVER_5_0_0_WIRE_VERSION: i32 = 13;
 const SERVER_8_0_0_WIRE_VERSION: i32 = 25;
 // The maximum number of bytes that may be included in a write payload when auto-encryption is
 // enabled.
@@ -148,9 +148,6 @@ pub(crate) trait Operation {
 
     /// Updates this operation as needed for a retry.
     fn update_for_retry(&mut self);
-
-    /// Updates this operation based on server topology.
-    fn update_for_topology(&mut self, _topology: &TopologyDescription);
 
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle>;
 
@@ -239,9 +236,6 @@ pub(crate) trait OperationWithDefaults: Send + Sync {
     /// Updates this operation as needed for a retry.
     fn update_for_retry(&mut self) {}
 
-    /// Updates this operation based on server topology.
-    fn update_for_topology(&mut self, _topology: &TopologyDescription) {}
-
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         None
     }
@@ -293,9 +287,6 @@ where
     }
     fn update_for_retry(&mut self) {
         self.update_for_retry()
-    }
-    fn update_for_topology(&mut self, topology: &TopologyDescription) {
-        self.update_for_topology(topology)
     }
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.pinned_connection()

--- a/src/operation/aggregate.rs
+++ b/src/operation/aggregate.rs
@@ -109,33 +109,6 @@ impl OperationWithDefaults for Aggregate {
         ))
     }
 
-    /*
-    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
-        eprintln!("aggregate: update_for_topology");
-        if !self.is_out_or_merge()
-            || matches!(
-                self.selection_criteria(),
-                None | Some(SelectionCriteria::ReadPreference(ReadPreference::Primary))
-            )
-            || topology.topology_type() == TopologyType::LoadBalanced
-        {
-            eprintln!("aggregate: skipping topology update");
-            return;
-        }
-        for server in topology.servers.values() {
-            let _ = dbg!(server.hello_response());
-            if let Ok(Some(v)) = server.max_wire_version() {
-                if v < SERVER_5_0_0_WIRE_VERSION {
-                    eprintln!("aggregate: updating topology");
-                    self.options.get_or_insert_default().selection_criteria =
-                        Some(SelectionCriteria::ReadPreference(ReadPreference::Primary));
-                    break;
-                }
-            }
-        }
-    }
-    */
-
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {
         self.options
             .as_ref()
@@ -161,10 +134,7 @@ impl OperationWithDefaults for Aggregate {
             Retryability::Read
         }
     }
-}
 
-impl Aggregate {
-    /// Returns whether this is a $out or $merge aggregation operation.
     fn is_out_or_merge(&self) -> bool {
         self.pipeline
             .last()

--- a/src/operation/aggregate.rs
+++ b/src/operation/aggregate.rs
@@ -7,7 +7,7 @@ use crate::{
     cursor::CursorSpecification,
     error::Result,
     operation::{append_options, remove_empty_write_concern, Retryability},
-    options::{AggregateOptions, ReadPreference, SelectionCriteria, WriteConcern},
+    options::{AggregateOptions, SelectionCriteria, WriteConcern},
     Namespace,
 };
 
@@ -109,13 +109,32 @@ impl OperationWithDefaults for Aggregate {
         ))
     }
 
-    fn update_for_topology(&mut self, _topology: &crate::sdam::TopologyDescription) {
-        match self.selection_criteria() {
-            None => return,
-            Some(SelectionCriteria::ReadPreference(ReadPreference::Primary)) => return,
-            _ => (),
+    /*
+    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
+        eprintln!("aggregate: update_for_topology");
+        if !self.is_out_or_merge()
+            || matches!(
+                self.selection_criteria(),
+                None | Some(SelectionCriteria::ReadPreference(ReadPreference::Primary))
+            )
+            || topology.topology_type() == TopologyType::LoadBalanced
+        {
+            eprintln!("aggregate: skipping topology update");
+            return;
+        }
+        for server in topology.servers.values() {
+            let _ = dbg!(server.hello_response());
+            if let Ok(Some(v)) = server.max_wire_version() {
+                if v < SERVER_5_0_0_WIRE_VERSION {
+                    eprintln!("aggregate: updating topology");
+                    self.options.get_or_insert_default().selection_criteria =
+                        Some(SelectionCriteria::ReadPreference(ReadPreference::Primary));
+                    break;
+                }
+            }
         }
     }
+    */
 
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {
         self.options

--- a/src/operation/aggregate.rs
+++ b/src/operation/aggregate.rs
@@ -109,7 +109,7 @@ impl OperationWithDefaults for Aggregate {
         ))
     }
 
-    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
+    fn update_for_topology(&mut self, _topology: &crate::sdam::TopologyDescription) {
         match self.selection_criteria() {
             None => return,
             Some(SelectionCriteria::ReadPreference(ReadPreference::Primary)) => return,

--- a/src/operation/aggregate.rs
+++ b/src/operation/aggregate.rs
@@ -7,7 +7,7 @@ use crate::{
     cursor::CursorSpecification,
     error::Result,
     operation::{append_options, remove_empty_write_concern, Retryability},
-    options::{AggregateOptions, SelectionCriteria, WriteConcern},
+    options::{AggregateOptions, ReadPreference, SelectionCriteria, WriteConcern},
     Namespace,
 };
 
@@ -107,6 +107,14 @@ impl OperationWithDefaults for Aggregate {
             self.options.as_ref().and_then(|opts| opts.max_await_time),
             comment,
         ))
+    }
+
+    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
+        match self.selection_criteria() {
+            None => return,
+            Some(SelectionCriteria::ReadPreference(ReadPreference::Primary)) => return,
+            _ => (),
+        }
     }
 
     fn selection_criteria(&self) -> Option<&SelectionCriteria> {

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -68,6 +68,10 @@ impl<Op: Operation> Operation for RawOutput<Op> {
         self.0.update_for_retry()
     }
 
+    fn is_out_or_merge(&self) -> bool {
+        self.0.is_out_or_merge()
+    }
+
     fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
         self.0.pinned_connection()
     }

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -68,10 +68,6 @@ impl<Op: Operation> Operation for RawOutput<Op> {
         self.0.update_for_retry()
     }
 
-    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
-        self.0.update_for_topology(topology)
-    }
-
     fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
         self.0.pinned_connection()
     }

--- a/src/operation/raw_output.rs
+++ b/src/operation/raw_output.rs
@@ -68,6 +68,10 @@ impl<Op: Operation> Operation for RawOutput<Op> {
         self.0.update_for_retry()
     }
 
+    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
+        self.0.update_for_topology(topology)
+    }
+
     fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
         self.0.pinned_connection()
     }

--- a/src/operation/run_cursor_command.rs
+++ b/src/operation/run_cursor_command.rs
@@ -79,6 +79,10 @@ impl Operation for RunCursorCommand<'_> {
         self.run_command.update_for_retry()
     }
 
+    fn is_out_or_merge(&self) -> bool {
+        self.run_command.is_out_or_merge()
+    }
+
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.run_command.pinned_connection()
     }

--- a/src/operation/run_cursor_command.rs
+++ b/src/operation/run_cursor_command.rs
@@ -79,10 +79,6 @@ impl Operation for RunCursorCommand<'_> {
         self.run_command.update_for_retry()
     }
 
-    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
-        self.run_command.update_for_topology(topology)
-    }
-
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.run_command.pinned_connection()
     }

--- a/src/operation/run_cursor_command.rs
+++ b/src/operation/run_cursor_command.rs
@@ -79,6 +79,10 @@ impl Operation for RunCursorCommand<'_> {
         self.run_command.update_for_retry()
     }
 
+    fn update_for_topology(&mut self, topology: &crate::sdam::TopologyDescription) {
+        self.run_command.update_for_topology(topology)
+    }
+
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
         self.run_command.pinned_connection()
     }

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -386,6 +386,13 @@ impl ServerDescription {
         Ok(me)
     }
 
+    pub(crate) fn hello_response(&self) -> Result<Option<&HelloCommandResponse>> {
+        self.reply
+            .as_ref()
+            .map_err(Clone::clone)
+            .map(|o| o.as_ref().map(|r| &r.command_response))
+    }
+
     pub(crate) fn last_write_date(&self) -> Result<Option<DateTime>> {
         match self.reply {
             Ok(None) => Ok(None),

--- a/src/sdam/description/topology.rs
+++ b/src/sdam/description/topology.rs
@@ -205,7 +205,7 @@ impl TopologyDescription {
         &self,
         address: &ServerAddress,
         command: &mut Command,
-        criteria: Option<&SelectionCriteria>,
+        criteria: &SelectionCriteria,
     ) {
         let server_type = self
             .get_server_description(address)
@@ -220,8 +220,7 @@ impl TopologyDescription {
             }
             (TopologyType::Single, ServerType::Standalone) => {}
             (TopologyType::Single, _) => {
-                let specified_read_pref =
-                    criteria.and_then(SelectionCriteria::as_read_pref).cloned();
+                let specified_read_pref = criteria.as_read_pref().cloned();
 
                 let resolved_read_pref = match specified_read_pref {
                     Some(ReadPreference::Primary) | None => ReadPreference::PrimaryPreferred {
@@ -235,11 +234,10 @@ impl TopologyDescription {
             }
             _ => {
                 let read_pref = match criteria {
-                    Some(SelectionCriteria::ReadPreference(rp)) => rp.clone(),
-                    Some(SelectionCriteria::Predicate(_)) => ReadPreference::PrimaryPreferred {
+                    SelectionCriteria::ReadPreference(rp) => rp.clone(),
+                    SelectionCriteria::Predicate(_) => ReadPreference::PrimaryPreferred {
                         options: Default::default(),
                     },
-                    None => ReadPreference::Primary,
                 };
                 if read_pref != ReadPreference::Primary {
                     command.set_read_preference(read_pref)
@@ -251,10 +249,10 @@ impl TopologyDescription {
     fn update_command_read_pref_for_mongos(
         &self,
         command: &mut Command,
-        criteria: Option<&SelectionCriteria>,
+        criteria: &SelectionCriteria,
     ) {
         let read_preference = match criteria {
-            Some(SelectionCriteria::ReadPreference(rp)) => rp,
+            SelectionCriteria::ReadPreference(rp) => rp,
             _ => return,
         };
         match read_preference {

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -200,7 +200,7 @@ impl Topology {
         &self,
         server_address: &ServerAddress,
         command: &mut Command,
-        criteria: Option<&SelectionCriteria>,
+        criteria: &SelectionCriteria,
     ) {
         self.watcher
             .peek_latest()

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -229,7 +229,6 @@ impl Topology {
         self.watcher.peek_latest().servers()
     }
 
-    #[cfg(test)]
     pub(crate) fn description(&self) -> TopologyDescription {
         self.watcher.peek_latest().description.clone()
     }

--- a/src/sdam/topology.rs
+++ b/src/sdam/topology.rs
@@ -229,6 +229,7 @@ impl Topology {
         self.watcher.peek_latest().servers()
     }
 
+    #[cfg(test)]
     pub(crate) fn description(&self) -> TopologyDescription {
         self.watcher.peek_latest().description.clone()
     }

--- a/src/test/spec/crud.rs
+++ b/src/test/spec/crud.rs
@@ -43,13 +43,6 @@ async fn run_unified() {
          pre-5.0 server",
         "Requesting unacknowledged write with verboseResults is a client-side error",
         "Requesting unacknowledged write with ordered is a client-side error",
-        // TODO RUST-663: Unskip these tests.
-        "Aggregate with $out includes read preference for 5.0+ server",
-        "Aggregate with $out omits read preference for pre-5.0 server",
-        "Aggregate with $merge includes read preference for 5.0+ server",
-        "Aggregate with $merge omits read preference for pre-5.0 server",
-        "Database-level aggregate with $out omits read preference for pre-5.0 server",
-        "Database-level aggregate with $merge omits read preference for pre-5.0 server",
     ];
     // TODO: remove this manual skip when this test is fixed to skip on serverless
     if *SERVERLESS {


### PR DESCRIPTION
RUST-663

My original plan to have a new method on `Operation` that could update the stored selection criteria based on operation-specific logic given a topology snapshot didn't work out because server selection might need to wait for handshake to finish and if so the snapshot won't have the version information.

I did consider making `Client::select_server` take an `Operation` rather than a string operation name, but it's called from various contexts that don't have an operation to give which would need to synthesize one, and that seemed worse.

In the end, what this means is:
* server selection needs to know if it's selecting a server for an Aggregate-with-$merge/$out operation, and
* server command construction needs to know what criteria server selection _actually_ ended up using, not just the one the operation reports

So this PR does the plumbing for that.