### PR TITLE
RUST-2219 Relax domain name parsing

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -290,6 +290,14 @@ impl Error {
         .into()
     }
 
+    #[cfg(feature = "dns-resolver")]
+    pub(crate) fn from_resolve_proto_error(error: hickory_proto::error::ProtoError) -> Self {
+        ErrorKind::DnsResolve {
+            message: error.to_string(),
+        }
+        .into()
+    }
+
     pub(crate) fn is_non_timeout_network_error(&self) -> bool {
         matches!(self.kind.as_ref(), ErrorKind::Io(ref io_err) if io_err.kind() != std::io::ErrorKind::TimedOut)
     }

--- a/src/runtime/resolver.rs
+++ b/src/runtime/resolver.rs
@@ -2,7 +2,7 @@ use hickory_resolver::{
     config::ResolverConfig,
     error::ResolveErrorKind,
     lookup::{SrvLookup, TxtLookup},
-    IntoName,
+    Name,
 };
 
 use crate::error::{Error, Result};
@@ -25,17 +25,19 @@ impl AsyncResolver {
 }
 
 impl AsyncResolver {
-    pub async fn srv_lookup<N: IntoName>(&self, query: N) -> Result<SrvLookup> {
+    pub async fn srv_lookup(&self, query: &str) -> Result<SrvLookup> {
+        let name = Name::from_str_relaxed(query).map_err(Error::from_resolve_proto_error)?;
         let lookup = self
             .resolver
-            .srv_lookup(query)
+            .srv_lookup(name)
             .await
             .map_err(Error::from_resolve_error)?;
         Ok(lookup)
     }
 
-    pub async fn txt_lookup<N: IntoName>(&self, query: N) -> Result<Option<TxtLookup>> {
-        let lookup_result = self.resolver.txt_lookup(query).await;
+    pub async fn txt_lookup(&self, query: &str) -> Result<Option<TxtLookup>> {
+        let name = Name::from_str_relaxed(query).map_err(Error::from_resolve_proto_error)?;
+        let lookup_result = self.resolver.txt_lookup(name).await;
         match lookup_result {
             Ok(lookup) => Ok(Some(lookup)),
             Err(e) => match e.kind() {


### PR DESCRIPTION
RUST-2219

This relaxes domain name parsing to allow characters that would normally be invalid in DNS names (e.g. "_"), since it turns out those are actually present in some user setups.