### PR TITLE
Switch chrono clock feature to now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,15 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,9 +657,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "iana-time-zone",
  "num-traits",
- "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1509,30 +1498,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ text-indexes-unstable = []
 [dependencies]
 base64 = "0.13.0"
 bitflags = "2"
-chrono = { version = "0.4.7", default-features = false, features = [
-    "clock",
+chrono = { version = "0.4.32", default-features = false, features = [
+    "now",
     "std",
 ] }
 derive_more = "0.99.17"


### PR DESCRIPTION
Switches `chrono` `clock` feature to the subset, `now` which was introduced in `0.4.32`. This reduces some dependencies.

https://github.com/chronotope/chrono/releases/tag/v0.4.32