### PR TITLE
RUST-1887 Update driver for bson append changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#fe284454c2e55d65f64c3dc067c0ab196be643db"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#c038fb569472936d26fee3b27bf5257470c3cc45"
 dependencies = [
  "ahash",
  "base64 0.22.1",

--- a/src/bson_compat.rs
+++ b/src/bson_compat.rs
@@ -1,0 +1,17 @@
+pub(crate) trait RawDocumentBufExt {
+    fn append_ref<'a>(
+        &mut self,
+        key: impl AsRef<str>,
+        value: impl Into<crate::bson::raw::RawBsonRef<'a>>,
+    );
+}
+
+impl RawDocumentBufExt for crate::bson::RawDocumentBuf {
+    fn append_ref<'a>(
+        &mut self,
+        key: impl AsRef<str>,
+        value: impl Into<crate::bson::raw::RawBsonRef<'a>>,
+    ) {
+        self.append(key, value)
+    }
+}

--- a/src/bson_util.rs
+++ b/src/bson_util.rs
@@ -22,6 +22,9 @@ use crate::{
     runtime::SyncLittleEndianRead,
 };
 
+#[cfg(feature = "bson-3")]
+use crate::bson_compat::RawDocumentBufExt as _;
+
 /// Coerce numeric types into an `i64` if it would be lossless to do so. If this Bson is not numeric
 /// or the conversion would be lossy (e.g. 1.5 -> 1), this returns `None`.
 #[allow(clippy::cast_possible_truncation)]

--- a/src/cmap/establish/handshake.rs
+++ b/src/cmap/establish/handshake.rs
@@ -121,6 +121,17 @@ impl From<&OsMetadata> for RawBson {
     }
 }
 
+#[cfg(feature = "bson-3")]
+impl crate::bson::raw::BindRawBsonRef for &OsMetadata {
+    fn bind<F, R>(self, f: F) -> R
+    where
+        F: for<'a> FnOnce(bson3::RawBsonRef<'a>) -> R,
+    {
+        let raw: RawBson = self.into();
+        raw.bind(f)
+    }
+}
+
 impl From<&RuntimeEnvironment> for RawBson {
     fn from(env: &RuntimeEnvironment) -> Self {
         let RuntimeEnvironment {
@@ -155,6 +166,17 @@ impl From<&RuntimeEnvironment> for RawBson {
             out.append("container", c.clone());
         }
         RawBson::Document(out)
+    }
+}
+
+#[cfg(feature = "bson-3")]
+impl crate::bson::raw::BindRawBsonRef for &RuntimeEnvironment {
+    fn bind<F, R>(self, f: F) -> R
+    where
+        F: for<'a> FnOnce(bson3::RawBsonRef<'a>) -> R,
+    {
+        let raw: RawBson = self.into();
+        raw.bind(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod options;
 pub use ::mongocrypt;
 
 pub mod action;
+#[cfg(feature = "bson-3")]
+pub(crate) mod bson_compat;
 mod bson_util;
 pub mod change_stream;
 pub(crate) mod checked;

--- a/src/operation/update.rs
+++ b/src/operation/update.rs
@@ -13,6 +13,9 @@ use crate::{
 
 use super::ExecutionContext;
 
+#[cfg(feature = "bson-3")]
+use crate::bson_compat::RawDocumentBufExt as _;
+
 #[derive(Clone, Debug)]
 pub(crate) enum UpdateOrReplace {
     UpdateModifications(UpdateModifications),

--- a/src/sdam/description/server.rs
+++ b/src/sdam/description/server.rs
@@ -111,6 +111,17 @@ impl From<TopologyVersion> for RawBson {
     }
 }
 
+#[cfg(feature = "bson-3")]
+impl crate::bson::raw::BindRawBsonRef for TopologyVersion {
+    fn bind<F, R>(self, f: F) -> R
+    where
+        F: for<'a> FnOnce(bson3::RawBsonRef<'a>) -> R,
+    {
+        let raw: RawBson = self.into();
+        raw.bind(f)
+    }
+}
+
 /// A description of the most up-to-date information known about a server.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct ServerDescription {


### PR DESCRIPTION
RUST-1887

When I went to update the driver for the lossy utf8 changes, I realized I hadn't been updating for the previous changes, and it'll be much easier to review as distinct PRs, so here's the first one.  Very little compatibility machinery needed so far to make it work with both 2.x and 3.0.