### PR TITLE
RUST-2264 Fix handling of tlsInsecure in the URI

### DIFF
--- a/src/action/client_options.rs
+++ b/src/action/client_options.rs
@@ -51,10 +51,10 @@ impl ClientOptions {
     ///   * `socketTimeoutMS`: unsupported, does not map to any field
     ///   * `ssl`: an alias of the `tls` option
     ///   * `tls`: maps to the TLS variant of the `tls` field`.
-    ///   * `tlsInsecure`: relaxes the TLS constraints on connections being made; currently is just
-    ///     an alias of `tlsAllowInvalidCertificates`, but more behavior may be added to this option
-    ///     in the future
-    ///   * `tlsAllowInvalidCertificates`: maps to the `allow_invalidCertificates` field of the
+    ///   * `tlsInsecure`: relaxes the TLS constraints on connections being made; if set, the
+    ///     `allow_invalid_certificates` and `allow_invalid_hostnames` fields of the `tls` field are
+    ///     set to its value
+    ///   * `tlsAllowInvalidCertificates`: maps to the `allow_invalid_certificates` field of the
     ///     `tls` field
     ///   * `tlsCAFile`: maps to the `ca_file_path` field of the `tls` field
     ///   * `tlsCertificateKeyFile`: maps to the `cert_key_file_path` field of the `tls` field


### PR DESCRIPTION
Fixes handling of the `tlsInsecure` option in a URI. `tlsInsecure=bool` now sets `TlsOptions::allow_invalid_certificates` and `TlsOptions::allow_invalid_hostnames` (if `openssl-tls` is enabled) to the value of `bool`.

Note that `tlsInsecure` can _only_ be set via a URI; the `ConnectionString` and `ClientOptions` types both store the `TlsOptions` type, which only has fields for the more granular options.