### PR TITLE
RUST-2337 deflake retryable_reads::retry_read_different_mongos

### DIFF
--- a/driver/src/test/spec/retryable_reads.rs
+++ b/driver/src/test/spec/retryable_reads.rs
@@ -156,6 +156,7 @@ async fn retry_read_different_mongos() {
     }
     client_options.hosts.drain(2..);
     client_options.retry_reads = Some(true);
+    client_options.local_threshold = Some(Duration::from_secs(1));
 
     let hosts = client_options.hosts.clone();
     let client = Client::for_test()


### PR DESCRIPTION
RUST-2337

This test looks for a retry landing on a different server than the original attempt.  However, in rare cases latency to the test server is high enough that one of the shards gets filtered out based on the default 15ms threshold and with only a single one remaining, the deprioritization from the retry is ignored (this is by design and following spec).

Side commentary:
* why the heck is latency to a server running on localhost ~250ms?
* this might be my personal record for "time spent debugging" to "size of fix" ratio.