### PR TITLE
RUST-2315 Update search index test assertions

### DIFF
--- a/driver/src/test/index_management/search_index.rs
+++ b/driver/src/test/index_management/search_index.rs
@@ -232,7 +232,7 @@ async fn search_index_update() {
     let dynamic = found["latestDefinition"]["mappings"]["dynamic"]
         .as_bool()
         .unwrap();
-    assert!(!dynamic);
+    assert!(dynamic);
 }
 
 /// Search Index Case 5: dropSearchIndex suppresses namespace not found errors


### PR DESCRIPTION
These weren't failing for us, but I changed the assertions to keep us up-to-date with the spec.

patch: https://spruce.mongodb.com/version/694ec6b0304aa80007596223/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC