### PR TITLE
minor: update bytes dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,9 +671,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"


### PR DESCRIPTION
cargo-deny flagged a [security advisory](https://rustsec.org/advisories/RUSTSEC-2026-0007).