### PR TITLE
RUST-2295 fix wildcard dev-dependencies

### DIFF
--- a/bevy/Cargo.toml
+++ b/bevy/Cargo.toml
@@ -33,11 +33,11 @@ default-features = false
 features = ["io"]
 
 [dev-dependencies.tokio]
-version = "*"
+version = ">= 0.0.0"
 default-features = false
 features = ["rt-multi-thread"]
 
 [dev-dependencies.bevy]
-version = "*"
+version = ">= 0.0.0"
 default-features = false
 features = ["debug", "bevy_render", "pnm"]


### PR DESCRIPTION
RUST-2295

The crate has a couple of dev-dependencies with version `"*"` to mean "the same version as used with the main library, but with these extra features".  However, crates.io doesn't allow `"*"` versions for any dependency, even a dev-dependency, so this switches to the equivalent `">= 0.0.0"`.