### PR TITLE
Fix reference from`trust-dns-resolver` to `hickory-resolver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to connect to a pre-4.2 Atlas instance that's M2 or bigger, the `openss
 
 ## Windows DNS note
 
-On Windows, there is a known issue in the `trust-dns-resolver` crate, which the driver uses to perform DNS lookups, that causes severe performance degradation in resolvers that use the system configuration. Since the driver uses the system configuration by default, users are recommended to specify an alternate resolver configuration on Windows (e.g. `ResolverConfig::cloudflare()`) until that issue is resolved. This only has an effect when connecting to deployments using a `mongodb+srv` connection string.
+On Windows, there is a known issue in the `hickory-resolver` crate, which the driver uses to perform DNS lookups, that causes severe performance degradation in resolvers that use the system configuration. Since the driver uses the system configuration by default, users are recommended to specify an alternate resolver configuration on Windows (e.g. `ResolverConfig::cloudflare()`) until that issue is resolved. This only has an effect when connecting to deployments using a `mongodb+srv` connection string.
 
 ## Warning about timeouts / cancellation
 


### PR DESCRIPTION
`trust-dns-resolver` was [renamed](https://github.com/bluejekyll/trust-dns) to `hickory-resolver`