### PR TITLE
RUST-2080 spec tests (and fix) for gridfs rename

### DIFF
--- a/src/test/spec/json/gridfs/rename.json
+++ b/src/test/spec/json/gridfs/rename.json
@@ -93,7 +93,7 @@
       "description": "rename by id",
       "operations": [
         {
-          "name": "renameById",
+          "name": "rename",
           "object": "bucket0",
           "arguments": {
             "id": {
@@ -161,7 +161,7 @@
       "description": "rename when file id does not exist",
       "operations": [
         {
-          "name": "renameById",
+          "name": "rename",
           "object": "bucket0",
           "arguments": {
             "id": {

--- a/src/test/spec/json/gridfs/rename.json
+++ b/src/test/spec/json/gridfs/rename.json
@@ -1,0 +1,179 @@
+{
+  "description": "gridfs-rename",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "rename by id",
+      "operations": [
+        {
+          "name": "renameById",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            },
+            "newFilename": "newfilename"
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "filename",
+              "metadata": {}
+            }
+          ]
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rename when file id does not exist",
+      "operations": [
+        {
+          "name": "renameById",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000003"
+            },
+            "newFilename": "newfilename"
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/spec/json/gridfs/rename.yml
+++ b/src/test/spec/json/gridfs/rename.yml
@@ -51,7 +51,7 @@ initialData:
 tests:
   - description: "rename by id"
     operations:
-      - name: renameById
+      - name: rename
         object: *bucket0
         arguments:
           id: { "$oid": "000000000000000000000001" }
@@ -70,7 +70,7 @@ tests:
           - *file2_chunk0
   - description: "rename when file id does not exist"
     operations:
-      - name: renameById
+      - name: rename
         object: *bucket0
         arguments:
           id: { "$oid": "000000000000000000000003" }

--- a/src/test/spec/json/gridfs/rename.yml
+++ b/src/test/spec/json/gridfs/rename.yml
@@ -1,0 +1,78 @@
+description: "gridfs-rename"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file1
+        _id: { "$oid": "000000000000000000000001" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file2
+        _id: { "$oid": "000000000000000000000002" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file2_chunk0
+        _id: { "$oid": "000000000000000000000001" }
+        files_id: { "$oid": "000000000000000000000002" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+
+tests:
+  - description: "rename by id"
+    operations:
+      - name: renameById
+        object: *bucket0
+        arguments:
+          id: { "$oid": "000000000000000000000001" }
+          newFilename: newfilename
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents:
+          - <<: *file1
+            filename: newfilename
+          - <<: *file2
+            filename: filename
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents:
+          - *file2_chunk0
+  - description: "rename when file id does not exist"
+    operations:
+      - name: renameById
+        object: *bucket0
+        arguments:
+          id: { "$oid": "000000000000000000000003" }
+          newFilename: newfilename
+        expectError: { isClientError: true } # FileNotFound

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -13,6 +13,7 @@ mod index;
 mod insert;
 mod iteration;
 mod list;
+mod rename;
 mod search_index;
 mod session;
 mod thread;
@@ -37,7 +38,6 @@ use collection::{
     AssertCollectionNotExists,
     CreateCollection,
     DropCollection,
-    RenameCollection,
 };
 use command::{CreateCommandCursor, RunCommand, RunCursorCommand};
 use connection::{AssertNumberConnectionsCheckedOut, Close};
@@ -53,7 +53,7 @@ use find::{
     FindOneAndUpdate,
 };
 use futures::{future::BoxFuture, FutureExt};
-use gridfs::{Delete, DeleteByName, Download, DownloadByName, RenameById, RenameByName, Upload};
+use gridfs::{Delete, DeleteByName, Download, DownloadByName, RenameByName, Upload};
 use index::{
     AssertIndexExists,
     AssertIndexNotExists,
@@ -65,6 +65,7 @@ use index::{
 use insert::{InsertMany, InsertOne};
 use iteration::{IterateOnce, IterateUntilDocumentOrError};
 use list::{ListCollectionNames, ListCollections, ListDatabaseNames, ListDatabases};
+use rename::Rename;
 use serde::{
     de::{DeserializeOwned, Deserializer},
     Deserialize,
@@ -408,7 +409,7 @@ impl<'de> Deserialize<'de> for Operation {
             }
             "close" => deserialize_op::<Close>(definition.arguments),
             "createChangeStream" => deserialize_op::<CreateChangeStream>(definition.arguments),
-            "rename" => deserialize_op::<RenameCollection>(definition.arguments),
+            "rename" => deserialize_op::<Rename>(definition.arguments),
             "loop" => deserialize_op::<Loop>(definition.arguments),
             "waitForEvent" => deserialize_op::<WaitForEvent>(definition.arguments),
             "assertEventCount" => deserialize_op::<AssertEventCount>(definition.arguments),
@@ -426,7 +427,6 @@ impl<'de> Deserialize<'de> for Operation {
             "delete" => deserialize_op::<Delete>(definition.arguments),
             "deleteByName" => deserialize_op::<DeleteByName>(definition.arguments),
             "upload" => deserialize_op::<Upload>(definition.arguments),
-            "renameById" => deserialize_op::<RenameById>(definition.arguments),
             "renameByName" => deserialize_op::<RenameByName>(definition.arguments),
             #[cfg(feature = "in-use-encryption")]
             "getKeyByAltName" => deserialize_op::<GetKeyByAltName>(definition.arguments),

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -53,7 +53,7 @@ use find::{
     FindOneAndUpdate,
 };
 use futures::{future::BoxFuture, FutureExt};
-use gridfs::{Delete, DeleteByName, Download, DownloadByName, RenameByName, Upload};
+use gridfs::{Delete, DeleteByName, Download, DownloadByName, RenameById, RenameByName, Upload};
 use index::{
     AssertIndexExists,
     AssertIndexNotExists,
@@ -426,6 +426,7 @@ impl<'de> Deserialize<'de> for Operation {
             "delete" => deserialize_op::<Delete>(definition.arguments),
             "deleteByName" => deserialize_op::<DeleteByName>(definition.arguments),
             "upload" => deserialize_op::<Upload>(definition.arguments),
+            "renameById" => deserialize_op::<RenameById>(definition.arguments),
             "renameByName" => deserialize_op::<RenameByName>(definition.arguments),
             #[cfg(feature = "in-use-encryption")]
             "getKeyByAltName" => deserialize_op::<GetKeyByAltName>(definition.arguments),

--- a/src/test/spec/unified_runner/operation/collection.rs
+++ b/src/test/spec/unified_runner/operation/collection.rs
@@ -120,35 +120,6 @@ impl TestOperation for DropCollection {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct RenameCollection {
-    to: String,
-}
-
-impl TestOperation for RenameCollection {
-    fn execute_entity_operation<'a>(
-        &'a self,
-        id: &'a str,
-        test_runner: &'a TestRunner,
-    ) -> BoxFuture<'a, Result<Option<Entity>>> {
-        async move {
-            let target = test_runner.get_collection(id).await;
-            let ns = target.namespace();
-            let mut to_ns = ns.clone();
-            to_ns.coll.clone_from(&self.to);
-            let cmd = doc! {
-                "renameCollection": crate::bson::to_bson(&ns)?,
-                "to": crate::bson::to_bson(&to_ns)?,
-            };
-            let admin = test_runner.internal_client.database("admin");
-            admin.run_command(cmd).await?;
-            Ok(None)
-        }
-        .boxed()
-    }
-}
-
-#[derive(Debug, Deserialize)]
 pub(super) struct Aggregate {
     pipeline: Vec<Document>,
     session: Option<String>,

--- a/src/test/spec/unified_runner/operation/gridfs.rs
+++ b/src/test/spec/unified_runner/operation/gridfs.rs
@@ -170,3 +170,25 @@ impl TestOperation for RenameByName {
         .boxed()
     }
 }
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct RenameById {
+    id: Bson,
+    new_filename: String,
+}
+
+impl TestOperation for RenameById {
+    fn execute_entity_operation<'a>(
+        &'a self,
+        id: &'a str,
+        test_runner: &'a TestRunner,
+    ) -> BoxFuture<'a, Result<Option<Entity>>> {
+        async move {
+            let bucket = test_runner.get_bucket(id).await;
+            bucket.rename(self.id.clone(), &self.new_filename).await?;
+            Ok(None)
+        }
+        .boxed()
+    }
+}

--- a/src/test/spec/unified_runner/operation/gridfs.rs
+++ b/src/test/spec/unified_runner/operation/gridfs.rs
@@ -170,25 +170,3 @@ impl TestOperation for RenameByName {
         .boxed()
     }
 }
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(super) struct RenameById {
-    id: Bson,
-    new_filename: String,
-}
-
-impl TestOperation for RenameById {
-    fn execute_entity_operation<'a>(
-        &'a self,
-        id: &'a str,
-        test_runner: &'a TestRunner,
-    ) -> BoxFuture<'a, Result<Option<Entity>>> {
-        async move {
-            let bucket = test_runner.get_bucket(id).await;
-            bucket.rename(self.id.clone(), &self.new_filename).await?;
-            Ok(None)
-        }
-        .boxed()
-    }
-}

--- a/src/test/spec/unified_runner/operation/rename.rs
+++ b/src/test/spec/unified_runner/operation/rename.rs
@@ -1,0 +1,79 @@
+use bson::{doc, Bson, Document};
+use futures::FutureExt;
+use serde::Deserialize;
+
+use crate::{
+    error::Result,
+    gridfs::GridFsBucket,
+    test::spec::unified_runner::{Entity, TestRunner},
+    BoxFuture,
+    Collection,
+};
+
+use super::TestOperation;
+
+#[derive(Debug, Deserialize)]
+#[serde(transparent)]
+pub(super) struct Rename(Document);
+
+impl TestOperation for Rename {
+    fn execute_entity_operation<'a>(
+        &'a self,
+        id: &'a str,
+        test_runner: &'a TestRunner,
+    ) -> BoxFuture<'a, Result<Option<Entity>>> {
+        async move {
+            match test_runner.entities.read().await.get(id).unwrap() {
+                Entity::Collection(c) => {
+                    let args: RenameCollection = bson::from_document(self.0.clone()).unwrap();
+                    args.run(c.clone(), test_runner).await
+                }
+                Entity::Bucket(b) => {
+                    let args: RenameBucket = bson::from_document(self.0.clone()).unwrap();
+                    args.run(b.clone()).await
+                }
+                other => panic!("cannot execute rename on {:?}", other),
+            }
+        }
+        .boxed()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RenameCollection {
+    to: String,
+}
+
+impl RenameCollection {
+    async fn run(
+        &self,
+        target: Collection<Document>,
+        test_runner: &TestRunner,
+    ) -> Result<Option<Entity>> {
+        let ns = target.namespace();
+        let mut to_ns = ns.clone();
+        to_ns.coll.clone_from(&self.to);
+        let cmd = doc! {
+            "renameCollection": crate::bson::to_bson(&ns)?,
+            "to": crate::bson::to_bson(&to_ns)?,
+        };
+        let admin = test_runner.internal_client.database("admin");
+        admin.run_command(cmd).await?;
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RenameBucket {
+    id: Bson,
+    new_filename: String,
+}
+
+impl RenameBucket {
+    async fn run(&self, target: GridFsBucket) -> Result<Option<Entity>> {
+        target.rename(self.id.clone(), &self.new_filename).await?;
+        Ok(None)
+    }
+}


### PR DESCRIPTION
RUST-2080

This syncs the tests and adds the missing file-not-found logic that the tests caught.

This did require making the `rename` test operation a little odd because it can either target a collection, in which case it accepts arguments of the form `{ to: String }`, or it can target a gridfs bucket, where the arguments are `{ id: Bson, newFilename: String }`.  We parse the test file json into `TestOperation` values at file load time, where entity type isn't known, so we can't have distinct operation types for "rename collection" and "rename bucket", so instead there's now a wrapper layer that defers parsing the args document until the test is actually executed at which point it checks entity type and parses appropriately.