### PR TITLE
RUST-2142 Strip WIP atlas search helpers from 3.3.0 release

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ pub mod options;
 pub use ::mongocrypt;
 
 pub mod action;
-pub mod atlas_search;
 pub(crate) mod bson_compat;
 mod bson_util;
 pub mod change_stream;


### PR DESCRIPTION
[RUST-2142](https://jira.mongodb.org/browse/RUST-2142)

It's not in a releasable state so this removes the module for the 3.3.x branch.