### PR TITLE
RUST-2304 Add workarounds for bulk write server bugs

### DIFF
--- a/driver/src/operation/bulk_write.rs
+++ b/driver/src/operation/bulk_write.rs
@@ -175,6 +175,12 @@ where
                 n_modified,
                 upserted,
             } => {
+                // small optimization for SERVER-113344: if the server unexpectedly returns a
+                // success response for an errors-only bulk write, skip deserializing the individual
+                // response, as the call to add_*_result will be a no-op
+                if R::errors_only() {
+                    return Ok(());
+                }
                 let model = self.get_model(response.index)?;
                 match model.operation_type() {
                     OperationType::Insert => {


### PR DESCRIPTION
> [SERVER-113026](https://jira.mongodb.org/browse/SERVER-113026)

This caused an error in the driver. The workaround is to default `nModified` to 0 when it is unexpectedly absent from an update reply.

> [SERVER-113344](https://jira.mongodb.org/browse/SERVER-113344)

This did not cause an error in the driver. If the user does not set `verbose_results()` in a call to `bulk_write()`, the driver will return the `SummaryBulkWriteResult` type for which populating an individual response is a [no-op](https://github.com/mongodb/mongo-rust-driver/blob/5ff2c7ba179f343cd6c5675e865fc93fee3d6b60/driver/src/results/bulk_write.rs#L86-L90). I added a small optimization to skip the deserialization step for success responses in summary bulk writes as a mitigation for this bug.