### PR TITLE
minor: document the bson-3 feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ features = ["sync"]
 | `gcp-oidc`           | Enable support for GCP OIDC environment authentication. |
 | `text-indexes-unstable` | Enables support for text indexes in explicit encryption. This feature is in preview and should be used for experimental workloads only. This feature is unstable and its security is not guaranteed until released as Generally Available (GA). The GA version of this feature may not be backwards compatible with the preview version. |
 | `error-backtrace`    | Capture backtraces in `Error` values.  This can be slow, memory intensive, and very verbose. |
+| `bson-3`             | Use version 3.x of the `bson` crate; for backwards compatibility, without this feature enabled `bson` 2.x is used. |
 
 ## Web Framework Examples
 


### PR DESCRIPTION
Turns out we forgot to do this, which means it's not at all clear that we actually support recent bson releases (e.g. https://github.com/mongodb/mongo-rust-driver/issues/1512).