### PR TITLE
release v3.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,7 @@ source = "git+https://github.com/mongodb/libmongocrypt-rust.git?branch=main#6fc0
 
 [[package]]
 name = "mongodb"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "macro_magic",
  "proc-macro2",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The driver is available on [crates.io](https://crates.io/crates/mongodb). To use
 
 ```toml
 [dependencies]
-mongodb = "3.4.0"
+mongodb = "3.4.1"
 ```
 
 Version 1 of this crate has reached end of life and will no longer be receiving any updates or bug fixes, so all users are recommended to always depend on the latest 2.x release. See the [2.0.0 release notes](https://github.com/mongodb/mongo-rust-driver/releases/tag/v2.0.0) for migration information if upgrading from a 1.x version.
@@ -34,7 +34,7 @@ The driver also provides a blocking sync API. To enable this, add the `"sync"` f
 
 ```toml
 [dependencies.mongodb]
-version = "3.4.0"
+version = "3.4.1"
 features = ["sync"]
 ```
 

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -5,7 +5,7 @@ categories = ["asynchronous", "database", "web-programming"]
 homepage = "https://www.mongodb.com/docs/drivers/rust/"
 readme = "README.md"
 name = "mongodb"
-version = "3.4.0"
+version = "3.4.1"
 
 authors.workspace = true
 license.workspace = true
@@ -97,7 +97,7 @@ hickory-resolver = { version = "0.25", optional = true }
 hmac = "0.12.1"
 log = { version = "0.4.17", optional = true }
 md-5 = "0.10.1"
-mongodb-internal-macros = { path = "../macros", version = "3.4.0" }
+mongodb-internal-macros = { path = "../macros", version = "3.4.1" }
 num_cpus = { version = "1.13.1", optional = true }
 openssl = { version = "0.10.38", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -15,7 +15,7 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, type_length_limit = "80000000")]
-#![doc(html_root_url = "https://docs.rs/mongodb/3.4.0")]
+#![doc(html_root_url = "https://docs.rs/mongodb/3.4.1")]
 
 #[macro_use]
 pub mod options;

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodb-internal-macros"
-version = "3.4.0"
+version = "3.4.1"
 description = "Internal macros for the mongodb crate"
 
 authors.workspace = true


### PR DESCRIPTION
Unfortunately, adding a dry run step to the release process won't work because once the version numbers have been updated, the `mongodb` package can't build until the new version of `mongodb-internal-macros` it's depending on is actually released. Instead, I did a dry run of `cargo publish` locally, and will add that as a step in the release process right before updating the version numbers.