### PR TITLE
minor: tidy up opentelemetry code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,6 @@ mod index;
 mod operation;
 #[cfg(feature = "opentelemetry")]
 pub mod otel;
-#[cfg(not(feature = "opentelemetry"))]
-mod otel_stub;
 pub mod results;
 pub(crate) mod runtime;
 mod sdam;
@@ -72,9 +70,6 @@ pub use bson2 as bson;
 
 #[cfg(feature = "bson-3")]
 pub use bson3 as bson;
-
-#[cfg(not(feature = "opentelemetry"))]
-pub(crate) use otel_stub as otel;
 
 #[cfg(feature = "in-use-encryption")]
 pub use crate::client::csfle::client_encryption;

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,6 +1,9 @@
 //! Support for OpenTelemetry.
 
-use std::sync::{Arc, LazyLock};
+use std::{
+    future::Future,
+    sync::{Arc, LazyLock},
+};
 
 use derive_where::derive_where;
 
@@ -229,7 +232,7 @@ impl Client {
 }
 
 pub(crate) struct OpSpan {
-    pub(crate) context: Context,
+    context: Context,
     enabled: bool,
 }
 
@@ -443,3 +446,12 @@ impl<'a> From<&'a AggregateTarget> for OperationTarget<'a> {
         }
     }
 }
+
+pub(crate) trait FutureExt: Future + Sized {
+    fn with_span(self, span: &OpSpan) -> impl Future<Output = Self::Output> {
+        use opentelemetry::context::FutureExt;
+        self.with_context(span.context.clone())
+    }
+}
+
+impl<T: Future> FutureExt for T {}

--- a/src/otel_stub.rs
+++ b/src/otel_stub.rs
@@ -1,7 +1,0 @@
-pub(crate) trait OtelFutureStub: Sized {
-    fn with_current_context(self) -> Self {
-        self
-    }
-}
-
-impl<T: std::future::Future> OtelFutureStub for T {}


### PR DESCRIPTION
This pulls in a few tidy-ups from my tracing spans branch (that I'm calling Not Worth The Effort):
* `.with_current_context()` is only actually needed if you're putting the future on a different task, which in turn means `otel_stub` isn't needed at all.
* created a thin wrapper around `with_context` so `OpSpan.context` can stay private to the `otel` module.