### PR TITLE
RUST-2240 Enable bson `serde_json-1` feature flag where necessary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#194177a1593835bf897dd2408db31ce949e32e77"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#174fe65a7a79a67742008c669bd672bd025d439a"
 dependencies = [
  "ahash",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ in-use-encryption-unstable = ["in-use-encryption"]
 # Enables support for emitting tracing events.
 # The tracing API is unstable and may have backwards-incompatible changes in minor version updates.
 # TODO: pending https://github.com/tokio-rs/tracing/issues/2036 stop depending directly on log.
-tracing-unstable = ["dep:tracing", "dep:log"]
+tracing-unstable = ["dep:tracing", "dep:log", "bson3?/serde_json-1"]
 
 [dependencies]
 async-trait = "0.1.42"
@@ -206,6 +206,13 @@ regex = "1.6.0"
 reqwest = { version = "0.12.2", features = ["rustls-tls"] }
 serde-hex = "0.1.0"
 serde_path_to_error = "0.1"
+
+[dev-dependencies.bson3]
+git = "https://github.com/mongodb/bson-rust"
+branch = "main"
+package = "bson"
+version = "3.0.0"
+features = ["serde", "serde_json-1"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Enables `serde_json-1` for testing and when `tracing-unstable` is enabled.