### PR TITLE
RUST-2157 Complete set of Atlas Search helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "bson"
 version = "3.0.0"
-source = "git+https://github.com/mongodb/bson-rust?branch=main#062c499dfc6f7960d332972b1b1bab1912833f30"
+source = "git+https://github.com/mongodb/bson-rust?branch=main#440bfeb54d68edaff4a86e57de30e2d0adcdb5fd"
 dependencies = [
  "ahash",
  "base64 0.22.1",

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -41,8 +41,12 @@ impl Operator {
 
     fn gen_helper(&self) -> TokenStream {
         let name_text = &self.name;
-        let name_ident = format_ident!("{}", name_text.to_case(Case::Pascal));
-        let constr_ident = format_ident!("{}", name_text.to_case(Case::Snake));
+        let ident_base = match name_text.as_str() {
+            "in" => "searchIn",
+            _ => name_text,
+        };
+        let name_ident = format_ident!("{}", ident_base.to_case(Case::Pascal));
+        let constr_ident = format_ident!("{}", ident_base.to_case(Case::Snake));
 
         let mut required_args = TokenStream::new();
         let mut required_arg_names = TokenStream::new();
@@ -123,6 +127,7 @@ struct Argument {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 enum ArgumentType {
+    Any,
     Array,
     BinData,
     Bool,
@@ -161,6 +166,7 @@ impl Argument {
             [SearchOperator, Array] => ArgumentRustType::SeachOperatorIter,
             [Int] => ArgumentRustType::I32,
             [Geometry] => ArgumentRustType::Document,
+            [Any, Array] => ArgumentRustType::IntoBson,
             _ => panic!("Unexpected argument types: {:?}", self.type_),
         }
     }
@@ -238,6 +244,7 @@ fn main() {
         "range",
         "geoShape",
         "geoWithin",
+        "in",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -50,7 +50,14 @@ impl Operator {
         let mut setters = TokenStream::new();
 
         for arg in &self.arguments {
-            let ident = format_ident!("{}", arg.name.to_case(Case::Snake));
+            let ident = format_ident!(
+                "{}",
+                match arg.name.as_str() {
+                    // `box` is a reserved word
+                    "box" => "geo_box".to_owned(),
+                    _ => arg.name.to_case(Case::Snake),
+                }
+            );
             let rust_type = arg.rust_type(&self.name);
             let type_ = rust_type.tokens();
             let arg_name = &arg.name;
@@ -230,6 +237,7 @@ fn main() {
         "facet",
         "range",
         "geoShape",
+        "geoWithin",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -225,6 +225,7 @@ fn main() {
         "compound",
         "embeddedDocument",
         "equals",
+        "exists",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -152,7 +152,7 @@ impl Argument {
             ("text", "matchCriteria") => return ArgumentRustType::MatchCriteria,
             ("equals", "value") => return ArgumentRustType::IntoBson,
             ("geoShape", "relation") => return ArgumentRustType::Relation,
-            ("range", "gt" | "gte" | "lt" | "lte") => return ArgumentRustType::IntoBson,
+            ("range", "gt" | "gte" | "lt" | "lte") => return ArgumentRustType::RangeValue,
             ("near", "origin") => return ArgumentRustType::NearOrigin,
             _ => (),
         }
@@ -183,6 +183,7 @@ enum ArgumentRustType {
     IntoBson,
     MatchCriteria,
     NearOrigin,
+    RangeValue,
     Relation,
     SearchOperator,
     SeachOperatorIter,
@@ -201,6 +202,7 @@ impl ArgumentRustType {
             Self::IntoBson => parse_quote! { impl Into<Bson> },
             Self::MatchCriteria => parse_quote! { MatchCriteria },
             Self::NearOrigin => parse_quote! { impl NearOrigin },
+            Self::RangeValue => parse_quote! { impl RangeValue },
             Self::Relation => parse_quote! { Relation },
             Self::SearchOperator => parse_quote! { impl SearchOperator },
             Self::SeachOperatorIter => {
@@ -224,6 +226,7 @@ impl ArgumentRustType {
             | Self::DocumentOrArray
             | Self::SearchOperator
             | Self::NearOrigin
+            | Self::RangeValue
             | Self::BsonNumber => {
                 parse_quote! { #ident.to_bson() }
             }
@@ -255,7 +258,6 @@ fn main() {
         "equals",
         "exists",
         "facet",
-        "range",
         "geoShape",
         "geoWithin",
         "in",
@@ -263,6 +265,7 @@ fn main() {
         "near",
         "phrase",
         "queryString",
+        "range",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -167,6 +167,7 @@ impl Argument {
             [Int] => ArgumentRustType::I32,
             [Geometry] => ArgumentRustType::Document,
             [Any, Array] => ArgumentRustType::IntoBson,
+            [Object, Array] => ArgumentRustType::DocumentOrArray,
             _ => panic!("Unexpected argument types: {:?}", self.type_),
         }
     }
@@ -174,6 +175,7 @@ impl Argument {
 
 enum ArgumentRustType {
     Document,
+    DocumentOrArray,
     I32,
     IntoBson,
     MatchCriteria,
@@ -189,6 +191,7 @@ impl ArgumentRustType {
     fn tokens(&self) -> syn::Type {
         match self {
             Self::Document => parse_quote! { Document },
+            Self::DocumentOrArray => parse_quote! { impl DocumentOrArray },
             Self::I32 => parse_quote! { i32 },
             Self::IntoBson => parse_quote! { impl Into<Bson> },
             Self::MatchCriteria => parse_quote! { MatchCriteria },
@@ -212,7 +215,7 @@ impl ArgumentRustType {
                 parse_quote! { #ident.into_iter().map(|o| o.to_doc()).collect::<Vec<_>>() }
             }
             Self::String => parse_quote! { #ident.as_ref() },
-            Self::StringOrArray => parse_quote! { #ident.to_bson() },
+            Self::StringOrArray | Self::DocumentOrArray => parse_quote! { #ident.to_bson() },
             Self::TokenOrder | Self::MatchCriteria | Self::Relation => {
                 parse_quote! { #ident.name() }
             }
@@ -245,6 +248,7 @@ fn main() {
         "geoShape",
         "geoWithin",
         "in",
+        "moreLikeThis",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -262,6 +262,7 @@ fn main() {
         "moreLikeThis",
         "near",
         "phrase",
+        "queryString",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
@@ -254,28 +254,14 @@ impl TokenStreamExt for TokenStream {
 
 fn main() {
     let mut operators = TokenStream::new();
-    for name in [
-        "autocomplete",
-        "compound",
-        "embeddedDocument",
-        "equals",
-        "exists",
-        "facet",
-        "geoShape",
-        "geoWithin",
-        "in",
-        "moreLikeThis",
-        "near",
-        "phrase",
-        "queryString",
-        "range",
-        "regex",
-        "text",
-        "wildcard",
-    ] {
-        let mut path = PathBuf::from("yaml/search");
-        path.push(name);
-        path.set_extension("yaml");
+    let mut paths = Path::new("yaml/search")
+        .read_dir()
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .filter(|p| p.extension().is_some_and(|e| e == "yaml"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    for path in paths {
         let contents = std::fs::read_to_string(path).unwrap();
         let parsed = serde_yaml::from_str::<Operator>(&contents)
             .unwrap()

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -138,6 +138,7 @@ impl Argument {
             ("autocomplete", "tokenOrder") => return ArgumentRustType::TokenOrder,
             ("text", "matchCriteria") => return ArgumentRustType::MatchCriteria,
             ("equals", "value") => return ArgumentRustType::IntoBson,
+            ("range", "gt" | "gte" | "lt" | "lte") => return ArgumentRustType::IntoBson,
             _ => (),
         }
         use ArgumentType::*;
@@ -219,6 +220,7 @@ fn main() {
         "equals",
         "exists",
         "facet",
+        "range",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -170,12 +170,14 @@ impl Argument {
             [Object, Array] => ArgumentRustType::DocumentOrArray,
             [Number] => ArgumentRustType::BsonNumber,
             [String, Array] => ArgumentRustType::StringOrArray,
+            [Bool] => ArgumentRustType::Bool,
             _ => panic!("Unexpected argument types: {:?}", self.type_),
         }
     }
 }
 
 enum ArgumentRustType {
+    Bool,
     BsonNumber,
     Document,
     DocumentOrArray,
@@ -195,6 +197,7 @@ enum ArgumentRustType {
 impl ArgumentRustType {
     fn tokens(&self) -> syn::Type {
         match self {
+            Self::Bool => parse_quote! { bool },
             Self::BsonNumber => parse_quote! { impl BsonNumber },
             Self::Document => parse_quote! { Document },
             Self::DocumentOrArray => parse_quote! { impl DocumentOrArray },
@@ -216,7 +219,7 @@ impl ArgumentRustType {
 
     fn bson_expr(&self, ident: &syn::Ident) -> syn::Expr {
         match self {
-            Self::Document | Self::I32 => parse_quote! { #ident },
+            Self::Document | Self::I32 | Self::Bool => parse_quote! { #ident },
             Self::IntoBson => parse_quote! { #ident.into() },
             Self::SeachOperatorIter => {
                 parse_quote! { #ident.into_iter().map(|o| o.to_bson()).collect::<Vec<_>>() }
@@ -266,6 +269,7 @@ fn main() {
         "phrase",
         "queryString",
         "range",
+        "regex",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -169,6 +169,7 @@ impl Argument {
             [Any, Array] => ArgumentRustType::IntoBson,
             [Object, Array] => ArgumentRustType::DocumentOrArray,
             [Number] => ArgumentRustType::BsonNumber,
+            [String, Array] => ArgumentRustType::StringOrArray,
             _ => panic!("Unexpected argument types: {:?}", self.type_),
         }
     }
@@ -260,6 +261,7 @@ fn main() {
         "in",
         "moreLikeThis",
         "near",
+        "phrase",
         "text",
     ] {
         let mut path = PathBuf::from("yaml/search");

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -271,6 +271,7 @@ fn main() {
         "range",
         "regex",
         "text",
+        "wildcard",
     ] {
         let mut path = PathBuf::from("yaml/search");
         path.push(name);

--- a/etc/gen_atlas_search/src/main.rs
+++ b/etc/gen_atlas_search/src/main.rs
@@ -210,12 +210,13 @@ impl ArgumentRustType {
         match self {
             Self::Document | Self::I32 => parse_quote! { #ident },
             Self::IntoBson => parse_quote! { #ident.into() },
-            Self::SearchOperator => parse_quote! { #ident.to_doc() },
             Self::SeachOperatorIter => {
-                parse_quote! { #ident.into_iter().map(|o| o.to_doc()).collect::<Vec<_>>() }
+                parse_quote! { #ident.into_iter().map(|o| o.to_bson()).collect::<Vec<_>>() }
             }
             Self::String => parse_quote! { #ident.as_ref() },
-            Self::StringOrArray | Self::DocumentOrArray => parse_quote! { #ident.to_bson() },
+            Self::StringOrArray | Self::DocumentOrArray | Self::SearchOperator => {
+                parse_quote! { #ident.to_bson() }
+            }
             Self::TokenOrder | Self::MatchCriteria | Self::Relation => {
                 parse_quote! { #ident.name() }
             }

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -281,5 +281,30 @@ async fn api_flow() {
                 },
             ])
             .await;
+        let _ = coll
+            .aggregate(vec![
+                AtlasSearch::embedded_document(
+                    "items",
+                    AtlasSearch::compound()
+                        .must(AtlasSearch::text("items.name", "school"))
+                        .should(AtlasSearch::text("items.name", "backpack")),
+                )
+                .score(doc! {
+                    "embedded": {
+                        "aggregate": "mean"
+                    }
+                })
+                .into(),
+                doc! { "$limit": 5 },
+                doc! {
+                    "$project": {
+                        "_id": 0,
+                        "items.name": 1,
+                        "items.tags": 1,
+                        "score": { "$meta": "searchScore" },
+                    }
+                },
+            ])
+            .await;
     }
 }

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -319,5 +319,20 @@ impl DocumentOrArray for Document {}
 //impl<const N: usize> DocumentOrArray for [Document; N] {}
 impl DocumentOrArray for &[Document] {}
 
+/// An Atlas Search operator parameter that can be a date, number, or GeoJSON point.
+pub trait NearOrigin: private::Parameter {}
+impl NearOrigin for crate::bson::DateTime {}
+impl NearOrigin for i32 {}
+impl NearOrigin for i64 {}
+impl NearOrigin for u32 {}
+impl NearOrigin for f32 {}
+impl NearOrigin for f64 {}
+impl NearOrigin for Document {}
+
 /// An Atlas Search operator parameter that can be any BSON numeric type.
-pub trait BsonNumber {}
+pub trait BsonNumber: private::Parameter {}
+impl BsonNumber for i32 {}
+impl BsonNumber for i64 {}
+impl BsonNumber for u32 {}
+impl BsonNumber for f32 {}
+impl BsonNumber for f64 {}

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -316,7 +316,8 @@ impl Relation {
 /// An Atlas Search operator parameter that can be either a document or array of documents.
 pub trait DocumentOrArray: private::Parameter {}
 impl DocumentOrArray for Document {}
-//impl<const N: usize> DocumentOrArray for [Document; N] {}
+#[cfg(feature = "bson-3")]
+impl<const N: usize> DocumentOrArray for [Document; N] {}
 impl DocumentOrArray for &[Document] {}
 
 macro_rules! numeric {

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -173,9 +173,9 @@ impl StringOrArray for String {
     fn sealed(_: private::Sealed) {}
 }
 
-impl StringOrArray for &String {
+impl<const N: usize> StringOrArray for [&str; N] {
     fn to_bson(self) -> Bson {
-        Bson::String(self.clone())
+        Bson::Array(self.iter().map(|&s| Bson::String(s.to_owned())).collect())
     }
     fn sealed(_: private::Sealed) {}
 }
@@ -187,69 +187,9 @@ impl StringOrArray for &[&str] {
     fn sealed(_: private::Sealed) {}
 }
 
-impl<const N: usize> StringOrArray for &[&str; N] {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.iter().map(|&s| Bson::String(s.to_owned())).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
 impl StringOrArray for &[String] {
     fn to_bson(self) -> Bson {
         Bson::Array(self.iter().map(|s| Bson::String(s.clone())).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl<const N: usize> StringOrArray for &[String; N] {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.iter().map(|s| Bson::String(s.clone())).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl<const N: usize> StringOrArray for [String; N] {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.into_iter().map(Bson::String).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl StringOrArray for &[&String] {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.iter().map(|&s| Bson::String(s.clone())).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl<const N: usize> StringOrArray for &[&String; N] {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.iter().map(|&s| Bson::String(s.clone())).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl StringOrArray for Vec<&str> {
-    fn to_bson(self) -> Bson {
-        Bson::Array(
-            self.into_iter()
-                .map(|s| Bson::String(s.to_owned()))
-                .collect(),
-        )
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl StringOrArray for Vec<String> {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.into_iter().map(Bson::String).collect())
-    }
-    fn sealed(_: private::Sealed) {}
-}
-
-impl StringOrArray for Vec<&String> {
-    fn to_bson(self) -> Bson {
-        Bson::Array(self.into_iter().map(|s| Bson::String(s.clone())).collect())
     }
     fn sealed(_: private::Sealed) {}
 }

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -14,10 +14,11 @@ use crate::bson::{doc, Bson, Document};
 ///
 /// ```no_run
 /// # async fn wrapper() -> mongodb::error::Result<()> {
-/// # use mongodb::{Collection, atlas_search::AtlasSearch, bson::{Document, doc}};
+/// # use mongodb::{Collection, bson::{Document, doc}};
 /// # let collection: Collection<Document> = todo!();
+/// use mongodb::atlas_search;
 /// let cursor = collection.aggregate(vec![
-///     AtlasSearch::autocomplete("title", "pre")
+///     atlas_search::autocomplete("title", "pre")
 ///         .fuzzy(doc! { "maxEdits": 1, "prefixLength": 1, "maxExpansions": 256 })
 ///         .into(),
 ///     doc! {
@@ -55,14 +56,15 @@ impl<T> AtlasSearch<T> {
     /// of different types in a single `Vec`:
     /// ```no_run
     /// # async fn wrapper() -> mongodb::error::Result<()> {
-    /// # use mongodb::{Collection, atlas_search::AtlasSearch, bson::{Document, doc}};
+    /// # use mongodb::{Collection, bson::{Document, doc}};
     /// # let collection: Collection<Document> = todo!();
+    /// use mongodb::atlas_search;
     /// let cursor = collection.aggregate(vec![
-    ///     AtlasSearch::compound()
+    ///     atlas_search::compound()
     ///         .must(vec![
-    ///             AtlasSearch::text("description", "varieties").unit(),
-    ///             AtlasSearch::compound()
-    ///                 .should(AtlasSearch::text("description", "Fuji"))
+    ///             atlas_search::text("description", "varieties").unit(),
+    ///             atlas_search::compound()
+    ///                 .should(atlas_search::text("description", "Fuji"))
     ///                 .unit(),
     ///         ])
     ///         .into(),
@@ -280,166 +282,4 @@ impl AtlasSearch<Facet> {
         self.meta = false;
         self
     }
-}
-
-#[test]
-fn api_flow() {
-    assert_eq!(
-        doc! {
-            "$search": {
-                "autocomplete": {
-                    "query": "pre",
-                    "path": "title",
-                    "fuzzy": {
-                        "maxEdits": 1,
-                        "prefixLength": 1,
-                        "maxExpansions": 256,
-                    },
-                }
-            }
-        },
-        AtlasSearch::autocomplete("title", "pre")
-            .fuzzy(doc! { "maxEdits": 1, "prefixLength": 1, "maxExpansions": 256 })
-            .into()
-    );
-    assert_eq!(
-        doc! {
-            "$search": {
-                "text": {
-                    "path": "plot",
-                    "query": "baseball",
-                }
-            }
-        },
-        AtlasSearch::text("plot", "baseball").into()
-    );
-    assert_eq!(
-        doc! {
-            "$search": {
-                "compound": {
-                    "must": [{
-                        "text": {
-                            "path": "description",
-                            "query": "varieties",
-                        }
-                    }],
-                    "should": [{
-                        "text": {
-                            "path": "description",
-                            "query": "Fuji",
-                        }
-                    }],
-                }
-            }
-        },
-        AtlasSearch::compound()
-            .must(AtlasSearch::text("description", "varieties"))
-            .should(AtlasSearch::text("description", "Fuji"))
-            .into()
-    );
-    {
-        use short::*;
-        assert_eq!(
-            doc! {
-                "$search": {
-                    "embeddedDocument": {
-                        "path": "items",
-                        "operator": {
-                            "compound": {
-                                "must": [{
-                                    "text": {
-                                        "path": "items.tags",
-                                        "query": "school",
-                                    }
-                                }],
-                                "should": [{
-                                    "text": {
-                                        "path": "items.name",
-                                        "query": "backpack",
-                                    }
-                                }]
-                            }
-                        },
-                        "score": {
-                            "embedded": {
-                                "aggregate": "mean"
-                            }
-                        },
-                    }
-                }
-            },
-            embedded_document(
-                "items",
-                compound()
-                    .must(text("items.tags", "school"))
-                    .should(text("items.name", "backpack")),
-            )
-            .score(doc! {
-                "embedded": {
-                    "aggregate": "mean"
-                }
-            })
-            .into()
-        );
-    }
-    assert_eq!(
-        doc! {
-            "$search": {
-                "equals": {
-                    "path": "verified_user",
-                    "value": true,
-                }
-            }
-        },
-        AtlasSearch::equals("verified_user", true).into()
-    );
-    let gte_dt = crate::bson::DateTime::parse_rfc3339_str("2000-01-01T00:00:00.000Z").unwrap();
-    let lte_dt = crate::bson::DateTime::parse_rfc3339_str("2015-01-31T00:00:00.000Z").unwrap();
-    assert_eq!(
-        doc! {
-            "$searchMeta": {
-                "facet": {
-                    "operator": {
-                        "range": {
-                            "path": "released",
-                            "gte": gte_dt,
-                            "lte": lte_dt,
-                        }
-                    },
-                    "facets": {
-                        "directorsFacet": {
-                            "type": "string",
-                            "path": "directors",
-                            "numBuckets": 7,
-                        },
-                        "yearFacet": {
-                            "type": "number",
-                            "path": "year",
-                            "boundaries": [2000, 2005, 2010, 2015]
-                        },
-                    }
-                }
-            }
-        },
-        AtlasSearch::facet(doc! {
-            "directorsFacet": {
-                "type": "string",
-                "path": "directors",
-                "numBuckets": 7,
-            },
-            "yearFacet": {
-                "type": "number",
-                "path": "year",
-                "boundaries": [2000, 2005, 2010, 2015]
-            },
-        })
-        .operator(doc! {
-            "range": {
-                "path": "released",
-                "gte": gte_dt,
-                "lte": lte_dt,
-            }
-        })
-        .into()
-    );
 }

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -281,13 +281,14 @@ async fn api_flow() {
                 },
             ])
             .await;
+        use short::*;
         let _ = coll
             .aggregate(vec![
-                AtlasSearch::embedded_document(
+                embedded_document(
                     "items",
-                    AtlasSearch::compound()
-                        .must(AtlasSearch::text("items.name", "school"))
-                        .should(AtlasSearch::text("items.name", "backpack")),
+                    compound()
+                        .must(text("items.name", "school"))
+                        .should(text("items.name", "backpack")),
                 )
                 .score(doc! {
                     "embedded": {

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -6,7 +6,7 @@ pub use gen::*;
 
 use std::marker::PhantomData;
 
-use crate::bson::{doc, Bson, Document};
+use crate::bson::{doc, Bson, DateTime, Document};
 
 /// A helper to build the aggregation stage for Atlas Search.  Use one of the constructor functions
 /// and chain optional value setters, and then convert to a pipeline stage [`Document`] via
@@ -319,20 +319,31 @@ impl DocumentOrArray for Document {}
 //impl<const N: usize> DocumentOrArray for [Document; N] {}
 impl DocumentOrArray for &[Document] {}
 
+macro_rules! numeric {
+    ($trait:ty) => {
+        impl $trait for i32 {}
+        impl $trait for i64 {}
+        impl $trait for u32 {}
+        impl $trait for f32 {}
+        impl $trait for f64 {}
+    };
+}
+
 /// An Atlas Search operator parameter that can be a date, number, or GeoJSON point.
 pub trait NearOrigin: private::Parameter {}
-impl NearOrigin for crate::bson::DateTime {}
-impl NearOrigin for i32 {}
-impl NearOrigin for i64 {}
-impl NearOrigin for u32 {}
-impl NearOrigin for f32 {}
-impl NearOrigin for f64 {}
+impl NearOrigin for DateTime {}
 impl NearOrigin for Document {}
+numeric! { NearOrigin }
 
 /// An Atlas Search operator parameter that can be any BSON numeric type.
 pub trait BsonNumber: private::Parameter {}
-impl BsonNumber for i32 {}
-impl BsonNumber for i64 {}
-impl BsonNumber for u32 {}
-impl BsonNumber for f32 {}
-impl BsonNumber for f64 {}
+numeric! { BsonNumber }
+
+/// At Atlas Search operator parameter that can be compared using [`range`].
+pub trait RangeValue: private::Parameter {}
+numeric! { RangeValue }
+impl RangeValue for DateTime {}
+impl RangeValue for &str {}
+impl RangeValue for &String {}
+impl RangeValue for String {}
+impl RangeValue for crate::bson::oid::ObjectId {}

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -378,3 +378,32 @@ pub mod facet {
         }
     }
 }
+
+/// Relation of the query shape geometry to the indexed field geometry.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum Relation {
+    /// Indicates that the indexed geometry contains the query geometry.
+    Contains,
+    /// Indicates that both the query and indexed geometries have nothing in common.
+    Disjoint,
+    /// Indicates that both the query and indexed geometries intersect.
+    Intersects,
+    /// Indicates that the indexed geometry is within the query geometry. You can't use within with
+    /// LineString or Point.
+    Within,
+    /// Fallback for future compatibility.
+    Other(String),
+}
+
+impl Relation {
+    fn name(&self) -> &str {
+        match self {
+            Self::Contains => "contains",
+            Self::Disjoint => "disjoint",
+            Self::Intersects => "intersects",
+            Self::Within => "within",
+            Self::Other(s) => &s,
+        }
+    }
+}

--- a/src/atlas_search.rs
+++ b/src/atlas_search.rs
@@ -153,9 +153,9 @@ mod private {
 
 /// An Atlas Search operator parameter that can be either a string or array of strings.
 pub trait StringOrArray {
-    #[allow(missing_docs)]
+    #[doc(hidden)]
     fn to_bson(self) -> Bson;
-    #[allow(missing_docs)]
+    #[doc(hidden)]
     fn sealed(_: private::Sealed);
 }
 
@@ -196,9 +196,9 @@ impl StringOrArray for &[String] {
 
 /// An Atlas Search operator parameter that is itself a search operator.
 pub trait SearchOperator {
-    #[allow(missing_docs)]
+    #[doc(hidden)]
     fn to_doc(self) -> Document;
-    #[allow(missing_docs)]
+    #[doc(hidden)]
     fn sealed(_: private::Sealed) {}
 }
 
@@ -226,10 +226,10 @@ impl AtlasSearch<Facet> {
 
 /// Facet definitions.  These can be used when constructing a facet definition doc:
 /// ```
-/// use mongodb::atlas_search;
-/// let search = atlas_search::facet(doc! {
-///   "directorsFacet": atlas_search::facet::string("directors").num_buckets(7),
-///   "yearFacet": atlas_search::facet::number("year", [2000, 2005, 2010, 2015]),
+/// use mongodb::atlas_search::facet;
+/// let search = facet(doc! {
+///   "directorsFacet": facet::string("directors").num_buckets(7),
+///   "yearFacet": facet::number("year", [2000, 2005, 2010, 2015]),
 /// });
 /// ```
 pub mod facet {
@@ -346,4 +346,33 @@ impl Relation {
             Self::Other(s) => &s,
         }
     }
+}
+
+/// An Atlas Search operator parameter that can be either a document or array of documents.
+pub trait DocumentOrArray {
+    #[doc(hidden)]
+    fn to_bson(self) -> Bson;
+    #[doc(hidden)]
+    fn sealed(_: private::Sealed);
+}
+
+impl DocumentOrArray for Document {
+    fn to_bson(self) -> Bson {
+        Bson::Document(self)
+    }
+    fn sealed(_: private::Sealed) {}
+}
+
+impl<const N: usize> DocumentOrArray for [Document; N] {
+    fn to_bson(self) -> Bson {
+        Bson::Array(self.into_iter().map(Bson::Document).collect())
+    }
+    fn sealed(_: private::Sealed) {}
+}
+
+impl DocumentOrArray for &[Document] {
+    fn to_bson(self) -> Bson {
+        Bson::from(self)
+    }
+    fn sealed(_: private::Sealed) {}
 }

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -36,6 +36,89 @@ impl AtlasSearch<Autocomplete> {
     }
 }
 #[allow(missing_docs)]
+pub struct Compound;
+impl AtlasSearch<Compound> {
+    /**The compound operator combines two or more operators into a single query.
+    Each element of a compound query is called a clause, and each clause
+    consists of one or more sub-queries.
+    */
+    ///
+    ///For more details, see the [compound operator reference](https://www.mongodb.com/docs/atlas/atlas-search/compound/).
+    pub fn compound() -> Self {
+        AtlasSearch {
+            name: "compound",
+            stage: doc! {},
+            _t: PhantomData,
+        }
+    }
+    #[allow(missing_docs)]
+    pub fn must(mut self, must: impl IntoIterator<Item = impl Into<Document>>) -> Self {
+        self.stage
+            .insert("must", must.into_iter().map(Into::into).collect::<Vec<_>>());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn must_not(mut self, must_not: impl IntoIterator<Item = impl Into<Document>>) -> Self {
+        self.stage.insert(
+            "mustNot",
+            must_not.into_iter().map(Into::into).collect::<Vec<_>>(),
+        );
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn should(mut self, should: impl IntoIterator<Item = impl Into<Document>>) -> Self {
+        self.stage.insert(
+            "should",
+            should.into_iter().map(Into::into).collect::<Vec<_>>(),
+        );
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn filter(mut self, filter: impl IntoIterator<Item = impl Into<Document>>) -> Self {
+        self.stage.insert(
+            "filter",
+            filter.into_iter().map(Into::into).collect::<Vec<_>>(),
+        );
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn minimum_should_match(mut self, minimum_should_match: i32) -> Self {
+        self.stage
+            .insert("minimumShouldMatch", minimum_should_match);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
+pub struct EmbeddedDocument;
+impl AtlasSearch<EmbeddedDocument> {
+    /**The embeddedDocument operator is similar to $elemMatch operator.
+    It constrains multiple query predicates to be satisfied from a single
+    element of an array of embedded documents. embeddedDocument can be used only
+    for queries over fields of the embeddedDocuments
+    */
+    ///
+    ///For more details, see the [embeddedDocument operator reference](https://www.mongodb.com/docs/atlas/atlas-search/embedded-document/).
+    pub fn embedded_document(path: impl StringOrArray, operator: impl Into<Document>) -> Self {
+        AtlasSearch {
+            name: "embeddedDocument",
+            stage: doc! {
+                "path" : path.to_bson(), "operator" : operator.into(),
+            },
+            _t: PhantomData,
+        }
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 impl AtlasSearch<Text> {
     /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
@@ -65,66 +148,6 @@ impl AtlasSearch<Text> {
     #[allow(missing_docs)]
     pub fn synonyms(mut self, synonyms: impl AsRef<str>) -> Self {
         self.stage.insert("synonyms", synonyms.as_ref());
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn score(mut self, score: Document) -> Self {
-        self.stage.insert("score", score);
-        self
-    }
-}
-#[allow(missing_docs)]
-pub struct Compound;
-impl AtlasSearch<Compound> {
-    /**The compound operator combines two or more operators into a single query.
-    Each element of a compound query is called a clause, and each clause
-    consists of one or more sub-queries.
-    */
-    ///
-    ///For more details, see the [compound operator reference](https://www.mongodb.com/docs/atlas/atlas-search/compound/).
-    pub fn compound() -> Self {
-        AtlasSearch {
-            name: "compound",
-            stage: doc! {},
-            _t: PhantomData,
-        }
-    }
-    #[allow(missing_docs)]
-    pub fn must<T>(mut self, must: impl IntoIterator<Item = AtlasSearch<T>>) -> Self {
-        self.stage.insert(
-            "must",
-            must.into_iter().map(Document::from).collect::<Vec<_>>(),
-        );
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn must_not<T>(mut self, must_not: impl IntoIterator<Item = AtlasSearch<T>>) -> Self {
-        self.stage.insert(
-            "mustNot",
-            must_not.into_iter().map(Document::from).collect::<Vec<_>>(),
-        );
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn should<T>(mut self, should: impl IntoIterator<Item = AtlasSearch<T>>) -> Self {
-        self.stage.insert(
-            "should",
-            should.into_iter().map(Document::from).collect::<Vec<_>>(),
-        );
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn filter<T>(mut self, filter: impl IntoIterator<Item = AtlasSearch<T>>) -> Self {
-        self.stage.insert(
-            "filter",
-            filter.into_iter().map(Document::from).collect::<Vec<_>>(),
-        );
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn minimum_should_match(mut self, minimum_should_match: i32) -> Self {
-        self.stage
-            .insert("minimumShouldMatch", minimum_should_match);
         self
     }
     #[allow(missing_docs)]

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -512,3 +512,33 @@ impl AtlasSearch<Text> {
         self
     }
 }
+#[allow(missing_docs)]
+pub struct Wildcard;
+/**The wildcard operator enables queries which use special characters in the search string that
+ * can match any character.
+ * */
+///
+///For more details, see the [wildcard operator reference](https://www.mongodb.com/docs/atlas/atlas-search/wildcard/).
+pub fn wildcard(path: impl StringOrArray, query: impl AsRef<str>) -> AtlasSearch<Wildcard> {
+    AtlasSearch {
+        name: "wildcard",
+        stage: doc! {
+            "path" : path.to_bson(), "query" : query.as_ref(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<Wildcard> {
+    #[allow(missing_docs)]
+    pub fn allow_analyzed_field(mut self, allow_analyzed_field: bool) -> Self {
+        self.stage
+            .insert("allowAnalyzedField", allow_analyzed_field);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -335,6 +335,31 @@ impl AtlasSearch<SearchIn> {
     }
 }
 #[allow(missing_docs)]
+pub struct MoreLikeThis;
+/**The moreLikeThis operator returns documents similar to input documents.
+The moreLikeThis operator allows you to build features for your applications
+that display similar or alternative results based on one or more given documents.
+*/
+///
+///For more details, see the [moreLikeThis operator reference](https://www.mongodb.com/docs/atlas/atlas-search/moreLikeThis/).
+pub fn more_like_this(like: impl DocumentOrArray) -> AtlasSearch<MoreLikeThis> {
+    AtlasSearch {
+        name: "moreLikeThis",
+        stage: doc! {
+            "like" : like.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<MoreLikeThis> {
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -2,24 +2,27 @@
 use super::*;
 #[allow(missing_docs)]
 pub struct Autocomplete;
-impl AtlasSearch<Autocomplete> {
-    /**The autocomplete operator performs a search for a word or phrase that
-    contains a sequence of characters from an incomplete input string. The
-    fields that you intend to query with the autocomplete operator must be
-    indexed with the autocomplete data type in the collection's index definition.
-    */
-    ///
-    ///For more details, see the [autocomplete operator reference](https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/).
-    pub fn autocomplete(path: impl StringOrArray, query: impl StringOrArray) -> Self {
-        AtlasSearch {
-            name: "autocomplete",
-            stage: doc! {
-                "path" : path.to_bson(), "query" : query.to_bson(),
-            },
-            meta: false,
-            _t: PhantomData,
-        }
+/**The autocomplete operator performs a search for a word or phrase that
+contains a sequence of characters from an incomplete input string. The
+fields that you intend to query with the autocomplete operator must be
+indexed with the autocomplete data type in the collection's index definition.
+*/
+///
+///For more details, see the [autocomplete operator reference](https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/).
+pub fn autocomplete(
+    path: impl StringOrArray,
+    query: impl StringOrArray,
+) -> AtlasSearch<Autocomplete> {
+    AtlasSearch {
+        name: "autocomplete",
+        stage: doc! {
+            "path" : path.to_bson(), "query" : query.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<Autocomplete> {
     #[allow(missing_docs)]
     pub fn token_order(mut self, token_order: TokenOrder) -> Self {
         self.stage.insert("tokenOrder", token_order.name());
@@ -38,21 +41,21 @@ impl AtlasSearch<Autocomplete> {
 }
 #[allow(missing_docs)]
 pub struct Compound;
-impl AtlasSearch<Compound> {
-    /**The compound operator combines two or more operators into a single query.
-    Each element of a compound query is called a clause, and each clause
-    consists of one or more sub-queries.
-    */
-    ///
-    ///For more details, see the [compound operator reference](https://www.mongodb.com/docs/atlas/atlas-search/compound/).
-    pub fn compound() -> Self {
-        AtlasSearch {
-            name: "compound",
-            stage: doc! {},
-            meta: false,
-            _t: PhantomData,
-        }
+/**The compound operator combines two or more operators into a single query.
+Each element of a compound query is called a clause, and each clause
+consists of one or more sub-queries.
+*/
+///
+///For more details, see the [compound operator reference](https://www.mongodb.com/docs/atlas/atlas-search/compound/).
+pub fn compound() -> AtlasSearch<Compound> {
+    AtlasSearch {
+        name: "compound",
+        stage: doc! {},
+        meta: false,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<Compound> {
     #[allow(missing_docs)]
     pub fn must(mut self, must: impl IntoIterator<Item = impl SearchOperator>) -> Self {
         self.stage.insert(
@@ -99,24 +102,27 @@ impl AtlasSearch<Compound> {
 }
 #[allow(missing_docs)]
 pub struct EmbeddedDocument;
-impl AtlasSearch<EmbeddedDocument> {
-    /**The embeddedDocument operator is similar to $elemMatch operator.
-    It constrains multiple query predicates to be satisfied from a single
-    element of an array of embedded documents. embeddedDocument can be used only
-    for queries over fields of the embeddedDocuments
-    */
-    ///
-    ///For more details, see the [embeddedDocument operator reference](https://www.mongodb.com/docs/atlas/atlas-search/embedded-document/).
-    pub fn embedded_document(path: impl StringOrArray, operator: impl SearchOperator) -> Self {
-        AtlasSearch {
-            name: "embeddedDocument",
-            stage: doc! {
-                "path" : path.to_bson(), "operator" : operator.to_doc(),
-            },
-            meta: false,
-            _t: PhantomData,
-        }
+/**The embeddedDocument operator is similar to $elemMatch operator.
+It constrains multiple query predicates to be satisfied from a single
+element of an array of embedded documents. embeddedDocument can be used only
+for queries over fields of the embeddedDocuments
+*/
+///
+///For more details, see the [embeddedDocument operator reference](https://www.mongodb.com/docs/atlas/atlas-search/embedded-document/).
+pub fn embedded_document(
+    path: impl StringOrArray,
+    operator: impl SearchOperator,
+) -> AtlasSearch<EmbeddedDocument> {
+    AtlasSearch {
+        name: "embeddedDocument",
+        stage: doc! {
+            "path" : path.to_bson(), "operator" : operator.to_doc(),
+        },
+        meta: false,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<EmbeddedDocument> {
     #[allow(missing_docs)]
     pub fn score(mut self, score: Document) -> Self {
         self.stage.insert("score", score);
@@ -125,21 +131,21 @@ impl AtlasSearch<EmbeddedDocument> {
 }
 #[allow(missing_docs)]
 pub struct Equals;
-impl AtlasSearch<Equals> {
-    /**The equals operator checks whether a field matches a value you specify.
-     * */
-    ///
-    ///For more details, see the [equals operator reference](https://www.mongodb.com/docs/atlas/atlas-search/equals/).
-    pub fn equals(path: impl StringOrArray, value: impl Into<Bson>) -> Self {
-        AtlasSearch {
-            name: "equals",
-            stage: doc! {
-                "path" : path.to_bson(), "value" : value.into(),
-            },
-            meta: false,
-            _t: PhantomData,
-        }
+/**The equals operator checks whether a field matches a value you specify.
+ * */
+///
+///For more details, see the [equals operator reference](https://www.mongodb.com/docs/atlas/atlas-search/equals/).
+pub fn equals(path: impl StringOrArray, value: impl Into<Bson>) -> AtlasSearch<Equals> {
+    AtlasSearch {
+        name: "equals",
+        stage: doc! {
+            "path" : path.to_bson(), "value" : value.into(),
+        },
+        meta: false,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<Equals> {
     #[allow(missing_docs)]
     pub fn score(mut self, score: Document) -> Self {
         self.stage.insert("score", score);
@@ -148,22 +154,21 @@ impl AtlasSearch<Equals> {
 }
 #[allow(missing_docs)]
 pub struct Exists;
-impl AtlasSearch<Exists> {
-    /**The exists operator tests if a path to a specified indexed field name exists in a
-     * document.
-     * */
-    ///
-    ///For more details, see the [exists operator reference](https://www.mongodb.com/docs/atlas/atlas-search/exists/).
-    pub fn exists(path: impl StringOrArray) -> Self {
-        AtlasSearch {
-            name: "exists",
-            stage: doc! {
-                "path" : path.to_bson(),
-            },
-            meta: false,
-            _t: PhantomData,
-        }
+/**The exists operator tests if a path to a specified indexed field name exists in a document.
+ * */
+///
+///For more details, see the [exists operator reference](https://www.mongodb.com/docs/atlas/atlas-search/exists/).
+pub fn exists(path: impl StringOrArray) -> AtlasSearch<Exists> {
+    AtlasSearch {
+        name: "exists",
+        stage: doc! {
+            "path" : path.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<Exists> {
     #[allow(missing_docs)]
     pub fn score(mut self, score: Document) -> Self {
         self.stage.insert("score", score);
@@ -172,22 +177,22 @@ impl AtlasSearch<Exists> {
 }
 #[allow(missing_docs)]
 pub struct Facet;
-impl AtlasSearch<Facet> {
-    /**The facet collector groups results by values or ranges in the specified
-    faceted fields and returns the count for each of those groups.
-    */
-    ///
-    ///For more details, see the [facet operator reference](https://www.mongodb.com/docs/atlas/atlas-search/facet/).
-    pub fn facet(facets: Document) -> Self {
-        AtlasSearch {
-            name: "facet",
-            stage: doc! {
-                "facets" : facets,
-            },
-            meta: true,
-            _t: PhantomData,
-        }
+/**The facet collector groups results by values or ranges in the specified
+faceted fields and returns the count for each of those groups.
+*/
+///
+///For more details, see the [facet operator reference](https://www.mongodb.com/docs/atlas/atlas-search/facet/).
+pub fn facet(facets: Document) -> AtlasSearch<Facet> {
+    AtlasSearch {
+        name: "facet",
+        stage: doc! {
+            "facets" : facets,
+        },
+        meta: true,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<Facet> {
     #[allow(missing_docs)]
     pub fn operator(mut self, operator: impl SearchOperator) -> Self {
         self.stage.insert("operator", operator.to_doc());
@@ -196,22 +201,22 @@ impl AtlasSearch<Facet> {
 }
 #[allow(missing_docs)]
 pub struct Text;
-impl AtlasSearch<Text> {
-    /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
-    If you omit an analyzer, the text operator uses the default standard analyzer.
-    */
-    ///
-    ///For more details, see the [text operator reference](https://www.mongodb.com/docs/atlas/atlas-search/text/).
-    pub fn text(path: impl StringOrArray, query: impl StringOrArray) -> Self {
-        AtlasSearch {
-            name: "text",
-            stage: doc! {
-                "path" : path.to_bson(), "query" : query.to_bson(),
-            },
-            meta: false,
-            _t: PhantomData,
-        }
+/**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
+If you omit an analyzer, the text operator uses the default standard analyzer.
+*/
+///
+///For more details, see the [text operator reference](https://www.mongodb.com/docs/atlas/atlas-search/text/).
+pub fn text(path: impl StringOrArray, query: impl StringOrArray) -> AtlasSearch<Text> {
+    AtlasSearch {
+        name: "text",
+        stage: doc! {
+            "path" : path.to_bson(), "query" : query.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
     }
+}
+impl AtlasSearch<Text> {
     #[allow(missing_docs)]
     pub fn fuzzy(mut self, fuzzy: Document) -> Self {
         self.stage.insert("fuzzy", fuzzy);
@@ -231,76 +236,5 @@ impl AtlasSearch<Text> {
     pub fn score(mut self, score: Document) -> Self {
         self.stage.insert("score", score);
         self
-    }
-}
-/// Atlas Search constructor functions without the `AtlasSearch::` prefix; can be useful to
-/// improve readability when constructing deeply nested searches.
-pub mod short {
-    use super::*;
-    /**The autocomplete operator performs a search for a word or phrase that
-    contains a sequence of characters from an incomplete input string. The
-    fields that you intend to query with the autocomplete operator must be
-    indexed with the autocomplete data type in the collection's index definition.
-    */
-    ///
-    ///For more details, see the [autocomplete operator reference](https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/).
-    pub fn autocomplete(
-        path: impl StringOrArray,
-        query: impl StringOrArray,
-    ) -> AtlasSearch<Autocomplete> {
-        AtlasSearch::autocomplete(path, query)
-    }
-    /**The compound operator combines two or more operators into a single query.
-    Each element of a compound query is called a clause, and each clause
-    consists of one or more sub-queries.
-    */
-    ///
-    ///For more details, see the [compound operator reference](https://www.mongodb.com/docs/atlas/atlas-search/compound/).
-    pub fn compound() -> AtlasSearch<Compound> {
-        AtlasSearch::compound()
-    }
-    /**The embeddedDocument operator is similar to $elemMatch operator.
-    It constrains multiple query predicates to be satisfied from a single
-    element of an array of embedded documents. embeddedDocument can be used only
-    for queries over fields of the embeddedDocuments
-    */
-    ///
-    ///For more details, see the [embeddedDocument operator reference](https://www.mongodb.com/docs/atlas/atlas-search/embedded-document/).
-    pub fn embedded_document(
-        path: impl StringOrArray,
-        operator: impl SearchOperator,
-    ) -> AtlasSearch<EmbeddedDocument> {
-        AtlasSearch::embedded_document(path, operator)
-    }
-    /**The equals operator checks whether a field matches a value you specify.
-     * */
-    ///
-    ///For more details, see the [equals operator reference](https://www.mongodb.com/docs/atlas/atlas-search/equals/).
-    pub fn equals(path: impl StringOrArray, value: impl Into<Bson>) -> AtlasSearch<Equals> {
-        AtlasSearch::equals(path, value)
-    }
-    /**The exists operator tests if a path to a specified indexed field name exists in a
-     * document.
-     * */
-    ///
-    ///For more details, see the [exists operator reference](https://www.mongodb.com/docs/atlas/atlas-search/exists/).
-    pub fn exists(path: impl StringOrArray) -> AtlasSearch<Exists> {
-        AtlasSearch::exists(path)
-    }
-    /**The facet collector groups results by values or ranges in the specified
-    faceted fields and returns the count for each of those groups.
-    */
-    ///
-    ///For more details, see the [facet operator reference](https://www.mongodb.com/docs/atlas/atlas-search/facet/).
-    pub fn facet(facets: Document) -> AtlasSearch<Facet> {
-        AtlasSearch::facet(facets)
-    }
-    /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
-    If you omit an analyzer, the text operator uses the default standard analyzer.
-    */
-    ///
-    ///For more details, see the [text operator reference](https://www.mongodb.com/docs/atlas/atlas-search/text/).
-    pub fn text(path: impl StringOrArray, query: impl StringOrArray) -> AtlasSearch<Text> {
-        AtlasSearch::text(path, query)
     }
 }

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -391,6 +391,40 @@ impl AtlasSearch<Near> {
     }
 }
 #[allow(missing_docs)]
+pub struct Phrase;
+/**The phrase operator performs search for documents containing an ordered sequence of terms
+ * using the analyzer specified in the index configuration.
+ * */
+///
+///For more details, see the [phrase operator reference](https://www.mongodb.com/docs/atlas/atlas-search/phrase/).
+pub fn phrase(path: impl StringOrArray, query: impl StringOrArray) -> AtlasSearch<Phrase> {
+    AtlasSearch {
+        name: "phrase",
+        stage: doc! {
+            "path" : path.to_bson(), "query" : query.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<Phrase> {
+    #[allow(missing_docs)]
+    pub fn slop(mut self, slop: i32) -> Self {
+        self.stage.insert("slop", slop);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn synonyms(mut self, synonyms: impl AsRef<str>) -> Self {
+        self.stage.insert("synonyms", synonyms.as_ref());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -156,3 +156,51 @@ impl AtlasSearch<Text> {
         self
     }
 }
+/// Atlas Search constructor functions without the `AtlasSearch::` prefix; can be useful to
+/// improve readability when constructing deeply nested searches.
+pub mod short {
+    use super::*;
+    /**The autocomplete operator performs a search for a word or phrase that
+    contains a sequence of characters from an incomplete input string. The
+    fields that you intend to query with the autocomplete operator must be
+    indexed with the autocomplete data type in the collection's index definition.
+    */
+    ///
+    ///For more details, see the [autocomplete operator reference](https://www.mongodb.com/docs/atlas/atlas-search/autocomplete/).
+    pub fn autocomplete(
+        path: impl StringOrArray,
+        query: impl StringOrArray,
+    ) -> AtlasSearch<Autocomplete> {
+        AtlasSearch::autocomplete(path, query)
+    }
+    /**The compound operator combines two or more operators into a single query.
+    Each element of a compound query is called a clause, and each clause
+    consists of one or more sub-queries.
+    */
+    ///
+    ///For more details, see the [compound operator reference](https://www.mongodb.com/docs/atlas/atlas-search/compound/).
+    pub fn compound() -> AtlasSearch<Compound> {
+        AtlasSearch::compound()
+    }
+    /**The embeddedDocument operator is similar to $elemMatch operator.
+    It constrains multiple query predicates to be satisfied from a single
+    element of an array of embedded documents. embeddedDocument can be used only
+    for queries over fields of the embeddedDocuments
+    */
+    ///
+    ///For more details, see the [embeddedDocument operator reference](https://www.mongodb.com/docs/atlas/atlas-search/embedded-document/).
+    pub fn embedded_document(
+        path: impl StringOrArray,
+        operator: impl Into<Document>,
+    ) -> AtlasSearch<EmbeddedDocument> {
+        AtlasSearch::embedded_document(path, operator)
+    }
+    /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
+    If you omit an analyzer, the text operator uses the default standard analyzer.
+    */
+    ///
+    ///For more details, see the [text operator reference](https://www.mongodb.com/docs/atlas/atlas-search/text/).
+    pub fn text(path: impl StringOrArray, query: impl StringOrArray) -> AtlasSearch<Text> {
+        AtlasSearch::text(path, query)
+    }
+}

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -425,6 +425,25 @@ impl AtlasSearch<Phrase> {
     }
 }
 #[allow(missing_docs)]
+pub struct QueryString;
+///
+///
+///For more details, see the [queryString operator reference](https://www.mongodb.com/docs/atlas/atlas-search/queryString/).
+pub fn query_string(
+    default_path: impl StringOrArray,
+    query: impl AsRef<str>,
+) -> AtlasSearch<QueryString> {
+    AtlasSearch {
+        name: "queryString",
+        stage: doc! {
+            "defaultPath" : default_path.to_bson(), "query" : query.as_ref(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<QueryString> {}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -444,6 +444,36 @@ impl AtlasSearch<Range> {
     }
 }
 #[allow(missing_docs)]
+pub struct Regex;
+/**regex interprets the query field as a regular expression.
+regex is a term-level operator, meaning that the query field isn't analyzed.
+*/
+///
+///For more details, see the [regex operator reference](https://www.mongodb.com/docs/atlas/atlas-search/regex/).
+pub fn regex(path: impl StringOrArray, query: impl AsRef<str>) -> AtlasSearch<Regex> {
+    AtlasSearch {
+        name: "regex",
+        stage: doc! {
+            "path" : path.to_bson(), "query" : query.as_ref(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<Regex> {
+    #[allow(missing_docs)]
+    pub fn allow_analyzed_field(mut self, allow_analyzed_field: bool) -> Self {
+        self.stage
+            .insert("allowAnalyzedField", allow_analyzed_field);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -363,6 +363,34 @@ impl AtlasSearch<MoreLikeThis> {
     }
 }
 #[allow(missing_docs)]
+pub struct Near;
+/**The near operator supports querying and scoring numeric, date, and GeoJSON point values.
+ * */
+///
+///For more details, see the [near operator reference](https://www.mongodb.com/docs/atlas/atlas-search/near/).
+pub fn near(
+    path: impl StringOrArray,
+    origin: impl NearOrigin,
+    pivot: impl BsonNumber,
+) -> AtlasSearch<Near> {
+    AtlasSearch {
+        name: "near",
+        stage: doc! {
+            "path" : path.to_bson(), "origin" : origin.to_bson(), "pivot" : pivot
+            .to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<Near> {
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -200,6 +200,50 @@ impl AtlasSearch<Facet> {
     }
 }
 #[allow(missing_docs)]
+pub struct Range;
+/**The range operator supports querying and scoring numeric, date, and string values.
+You can use this operator to find results that are within a given numeric, date, objectId, or letter (from the English alphabet) range.
+*/
+///
+///For more details, see the [range operator reference](https://www.mongodb.com/docs/atlas/atlas-search/range/).
+pub fn range(path: impl StringOrArray) -> AtlasSearch<Range> {
+    AtlasSearch {
+        name: "range",
+        stage: doc! {
+            "path" : path.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<Range> {
+    #[allow(missing_docs)]
+    pub fn gt(mut self, gt: impl Into<Bson>) -> Self {
+        self.stage.insert("gt", gt.into());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn gte(mut self, gte: impl Into<Bson>) -> Self {
+        self.stage.insert("gte", gte.into());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn lt(mut self, lt: impl Into<Bson>) -> Self {
+        self.stage.insert("lt", lt.into());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn lte(mut self, lte: impl Into<Bson>) -> Self {
+        self.stage.insert("lte", lte.into());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -119,6 +119,28 @@ impl AtlasSearch<EmbeddedDocument> {
     }
 }
 #[allow(missing_docs)]
+pub struct Equals;
+impl AtlasSearch<Equals> {
+    /**The equals operator checks whether a field matches a value you specify.
+     * */
+    ///
+    ///For more details, see the [equals operator reference](https://www.mongodb.com/docs/atlas/atlas-search/equals/).
+    pub fn equals(path: impl StringOrArray, value: impl Into<Bson>) -> Self {
+        AtlasSearch {
+            name: "equals",
+            stage: doc! {
+                "path" : path.to_bson(), "value" : value.into(),
+            },
+            _t: PhantomData,
+        }
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 impl AtlasSearch<Text> {
     /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
@@ -194,6 +216,13 @@ pub mod short {
         operator: impl Into<Document>,
     ) -> AtlasSearch<EmbeddedDocument> {
         AtlasSearch::embedded_document(path, operator)
+    }
+    /**The equals operator checks whether a field matches a value you specify.
+     * */
+    ///
+    ///For more details, see the [equals operator reference](https://www.mongodb.com/docs/atlas/atlas-search/equals/).
+    pub fn equals(path: impl StringOrArray, value: impl Into<Bson>) -> AtlasSearch<Equals> {
+        AtlasSearch::equals(path, value)
     }
     /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
     If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -244,6 +244,34 @@ impl AtlasSearch<Range> {
     }
 }
 #[allow(missing_docs)]
+pub struct GeoShape;
+/**The geoShape operator supports querying shapes with a relation to a given
+geometry if indexShapes is set to true in the index definition.
+*/
+///
+///For more details, see the [geoShape operator reference](https://www.mongodb.com/docs/atlas/atlas-search/geoShape/).
+pub fn geo_shape(
+    path: impl StringOrArray,
+    relation: Relation,
+    geometry: Document,
+) -> AtlasSearch<GeoShape> {
+    AtlasSearch {
+        name: "geoShape",
+        stage: doc! {
+            "path" : path.to_bson(), "relation" : relation.name(), "geometry" : geometry,
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<GeoShape> {
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -203,50 +203,6 @@ impl AtlasSearch<Facet> {
     }
 }
 #[allow(missing_docs)]
-pub struct Range;
-/**The range operator supports querying and scoring numeric, date, and string values.
-You can use this operator to find results that are within a given numeric, date, objectId, or letter (from the English alphabet) range.
-*/
-///
-///For more details, see the [range operator reference](https://www.mongodb.com/docs/atlas/atlas-search/range/).
-pub fn range(path: impl StringOrArray) -> AtlasSearch<Range> {
-    AtlasSearch {
-        name: "range",
-        stage: doc! {
-            "path" : path.to_bson(),
-        },
-        meta: false,
-        _t: PhantomData,
-    }
-}
-impl AtlasSearch<Range> {
-    #[allow(missing_docs)]
-    pub fn gt(mut self, gt: impl Into<Bson>) -> Self {
-        self.stage.insert("gt", gt.into());
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn gte(mut self, gte: impl Into<Bson>) -> Self {
-        self.stage.insert("gte", gte.into());
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn lt(mut self, lt: impl Into<Bson>) -> Self {
-        self.stage.insert("lt", lt.into());
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn lte(mut self, lte: impl Into<Bson>) -> Self {
-        self.stage.insert("lte", lte.into());
-        self
-    }
-    #[allow(missing_docs)]
-    pub fn score(mut self, score: Document) -> Self {
-        self.stage.insert("score", score);
-        self
-    }
-}
-#[allow(missing_docs)]
 pub struct GeoShape;
 /**The geoShape operator supports querying shapes with a relation to a given
 geometry if indexShapes is set to true in the index definition.
@@ -443,6 +399,50 @@ pub fn query_string(
     }
 }
 impl AtlasSearch<QueryString> {}
+#[allow(missing_docs)]
+pub struct Range;
+/**The range operator supports querying and scoring numeric, date, and string values.
+You can use this operator to find results that are within a given numeric, date, objectId, or letter (from the English alphabet) range.
+*/
+///
+///For more details, see the [range operator reference](https://www.mongodb.com/docs/atlas/atlas-search/range/).
+pub fn range(path: impl StringOrArray) -> AtlasSearch<Range> {
+    AtlasSearch {
+        name: "range",
+        stage: doc! {
+            "path" : path.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<Range> {
+    #[allow(missing_docs)]
+    pub fn gt(mut self, gt: impl RangeValue) -> Self {
+        self.stage.insert("gt", gt.to_bson());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn gte(mut self, gte: impl RangeValue) -> Self {
+        self.stage.insert("gte", gte.to_bson());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn lt(mut self, lt: impl RangeValue) -> Self {
+        self.stage.insert("lt", lt.to_bson());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn lte(mut self, lte: impl RangeValue) -> Self {
+        self.stage.insert("lte", lte.to_bson());
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
 #[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -141,6 +141,29 @@ impl AtlasSearch<Equals> {
     }
 }
 #[allow(missing_docs)]
+pub struct Exists;
+impl AtlasSearch<Exists> {
+    /**The exists operator tests if a path to a specified indexed field name exists in a
+     * document.
+     * */
+    ///
+    ///For more details, see the [exists operator reference](https://www.mongodb.com/docs/atlas/atlas-search/exists/).
+    pub fn exists(path: impl StringOrArray) -> Self {
+        AtlasSearch {
+            name: "exists",
+            stage: doc! {
+                "path" : path.to_bson(),
+            },
+            _t: PhantomData,
+        }
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 impl AtlasSearch<Text> {
     /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
@@ -223,6 +246,14 @@ pub mod short {
     ///For more details, see the [equals operator reference](https://www.mongodb.com/docs/atlas/atlas-search/equals/).
     pub fn equals(path: impl StringOrArray, value: impl Into<Bson>) -> AtlasSearch<Equals> {
         AtlasSearch::equals(path, value)
+    }
+    /**The exists operator tests if a path to a specified indexed field name exists in a
+     * document.
+     * */
+    ///
+    ///For more details, see the [exists operator reference](https://www.mongodb.com/docs/atlas/atlas-search/exists/).
+    pub fn exists(path: impl StringOrArray) -> AtlasSearch<Exists> {
+        AtlasSearch::exists(path)
     }
     /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
     If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -60,7 +60,7 @@ impl AtlasSearch<Compound> {
     pub fn must(mut self, must: impl IntoIterator<Item = impl SearchOperator>) -> Self {
         self.stage.insert(
             "must",
-            must.into_iter().map(|o| o.to_doc()).collect::<Vec<_>>(),
+            must.into_iter().map(|o| o.to_bson()).collect::<Vec<_>>(),
         );
         self
     }
@@ -68,7 +68,10 @@ impl AtlasSearch<Compound> {
     pub fn must_not(mut self, must_not: impl IntoIterator<Item = impl SearchOperator>) -> Self {
         self.stage.insert(
             "mustNot",
-            must_not.into_iter().map(|o| o.to_doc()).collect::<Vec<_>>(),
+            must_not
+                .into_iter()
+                .map(|o| o.to_bson())
+                .collect::<Vec<_>>(),
         );
         self
     }
@@ -76,7 +79,7 @@ impl AtlasSearch<Compound> {
     pub fn should(mut self, should: impl IntoIterator<Item = impl SearchOperator>) -> Self {
         self.stage.insert(
             "should",
-            should.into_iter().map(|o| o.to_doc()).collect::<Vec<_>>(),
+            should.into_iter().map(|o| o.to_bson()).collect::<Vec<_>>(),
         );
         self
     }
@@ -84,7 +87,7 @@ impl AtlasSearch<Compound> {
     pub fn filter(mut self, filter: impl IntoIterator<Item = impl SearchOperator>) -> Self {
         self.stage.insert(
             "filter",
-            filter.into_iter().map(|o| o.to_doc()).collect::<Vec<_>>(),
+            filter.into_iter().map(|o| o.to_bson()).collect::<Vec<_>>(),
         );
         self
     }
@@ -116,7 +119,7 @@ pub fn embedded_document(
     AtlasSearch {
         name: "embeddedDocument",
         stage: doc! {
-            "path" : path.to_bson(), "operator" : operator.to_doc(),
+            "path" : path.to_bson(), "operator" : operator.to_bson(),
         },
         meta: false,
         _t: PhantomData,
@@ -195,7 +198,7 @@ pub fn facet(facets: Document) -> AtlasSearch<Facet> {
 impl AtlasSearch<Facet> {
     #[allow(missing_docs)]
     pub fn operator(mut self, operator: impl SearchOperator) -> Self {
-        self.stage.insert("operator", operator.to_doc());
+        self.stage.insert("operator", operator.to_bson());
         self
     }
 }

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -272,6 +272,46 @@ impl AtlasSearch<GeoShape> {
     }
 }
 #[allow(missing_docs)]
+pub struct GeoWithin;
+/**The geoWithin operator supports querying geographic points within a given
+geometry. Only points are returned, even if indexShapes value is true in
+the index definition.
+*/
+///
+///For more details, see the [geoWithin operator reference](https://www.mongodb.com/docs/atlas/atlas-search/geoWithin/).
+pub fn geo_within(path: impl StringOrArray) -> AtlasSearch<GeoWithin> {
+    AtlasSearch {
+        name: "geoWithin",
+        stage: doc! {
+            "path" : path.to_bson(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<GeoWithin> {
+    #[allow(missing_docs)]
+    pub fn geo_box(mut self, geo_box: Document) -> Self {
+        self.stage.insert("box", geo_box);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn circle(mut self, circle: Document) -> Self {
+        self.stage.insert("circle", circle);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn geometry(mut self, geometry: Document) -> Self {
+        self.stage.insert("geometry", geometry);
+        self
+    }
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/atlas_search/gen.rs
+++ b/src/atlas_search/gen.rs
@@ -312,6 +312,29 @@ impl AtlasSearch<GeoWithin> {
     }
 }
 #[allow(missing_docs)]
+pub struct SearchIn;
+/**The in operator performs a search for an array of BSON values in a field.
+ * */
+///
+///For more details, see the [in operator reference](https://www.mongodb.com/docs/atlas/atlas-search/in/).
+pub fn search_in(path: impl StringOrArray, value: impl Into<Bson>) -> AtlasSearch<SearchIn> {
+    AtlasSearch {
+        name: "in",
+        stage: doc! {
+            "path" : path.to_bson(), "value" : value.into(),
+        },
+        meta: false,
+        _t: PhantomData,
+    }
+}
+impl AtlasSearch<SearchIn> {
+    #[allow(missing_docs)]
+    pub fn score(mut self, score: Document) -> Self {
+        self.stage.insert("score", score);
+        self
+    }
+}
+#[allow(missing_docs)]
 pub struct Text;
 /**The text operator performs a full-text search using the analyzer that you specify in the index configuration.
 If you omit an analyzer, the text operator uses the default standard analyzer.

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "dns-resolver")]
 #[path = "test/atlas_connectivity.rs"]
 mod atlas_connectivity_skip_ci; // requires Atlas URI environment variables set
+mod atlas_search;
 mod auth;
 mod bulk_write;
 mod change_stream;

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -146,4 +146,33 @@ fn helper_output_doc() {
         .operator(range("released").gte(gte_dt).lte(lte_dt))
         .into()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "geoShape": {
+                    "relation": "disjoint",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [[[-161.323242,22.512557],
+                                        [-152.446289,22.065278],
+                                        [-156.09375,17.811456],
+                                        [-161.323242,22.512557]]]
+                    },
+                    "path": "address.location"
+                }
+            }
+        },
+        geo_shape(
+            "address.location",
+            Relation::Disjoint,
+            doc! {
+                "type": "Polygon",
+                "coordinates": [[[-161.323242,22.512557],
+                                [-152.446289,22.065278],
+                                [-156.09375,17.811456],
+                                [-161.323242,22.512557]]]
+            }
+        )
+        .into()
+    );
 }

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -217,6 +217,23 @@ fn helper_output_doc() {
         },
         search_in("accounts", [371138, 371139, 371140].as_ref()).into()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "moreLikeThis": {
+                    "like": {
+                        "title": "The Godfather",
+                        "genres": "action"
+                    }
+                }
+            }
+        },
+        more_like_this(doc! {
+            "title": "The Godfather",
+            "genres": "action"
+        })
+        .into()
+    );
 }
 
 #[test]

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -175,4 +175,35 @@ fn helper_output_doc() {
         )
         .into()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "geoWithin": {
+                    "path": "address.location",
+                    "box": {
+                        "bottomLeft": {
+                            "type": "Point",
+                            "coordinates": [112.467, -55.050]
+                        },
+                        "topRight": {
+                            "type": "Point",
+                            "coordinates": [168.000, -9.133]
+                        }
+                    }
+                }
+            }
+        },
+        geo_within("address.location")
+            .geo_box(doc! {
+                "bottomLeft": {
+                    "type": "Point",
+                    "coordinates": [112.467, -55.050]
+                },
+                "topRight": {
+                    "type": "Point",
+                    "coordinates": [168.000, -9.133]
+                }
+            })
+            .into()
+    )
 }

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -207,3 +207,12 @@ fn helper_output_doc() {
             .into()
     )
 }
+
+#[test]
+fn string_or_array_forms() {
+    exists("hello");
+    exists("hello".to_owned());
+    exists(["hello", "world"]);
+    exists(&["hello", "world"] as &[&str]);
+    exists(&["hello".to_owned()] as &[String]);
+}

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -1,0 +1,163 @@
+use crate::{atlas_search, bson::doc};
+
+#[test]
+fn api_flow() {
+    assert_eq!(
+        doc! {
+            "$search": {
+                "autocomplete": {
+                    "query": "pre",
+                    "path": "title",
+                    "fuzzy": {
+                        "maxEdits": 1,
+                        "prefixLength": 1,
+                        "maxExpansions": 256,
+                    },
+                }
+            }
+        },
+        atlas_search::autocomplete("title", "pre")
+            .fuzzy(doc! { "maxEdits": 1, "prefixLength": 1, "maxExpansions": 256 })
+            .into()
+    );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "text": {
+                    "path": "plot",
+                    "query": "baseball",
+                }
+            }
+        },
+        atlas_search::text("plot", "baseball").into()
+    );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "compound": {
+                    "must": [{
+                        "text": {
+                            "path": "description",
+                            "query": "varieties",
+                        }
+                    }],
+                    "should": [{
+                        "text": {
+                            "path": "description",
+                            "query": "Fuji",
+                        }
+                    }],
+                }
+            }
+        },
+        atlas_search::compound()
+            .must(atlas_search::text("description", "varieties"))
+            .should(atlas_search::text("description", "Fuji"))
+            .into()
+    );
+    {
+        use atlas_search::*;
+        assert_eq!(
+            doc! {
+                "$search": {
+                    "embeddedDocument": {
+                        "path": "items",
+                        "operator": {
+                            "compound": {
+                                "must": [{
+                                    "text": {
+                                        "path": "items.tags",
+                                        "query": "school",
+                                    }
+                                }],
+                                "should": [{
+                                    "text": {
+                                        "path": "items.name",
+                                        "query": "backpack",
+                                    }
+                                }]
+                            }
+                        },
+                        "score": {
+                            "embedded": {
+                                "aggregate": "mean"
+                            }
+                        },
+                    }
+                }
+            },
+            embedded_document(
+                "items",
+                compound()
+                    .must(text("items.tags", "school"))
+                    .should(text("items.name", "backpack")),
+            )
+            .score(doc! {
+                "embedded": {
+                    "aggregate": "mean"
+                }
+            })
+            .into()
+        );
+    }
+    assert_eq!(
+        doc! {
+            "$search": {
+                "equals": {
+                    "path": "verified_user",
+                    "value": true,
+                }
+            }
+        },
+        atlas_search::equals("verified_user", true).into()
+    );
+    let gte_dt = crate::bson::DateTime::parse_rfc3339_str("2000-01-01T00:00:00.000Z").unwrap();
+    let lte_dt = crate::bson::DateTime::parse_rfc3339_str("2015-01-31T00:00:00.000Z").unwrap();
+    assert_eq!(
+        doc! {
+            "$searchMeta": {
+                "facet": {
+                    "operator": {
+                        "range": {
+                            "path": "released",
+                            "gte": gte_dt,
+                            "lte": lte_dt,
+                        }
+                    },
+                    "facets": {
+                        "directorsFacet": {
+                            "type": "string",
+                            "path": "directors",
+                            "numBuckets": 7,
+                        },
+                        "yearFacet": {
+                            "type": "number",
+                            "path": "year",
+                            "boundaries": [2000, 2005, 2010, 2015]
+                        },
+                    }
+                }
+            }
+        },
+        atlas_search::facet(doc! {
+            "directorsFacet": {
+                "type": "string",
+                "path": "directors",
+                "numBuckets": 7,
+            },
+            "yearFacet": {
+                "type": "number",
+                "path": "year",
+                "boundaries": [2000, 2005, 2010, 2015]
+            },
+        })
+        .operator(doc! {
+            "range": {
+                "path": "released",
+                "gte": gte_dt,
+                "lte": lte_dt,
+            }
+        })
+        .into()
+    );
+}

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -205,7 +205,18 @@ fn helper_output_doc() {
                 }
             })
             .into()
-    )
+    );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "in": {
+                    "path": "accounts",
+                    "value": [371138, 371139, 371140]
+                }
+            }
+        },
+        search_in("accounts", [371138, 371139, 371140].as_ref()).into()
+    );
 }
 
 #[test]

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -21,7 +21,7 @@ fn helper_output_doc() {
         },
         autocomplete("title", "pre")
             .fuzzy(doc! { "maxEdits": 1, "prefixLength": 1, "maxExpansions": 256 })
-            .into()
+            .stage()
     );
     assert_eq!(
         doc! {
@@ -32,7 +32,7 @@ fn helper_output_doc() {
                 }
             }
         },
-        text("plot", "baseball").into()
+        text("plot", "baseball").stage()
     );
     assert_eq!(
         doc! {
@@ -56,7 +56,7 @@ fn helper_output_doc() {
         compound()
             .must(text("description", "varieties"))
             .should(text("description", "Fuji"))
-            .into()
+            .stage()
     );
     assert_eq!(
         doc! {
@@ -98,7 +98,7 @@ fn helper_output_doc() {
                 "aggregate": "mean"
             }
         })
-        .into()
+        .stage()
     );
     assert_eq!(
         doc! {
@@ -109,7 +109,7 @@ fn helper_output_doc() {
                 }
             }
         },
-        equals("verified_user", true).into()
+        equals("verified_user", true).stage()
     );
     let gte_dt = DateTime::parse_rfc3339_str("2000-01-01T00:00:00.000Z").unwrap();
     let lte_dt = DateTime::parse_rfc3339_str("2015-01-31T00:00:00.000Z").unwrap();
@@ -144,7 +144,7 @@ fn helper_output_doc() {
             "yearFacet": facet::number("year", [2000, 2005, 2010, 2015]),
         })
         .operator(range("released").gte(gte_dt).lte(lte_dt))
-        .into()
+        .stage()
     );
     assert_eq!(
         doc! {
@@ -173,7 +173,7 @@ fn helper_output_doc() {
                                 [-161.323242,22.512557]]]
             }
         )
-        .into()
+        .stage()
     );
     assert_eq!(
         doc! {
@@ -204,7 +204,7 @@ fn helper_output_doc() {
                     "coordinates": [168.000, -9.133]
                 }
             })
-            .into()
+            .stage()
     );
     assert_eq!(
         doc! {
@@ -215,7 +215,7 @@ fn helper_output_doc() {
                 }
             }
         },
-        search_in("accounts", [371138, 371139, 371140].as_ref()).into()
+        search_in("accounts", [371138, 371139, 371140].as_ref()).stage()
     );
     assert_eq!(
         doc! {
@@ -232,7 +232,7 @@ fn helper_output_doc() {
             "title": "The Godfather",
             "genres": "action"
         })
-        .into()
+        .stage()
     );
 }
 
@@ -240,6 +240,7 @@ fn helper_output_doc() {
 fn string_or_array_forms() {
     exists("hello");
     exists("hello".to_owned());
+    #[cfg(feature = "bson-3")]
     exists(["hello", "world"]);
     exists(&["hello", "world"] as &[&str]);
     exists(&["hello".to_owned()] as &[String]);

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -284,6 +284,29 @@ fn helper_output_doc() {
         )
         .stage()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "phrase": {
+                    "path": "title",
+                    "query": "new york"
+                }
+            }
+        },
+        phrase("title", "new york").stage()
+    );
+    #[cfg(feature = "bson-3")]
+    assert_eq!(
+        doc! {
+            "$search": {
+                "phrase": {
+                    "path": "title",
+                    "query": ["the man", "the moon"]
+                }
+            }
+        },
+        phrase("title", ["the man", "the moon"]).stage()
+    );
 }
 
 #[test]

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -234,6 +234,56 @@ fn helper_output_doc() {
         })
         .stage()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "index": "runtimes",
+                "near": {
+                    "path": "year",
+                    "origin": 2000,
+                    "pivot": 2
+                }
+            }
+        },
+        near("year", 2000, 2).on_index("runtimes")
+    );
+    let dt = DateTime::parse_rfc3339_str("1915-09-13T00:00:00.000+00:00").unwrap();
+    assert_eq!(
+        doc! {
+            "$search": {
+                "index": "releaseddate",
+                "near": {
+                    "path": "released",
+                    "origin": dt,
+                    "pivot": 7776000000i64
+                }
+            }
+        },
+        near("released", dt, 7776000000i64).on_index("releaseddate")
+    );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "near": {
+                    "origin": {
+                        "type": "Point",
+                        "coordinates": [-8.61308, 41.1413]
+                    },
+                    "pivot": 1000,
+                    "path": "address.location"
+                }
+            }
+        },
+        near(
+            "address.location",
+            doc! {
+                "type": "Point",
+                "coordinates": [-8.61308, 41.1413]
+            },
+            1000,
+        )
+        .stage()
+    );
 }
 
 #[test]

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -318,6 +318,17 @@ fn helper_output_doc() {
         },
         query_string("title", "Rocky AND (IV OR 4 OR Four)").stage()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "regex": {
+                    "path": "title",
+                    "query": "(.*) Seattle"
+                }
+            }
+        },
+        regex("title", "(.*) Seattle").stage()
+    );
 }
 
 #[test]

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -329,6 +329,17 @@ fn helper_output_doc() {
         },
         regex("title", "(.*) Seattle").stage()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "wildcard": {
+                    "query": "Green D*",
+                    "path": "title"
+                }
+            }
+        },
+        wildcard("title", "Green D*").stage()
+    );
 }
 
 #[test]

--- a/src/test/atlas_search.rs
+++ b/src/test/atlas_search.rs
@@ -307,6 +307,17 @@ fn helper_output_doc() {
         },
         phrase("title", ["the man", "the moon"]).stage()
     );
+    assert_eq!(
+        doc! {
+            "$search": {
+                "queryString": {
+                    "defaultPath": "title",
+                    "query": "Rocky AND (IV OR 4 OR Four)"
+                }
+            }
+        },
+        query_string("title", "Rocky AND (IV OR 4 OR Four)").stage()
+    );
 }
 
 #[test]


### PR DESCRIPTION
RUST-2157

This builds on #1451 and implements the expanded machinery to generate the rest of the helpers.  I'd say most of them needed some kind of addition beyond just "include the yaml file".