### PR TITLE
DEVPROD-17371 - Replace perf.send with direct data submission to new end point

### DIFF
--- a/.evergreen/benchmarks.yml
+++ b/.evergreen/benchmarks.yml
@@ -202,9 +202,39 @@ functions:
         display_name: "mongodb-logs.tar.gz"
 
   "upload benchmark results":
-    - command: perf.send
+    - command: shell.exec
       params:
-        file: "src/benchmark-results.json"
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            is_mainline=true
+          else
+            is_mainline=false
+          fi
+
+          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+          ENCODED_URL=$(echo "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" | sed -e 's/ /%20/g')
+
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "$ENCODED_URL" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @src/benchmark-results.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
 
   "stop mongo orchestration":
     - command: shell.exec


### PR DESCRIPTION
The perf.send command is no longer being maintained and is in a maintenance state and will be decommissioned eventually. It has been replaced instead by a new end point that users are able to call from their evergreen files; [this doc](https://github.com/10gen/performance-tooling-docs/blob/main/getting_started/migrating_from_perfSend_to_sps.md) outlines a drop in solution that we apply to the existing evergreen config file in this PR.

This PR updats the Mongo-Rust-Driver project to send performance data downstream using the newest supported method.

Successful patch: https://spruce.mongodb.com/task/mongo_rust_driver_benchmarking_driver_benchmarks__topology~standalone_os~rhel90_dbx_perf_large_benchmark_driver_patch_0f0d84ae872cd439aff857e0bebf9cf9dbca187d_6813c9b160135a00074a9f7c_25_05_01_19_21_53/trend-charts?execution=0