### PR TITLE
RUST-2303 extend `ALLOWED_HOSTS`

### DIFF
--- a/driver/src/client/auth/oidc.rs
+++ b/driver/src/client/auth/oidc.rs
@@ -57,6 +57,7 @@ const DEFAULT_ALLOWED_HOSTS: &[&str] = &[
     "localhost",
     "127.0.0.1",
     "::1",
+    "*.mongo.com",
 ];
 
 /// The callback to use for OIDC authentication.


### PR DESCRIPTION
Adds the pattern `*.mongo.com` to the default `ALLOWED_HOSTS`.

(Note: the spec doubly includes `*.mongodbgov.net`, which is removed in https://github.com/mongodb/specifications/pull/1859).