### PR TITLE
RUST-2351 skip BSON size limits

### DIFF
--- a/driver/src/test/csfle/prose.rs
+++ b/driver/src/test/csfle/prose.rs
@@ -122,7 +122,9 @@ async fn custom_key_material() -> Result<()> {
 #[tokio::test]
 async fn bson_size_limits() -> Result<()> {
     if *DISABLE_CRYPT_SHARED && server_version_gte(7, 0).await {
-        log_uncaptured("skipping BSON size limits test on mongocryptd due to SERVER-118428: server >= 7.0");
+        log_uncaptured(
+            "skipping BSON size limits test on mongocryptd due to SERVER-118428: server >= 7.0",
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
Skip encryption BSON size limits when testing mongocryptd >= 7.0 due to SERVER-118428.

Patch build: https://spruce.mongodb.com/version/6982607367710400072179d6

Removing the skip is tracked in RUST-2351.
