### PR TITLE
RUST-2142 Pre-3.0 release tooling update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,9 +164,9 @@ optional = true
 features = ["serde"]
 
 [dependencies.mongocrypt]
+version = "0.3.1"
 git = "https://github.com/mongodb/libmongocrypt-rust.git"
 branch = "main"
-version = "0.3.1"
 default-features = false
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,17 +149,17 @@ optional = true
 default-features = false
 
 [dependencies.bson2]
+version = "2.15.0"
 git = "https://github.com/mongodb/bson-rust"
 branch = "2.15.x"
 package = "bson"
-version = "2.15.0"
 optional = true
 
 [dependencies.bson3]
+version = "3.0.0"
 git = "https://github.com/mongodb/bson-rust"
 branch = "main"
 package = "bson"
-version = "3.0.0"
 optional = true
 features = ["serde"]
 

--- a/etc/update_version/src/main.rs
+++ b/etc/update_version/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
     if let Some(mongocrypt) = args.mongocrypt {
         let mongocrypt_version_loc = Location::new(
             "Cargo.toml",
-            r#"mongocrypt =.*version = "(?<target>.*?)".*"#,
+            r#"\[dependencies.mongocrypt\]\nversion = "(?<target>.*?)".*"#,
         );
         pending.apply(&mongocrypt_version_loc, &mongocrypt);
     }

--- a/etc/update_version/src/main.rs
+++ b/etc/update_version/src/main.rs
@@ -64,9 +64,13 @@ struct Args {
     #[argh(option)]
     version: String,
 
-    /// version of the bson crate
+    /// version of the bson crate (2.x)
     #[argh(option)]
-    bson: Option<String>,
+    bson2: Option<String>,
+
+    /// version of the bson crate (3.x)
+    #[argh(option)]
+    bson3: Option<String>,
 
     /// version of the mongocrypt crate
     #[argh(option)]
@@ -110,10 +114,20 @@ fn main() {
         pending.apply(loc, &args.version);
     }
 
-    if let Some(bson) = args.bson {
-        let bson_version_loc =
-            Location::new("Cargo.toml", r#"bson =.*version = "(?<target>.*?)".*"#);
-        pending.apply(&bson_version_loc, &bson);
+    if let Some(bson2) = args.bson2 {
+        let bson_version_loc = Location::new(
+            "Cargo.toml",
+            r#"\[dependencies.bson2\]\nversion = "(?<target>.*?)"\n"#,
+        );
+        pending.apply(&bson_version_loc, &bson2);
+    }
+
+    if let Some(bson3) = args.bson3 {
+        let bson_version_loc = Location::new(
+            "Cargo.toml",
+            r#"\[dependencies.bson3\]\nversion = "(?<target>.*?)"\n"#,
+        );
+        pending.apply(&bson_version_loc, &bson3);
     }
 
     if let Some(mongocrypt) = args.mongocrypt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod options;
 pub use ::mongocrypt;
 
 pub mod action;
-pub mod atlas_search;
+//pub mod atlas_search;
 pub(crate) mod bson_compat;
 mod bson_util;
 pub mod change_stream;


### PR DESCRIPTION
RUST-2142

This updates the `update_version` helper to work with the bson2/bson3 setup and disables the WIP `atlas_search` module from release.