### PR TITLE
RUST-1998 Update driver to match lossy utf8 api changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#328d540df28d01afa71da55d485e4b83e61913c7"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#8389d37175a6e9018ac82dacd62b20415e9c4469"
 dependencies = [
  "ahash",
  "base64 0.22.1",

--- a/src/cmap/conn/command.rs
+++ b/src/cmap/conn/command.rs
@@ -209,16 +209,6 @@ impl RawCommandResponse {
         })
     }
 
-    /// Used to handle decoding responses where the server may return invalid UTF-8 in error
-    /// messages.
-    pub(crate) fn body_utf8_lossy<'a, T: Deserialize<'a>>(&'a self) -> Result<T> {
-        crate::bson::from_slice_utf8_lossy(self.raw.as_bytes()).map_err(|e| {
-            Error::from(ErrorKind::InvalidResponse {
-                message: format!("{}", e),
-            })
-        })
-    }
-
     pub(crate) fn raw_body(&self) -> &RawDocument {
         &self.raw
     }

--- a/src/operation/insert.rs
+++ b/src/operation/insert.rs
@@ -133,7 +133,7 @@ impl OperationWithDefaults for Insert<'_> {
         response: RawCommandResponse,
         _context: ExecutionContext<'b>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody = response.body_utf8_lossy()?;
+        let response: WriteResponseBody = response.body()?;
         let response_n = Checked::<usize>::try_from(response.n)?;
 
         let mut map = HashMap::new();

--- a/src/operation/update.rs
+++ b/src/operation/update.rs
@@ -173,7 +173,7 @@ impl OperationWithDefaults for Update {
         response: RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody<UpdateBody> = response.body_utf8_lossy()?;
+        let response: WriteResponseBody<UpdateBody> = response.body()?;
         response.validate().map_err(convert_insert_many_error)?;
 
         let modified_count = response.n_modified;


### PR DESCRIPTION
RUST-1998

This brings the driver up to date with the bson repo head, and also (IMO) shows why the wrapper type is the better API - the two fields that can have invalid text are tagged in a deserialization helper and nothing else needs to care about it.