### PR TITLE
RUST-1826 Use serde attribute to remove empty write concerns

### DIFF
--- a/src/client/options.rs
+++ b/src/client/options.rs
@@ -43,7 +43,7 @@ use crate::{
     options::ReadConcernLevel,
     sdam::{verify_max_staleness, DEFAULT_HEARTBEAT_FREQUENCY, MIN_HEARTBEAT_FREQUENCY},
     selection_criteria::{ReadPreference, SelectionCriteria, TagSet},
-    serde_util,
+    serde_util::{self, write_concern_is_empty},
     srv::{OriginalSrvInfo, SrvResolver},
 };
 
@@ -2670,6 +2670,7 @@ pub struct TransactionOptions {
 
     /// The write concern to use when committing or aborting a transaction.
     #[builder(default)]
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// The selection criteria to use for all read operations in a transaction.

--- a/src/client/options/bulk_write.rs
+++ b/src/client/options/bulk_write.rs
@@ -10,7 +10,7 @@ use crate::{
     bson_util::{get_or_prepend_id_field, replacement_document_check, update_document_check},
     error::Result,
     options::{UpdateModifications, WriteConcern},
-    serde_util::serialize_bool_or_true,
+    serde_util::{serialize_bool_or_true, write_concern_is_empty},
     Collection,
     Namespace,
 };
@@ -48,6 +48,7 @@ pub struct BulkWriteOptions {
     pub let_vars: Option<Document>,
 
     /// The write concern to use for this operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 }
 

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -117,6 +117,7 @@ pub struct InsertOneOptions {
     pub bypass_document_validation: Option<bool>,
 
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// Tags the query with an arbitrary [`Bson`] value to help trace the operation through the
@@ -295,6 +296,7 @@ pub struct ReplaceOptions {
     pub hint: Option<Hint>,
 
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// Map of parameter names and values. Values must be constant or closed
@@ -335,6 +337,7 @@ pub struct DeleteOptions {
     pub collation: Option<Collation>,
 
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// The index to use for the operation.
@@ -379,6 +382,7 @@ pub struct FindOneAndDeleteOptions {
     pub sort: Option<Document>,
 
     /// The level of the write concern
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// The collation to use for the operation.
@@ -438,6 +442,7 @@ pub struct FindOneAndReplaceOptions {
     pub upsert: Option<bool>,
 
     /// The level of the write concern
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// The collation to use for the operation.
@@ -503,6 +508,7 @@ pub struct FindOneAndUpdateOptions {
     pub upsert: Option<bool>,
 
     /// The level of the write concern
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// The collation to use for the operation.
@@ -615,6 +621,7 @@ pub struct AggregateOptions {
     ///
     /// If none is specified, the write concern defined on the object executing this operation will
     /// be used.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// A document with any amount of parameter names, each followed by definitions of constants in
@@ -1056,6 +1063,7 @@ pub struct CreateIndexOptions {
     pub max_time: Option<Duration>,
 
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// Tags the query with an arbitrary [`Bson`] value to help trace the operation through the
@@ -1075,6 +1083,7 @@ pub struct CreateIndexOptions {
 #[export_tokens]
 pub struct DropCollectionOptions {
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// Map of encrypted fields for the collection.
@@ -1108,6 +1117,7 @@ pub struct DropIndexOptions {
     pub max_time: Option<Duration>,
 
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// Tags the query with an arbitrary [`Bson`] value to help trace the operation through the

--- a/src/db/options.rs
+++ b/src/db/options.rs
@@ -11,7 +11,7 @@ use crate::{
     concern::{ReadConcern, WriteConcern},
     options::{Collation, CursorType},
     selection_criteria::SelectionCriteria,
-    serde_util,
+    serde_util::{self, write_concern_is_empty},
 };
 
 /// These are the valid options for creating a [`Database`](../struct.Database.html) with
@@ -84,6 +84,7 @@ pub struct CreateCollectionOptions {
     pub collation: Option<Collation>,
 
     /// The write concern for the operation.   
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 
     /// The default configuration for indexes created on this collection, including the _id index.
@@ -288,6 +289,7 @@ pub enum TimeseriesGranularity {
 #[export_tokens]
 pub struct DropDatabaseOptions {
     /// The write concern for the operation.
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub write_concern: Option<WriteConcern>,
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -531,4 +531,3 @@ where
         Ok(SingleCursorResult(full_body.cursor.first_batch.pop()))
     }
 }
-

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -532,16 +532,3 @@ where
     }
 }
 
-macro_rules! remove_empty_write_concern {
-    ($opts:expr) => {
-        if let Some(ref mut options) = $opts {
-            if let Some(ref write_concern) = options.write_concern {
-                if write_concern.is_empty() {
-                    options.write_concern = None;
-                }
-            }
-        }
-    };
-}
-
-pub(crate) use remove_empty_write_concern;

--- a/src/operation/aggregate.rs
+++ b/src/operation/aggregate.rs
@@ -6,7 +6,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::CursorSpecification,
     error::Result,
-    operation::{append_options, remove_empty_write_concern, Retryability},
+    operation::{append_options, Retryability},
     options::{AggregateOptions, ReadPreference, SelectionCriteria, WriteConcern},
     Namespace,
 };
@@ -55,7 +55,6 @@ impl OperationWithDefaults for Aggregate {
             "cursor": {}
         };
 
-        remove_empty_write_concern!(self.options);
         append_options(&mut body, self.options.as_ref())?;
 
         if self.is_out_or_merge() {

--- a/src/operation/commit_transaction.rs
+++ b/src/operation/commit_transaction.rs
@@ -5,11 +5,7 @@ use crate::bson::rawdoc;
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        OperationWithDefaults,
-        Retryability,
-    },
+    operation::{append_options_to_raw_document, OperationWithDefaults, Retryability},
     options::{Acknowledgment, TransactionOptions, WriteConcern},
 };
 

--- a/src/operation/commit_transaction.rs
+++ b/src/operation/commit_transaction.rs
@@ -7,7 +7,6 @@ use crate::{
     error::Result,
     operation::{
         append_options_to_raw_document,
-        remove_empty_write_concern,
         OperationWithDefaults,
         Retryability,
     },
@@ -36,7 +35,6 @@ impl OperationWithDefaults for CommitTransaction {
             Self::NAME: 1,
         };
 
-        remove_empty_write_concern!(self.options);
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/create.rs
+++ b/src/operation/create.rs
@@ -5,7 +5,6 @@ use crate::{
     error::Result,
     operation::{
         append_options_to_raw_document,
-        remove_empty_write_concern,
         OperationWithDefaults,
         WriteConcernOnlyBody,
     },
@@ -37,7 +36,6 @@ impl OperationWithDefaults for Create {
             Self::NAME: self.ns.coll.clone(),
         };
 
-        remove_empty_write_concern!(self.options);
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/create.rs
+++ b/src/operation/create.rs
@@ -3,11 +3,7 @@ use crate::bson::rawdoc;
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        OperationWithDefaults,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, OperationWithDefaults, WriteConcernOnlyBody},
     options::{CreateCollectionOptions, WriteConcern},
     Namespace,
 };

--- a/src/operation/create_indexes.rs
+++ b/src/operation/create_indexes.rs
@@ -7,7 +7,6 @@ use crate::{
     index::IndexModel,
     operation::{
         append_options_to_raw_document,
-        remove_empty_write_concern,
         OperationWithDefaults,
     },
     options::{CreateIndexOptions, WriteConcern},
@@ -65,7 +64,6 @@ impl OperationWithDefaults for CreateIndexes {
             "indexes": indexes,
         };
 
-        remove_empty_write_concern!(self.options);
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/create_indexes.rs
+++ b/src/operation/create_indexes.rs
@@ -5,10 +5,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{ErrorKind, Result},
     index::IndexModel,
-    operation::{
-        append_options_to_raw_document,
-        OperationWithDefaults,
-    },
+    operation::{append_options_to_raw_document, OperationWithDefaults},
     options::{CreateIndexOptions, WriteConcern},
     results::CreateIndexesResult,
     Namespace,

--- a/src/operation/delete.rs
+++ b/src/operation/delete.rs
@@ -6,7 +6,6 @@ use crate::{
     error::{convert_insert_many_error, Result},
     operation::{
         append_options,
-        remove_empty_write_concern,
         OperationWithDefaults,
         Retryability,
         WriteResponseBody,
@@ -70,7 +69,6 @@ impl OperationWithDefaults for Delete {
             "ordered": true, // command monitoring tests expect this (SPEC-1130)
         };
 
-        remove_empty_write_concern!(self.options);
         append_options(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/delete.rs
+++ b/src/operation/delete.rs
@@ -4,12 +4,7 @@ use crate::{
     coll::Namespace,
     collation::Collation,
     error::{convert_insert_many_error, Result},
-    operation::{
-        append_options,
-        OperationWithDefaults,
-        Retryability,
-        WriteResponseBody,
-    },
+    operation::{append_options, OperationWithDefaults, Retryability, WriteResponseBody},
     options::{DeleteOptions, Hint, WriteConcern},
     results::DeleteResult,
 };

--- a/src/operation/drop_collection.rs
+++ b/src/operation/drop_collection.rs
@@ -3,11 +3,7 @@ use crate::bson::rawdoc;
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
-    operation::{
-        append_options_to_raw_document,
-        OperationWithDefaults,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, OperationWithDefaults, WriteConcernOnlyBody},
     options::{DropCollectionOptions, WriteConcern},
     Namespace,
 };

--- a/src/operation/drop_collection.rs
+++ b/src/operation/drop_collection.rs
@@ -5,7 +5,6 @@ use crate::{
     error::{Error, Result},
     operation::{
         append_options_to_raw_document,
-        remove_empty_write_concern,
         OperationWithDefaults,
         WriteConcernOnlyBody,
     },
@@ -37,7 +36,6 @@ impl OperationWithDefaults for DropCollection {
             Self::NAME: self.ns.coll.clone(),
         };
 
-        remove_empty_write_concern!(self.options);
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/drop_database.rs
+++ b/src/operation/drop_database.rs
@@ -4,11 +4,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::DropDatabaseOptions,
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        OperationWithDefaults,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, OperationWithDefaults, WriteConcernOnlyBody},
     options::WriteConcern,
 };
 

--- a/src/operation/drop_database.rs
+++ b/src/operation/drop_database.rs
@@ -6,7 +6,6 @@ use crate::{
     error::Result,
     operation::{
         append_options_to_raw_document,
-        remove_empty_write_concern,
         OperationWithDefaults,
         WriteConcernOnlyBody,
     },
@@ -37,7 +36,6 @@ impl OperationWithDefaults for DropDatabase {
             Self::NAME: 1,
         };
 
-        remove_empty_write_concern!(self.options);
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/drop_indexes.rs
+++ b/src/operation/drop_indexes.rs
@@ -5,7 +5,6 @@ use crate::{
     error::Result,
     operation::{
         append_options_to_raw_document,
-        remove_empty_write_concern,
         OperationWithDefaults,
     },
     options::{DropIndexOptions, WriteConcern},
@@ -36,7 +35,6 @@ impl OperationWithDefaults for DropIndexes {
             "index": self.name.clone(),
         };
 
-        remove_empty_write_concern!(self.options);
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/drop_indexes.rs
+++ b/src/operation/drop_indexes.rs
@@ -3,10 +3,7 @@ use crate::bson::rawdoc;
 use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        OperationWithDefaults,
-    },
+    operation::{append_options_to_raw_document, OperationWithDefaults},
     options::{DropIndexOptions, WriteConcern},
     Namespace,
 };

--- a/src/operation/find_and_modify.rs
+++ b/src/operation/find_and_modify.rs
@@ -14,7 +14,6 @@ use crate::{
     operation::{
         append_options_to_raw_document,
         find_and_modify::options::Modification,
-        remove_empty_write_concern,
         OperationWithDefaults,
         Retryability,
     },
@@ -82,9 +81,6 @@ impl<T: DeserializeOwned> OperationWithDefaults for FindAndModify<T> {
             }
         }
 
-        if let Some(ref mut options) = self.options {
-            remove_empty_write_concern!(Some(options));
-        }
         append_options_to_raw_document(&mut body, self.options.as_ref())?;
 
         Ok(Command::new(

--- a/src/operation/find_and_modify/options.rs
+++ b/src/operation/find_and_modify/options.rs
@@ -15,7 +15,7 @@ use crate::{
     collation::Collation,
     concern::WriteConcern,
     operation::UpdateOrReplace,
-    serde_util,
+    serde_util::{self, write_concern_is_empty},
 };
 
 #[derive(Clone, Debug)]
@@ -37,6 +37,7 @@ pub(crate) struct FindAndModifyOptions {
 
     pub(crate) bypass_document_validation: Option<bool>,
 
+    #[serde(skip_serializing_if = "write_concern_is_empty")]
     pub(crate) write_concern: Option<WriteConcern>,
 
     pub(crate) array_filters: Option<Vec<Document>>,


### PR DESCRIPTION
Replaced `remove_empty_write_concern` macro with serde attribute `#[serde(skip_serializing_if = "write_concern_is_empty")]` to remove empty write concerns before serialization. 

## Updated structs
Applied the new serde attribute to `write_concern` fields in the following structs that previously used `remove_empty_write_concern`:
- `TransactionOptions` 
- `DeleteOptions` 
- `AggregateOptions` 
- `CreateIndexOptions` 
- `DropCollectionOptions` 
- `CreateCollectionOptions` 
- `DropDatabaseOptions` 
- `FindAndModifyOptions` 
- `DropIndexOptions` 

Also updated additional structs with `write_concern` fields that serialized empty values before:
- `BulkWriteOptions`
- `InsertOneOptions`
- `ReplaceOptions`
- `FindOneAndDeleteOptions`
- `FindOneAndReplaceOptions`
- `FindOneAndUpdateOptions`

Special cases 
Certains structs with `write_concern` fields do not use the serde attribute for one of the following reasons:
- Fields are added manually only if not empty 
  - E.x. `UpdateOptions`
- The struct itself does not implement serialization (`Serialize`)
  - E.x. `CollectionOrDatabaseOptions`, `DatabaseOptions`, `GridFsBucketOptions`, `AbortTransaction`



