### PR TITLE
RUST-2113 Add has_next to cursor API

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -142,24 +142,6 @@ impl<T> Cursor<T> {
             .and_then(|c| c.post_batch_resume_token())
     }
 
-    /// Whether this cursor has exhausted all of its getMore calls. The cursor may have more
-    /// items remaining in the buffer.
-    pub(crate) fn is_exhausted(&self) -> bool {
-        self.wrapped_cursor.as_ref().unwrap().is_exhausted()
-    }
-
-    /// Whether this cursor has any additional items to return.
-    pub(crate) fn has_next(&self) -> bool {
-        !self.is_exhausted()
-            || !self
-                .wrapped_cursor
-                .as_ref()
-                .unwrap()
-                .state()
-                .buffer
-                .is_empty()
-    }
-
     pub(crate) fn client(&self) -> &Client {
         &self.client
     }
@@ -240,6 +222,26 @@ impl<T> Cursor<T> {
         self.wrapped_cursor.as_ref().unwrap().current().unwrap()
     }
 
+    /// Whether this cursor has exhausted all of its getMore calls. The cursor may have more
+    /// items remaining in the buffer.
+    pub(crate) fn is_exhausted(&self) -> bool {
+        self.wrapped_cursor.as_ref().unwrap().is_exhausted()
+    }
+
+    /// Returns true if the cursor has any additional buffered items to return and false otherwise.
+    ///
+    /// This method only checks the local buffer and exhaustion state; it does not contact the
+    /// server.
+    pub fn has_next(&self) -> bool {
+        !self.is_exhausted()
+            || !self
+                .wrapped_cursor
+                .as_ref()
+                .unwrap()
+                .state()
+                .buffer
+                .is_empty()
+    }
     /// Deserialize the current result to the generic type associated with this cursor.
     ///
     /// # Panics

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -228,10 +228,7 @@ impl<T> Cursor<T> {
         self.wrapped_cursor.as_ref().unwrap().is_exhausted()
     }
 
-    /// Returns true if the cursor has any additional buffered items to return and false otherwise.
-    ///
-    /// This method only checks the local buffer and exhaustion state; it does not contact the
-    /// server.
+    /// Returns true if the cursor has any additional items to return and false otherwise.
     pub fn has_next(&self) -> bool {
         !self.is_exhausted()
             || !self

--- a/src/sync/cursor.rs
+++ b/src/sync/cursor.rs
@@ -130,6 +130,14 @@ impl<T> Cursor<T> {
         self.async_cursor.current()
     }
 
+    /// Returns true if the cursor has any additional buffered items to return and false otherwise.
+    ///
+    /// This method only checks the local buffer and exhaustion state; it does not contact the
+    /// server.
+    pub fn has_next(&self) -> bool {
+        self.async_cursor.has_next()
+    }
+
     /// Deserialize the current result to the generic type associated with this cursor.
     ///
     /// # Panics

--- a/src/sync/cursor.rs
+++ b/src/sync/cursor.rs
@@ -130,10 +130,7 @@ impl<T> Cursor<T> {
         self.async_cursor.current()
     }
 
-    /// Returns true if the cursor has any additional buffered items to return and false otherwise.
-    ///
-    /// This method only checks the local buffer and exhaustion state; it does not contact the
-    /// server.
+    /// Returns true if the cursor has any additional items to return and false otherwise.
     pub fn has_next(&self) -> bool {
         self.async_cursor.has_next()
     }

--- a/src/test/cursor.rs
+++ b/src/test/cursor.rs
@@ -263,3 +263,29 @@ async fn cursor_final_batch() {
     }
     assert_eq!(found, 5);
 }
+
+#[tokio::test]
+async fn cursor_has_next() {
+    let client = Client::for_test().await;
+    let coll = client
+        .create_fresh_collection("test_cursor_has_next", "test", None)
+        .await;
+    coll.insert_many(vec![
+        doc! { "foo": 1 },
+        doc! { "foo": 2 },
+        doc! { "foo": 3 },
+        doc! { "foo": 4 },
+        doc! { "foo": 5 },
+    ])
+    .await
+    .unwrap();
+
+    let mut cursor = coll.find(doc! {}).batch_size(2).await.unwrap();
+    let mut found = 0;
+    while cursor.has_next() {
+        if cursor.advance().await.unwrap() {
+            found += 1;
+        }
+    }
+    assert_eq!(found, 5);
+}


### PR DESCRIPTION
Resolves #1258

- Made `has_next()` pub + added doc comments
- Added `has_next()` to sync cursor API
- Added simple test