### PR TITLE
RUST-1406 Update driver to use merged bson serde errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#2c00882180f2535a16127f41ad18e4e0da3085e1"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#431d4483856b18d1b8885d0b46a60be7f2eb2dee"
 dependencies = [
  "ahash",
  "base64 0.22.1",

--- a/src/bson_compat.rs
+++ b/src/bson_compat.rs
@@ -110,6 +110,7 @@ macro_rules! use_either {
     ($($name:ident => $path3:path | $path2:path);+;) => {
         $(
             #[cfg(feature = "bson-3")]
+            #[allow(unused_imports)]
             pub(crate) use crate::bson::{$path3 as $name};
 
             #[cfg(not(feature = "bson-3"))]
@@ -123,6 +124,8 @@ macro_rules! use_either {
 use_either! {
     RawResult                       => error::Result                    | raw::Result;
     RawError                        => error::Error                     | raw::Error;
+    DeError                         => error::Error                     | de::Error;
+    SerError                        => error::Error                     | ser::Error;
     serialize_to_raw_document_buf   => serialize_to_raw_document_buf    | to_raw_document_buf;
     serialize_to_document           => serialize_to_document            | to_document;
     serialize_to_bson               => serialize_to_bson                | to_bson;

--- a/src/test/spec/unified_runner/operation.rs
+++ b/src/test/spec/unified_runner/operation.rs
@@ -317,7 +317,7 @@ pub(crate) enum Expectation {
 
 fn deserialize_op<'de, 'a, T: 'a + DeserializeOwned + TestOperation>(
     value: Document,
-) -> std::result::Result<Box<dyn TestOperation + 'a>, crate::bson::de::Error> {
+) -> std::result::Result<Box<dyn TestOperation + 'a>, crate::bson_compat::DeError> {
     crate::bson_compat::deserialize_from_document::<T>(value)
         .map(|op| Box::new(op) as Box<dyn TestOperation>)
 }

--- a/src/test/spec/v2_runner/operation.rs
+++ b/src/test/spec/v2_runner/operation.rs
@@ -311,7 +311,7 @@ impl<'de> Deserialize<'de> for Operation {
 
 fn deserialize_op<'de, 'a, Op: TestOperation + Deserialize<'de> + 'a>(
     arguments: Document,
-) -> std::result::Result<Box<dyn TestOperation + 'a>, crate::bson::de::Error> {
+) -> std::result::Result<Box<dyn TestOperation + 'a>, crate::bson_compat::DeError> {
     Ok(Box::new(Op::deserialize(BsonDeserializer::new(
         Bson::Document(arguments),
     ))?))


### PR DESCRIPTION
RUST-1406

I decided to provide a single unified `ErrorKind::Bson` variant when the user's opted in to `bson-3` rather than having a run-time switch to emulate the old behavior.