### PR TITLE
Fix MSRV check

### DIFF
--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -24,7 +24,7 @@ fi
 
 # Test with no default features.
 if [ "$RUST_VERSION" != "" ]; then
-  cargo $TOOLCHAIN build --no-default-features --features compat-3-3-0,rustls-tls
+  cargo $TOOLCHAIN build --no-default-features --features compat-3-0-0,rustls-tls
 else
   cargo $TOOLCHAIN build --no-default-features --features compat-3-3-0,bson-3,rustls-tls
 fi

--- a/.evergreen/compile-only.sh
+++ b/.evergreen/compile-only.sh
@@ -16,7 +16,15 @@ fi
 cargo $TOOLCHAIN build
 
 # Test with all features.
-cargo $TOOLCHAIN build --all-features
+if [ "$RUST_VERSION" != "" ]; then
+  cargo $TOOLCHAIN build --features openssl-tls,sync,aws-auth,zlib-compression,zstd-compression,snappy-compression,in-use-encryption,tracing-unstable
+else
+  cargo $TOOLCHAIN build --all-features
+fi
 
 # Test with no default features.
-cargo $TOOLCHAIN build --no-default-features --features compat-3-3-0,bson-3,rustls-tls
+if [ "$RUST_VERSION" != "" ]; then
+  cargo $TOOLCHAIN build --no-default-features --features compat-3-3-0,rustls-tls
+else
+  cargo $TOOLCHAIN build --no-default-features --features compat-3-3-0,bson-3,rustls-tls
+fi


### PR DESCRIPTION
The MSRV task generates a fresh lockfile, which pulls in the latest commit on the bson-rust main branch for the `bson-3` dependency, which will break compilation if we haven't yet updated the driver to accommodate any recent breaking changes. This PR updates the MSRV check not to compile with `bson-3` enabled so that merging PRs isn't blocked on us making the necessary changes in the driver when the bson API breaks. (I'm not concerned about losing coverage because we already test MSRV compilation for the bson crate, so we know a 1.81-compliant version exists.) If this approach sounds good, I'll file a ticket to revert these changes once the 3.0 API is stabilized and integrated into the driver.