### PR TITLE
RUST-2233 Cherrypick more fixes for 3.2.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_with",
- "sha-1",
+ "sha1",
  "sha2",
  "snap",
  "socket2",
@@ -2486,17 +2486,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ rayon = { version = "1.5.3", optional = true }
 rustc_version_runtime = "0.3.0"
 rustls-pemfile = { version = "1.0.1", optional = true }
 serde_with = "3.8.1"
-sha-1 = "0.10.0"
+sha1 = "0.10.0"
 sha2 = "0.10.2"
 snap = { version = "1.0.5", optional = true }
 socket2 = "0.5.5"


### PR DESCRIPTION
RUST-2233

This picks up RUST-2204 (which fixes RUST-2234) and RUST-2227.  After this the branch should be ready for release.