### PR TITLE
minor: bump `bson-3` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#1669bc07652999f15e15d73ba658e63c0dace815"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#2c00882180f2535a16127f41ad18e4e0da3085e1"
 dependencies = [
  "ahash",
  "base64 0.22.1",


### PR DESCRIPTION
Bumps the `bson-3` dependency to the latest commit. There weren't any driver changes needed to accommodate https://github.com/mongodb/bson-rust/pull/555, so this PR is just for the sake of getting us up-to-date.