### PR TITLE
RUST-2224 Fix OIDC test role setup

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -692,6 +692,10 @@ task_groups:
       - func: init test-results
       - func: make files executable
       - func: install rust
+      - command: ec2.assume_role
+        params:
+          role_arn: ${aws_test_secrets_role}
+          duration_seconds: 3600
       - command: subprocess.exec
         params:
           binary: bash
@@ -699,6 +703,10 @@ task_groups:
             AZUREOIDC_VMNAME_PREFIX: "RUST_DRIVER"
           args:
             - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/azure/create-and-setup-vm.sh
+          include_expansions_in_env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
     teardown_task:
       - command: subprocess.exec
         params:
@@ -719,6 +727,10 @@ task_groups:
       - func: init test-results
       - func: make files executable
       - func: install rust
+      - command: ec2.assume_role
+        params:
+          role_arn: ${aws_test_secrets_role}
+          duration_seconds: 3600
       - command: subprocess.exec
         params:
           binary: bash
@@ -726,6 +738,10 @@ task_groups:
             GCPOIDC_VMNAME_PREFIX: "RUST_DRIVER"
           args:
             - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/gcp/setup.sh
+          include_expansions_in_env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
     teardown_task:
       - command: subprocess.exec
         params:
@@ -746,11 +762,19 @@ task_groups:
       - func: init test-results
       - func: make files executable
       - func: install rust
+      - command: ec2.assume_role
+        params:
+          role_arn: ${aws_test_secrets_role}
+          duration_seconds: 3600
       - command: subprocess.exec
         params:
           binary: bash
           args:
             - ${DRIVERS_TOOLS}/.evergreen/auth_oidc/k8s/setup.sh
+          include_expansions_in_env:
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
     teardown_task:
       - command: subprocess.exec
         params:


### PR DESCRIPTION
RUST-2224

This adds the explicit `ec2.assume_role` so we're not using the (now-removed) implicit instance credentials.  Note that the tests are still flaky so they can still fail occasionally, but that predates this breakage; this is fixing the "SYSTEM FAILED" status.