### PR TITLE
RUST-2187 Test stable API on sharded clusters

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -199,8 +199,9 @@ buildvariants:
       # Configuring SSL: ssl causes errors in bootstrap mongo-orchestration.
     tasks:
       # The Stable API was introduced in MongoDB version 5.0. Drivers Evergreen Tools only supports
-      # setting REQUIRE_API_VERSION on standalones.
+      # setting REQUIRE_API_VERSION on standalones and sharded clusters.
       - .standalone !.4.0 !.4.2 !.4.4
+      - .sharded !.4.0 !.4.2 !.4.4
 
   - name: sync-api
     display_name: "Sync API"


### PR DESCRIPTION
RUST-2187

Evergreen patch run of the `stable-api` variant [here](https://spruce.mongodb.com/version/687779b345c54800075baac0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).