### PR TITLE
minor: fix gssapi tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -261,7 +261,7 @@ buildvariants:
     display_name: "GSSAPI Authentication - Linux"
     patchable: true
     run_on:
-      - ubuntu2204-small
+      - rhel87-small
     tasks:
       - test-gssapi-auth
 
@@ -278,7 +278,7 @@ buildvariants:
     display_name: "GSSAPI Authentication - Windows"
     patchable: true
     run_on:
-      - windows-vsCurrent-small
+      - windows-64-vs2017-small
     tasks:
       - test-gssapi-auth
 

--- a/src/client/auth/gssapi.rs
+++ b/src/client/auth/gssapi.rs
@@ -55,7 +55,8 @@ pub(crate) async fn authenticate_stream(
         &properties.canonicalize_host_name,
         resolver_config,
     )
-    .await?;
+    .await
+    .unwrap_or_else(|_| hostname.clone());
 
     let user_principal = credential.username.clone();
     let service_principal = properties.service_principal_name(&hostname, user_principal.as_ref());


### PR DESCRIPTION
The root cause here is that the test domain was switched from an actual DNS entry to a line in `/etc/hosts`; the latter means it has no CNAME record, so the lookup for forward-only canonicalization would error.  _However_, the [spec says](https://github.com/mongodb/specifications/blob/master/source/auth/auth.md#gssapi):

> The driver MUST fallback to the provided host if any lookup errors or returns no results.

so this fixes the behavior to do that rather than propagate up the error.