### PR TITLE
RUST-1748 Fix use of functions from `bson::serde_helpers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#174fe65a7a79a67742008c669bd672bd025d439a"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#266aa3039e603cad96a5dde377aaf8251be76c79"
 dependencies = [
  "ahash",
  "base64 0.22.1",

--- a/src/coll/options.rs
+++ b/src/coll/options.rs
@@ -6,7 +6,7 @@ use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
 
 use crate::{
-    bson::{doc, serde_helpers, Bson, Document, RawBson, RawDocumentBuf},
+    bson::{doc, Bson, Document, RawBson, RawDocumentBuf},
     concern::{ReadConcern, WriteConcern},
     error::Result,
     options::Collation,
@@ -1186,7 +1186,7 @@ impl Serialize for CommitQuorum {
         S: Serializer,
     {
         match self {
-            CommitQuorum::Nodes(n) => serde_helpers::serialize_u32_as_i32(n, serializer),
+            CommitQuorum::Nodes(n) => serde_util::serialize_u32_as_i32(n, serializer),
             CommitQuorum::VotingMembers => serializer.serialize_str("votingMembers"),
             CommitQuorum::Majority => serializer.serialize_str("majority"),
             CommitQuorum::Custom(s) => serializer.serialize_str(s),

--- a/src/concern.rs
+++ b/src/concern.rs
@@ -10,7 +10,7 @@ use serde_with::skip_serializing_none;
 use typed_builder::TypedBuilder;
 
 use crate::{
-    bson::{doc, serde_helpers, Timestamp},
+    bson::{doc, Timestamp},
     error::{ErrorKind, Result},
     serde_util,
 };
@@ -244,7 +244,7 @@ impl Serialize for Acknowledgment {
     {
         match self {
             Acknowledgment::Majority => serializer.serialize_str("majority"),
-            Acknowledgment::Nodes(n) => serde_helpers::serialize_u32_as_i32(n, serializer),
+            Acknowledgment::Nodes(n) => serde_util::serialize_u32_as_i32(n, serializer),
             Acknowledgment::Custom(name) => serializer.serialize_str(name),
         }
     }

--- a/src/gridfs.rs
+++ b/src/gridfs.rs
@@ -14,6 +14,7 @@ use crate::{
     checked::Checked,
     error::Error,
     options::{CollectionOptions, ReadConcern, SelectionCriteria, WriteConcern},
+    serde_util,
     Collection,
     Database,
 };
@@ -31,7 +32,7 @@ pub(crate) struct Chunk<'a> {
     #[serde(rename = "_id")]
     id: ObjectId,
     files_id: Bson,
-    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u32_as_i32")]
+    #[serde(serialize_with = "serde_util::serialize_u32_as_i32")]
     n: u32,
     #[serde(borrow)]
     data: RawBinaryRef<'a>,
@@ -54,7 +55,7 @@ pub struct FilesCollectionDocument {
     /// The size of the file's chunks in bytes.
     #[serde(
         rename = "chunkSize",
-        serialize_with = "crate::bson::serde_helpers::serialize_u32_as_i32"
+        serialize_with = "serde_util::serialize_u32_as_i32"
     )]
     pub chunk_size_bytes: u32,
 

--- a/src/index/options.rs
+++ b/src/index/options.rs
@@ -1,10 +1,6 @@
 use std::time::Duration;
 
-use crate::{
-    bson::{serde_helpers, Document},
-    collation::Collation,
-    serde_util,
-};
+use crate::{bson::Document, collation::Collation, serde_util};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use typed_builder::TypedBuilder;
@@ -157,7 +153,7 @@ impl Serialize for IndexVersion {
             IndexVersion::V0 => serializer.serialize_i32(0),
             IndexVersion::V1 => serializer.serialize_i32(1),
             IndexVersion::V2 => serializer.serialize_i32(2),
-            IndexVersion::Custom(i) => serde_helpers::serialize_u32_as_i32(i, serializer),
+            IndexVersion::Custom(i) => serde_util::serialize_u32_as_i32(i, serializer),
         }
     }
 }
@@ -203,7 +199,7 @@ impl Serialize for TextIndexVersion {
             TextIndexVersion::V1 => serializer.serialize_i32(1),
             TextIndexVersion::V2 => serializer.serialize_i32(2),
             TextIndexVersion::V3 => serializer.serialize_i32(3),
-            TextIndexVersion::Custom(i) => serde_helpers::serialize_u32_as_i32(i, serializer),
+            TextIndexVersion::Custom(i) => serde_util::serialize_u32_as_i32(i, serializer),
         }
     }
 }
@@ -244,7 +240,7 @@ impl Serialize for Sphere2DIndexVersion {
         match self {
             Sphere2DIndexVersion::V2 => serializer.serialize_i32(2),
             Sphere2DIndexVersion::V3 => serializer.serialize_i32(3),
-            Sphere2DIndexVersion::Custom(i) => serde_helpers::serialize_u32_as_i32(i, serializer),
+            Sphere2DIndexVersion::Custom(i) => serde_util::serialize_u32_as_i32(i, serializer),
         }
     }
 }

--- a/src/results.rs
+++ b/src/results.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
 use crate::{
-    bson::{serde_helpers, Binary, Bson, Document, RawDocumentBuf},
+    bson::{Binary, Bson, Document, RawDocumentBuf},
     change_stream::event::ResumeToken,
     db::options::CreateCollectionOptions,
     serde_util,
@@ -53,11 +53,11 @@ pub struct InsertManyResult {
 #[non_exhaustive]
 pub struct UpdateResult {
     /// The number of documents that matched the filter.
-    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u64_as_i64")]
+    #[serde(serialize_with = "serde_util::serialize_u64_as_i64")]
     pub matched_count: u64,
 
     /// The number of documents that were modified by the operation.
-    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u64_as_i64")]
+    #[serde(serialize_with = "serde_util::serialize_u64_as_i64")]
     pub modified_count: u64,
 
     /// The `_id` field of the upserted document.
@@ -71,7 +71,7 @@ pub struct UpdateResult {
 #[non_exhaustive]
 pub struct DeleteResult {
     /// The number of documents deleted by the operation.
-    #[serde(serialize_with = "crate::bson::serde_helpers::serialize_u64_as_i64")]
+    #[serde(serialize_with = "serde_util::serialize_u64_as_i64")]
     pub deleted_count: u64,
 }
 
@@ -182,7 +182,7 @@ pub struct DatabaseSpecification {
     /// The amount of disk space in bytes that is consumed by the database.
     #[serde(
         deserialize_with = "serde_util::deserialize_u64_from_bson_number",
-        serialize_with = "serde_helpers::serialize_u64_as_i64"
+        serialize_with = "serde_util::serialize_u64_as_i64"
     )]
     pub size_on_disk: u64,
 

--- a/src/serde_util.rs
+++ b/src/serde_util.rs
@@ -7,6 +7,7 @@ use crate::{
     bson_util::get_u64,
     error::{Error, Result},
     options::WriteConcern,
+    serde_util,
 };
 
 pub(crate) mod duration_option_as_int_seconds {
@@ -73,7 +74,7 @@ pub(crate) fn serialize_u32_option_as_i32<S: Serializer>(
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {
     match val {
-        Some(ref val) => crate::bson::serde_helpers::serialize_u32_as_i32(val, serializer),
+        Some(ref val) => serde_util::serialize_u32_as_i32(val, serializer),
         None => serializer.serialize_none(),
     }
 }
@@ -101,7 +102,7 @@ pub(crate) fn serialize_u64_option_as_i64<S: Serializer>(
     serializer: S,
 ) -> std::result::Result<S::Ok, S::Error> {
     match val {
-        Some(ref v) => crate::bson::serde_helpers::serialize_u64_as_i64(v, serializer),
+        Some(ref v) => serde_util::serialize_u64_as_i64(v, serializer),
         None => serializer.serialize_none(),
     }
 }
@@ -224,4 +225,30 @@ pub(crate) fn serialize_bool_or_true<S: Serializer>(
 ) -> std::result::Result<S::Ok, S::Error> {
     let val = val.unwrap_or(true);
     serializer.serialize_bool(val)
+}
+
+pub(crate) fn serialize_u32_as_i32<S: Serializer>(
+    n: &u32,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    match i32::try_from(*n) {
+        Ok(n) => n.serialize(serializer),
+        Err(_) => Err(serde::ser::Error::custom(format!(
+            "cannot serialize u32 {} as i32",
+            n
+        ))),
+    }
+}
+
+pub(crate) fn serialize_u64_as_i64<S: Serializer>(
+    n: &u64,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    match i64::try_from(*n) {
+        Ok(n) => n.serialize(serializer),
+        Err(_) => Err(serde::ser::Error::custom(format!(
+            "cannot serialize u64 {} as i64",
+            n
+        ))),
+    }
 }


### PR DESCRIPTION
We were only using two of the helper functions, so I added them to the driver's `serde_util` module rather than adding conditional logic for helper functions vs. `serde_with` in `bson_compat`.