### PR TITLE
RUST-2327 Update windows host versions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -335,7 +335,7 @@ buildvariants:
     display_name: "OIDC Windows"
     patchable: true
     run_on:
-      - windows-64-vs2017-small
+      - windows-2022-latest-small
     expansions:
       AUTH: auth
       SSL: ssl


### PR DESCRIPTION
RUST-2327

Turns out the reason the patches were failing is that mongod doesn't support older versions of Windows.