### PR TITLE
RUST-2281 Cache test binary for cross-topololgy tests

### DIFF
--- a/.evergreen/build-nextest-archive.sh
+++ b/.evergreen/build-nextest-archive.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+source .evergreen/env.sh
+source .evergreen/features.sh
+
+FEATURE_FLAGS+=("${STANDARD_FEATURES[@]}")
+
+add_conditional_features
+
+if [[ "$LIBMONGOCRYPT_OS" != "" ]]; then
+    FEATURE_FLAGS+=("in-use-encryption" "azure-kms" "text-indexes-unstable" "aws-auth")
+    .evergreen/install-dependencies.sh libmongocrypt
+fi
+
+cargo nextest archive --workspace $(features_option) --archive-file nextest-archive.tar.zst

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -54,7 +54,7 @@ buildvariants:
   - name: compile
     display_name: "Compile Only"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
       - name: compile-on-latest
       - name: compile-on-msrv
@@ -62,25 +62,28 @@ buildvariants:
   - name: lint
     display_name: "Lint"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
+    expansions:
+      LIBMONGOCRYPT_OS: rhel-80-64-bit
     tasks:
       - name: .lint
 
   - name: cargo-deny
     display_name: "Cargo Deny"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
       - name: check-cargo-deny
 
   - name: rhel-8
     display_name: "RHEL 8"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     expansions:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .standalone
       - name: .replicaset
       - name: .sharded
@@ -93,6 +96,7 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       # Ubuntu 22.04 does not support MongoDB versions below 6.0.
       - name: .standalone !.4.2 !.4.4 !.5.0
       - name: .replicaset !.4.2 !.4.4 !.5.0
@@ -106,6 +110,7 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .standalone
       - name: .replicaset
       - name: .sharded
@@ -118,6 +123,7 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .standalone
       - name: .replicaset
       - name: .sharded
@@ -125,12 +131,13 @@ buildvariants:
   - name: openssl-rhel
     display_name: "OpenSSL (RHEL)"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     expansions:
       OPENSSL: true
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .rapid .replicaset
 
   - name: openssl-ubuntu
@@ -143,6 +150,7 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .rapid .replicaset
 
   - name: openssl-macos
@@ -155,6 +163,7 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .rapid .replicaset
 
   - name: openssl-windows
@@ -167,20 +176,22 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - name: .rapid .replicaset
 
   - name: no-auth-tls
     display_name: "No Auth/TLS"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
+      - name: build-nextest-archive
       - .rapid .replicaset
 
   - name: compression
     display_name: "Compression"
     patchable: false
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     expansions:
       AUTH: auth
       SSL: ssl
@@ -191,13 +202,14 @@ buildvariants:
     display_name: "Stable API V1"
     patchable: false
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     expansions:
       REQUIRE_API_VERSION: true
       MONGODB_API_VERSION: 1
       AUTH: auth
       # Configuring SSL: ssl causes errors in bootstrap mongo-orchestration.
     tasks:
+      - name: build-nextest-archive
       # The Stable API was introduced in MongoDB version 5.0. Drivers Evergreen Tools only supports
       # setting REQUIRE_API_VERSION on standalones and sharded clusters.
       - .standalone !.4.2 !.4.4
@@ -206,7 +218,7 @@ buildvariants:
   - name: sync-api
     display_name: "Sync API"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     expansions:
       AUTH: auth
       SSL: ssl
@@ -217,7 +229,7 @@ buildvariants:
     display_name: "Atlas Connectivity"
     patchable: false
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
       - test-atlas-connectivity
 
@@ -261,7 +273,7 @@ buildvariants:
     display_name: "GSSAPI Authentication - Linux"
     patchable: true
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
       - test-gssapi-auth
 
@@ -286,7 +298,7 @@ buildvariants:
     display_name: "x509 Authentication"
     patchable: false
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     expansions:
       AUTH: auth
       SSL: ssl
@@ -341,6 +353,7 @@ buildvariants:
       AUTH: auth
       SSL: ssl
     tasks:
+      - name: build-nextest-archive
       - .in-use-encryption
 
   - name: in-use-encryption-disable-crypt-shared
@@ -354,6 +367,7 @@ buildvariants:
       SSL: ssl
       DISABLE_CRYPT_SHARED: true
     tasks:
+      - name: build-nextest-archive
       - .in-use-encryption
 
   - name: in-use-encryption-openssl
@@ -366,20 +380,22 @@ buildvariants:
       SSL: ssl
       OPENSSL: true
     tasks:
-      - test-in-use-encryption-openssl
+      - name: build-nextest-archive
+      - test-in-use-encryption-rapid
 
   - name: load-balancer
     display_name: "Load Balancer"
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
+      - name: build-nextest-archive
       - .load-balancer
 
   - name: search-index
     display_name: "Search Index Helpers"
     patchable: false
     run_on:
-      - rhel87-small
+      - rhel8-latest-small
     tasks:
       - name: search-index-task-group
 
@@ -444,6 +460,7 @@ buildvariants:
     run_on:
       - amazon2023-arm64-latest-large-m8g
     tasks:
+      - name: build-nextest-archive
       - name: .latest
       #- name: .8.0
       #- name: .7.0
@@ -831,27 +848,81 @@ tasks:
 
   - name: check-cargo-deny
     commands:
-      - func: "check cargo deny"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env: [PROJECT_DIRECTORY]
+          binary: bash
+          args: [.evergreen/check-cargo-deny.sh]
 
   - name: check-rustfmt
     tags: [lint]
     commands:
-      - func: "check rustfmt"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env: [PROJECT_DIRECTORY]
+          binary: bash
+          args: [.evergreen/check-rustfmt.sh]
 
   - name: check-clippy
     tags: [lint]
     commands:
-      - func: "check clippy"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env: [PROJECT_DIRECTORY]
+          binary: bash
+          script: [.evergreen/check-clippy.sh]
 
   - name: check-semgrep
     tags: [lint]
     commands:
-      - func: "check semgrep"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - PROJECT_DIRECTORY
+            - MONGOCRYPT_LIB_DIR
+          binary: bash
+          args:
+            - .evergreen/check-semgrep.sh
 
   - name: check-rustdoc
     tags: [lint]
     commands:
-      - func: "check rustdoc"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env:
+            - PROJECT_DIRECTORY
+            - MONGOCRYPT_LIB_DIR
+            - LD_LIBRARY_PATH
+          binary: bash
+          args: [.evergreen/check-rustdoc.sh]
+
+  - name: test-rustdoc
+    tags: [lint]
+    commands:
+      - func: "install libmongocrypt"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - PROJECT_DIRECTORY
+            - MONGOCRYPT_LIB_DIR
+            - LD_LIBRARY_PATH
+          binary: bash
+          args:
+            - .evergreen/run-rustdoc-tests.sh
 
   # Driver test suite runs for the full set of versions and topologies are in
   # suite-tasks.yml, generated by .evergreen/generate_tasks.
@@ -1035,7 +1106,10 @@ tasks:
 
   - name: test-in-use-encryption-4.2
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1046,7 +1120,10 @@ tasks:
 
   - name: test-in-use-encryption-4.4
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1057,7 +1134,10 @@ tasks:
 
   - name: test-in-use-encryption-5.0
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1068,7 +1148,10 @@ tasks:
 
   - name: test-in-use-encryption-6.0
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1079,7 +1162,10 @@ tasks:
 
   - name: test-in-use-encryption-7.0
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1090,7 +1176,10 @@ tasks:
 
   - name: test-in-use-encryption-rapid
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1101,7 +1190,10 @@ tasks:
 
   - name: test-in-use-encryption-latest
     tags: [in-use-encryption]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: "install libmongocrypt"
       - func: "bootstrap mongo-orchestration"
         vars:
@@ -1110,19 +1202,12 @@ tasks:
       - func: "start csfle servers"
       - func: "run csfle tests"
 
-  - name: test-in-use-encryption-openssl
-    commands:
-      - func: "install libmongocrypt"
-      - func: "bootstrap mongo-orchestration"
-        vars:
-          MONGODB_VERSION: rapid
-          TOPOLOGY: replica_set
-      - func: "start csfle servers"
-      - func: "run csfle tests"
-
   - name: test-load-balancer-5.0
     tags: [load-balancer]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: bootstrap mongo-orchestration
         vars:
           MONGODB_VERSION: 5.0
@@ -1133,7 +1218,10 @@ tasks:
 
   - name: test-load-balancer-6.0
     tags: [load-balancer]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: bootstrap mongo-orchestration
         vars:
           MONGODB_VERSION: 6.0
@@ -1144,7 +1232,10 @@ tasks:
 
   - name: test-load-balancer-7.0
     tags: [load-balancer]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: bootstrap mongo-orchestration
         vars:
           MONGODB_VERSION: 7.0
@@ -1155,7 +1246,10 @@ tasks:
 
   - name: test-load-balancer-rapid
     tags: [load-balancer]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: bootstrap mongo-orchestration
         vars:
           MONGODB_VERSION: rapid
@@ -1166,7 +1260,10 @@ tasks:
 
   - name: test-load-balancer-latest
     tags: [load-balancer]
+    depends_on:
+      - name: build-nextest-archive
     commands:
+      - func: "fetch nextest archive"
       - func: bootstrap mongo-orchestration
         vars:
           MONGODB_VERSION: latest
@@ -1294,6 +1391,36 @@ tasks:
           - DRIVERS_TOOLS
           - PYTHON3
           - OPENSSL
+
+  - name: build-nextest-archive
+    commands:
+    - command: subprocess.exec
+      type: setup
+      params:
+        working_dir: src
+        binary: bash
+        args:
+          - .evergreen/build-nextest-archive.sh
+        include_expansions_in_env:
+          - PROJECT_DIRECTORY
+          - OPENSSL
+          - ZSTD
+          - ZLIB
+          - SNAPPY
+          - MONGOCRYPT_LIB_DIR
+          - LD_LIBRARY_PATH
+          - LIBMONGOCRYPT_OS
+    - command: s3.put
+      type: setup
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nextest-archive.tar.zst
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${build_id}-nextest-archive.tar.zst
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/zstd
+        display_name: nextest-archive.tar.zst
 
 #############
 # Functions #
@@ -1547,6 +1674,7 @@ functions:
 
   "bootstrap mongo-orchestration":
     - command: subprocess.exec
+      type: setup
       params:
         binary: sh
         args:
@@ -1578,6 +1706,12 @@ functions:
     - command: expansions.update
       params:
         file: src/uri-expansions.yml
+    # The server needs some time after startup otherwise it won't include things like
+    # cluster time in replies.
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args: ["-c", "sleep 30"]
 
   "run driver test suite":
     - command: subprocess.exec
@@ -1789,59 +1923,6 @@ functions:
           ${PREPARE_SHELL}
           RUST_VERSION=${RUST_VERSION} .evergreen/compile-only.sh
 
-  "check cargo deny":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          .evergreen/check-cargo-deny.sh
-
-  "check rustfmt":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          .evergreen/check-rustfmt.sh
-
-  "check clippy":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          .evergreen/check-clippy.sh
-
-  "check semgrep":
-    - command: subprocess.exec
-      type: test
-      params:
-        working_dir: src
-        include_expansions_in_env:
-          - DRIVERS_TOOLS
-          - PROJECT_DIRECTORY
-          - MONGOCRYPT_LIB_DIR
-        binary: bash
-        args:
-          - .evergreen/check-semgrep.sh
-
-  "check rustdoc":
-    - command: shell.exec
-      type: test
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          ${PREPARE_SHELL}
-          .evergreen/check-rustdoc.sh
-
   "upload-mo-artifacts":
     - command: shell.exec
       params:
@@ -2012,3 +2093,14 @@ functions:
         - AWS_ACCESS_KEY_ID
         - AWS_SECRET_ACCESS_KEY
         - AWS_SESSION_TOKEN
+  
+  "fetch nextest archive":
+  - command: s3.get
+    type: setup
+    params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${build_id}-nextest-archive.tar.zst
+        bucket: mciuploads
+        local_file: src/nextest-archive.tar.zst
+        optional: true

--- a/.evergreen/features.sh
+++ b/.evergreen/features.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+FEATURE_FLAGS=()
+
+STANDARD_FEATURES=("tracing-unstable" "cert-key-password" "opentelemetry" "error-backtrace")
+
+_join_by() {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+features_option() {
+    local FILTERED=()
+    for FEAT in "${FEATURE_FLAGS[@]}"; do
+        [[ "${FEAT}" != "" ]] && FILTERED+=("${FEAT}")
+    done
+    if ((${#FILTERED[@]} != 0)); then
+        echo "--features $(_join_by , "${FILTERED[@]}")"
+    fi
+}
+
+add_conditional_features() {
+    if [ "$OPENSSL" = true ]; then
+        FEATURE_FLAGS+=("openssl-tls")
+    fi
+
+    if [ "$ZSTD" = true ]; then
+        FEATURE_FLAGS+=("zstd-compression")
+    fi
+
+    if [ "$ZLIB" = true ]; then
+        FEATURE_FLAGS+=("zlib-compression")
+    fi
+
+    if [ "$SNAPPY" = true ]; then
+        FEATURE_FLAGS+=("snappy-compression")
+    fi
+}

--- a/.evergreen/generate-tasks/Cargo.toml
+++ b/.evergreen/generate-tasks/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[workspace]

--- a/.evergreen/generate-tasks/src/main.rs
+++ b/.evergreen/generate-tasks/src/main.rs
@@ -19,8 +19,13 @@ tasks:"
                 "
   - name: test-{version}-{top_name}
     tags: [{version}, {top_name}]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: \"fetch nextest archive\"
       - func: \"bootstrap mongo-orchestration\"
+        type: setup
         vars:
           MONGODB_VERSION: {version}
           TOPOLOGY: {topology}

--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -32,8 +32,7 @@ for arg; do
 
     # This file is not created by default on Windows
     echo 'export PATH="$PATH:${CARGO_HOME}/bin"' >>${CARGO_HOME}/env
-    echo "export CARGO_NET_GIT_FETCH_WITH_CLI=true" >>${CARGO_HOME}/env
-
+    
     source .evergreen/env.sh
     rustup toolchain install nightly -c rustfmt
   elif [ $arg == "junit-dependencies" ]; then

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -10,12 +10,7 @@ set -o xtrace
 
 export CSFLE_TLS_CERT_DIR="${DRIVERS_TOOLS}/.evergreen/x509gen"
 
-FEATURE_FLAGS+=("in-use-encryption" "azure-kms" "text-indexes-unstable")
 CARGO_OPTIONS+=("--ignore-default-filter")
-
-if [[ "$OPENSSL" = true ]]; then
-  FEATURE_FLAGS+=("openssl-tls")
-fi
 
 if [ "$OS" = "Windows_NT" ]; then
   export CSFLE_TLS_CERT_DIR=$(cygpath ${CSFLE_TLS_CERT_DIR} --windows)
@@ -28,16 +23,16 @@ fi
 # Add mongodb binaries to path for mongocryptd
 PATH=${PATH}:${DRIVERS_TOOLS}/mongodb/bin
 
+set -o xtrace
 set +o errexit
 
+TEST_OPTIONS=("--skip" "on_demand_aws::failure")
 cargo_test test::csfle
-
-FEATURE_FLAGS+=("aws-auth")
-cargo_test on_demand_aws::success
 
 # Unset variables for on-demand credential failure tests.
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
+TEST_OPTIONS=()
 cargo_test on_demand_aws::failure
 
 exit ${CARGO_RESULT}

--- a/.evergreen/run-rustdoc-tests.sh
+++ b/.evergreen/run-rustdoc-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -o errexit
+
+source ./.evergreen/env.sh
+
+cargo test --doc --package mongodb --all-features

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -6,23 +6,9 @@ set -o pipefail
 source .evergreen/env.sh
 source .evergreen/cargo-test.sh
 
-FEATURE_FLAGS+=("tracing-unstable" "cert-key-password" "opentelemetry" "error-backtrace")
+FEATURE_FLAGS+=("${STANDARD_FEATURES[@]}")
 
-if [ "$OPENSSL" = true ]; then
-  FEATURE_FLAGS+=("openssl-tls")
-fi
-
-if [ "$ZSTD" = true ]; then
-  FEATURE_FLAGS+=("zstd-compression")
-fi
-
-if [ "$ZLIB" = true ]; then
-  FEATURE_FLAGS+=("zlib-compression")
-fi
-
-if [ "$SNAPPY" = true ]; then
-  FEATURE_FLAGS+=("snappy-compression")
-fi
+add_conditional_features
 
 echo "cargo test options: $(cargo_test_options)"
 
@@ -34,9 +20,5 @@ if [ "Windows_NT" == "$OS" ]; then
 fi
 
 cargo_test ""
-
-# cargo-nextest doesn't support doc tests
-RUST_BACKTRACE=1 cargo test --doc $(cargo_test_options)
-((CARGO_RESULT = ${CARGO_RESULT} || $?))
 
 exit $CARGO_RESULT

--- a/.evergreen/suite-tasks.yml
+++ b/.evergreen/suite-tasks.yml
@@ -5,8 +5,13 @@ tasks:
 
   - name: test-4.2-standalone
     tags: [4.2, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 4.2
           TOPOLOGY: server
@@ -14,8 +19,13 @@ tasks:
 
   - name: test-4.4-standalone
     tags: [4.4, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 4.4
           TOPOLOGY: server
@@ -23,8 +33,13 @@ tasks:
 
   - name: test-5.0-standalone
     tags: [5.0, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 5.0
           TOPOLOGY: server
@@ -32,8 +47,13 @@ tasks:
 
   - name: test-6.0-standalone
     tags: [6.0, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 6.0
           TOPOLOGY: server
@@ -41,8 +61,13 @@ tasks:
 
   - name: test-7.0-standalone
     tags: [7.0, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 7.0
           TOPOLOGY: server
@@ -50,8 +75,13 @@ tasks:
 
   - name: test-8.0-standalone
     tags: [8.0, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 8.0
           TOPOLOGY: server
@@ -59,8 +89,13 @@ tasks:
 
   - name: test-rapid-standalone
     tags: [rapid, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: rapid
           TOPOLOGY: server
@@ -68,8 +103,13 @@ tasks:
 
   - name: test-latest-standalone
     tags: [latest, standalone]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: latest
           TOPOLOGY: server
@@ -77,8 +117,13 @@ tasks:
 
   - name: test-4.2-replicaset
     tags: [4.2, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 4.2
           TOPOLOGY: replica_set
@@ -86,8 +131,13 @@ tasks:
 
   - name: test-4.4-replicaset
     tags: [4.4, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 4.4
           TOPOLOGY: replica_set
@@ -95,8 +145,13 @@ tasks:
 
   - name: test-5.0-replicaset
     tags: [5.0, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 5.0
           TOPOLOGY: replica_set
@@ -104,8 +159,13 @@ tasks:
 
   - name: test-6.0-replicaset
     tags: [6.0, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 6.0
           TOPOLOGY: replica_set
@@ -113,8 +173,13 @@ tasks:
 
   - name: test-7.0-replicaset
     tags: [7.0, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 7.0
           TOPOLOGY: replica_set
@@ -122,8 +187,13 @@ tasks:
 
   - name: test-8.0-replicaset
     tags: [8.0, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 8.0
           TOPOLOGY: replica_set
@@ -131,8 +201,13 @@ tasks:
 
   - name: test-rapid-replicaset
     tags: [rapid, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: rapid
           TOPOLOGY: replica_set
@@ -140,8 +215,13 @@ tasks:
 
   - name: test-latest-replicaset
     tags: [latest, replicaset]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: latest
           TOPOLOGY: replica_set
@@ -149,8 +229,13 @@ tasks:
 
   - name: test-4.2-sharded
     tags: [4.2, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 4.2
           TOPOLOGY: sharded_cluster
@@ -158,8 +243,13 @@ tasks:
 
   - name: test-4.4-sharded
     tags: [4.4, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 4.4
           TOPOLOGY: sharded_cluster
@@ -167,8 +257,13 @@ tasks:
 
   - name: test-5.0-sharded
     tags: [5.0, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 5.0
           TOPOLOGY: sharded_cluster
@@ -176,8 +271,13 @@ tasks:
 
   - name: test-6.0-sharded
     tags: [6.0, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 6.0
           TOPOLOGY: sharded_cluster
@@ -185,8 +285,13 @@ tasks:
 
   - name: test-7.0-sharded
     tags: [7.0, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 7.0
           TOPOLOGY: sharded_cluster
@@ -194,8 +299,13 @@ tasks:
 
   - name: test-8.0-sharded
     tags: [8.0, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: 8.0
           TOPOLOGY: sharded_cluster
@@ -203,8 +313,13 @@ tasks:
 
   - name: test-rapid-sharded
     tags: [rapid, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: rapid
           TOPOLOGY: sharded_cluster
@@ -212,8 +327,13 @@ tasks:
 
   - name: test-latest-sharded
     tags: [latest, sharded]
+    depends_on:
+      - name: build-nextest-archive
+        patch_optional: true
     commands:
+      - func: "fetch nextest archive"
       - func: "bootstrap mongo-orchestration"
+        type: setup
         vars:
           MONGODB_VERSION: latest
           TOPOLOGY: sharded_cluster

--- a/driver/src/change_stream/session.rs
+++ b/driver/src/change_stream/session.rs
@@ -83,7 +83,7 @@ where
     /// # let mut session = client.start_session().await?;
     /// let mut cs = coll.watch().session(&mut session).await?;
     /// while let Some(event) = cs.next(&mut session).await? {
-    ///     let id = bson::to_bson(&event.id)?;
+    ///     let id = bson::serialize_to_bson(&event.id)?;
     ///     other_coll.insert_one(doc! { "id": id }).session(&mut session).await?;
     /// }
     /// # Ok::<(), mongodb::error::Error>(())

--- a/driver/src/sync/change_stream.rs
+++ b/driver/src/sync/change_stream.rs
@@ -190,7 +190,7 @@ where
     /// # let mut session = client.start_session().run()?;
     /// let mut cs = coll.watch().session(&mut session).run()?;
     /// while let Some(event) = cs.next(&mut session)? {
-    ///     let id = bson::to_bson(&event.id)?;
+    ///     let id = bson::serialize_to_bson(&event.id)?;
     ///     other_coll.insert_one(doc! { "id": id }).session(&mut session).run()?;
     /// }
     /// # Ok::<(), mongodb::error::Error>(())

--- a/driver/src/test/csfle.rs
+++ b/driver/src/test/csfle.rs
@@ -301,7 +301,7 @@ async fn validate_roundtrip(
 
 fn load_testdata_raw(name: &str) -> Result<String> {
     let path: PathBuf = [
-        env!("CARGO_MANIFEST_DIR"),
+        &std::env::var("CARGO_MANIFEST_DIR").unwrap(),
         "../spec/testdata/client-side-encryption",
         name,
     ]

--- a/driver/src/test/spec.rs
+++ b/driver/src/test/spec.rs
@@ -56,7 +56,9 @@ pub(crate) fn deserialize_spec_tests<T: DeserializeOwned>(
     spec: &[&str],
     skipped_files: Option<&[&str]>,
 ) -> Vec<(T, PathBuf)> {
-    let mut path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "..", "spec"].iter().collect();
+    let mut path: PathBuf = [&std::env::var("CARGO_MANIFEST_DIR").unwrap(), "..", "spec"]
+        .iter()
+        .collect();
     path.extend(spec);
     deserialize_spec_tests_common(path, skipped_files)
 }


### PR DESCRIPTION
RUST-2281

This converts all of these to using cached binaries shared across the server topology tasks:
* the main test suite
* openssl
* stable API
* in use encryption
* load balancer
* graviton

A lot of yaks to shave here:
* Archiving test runner binaries turns out to be nontrivial (rustc hash, dependent libraries, etc.).  Fortunately, `cargo nextest` has support for this.
* Tests needed a little bit of an update to pick up paths at runtime rather than compile-time since even on the same host tag different tasks will have different paths.
* Speaking of host tags, we were using an outdated one for rhel8.
* Some tests (e.g. compression) use the same tasks as the main suites, so I had to use some trickery to make the archived runner portion optional.
* `cargo nextest` doesn't support doctests (they're apparently built in a different and hard to manage way); we were running those alongside the main tests but that doesn't work if the run is using an archive, so I've split that out into its own lint task.