### PR TITLE
Disable socket2 dependency on wasi target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ serde_with = { version = "3.8.1", default-features = false, features = ["macros"
 sha1 = "0.10.0"
 sha2 = "0.10.2"
 snap = { version = "1.0.5", optional = true }
-socket2 = "0.5.5"
 stringprep = "0.1.2"
 strsim = "0.11.1"
 take_mut = "0.2.2"
@@ -246,6 +245,9 @@ features = ["serde", "serde_json-1"]
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
+
+[target.'cfg(not(wasi))'.dependencies]
+socket2 = "0.5.5"
 
 # Target-specific dependencies for GSSAPI authentication
 [target.'cfg(not(windows))'.dependencies]

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -74,14 +74,14 @@ async fn tcp_try_connect(address: &SocketAddr) -> Result<TcpStream> {
     let stream = TcpStream::connect(address).await?;
     stream.set_nodelay(true)?;
 
-    let socket = socket2::Socket::from(stream.into_std()?);
     #[cfg(not(target_os = "wasi"))]
     {
+        let sock_ref = socket2::SockRef::from(&stream);
         let conf = socket2::TcpKeepalive::new().with_time(KEEPALIVE_TIME);
-        socket.set_tcp_keepalive(&conf)?;
+        sock_ref.set_tcp_keepalive(&conf)?;
     }
-    let std_stream = std::net::TcpStream::from(socket);
-    Ok(TcpStream::from_std(std_stream)?)
+
+    Ok(stream)
 }
 
 pub(crate) async fn tcp_connect(resolved: Vec<SocketAddr>) -> Result<TcpStream> {


### PR DESCRIPTION
Disables `socket2` dependency on the wasi target.