### PR TITLE
RUST-577 Bump dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    # Only bump to the latest version compatible with the dependency's version
+    # in Cargo.toml. This is the equivalent of running `cargo update`.
+    versioning-strategy: lockfile-only
+    # Update all dependencies in a single PR.
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    # Include transitive dependencies.
+    allow:
+      - dependency-type: all
+    ignore:
+      - dependency-name: "mongocrypt-sys"


### PR DESCRIPTION
Here's an example PR from my fork: https://github.com/isabelatkinson/mongo-rust-driver/pull/5, and a patch for those changes: https://spruce.mongodb.com/version/682bbb5f2a3ef700075f76b4/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Ecompile%24.

This does the equivalent of running `cargo update`; i.e., it doesn't update the dependencies in `Cargo.toml`, as doing so may bump to a new major version requiring code changes and/or an MSRV update. Dependabot does allow configuring minor version bumps only, but this breaks for pre-1.0 dependencies, for which a minor version update (e.g. 0.2.0->0.3.0) can include breaking changes.

I chose a weekly cadence as I expect we should be able to merge these PRs as-is most of the time, but we can revisit if it becomes disruptive.