### PR TITLE
RUST-2308 Derive `Clone` for `ConnectionString`

### DIFF
--- a/driver/src/client/options.rs
+++ b/driver/src/client/options.rs
@@ -815,7 +815,7 @@ where
 ///
 /// The format of a MongoDB connection string is described [here](https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-formats).
 #[skip_serializing_none]
-#[derive(Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ConnectionString {


### PR DESCRIPTION
I've added the missing `Clone` derive to `ConnectionString` to make it easier to work with.

Build succeeds without any issues:
```sh
cargo build --all-features --all-targets
```