### PR TITLE
RUST-2328 Disable handshake metadata tests for compression

### DIFF
--- a/driver/src/test/spec.rs
+++ b/driver/src/test/spec.rs
@@ -6,6 +6,11 @@ mod connection_stepdown;
 mod crud;
 mod faas;
 mod gridfs;
+#[cfg(not(any(
+    feature = "zstd-compression",
+    feature = "zlib-compression",
+    feature = "snappy-compression"
+)))]
 mod handshake;
 #[cfg(feature = "dns-resolver")]
 mod initial_dns_seedlist_discovery;


### PR DESCRIPTION
RUST-2328

Turns out that the combo of speculative authentication and the compression method array pushes the handshake over the size limit, triggering metadata stripping, which in turn breaks these tests.

Passing test run: https://spruce.mongodb.com/version/695fbba2c11a0e000783b2aa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC