### PR TITLE
minor: add symlink for top-level README in driver directory

### DIFF
--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -3,7 +3,7 @@ description = "The official MongoDB driver for Rust"
 keywords = ["mongo", "mongodb", "database", "bson", "nosql"]
 categories = ["asynchronous", "database", "web-programming"]
 homepage = "https://www.mongodb.com/docs/drivers/rust/"
-readme = "../README.md"
+readme = "README.md"
 name = "mongodb"
 version = "3.4.0"
 

--- a/driver/README.md
+++ b/driver/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![warn(
     missing_docs,
     rustdoc::missing_crate_level_docs,


### PR DESCRIPTION
The driver portion of the 3.4.0 release failed because of a pesky problem with `include_str` that arose when we switched to using workspaces. Very brief summary: `cargo publish` is run from a different directory with a copied-in README file, so README's location relative to src is different for normal compilation vs. releases. This is further discussed in [this issue](https://github.com/rust-lang/cargo/issues/13309) and [this forum post](https://users.rust-lang.org/t/include-str-does-not-work-when-releasing-because-of-changed-pathes/15551), and the solution is to add a symlinked README file to the `driver` directory.

Unfortunately the macros crate was already successfully published, so I think I'll need to amend the release machinery to include an option to skip publishing mongodb-internal-macros. I'll put up a separate PR for that and then cherry-pick both to 3.4.x, add a new tag, and re-trigger the release process.