### PR TITLE
RUST-1996 SCRAM-SHA-256 FIPS Compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2025,6 +2026,7 @@ dependencies = [
  "approx",
  "aws-config",
  "aws-credential-types",
+ "aws-lc-rs",
  "aws-sigv4",
  "backtrace",
  "base64 0.13.1",
@@ -2087,6 +2089,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tokio-rustls",
+ "tokio-util",
  "tracing",
  "typed-builder",
  "uuid",
@@ -2703,7 +2706,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2798,7 +2801,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3437,6 +3440,7 @@ checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -3601,6 +3605,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ in-use-encryption-unstable = ["in-use-encryption"]
 tracing-unstable = ["dep:tracing", "dep:log", "bson3?/serde_json-1"]
 
 [dependencies]
+aws-lc-rs = "1.0.0"
 base64 = "0.13.0"
 bitflags = "1.1.0"
 chrono = { version = "0.4.7", default-features = false, features = [


### PR DESCRIPTION
### Motivation

The prior implementation of PBKDF2 key derivation uses the `pbkdf2` library which is just a pure Rust implementation and not FIPS-compliant.

### Changes

Switch to the `aws-lc-rs` version of `pbkdf2` which can be configured to be FIPS-compliant. 