### PR TITLE
[3.5.x] RUST-2363 ensure empty tag matches servers with no tag set

### DIFF
--- a/driver/src/sdam/description/server.rs
+++ b/driver/src/sdam/description/server.rs
@@ -447,6 +447,11 @@ impl ServerDescription {
     }
 
     pub(crate) fn matches_tag_set(&self, tag_set: &TagSet) -> bool {
+        // An empty tag set matches any server.
+        if tag_set.is_empty() {
+            return true;
+        }
+
         let reply = match self.reply.as_ref() {
             Ok(Some(ref reply)) => reply,
             _ => return false,

--- a/spec/server-selection/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.json
+++ b/spec/server-selection/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.json
@@ -1,0 +1,41 @@
+{
+  "topology_description": {
+    "type": "ReplicaSetWithPrimary",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSPrimary"
+      },
+      {
+        "address": "b:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSSecondary"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "SecondaryPreferred",
+    "tag_sets": [
+      {
+        "data_center": "nyc"
+      },
+      {}
+    ]
+  },
+  "suitable_servers": [
+    {
+      "address": "b:27017",
+      "avg_rtt_ms": 5,
+      "type": "RSSecondary"
+    }
+  ],
+  "in_latency_window": [
+    {
+      "address": "b:27017",
+      "avg_rtt_ms": 5,
+      "type": "RSSecondary"
+    }
+  ]
+}

--- a/spec/server-selection/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.yml
+++ b/spec/server-selection/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.yml
@@ -1,0 +1,26 @@
+# Attempt to select the secondary using an empty tag set. Expect empty tag set to match.
+---
+topology_description:
+  type: ReplicaSetWithPrimary
+  servers:
+  - &1
+    address: a:27017
+    avg_rtt_ms: 5
+    type: RSPrimary
+    # No "tags".
+  - &2
+    address: b:27017
+    avg_rtt_ms: 5
+    type: RSSecondary
+    # No "tags"
+operation: read
+read_preference:
+  mode: SecondaryPreferred
+  tag_sets:
+  - data_center: nyc # Does not match.
+  - {} # Empty tag set.
+suitable_servers:
+- *2
+in_latency_window:
+- *2
+


### PR DESCRIPTION
Cherry-pick of 422e871715f11d0bd9b488df8168f4f02573cb44 onto 3.5.x.