### PR TITLE
RUST-2243 - Added SBOM update automation

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -45,6 +45,8 @@ jobs:
         run: |
           cargo cyclonedx --manifest-path driver/Cargo.toml --spec-version 1.5 -vv --format json --override-filename sbom
           cp driver/sbom.json sbom.json
+          # Clean up workspace member SBOMs - we only want the driver SBOM
+          rm -f driver/sbom.json macros/sbom.json benchmarks/sbom.json etc/update_version/sbom.json
 
       - name: Download CycloneDX CLI
         run: |


### PR DESCRIPTION
[RUST-2243](https://jira.mongodb.org/browse/RUST-2243)

Added in Github action workflow for SBOM automation. This triggers on changes to the main driver cargos. A new branch will be created for the PR and closed on merge. 

Sample PR that it generates: https://github.com/thanhnguyen-mdb/mongo-rust-driver/pull/2

