### PR TITLE
RUST-2208 test Atlas with X509 auth

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -214,7 +214,7 @@ buildvariants:
 
   - name: atlas-connectivity
     display_name: "Atlas Connectivity"
-    patchable: false
+    patchable: true
     run_on:
       - rhel87-small
     tasks:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -214,7 +214,7 @@ buildvariants:
 
   - name: atlas-connectivity
     display_name: "Atlas Connectivity"
-    patchable: true
+    patchable: false
     run_on:
       - rhel87-small
     tasks:

--- a/.evergreen/run-atlas-tests.sh
+++ b/.evergreen/run-atlas-tests.sh
@@ -12,6 +12,13 @@ source "${DRIVERS_TOOLS}/.evergreen/secrets_handling/setup-secrets.sh" drivers/a
 
 set +o errexit
 
+# Create client certificate file from base64 encoded secret:
+mkdir -p .secrets
+chmod 700 .secrets
+echo "${ATLAS_X509_DEV_CERT_BASE64}" | base64 --decode > .secrets/clientcert.pem
+ATLAS_X509_DEV_WITH_CERT="${ATLAS_X509_DEV}&tlsCertificateKeyFile=.secrets/clientcert.pem"
+export ATLAS_X509_DEV_WITH_CERT
+
 cargo_test test::atlas_connectivity
 
 exit $CARGO_RESULT

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 mongocryptd.pid
 semgrep/
 sarif.json
+.secrets

--- a/src/test/atlas_connectivity.rs
+++ b/src/test/atlas_connectivity.rs
@@ -95,3 +95,9 @@ async fn atlas_tls12_srv() {
     run_test("ATLAS_SRV_TLS12", None).await;
     run_test("ATLAS_SRV_TLS12", Some(ResolverConfig::cloudflare())).await;
 }
+
+#[tokio::test]
+async fn atlas_x509() {
+    run_test("ATLAS_X509_DEV_WITH_CERT", None).await;
+    run_test("ATLAS_X509_DEV_WITH_CERT", Some(ResolverConfig::cloudflare())).await;
+}


### PR DESCRIPTION
Verified with this patch build: https://spruce.mongodb.com/version/68275dfc54237d0007a7e646