### PR TITLE
RUST-2324 Implement `Cursor` on top of `RawBatchCursor`

### DIFF
--- a/driver/src/change_stream.rs
+++ b/driver/src/change_stream.rs
@@ -1,4 +1,5 @@
 //! Contains the functionality for change streams.
+pub(crate) mod common;
 pub mod event;
 pub(crate) mod options;
 pub mod session;
@@ -6,32 +7,20 @@ pub mod session;
 #[cfg(test)]
 use std::collections::VecDeque;
 use std::{
-    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-#[cfg(test)]
-use crate::bson::RawDocumentBuf;
-use crate::{
-    bson::{Document, Timestamp},
-    operation::OperationTarget,
-};
+use crate::error::Error;
 use derive_where::derive_where;
 use futures_core::{future::BoxFuture, Stream};
+use futures_util::FutureExt;
 use serde::de::DeserializeOwned;
 #[cfg(test)]
 use tokio::sync::oneshot;
 
-#[cfg(feature = "bson-3")]
-use crate::bson_compat::RawBsonRefExt as _;
-use crate::{
-    change_stream::event::{ChangeStreamEvent, ResumeToken},
-    cursor::{stream_poll_next, BatchValue, CursorStream, NextInBatchFuture},
-    error::{ErrorKind, Result},
-    ClientSession,
-    Cursor,
-};
+use crate::{change_stream::event::ResumeToken, error::Result, Cursor};
+use common::{ChangeStreamData, WatchArgs};
 
 /// A `ChangeStream` streams the ongoing changes of its associated collection, database or
 /// deployment. `ChangeStream` instances should be created with method `watch` against the relevant
@@ -83,31 +72,16 @@ pub struct ChangeStream<T>
 where
     T: DeserializeOwned,
 {
-    /// The cursor to iterate over event instances.
-    cursor: Cursor<T>,
-
-    /// Arguments to `watch` that created this change stream.
-    args: WatchArgs,
-
-    /// Dynamic information associated with this change stream.
-    data: ChangeStreamData,
-
-    /// A pending future for a resume.
-    #[derive_where(skip)]
-    pending_resume: Option<BoxFuture<'static, Result<ChangeStream<T>>>>,
+    inner: StreamState<T>,
 }
 
 impl<T> ChangeStream<T>
 where
     T: DeserializeOwned,
 {
-    pub(crate) fn new(cursor: Cursor<T>, args: WatchArgs, data: ChangeStreamData) -> Self {
-        let pending_resume: Option<BoxFuture<'static, Result<ChangeStream<T>>>> = None;
+    pub(crate) fn new(cursor: Cursor<()>, args: WatchArgs, data: ChangeStreamData) -> Self {
         Self {
-            cursor,
-            args,
-            data,
-            pending_resume,
+            inner: StreamState::Idle(CursorWrapper::new(cursor, args, data)),
         }
     }
 
@@ -118,22 +92,19 @@ where
     /// [here](https://www.mongodb.com/docs/manual/changeStreams/#change-stream-resume-token) for more
     /// information on change stream resume tokens.
     pub fn resume_token(&self) -> Option<ResumeToken> {
-        self.data.resume_token.clone()
+        self.inner.state().data.resume_token.clone()
     }
 
     /// Update the type streamed values will be parsed as.
     pub fn with_type<D: DeserializeOwned>(self) -> ChangeStream<D> {
         ChangeStream {
-            cursor: self.cursor.with_type(),
-            args: self.args,
-            data: self.data,
-            pending_resume: None,
+            inner: StreamState::Idle(self.inner.take_state()),
         }
     }
 
     /// Returns whether the change stream will continue to receive events.
     pub fn is_alive(&self) -> bool {
-        !self.cursor.is_exhausted()
+        !self.inner.state().cursor.raw().is_exhausted()
     }
 
     /// Retrieves the next result from the change stream, if any.
@@ -161,154 +132,22 @@ where
     /// # }
     /// ```
     pub async fn next_if_any(&mut self) -> Result<Option<T>> {
-        Ok(match NextInBatchFuture::new(self).await? {
-            BatchValue::Some { doc, .. } => {
-                Some(crate::bson_compat::deserialize_from_slice(doc.as_bytes())?)
-            }
-            BatchValue::Empty | BatchValue::Exhausted => None,
-        })
+        self.inner.state_mut().next_if_any(&mut ()).await
     }
 
     #[cfg(test)]
     pub(crate) fn set_kill_watcher(&mut self, tx: oneshot::Sender<()>) {
-        self.cursor.set_kill_watcher(tx);
+        self.inner.state_mut().cursor.raw_mut().set_kill_watcher(tx);
     }
 
     #[cfg(test)]
-    pub(crate) fn current_batch(&self) -> &VecDeque<RawDocumentBuf> {
-        self.cursor.current_batch()
+    pub(crate) fn current_batch(&self) -> &VecDeque<crate::bson::RawDocumentBuf> {
+        self.inner.state().cursor.batch()
     }
 
     #[cfg(test)]
     pub(crate) fn client(&self) -> &crate::Client {
-        self.cursor.client()
-    }
-}
-
-/// Arguments passed to a `watch` method, captured to allow resume.
-#[derive(Debug, Clone)]
-pub(crate) struct WatchArgs {
-    /// The pipeline of stages to append to an initial `$changeStream` stage.
-    pub(crate) pipeline: Vec<Document>,
-
-    /// The original target of the change stream.
-    pub(crate) target: OperationTarget,
-
-    /// The options provided to the initial `$changeStream` stage.
-    pub(crate) options: Option<options::ChangeStreamOptions>,
-}
-
-/// Dynamic change stream data needed for resume.
-#[derive(Debug, Default)]
-pub(crate) struct ChangeStreamData {
-    /// The `operationTime` returned by the initial `aggregate` command.
-    pub(crate) initial_operation_time: Option<Timestamp>,
-
-    /// The cached resume token.
-    pub(crate) resume_token: Option<ResumeToken>,
-
-    /// Whether or not the change stream has attempted a resume, used to attempt a resume only
-    /// once.
-    pub(crate) resume_attempted: bool,
-
-    /// Whether or not the change stream has returned a document, used to update resume token
-    /// during an automatic resume.
-    pub(crate) document_returned: bool,
-
-    /// The implicit session used to create the original cursor.
-    pub(crate) implicit_session: Option<ClientSession>,
-}
-
-impl ChangeStreamData {
-    fn take(&mut self) -> Self {
-        Self {
-            initial_operation_time: self.initial_operation_time,
-            resume_token: self.resume_token.clone(),
-            resume_attempted: self.resume_attempted,
-            document_returned: self.document_returned,
-            implicit_session: self.implicit_session.take(),
-        }
-    }
-}
-
-fn get_resume_token(
-    batch_value: &BatchValue,
-    batch_token: Option<&ResumeToken>,
-) -> Result<Option<ResumeToken>> {
-    Ok(match batch_value {
-        BatchValue::Some { doc, is_last } => {
-            let doc_token = match doc.get("_id")? {
-                Some(val) => ResumeToken(val.to_raw_bson()),
-                None => return Err(ErrorKind::MissingResumeToken.into()),
-            };
-            if *is_last && batch_token.is_some() {
-                batch_token.cloned()
-            } else {
-                Some(doc_token)
-            }
-        }
-        BatchValue::Empty => batch_token.cloned(),
-        _ => None,
-    })
-}
-
-impl<T> CursorStream for ChangeStream<T>
-where
-    T: DeserializeOwned,
-{
-    fn poll_next_in_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<BatchValue>> {
-        loop {
-            if let Some(mut pending) = self.pending_resume.take() {
-                match Pin::new(&mut pending).poll(cx) {
-                    Poll::Pending => {
-                        self.pending_resume = Some(pending);
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(Ok(new_stream)) => {
-                        // Ensure that the old cursor is killed on the server selected for the new
-                        // one.
-                        self.cursor
-                            .set_drop_address(new_stream.cursor.address().clone());
-                        self.cursor = new_stream.cursor;
-                        self.args = new_stream.args;
-                        // After a successful resume, another resume must be allowed.
-                        self.data.resume_attempted = false;
-                        continue;
-                    }
-                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-                }
-            }
-            let out = self.cursor.poll_next_in_batch(cx);
-            match &out {
-                Poll::Ready(Ok(bv)) => {
-                    if let Some(token) =
-                        get_resume_token(bv, self.cursor.post_batch_resume_token())?
-                    {
-                        self.data.resume_token = Some(token);
-                    }
-                    if matches!(bv, BatchValue::Some { .. }) {
-                        self.data.document_returned = true;
-                    }
-                }
-                Poll::Ready(Err(e)) if e.is_resumable() && !self.data.resume_attempted => {
-                    self.data.resume_attempted = true;
-                    let client = self.cursor.client().clone();
-                    let args = self.args.clone();
-                    let mut data = self.data.take();
-                    data.implicit_session = self.cursor.take_implicit_session();
-                    self.pending_resume = Some(Box::pin(async move {
-                        let new_stream: Result<ChangeStream<ChangeStreamEvent<()>>> = client
-                            .execute_watch(args.pipeline, args.options, args.target, Some(data))
-                            .await;
-                        new_stream.map(|cs| cs.with_type::<T>())
-                    }));
-                    // Iterate the loop so the new future gets polled and can register wakers.
-                    continue;
-                }
-                _ => {}
-            }
-            return out;
-        }
+        self.inner.state().cursor.raw().client()
     }
 }
 
@@ -318,7 +157,124 @@ where
 {
     type Item = Result<T>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        stream_poll_next(Pin::into_inner(self), cx)
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+type CursorWrapper = common::CursorWrapper<Cursor<()>>;
+
+// This is almost entirely the same as `crate::cursor::stream::Stream`.  However, making a generic
+// version to underlie both has the side effect of changing the variance on `T` from covariant to
+// invariant, which breaks cursor zero-copy deserialization :(
+#[derive_where(Debug)]
+enum StreamState<T: DeserializeOwned> {
+    Idle(CursorWrapper),
+    Polling,
+    Next(#[derive_where(skip)] BoxFuture<'static, NextDone<T>>),
+}
+
+struct NextDone<T> {
+    state: CursorWrapper,
+    out: Result<Option<T>>,
+}
+
+impl<T: DeserializeOwned> StreamState<T> {
+    fn state(&self) -> &CursorWrapper {
+        match self {
+            Self::Idle(st) => st,
+            _ => panic!("invalid change stream state access"),
+        }
+    }
+
+    fn state_mut(&mut self) -> &mut CursorWrapper {
+        match self {
+            Self::Idle(st) => st,
+            _ => panic!("invalid change stream state access"),
+        }
+    }
+
+    fn take_state(self) -> CursorWrapper {
+        match self {
+            Self::Idle(st) => st,
+            _ => panic!("invalid change stream state access"),
+        }
+    }
+}
+
+impl<T: DeserializeOwned> Stream for StreamState<T> {
+    type Item = Result<T>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match std::mem::replace(&mut *self, StreamState::Polling) {
+                StreamState::Idle(mut state) => {
+                    *self = StreamState::Next(
+                        async move {
+                            let out = state.next_if_any(&mut ()).await;
+                            NextDone { state, out }
+                        }
+                        .boxed(),
+                    );
+                    continue;
+                }
+                StreamState::Next(mut fut) => match fut.poll_unpin(cx) {
+                    Poll::Pending => {
+                        *self = StreamState::Next(fut);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready(NextDone { state, out }) => {
+                        *self = StreamState::Idle(state);
+                        match out {
+                            Ok(Some(v)) => return Poll::Ready(Some(Ok(v))),
+                            Ok(None) => continue,
+                            Err(e) => return Poll::Ready(Some(Err(e))),
+                        }
+                    }
+                },
+                StreamState::Polling => {
+                    return Poll::Ready(Some(Err(Error::internal(
+                        "attempt to poll change stream already in polling state",
+                    ))))
+                }
+            }
+        }
+    }
+}
+
+impl common::InnerCursor for Cursor<()> {
+    type Session = ();
+
+    async fn try_advance(&mut self, _session: &mut Self::Session) -> Result<bool> {
+        self.try_advance().await
+    }
+
+    fn get_resume_token(&self) -> Result<Option<ResumeToken>> {
+        common::get_resume_token(self.batch(), self.raw().post_batch_resume_token())
+    }
+
+    fn current(&self) -> &crate::bson::RawDocument {
+        self.current()
+    }
+
+    async fn execute_watch(
+        &mut self,
+        args: WatchArgs,
+        mut data: ChangeStreamData,
+        _session: &mut Self::Session,
+    ) -> Result<(Self, WatchArgs)> {
+        data.implicit_session = self.raw_mut().take_implicit_session();
+        let new_stream: ChangeStream<event::ChangeStreamEvent<()>> = self
+            .raw()
+            .client()
+            .execute_watch(args.pipeline, args.options, args.target, Some(data))
+            .await?;
+        let new_wrapper = new_stream.inner.take_state();
+        Ok((new_wrapper.cursor, new_wrapper.args))
+    }
+
+    fn set_drop_address(&mut self, from: &Self) {
+        self.raw_mut()
+            .set_drop_address(from.raw().address().clone());
     }
 }

--- a/driver/src/change_stream/common.rs
+++ b/driver/src/change_stream/common.rs
@@ -1,0 +1,142 @@
+use std::collections::VecDeque;
+
+use crate::{
+    bson::{Document, RawDocument, RawDocumentBuf, Timestamp},
+    bson_compat::deserialize_from_slice,
+    error::Error,
+    operation::OperationTarget,
+};
+use serde::de::DeserializeOwned;
+
+#[cfg(feature = "bson-3")]
+use crate::bson_compat::RawBsonRefExt as _;
+use crate::{
+    change_stream::event::ResumeToken,
+    error::{ErrorKind, Result},
+    ClientSession,
+};
+
+/// Arguments passed to a `watch` method, captured to allow resume.
+#[derive(Debug, Clone)]
+pub(crate) struct WatchArgs {
+    /// The pipeline of stages to append to an initial `$changeStream` stage.
+    pub(crate) pipeline: Vec<Document>,
+
+    /// The original target of the change stream.
+    pub(crate) target: OperationTarget,
+
+    /// The options provided to the initial `$changeStream` stage.
+    pub(crate) options: Option<super::options::ChangeStreamOptions>,
+}
+
+/// Dynamic change stream data needed for resume.
+#[derive(Debug, Default)]
+pub(crate) struct ChangeStreamData {
+    /// The `operationTime` returned by the initial `aggregate` command.
+    pub(crate) initial_operation_time: Option<Timestamp>,
+
+    /// The cached resume token.
+    pub(crate) resume_token: Option<ResumeToken>,
+
+    /// Whether or not the change stream has returned a document, used to update resume token
+    /// during an automatic resume.
+    pub(crate) document_returned: bool,
+
+    /// The implicit session used to create the original cursor.
+    pub(crate) implicit_session: Option<ClientSession>,
+}
+
+impl ChangeStreamData {
+    pub(super) fn take(&mut self) -> Self {
+        Self {
+            initial_operation_time: self.initial_operation_time,
+            resume_token: self.resume_token.clone(),
+            document_returned: self.document_returned,
+            implicit_session: self.implicit_session.take(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct CursorWrapper<Inner> {
+    /// The cursor to iterate over event instances.
+    pub(super) cursor: Inner,
+
+    /// Arguments to `watch` that created this change stream.
+    pub(super) args: WatchArgs,
+
+    /// Dynamic information associated with this change stream.
+    pub(super) data: ChangeStreamData,
+}
+
+impl<Inner> CursorWrapper<Inner> {
+    pub(super) fn new(cursor: Inner, args: WatchArgs, data: ChangeStreamData) -> Self {
+        Self { cursor, args, data }
+    }
+
+    pub(super) async fn next_if_any<T: DeserializeOwned>(
+        &mut self,
+        session: &mut Inner::Session,
+    ) -> Result<Option<T>>
+    where
+        Inner: InnerCursor,
+    {
+        loop {
+            match self.cursor.try_advance(session).await {
+                Ok(has) => {
+                    self.data.resume_token = self.cursor.get_resume_token()?;
+                    return if has {
+                        self.data.document_returned = true;
+                        deserialize_from_slice(self.cursor.current().as_bytes())
+                            .map(Some)
+                            .map_err(Error::from)
+                    } else {
+                        Ok(None)
+                    };
+                }
+                Err(e) if e.is_resumable() => {
+                    let (new_cursor, new_args) = self
+                        .cursor
+                        .execute_watch(self.args.clone(), self.data.take(), session)
+                        .await?;
+                    // Ensure that the old cursor is killed on the server selected for the new one.
+                    self.cursor.set_drop_address(&new_cursor);
+                    self.cursor = new_cursor;
+                    self.args = new_args;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+pub(super) fn get_resume_token(
+    batch: &VecDeque<RawDocumentBuf>,
+    batch_token: Option<&ResumeToken>,
+) -> Result<Option<ResumeToken>> {
+    Ok(match batch.front() {
+        Some(doc) => {
+            let doc_token = doc
+                .get("_id")?
+                .ok_or_else(|| Error::from(ErrorKind::MissingResumeToken))?;
+            Some(ResumeToken(doc_token.to_raw_bson()))
+        }
+        None => batch_token.cloned(),
+    })
+}
+
+pub(super) trait InnerCursor: Sized {
+    type Session;
+
+    async fn try_advance(&mut self, session: &mut Self::Session) -> Result<bool>;
+    fn get_resume_token(&self) -> Result<Option<ResumeToken>>;
+    fn current(&self) -> &RawDocument;
+    async fn execute_watch(
+        &mut self,
+        args: WatchArgs,
+        data: ChangeStreamData,
+        session: &mut Self::Session,
+    ) -> Result<(Self, WatchArgs)>;
+    fn set_drop_address(&mut self, from: &Self);
+}

--- a/driver/src/change_stream/event.rs
+++ b/driver/src/change_stream/event.rs
@@ -6,7 +6,7 @@ use std::convert::TryInto;
 use crate::{bson::Bson, bson_compat::RawError};
 use crate::{
     bson::{DateTime, Document, RawBson, RawDocumentBuf, Timestamp},
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     options::ChangeStreamOptions,
 };
 

--- a/driver/src/client.rs
+++ b/driver/src/client.rs
@@ -709,10 +709,6 @@ impl AsyncDropToken {
             panic!("exhausted AsyncDropToken");
         }
     }
-
-    pub(crate) fn take(&mut self) -> Self {
-        Self { tx: self.tx.take() }
-    }
 }
 
 impl Drop for Client {

--- a/driver/src/client/executor.rs
+++ b/driver/src/client/executor.rs
@@ -2,7 +2,10 @@
 use crate::bson::RawDocumentBuf;
 use crate::{
     bson::{doc, RawBsonRef, RawDocument, Timestamp},
-    cursor::{CursorInformation, CursorSpecification},
+    cursor::{
+        common::{CursorInformation, CursorSpecification},
+        NewCursor,
+    },
     operation::{Feature, OperationTarget},
 };
 #[cfg(feature = "in-use-encryption")]
@@ -21,11 +24,10 @@ use super::{options::ServerAddress, session::TransactionState, Client, ClientSes
 use crate::{
     bson::Document,
     change_stream::{
+        common::{ChangeStreamData, WatchArgs},
         event::ChangeStreamEvent,
         session::SessionChangeStream,
         ChangeStream,
-        ChangeStreamData,
-        WatchArgs,
     },
     cmap::{
         conn::{
@@ -312,7 +314,8 @@ impl Client {
             let (cursor_spec, cs_data) = details.output;
             let pinned =
                 self.pin_connection_for_cursor(&cursor_spec.info, &mut details.connection, None)?;
-            let cursor = Cursor::new(self.clone(), cursor_spec, details.implicit_session, pinned)?;
+            let cursor =
+                Cursor::generic_new(self.clone(), cursor_spec, details.implicit_session, pinned)?;
 
             Ok(ChangeStream::new(cursor, args, cs_data))
         })
@@ -348,7 +351,7 @@ impl Client {
                 &mut details.connection,
                 Some(session),
             )?;
-            let cursor = SessionCursor::new(self.clone(), cursor_spec, pinned)?;
+            let cursor = SessionCursor::generic_new(self.clone(), cursor_spec, None, pinned)?;
 
             Ok(SessionChangeStream::new(cursor, args, cs_data))
         })

--- a/driver/src/cmap/conn/pooled.rs
+++ b/driver/src/cmap/conn/pooled.rs
@@ -323,6 +323,7 @@ impl PooledConnection {
             reason,
             #[cfg(feature = "tracing-unstable")]
             error: self.connection.error.clone(),
+            service_id: self.service_id(),
         }
     }
 }

--- a/driver/src/cmap/worker.rs
+++ b/driver/src/cmap/worker.rs
@@ -716,6 +716,7 @@ async fn establish_connection(
                     connection_id,
                     #[cfg(feature = "tracing-unstable")]
                     error: Some(e.cause.clone()),
+                    service_id: None,
                 }
                 .into()
             });

--- a/driver/src/cursor/common.rs
+++ b/driver/src/cursor/common.rs
@@ -1,418 +1,17 @@
-use std::{
-    collections::VecDeque,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
+use std::{collections::VecDeque, time::Duration};
 
-use crate::{
-    bson::{RawDocument, RawDocumentBuf},
-    cmap::RawCommandResponse,
-};
-use derive_where::derive_where;
-use futures_core::{future::BoxFuture, Future};
 #[cfg(test)]
 use tokio::sync::oneshot;
 
 use crate::{
-    bson::{Bson, Document},
+    bson::{Bson, Document, RawDocument, RawDocumentBuf},
     change_stream::event::ResumeToken,
-    client::{session::ClientSession, AsyncDropToken},
     cmap::conn::PinnedConnectionHandle,
-    error::{Error, ErrorKind, Result},
-    operation::GetMore,
+    error::{Error, Result},
     options::ServerAddress,
-    results::GetMoreResult,
     Client,
     Namespace,
 };
-
-/// The result of one attempt to advance a cursor.
-pub(super) enum AdvanceResult {
-    /// The cursor was successfully advanced and the buffer has at least one item.
-    Advanced,
-    /// The cursor does not have any more items and will not return any more in the future.
-    Exhausted,
-    /// The cursor does not currently have any items, but future calls to getMore may yield more.
-    Waiting,
-}
-
-/// An internal cursor that can be used in a variety of contexts depending on its `GetMoreProvider`.
-#[derive_where(Debug)]
-pub(super) struct GenericCursor<'s, S> {
-    #[derive_where(skip)]
-    provider: GetMoreProvider<'s, S>,
-    client: Client,
-    info: CursorInformation,
-    /// This is an `Option` to allow it to be "taken" when the cursor is no longer needed
-    /// but may be resumed in the future for `SessionCursor`.
-    state: Option<CursorState>,
-}
-
-impl GenericCursor<'static, ImplicitClientSessionHandle> {
-    pub(super) fn with_implicit_session(
-        client: Client,
-        spec: CursorSpecification,
-        pinned_connection: PinnedConnection,
-        session: ImplicitClientSessionHandle,
-    ) -> Result<Self> {
-        let exhausted = spec.id() == 0;
-        Ok(Self {
-            client,
-            provider: if exhausted {
-                GetMoreProvider::Done
-            } else {
-                GetMoreProvider::Idle(Box::new(session))
-            },
-            info: spec.info,
-            state: Some(CursorState {
-                buffer: CursorBuffer::new(reply_batch(&spec.initial_reply)?),
-                exhausted,
-                post_batch_resume_token: None,
-                pinned_connection,
-            }),
-        })
-    }
-
-    /// Extracts the stored implicit [`ClientSession`], if any.
-    pub(super) fn take_implicit_session(&mut self) -> Option<ClientSession> {
-        self.provider.take_implicit_session()
-    }
-}
-
-impl<'s> GenericCursor<'s, ExplicitClientSessionHandle<'s>> {
-    pub(super) fn with_explicit_session(
-        state: CursorState,
-        client: Client,
-        info: CursorInformation,
-        session: ExplicitClientSessionHandle<'s>,
-    ) -> Self {
-        Self {
-            provider: GetMoreProvider::Idle(Box::new(session)),
-            client,
-            info,
-            state: state.into(),
-        }
-    }
-}
-
-impl<'s, S: ClientSessionHandle<'s>> GenericCursor<'s, S> {
-    pub(super) fn current(&self) -> Option<&RawDocument> {
-        self.state().buffer.current()
-    }
-
-    #[cfg(test)]
-    pub(super) fn current_batch(&self) -> &VecDeque<RawDocumentBuf> {
-        self.state().buffer.as_ref()
-    }
-
-    fn state_mut(&mut self) -> &mut CursorState {
-        self.state.as_mut().unwrap()
-    }
-
-    pub(super) fn state(&self) -> &CursorState {
-        self.state.as_ref().unwrap()
-    }
-
-    /// Attempt to advance the cursor forward to the next item. If there are no items cached
-    /// locally, perform getMores until the cursor is exhausted or the buffer has been refilled.
-    /// Return whether or not the cursor has been advanced.
-    pub(super) async fn advance(&mut self) -> Result<bool> {
-        loop {
-            match self.try_advance().await? {
-                AdvanceResult::Advanced => return Ok(true),
-                AdvanceResult::Exhausted => return Ok(false),
-                AdvanceResult::Waiting => continue,
-            }
-        }
-    }
-
-    /// Attempt to advance the cursor forward to the next item. If there are no items cached
-    /// locally, perform a single getMore to attempt to retrieve more.
-    pub(super) async fn try_advance(&mut self) -> Result<AdvanceResult> {
-        if self.state_mut().buffer.advance() {
-            return Ok(AdvanceResult::Advanced);
-        } else if self.is_exhausted() {
-            return Ok(AdvanceResult::Exhausted);
-        }
-
-        // If the buffer is empty but the cursor is not exhausted, perform a getMore.
-        let client = self.client.clone();
-        let spec = self.info.clone();
-        let pin = self.state().pinned_connection.replicate();
-
-        let result = self.provider.execute(spec, client, pin).await;
-        self.handle_get_more_result(result)?;
-
-        match self.state_mut().buffer.advance() {
-            true => Ok(AdvanceResult::Advanced),
-            false => {
-                if self.is_exhausted() {
-                    Ok(AdvanceResult::Exhausted)
-                } else {
-                    Ok(AdvanceResult::Waiting)
-                }
-            }
-        }
-    }
-
-    pub(super) fn take_state(&mut self) -> CursorState {
-        self.state.take().unwrap()
-    }
-
-    pub(super) fn is_exhausted(&self) -> bool {
-        self.state().exhausted
-    }
-
-    pub(super) fn id(&self) -> i64 {
-        self.info.id
-    }
-
-    pub(super) fn namespace(&self) -> &Namespace {
-        &self.info.ns
-    }
-
-    pub(super) fn address(&self) -> &ServerAddress {
-        &self.info.address
-    }
-
-    pub(super) fn pinned_connection(&self) -> &PinnedConnection {
-        &self.state().pinned_connection
-    }
-
-    pub(super) fn post_batch_resume_token(&self) -> Option<&ResumeToken> {
-        self.state().post_batch_resume_token.as_ref()
-    }
-
-    fn mark_exhausted(&mut self) {
-        self.state_mut().exhausted = true;
-        self.state_mut().pinned_connection = PinnedConnection::Unpinned;
-    }
-
-    fn handle_get_more_result(&mut self, get_more_result: Result<GetMoreResult>) -> Result<()> {
-        match get_more_result {
-            Ok(get_more) => {
-                if get_more.exhausted {
-                    self.mark_exhausted();
-                }
-                if get_more.id != 0 {
-                    self.info.id = get_more.id
-                }
-                self.info.ns = get_more.ns;
-                self.state_mut().buffer = CursorBuffer::new(reply_batch(&get_more.raw_reply)?);
-                self.state_mut().post_batch_resume_token = get_more.post_batch_resume_token;
-
-                Ok(())
-            }
-            Err(e) => {
-                if matches!(*e.kind, ErrorKind::Command(ref e) if e.code == 43 || e.code == 237) {
-                    self.mark_exhausted();
-                }
-
-                if e.is_network_error() {
-                    // Flag the connection as invalid, preventing a killCursors command,
-                    // but leave the connection pinned.
-                    self.state_mut().pinned_connection.invalidate();
-                }
-
-                Err(e)
-            }
-        }
-    }
-}
-
-pub(crate) trait CursorStream {
-    fn poll_next_in_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<BatchValue>>;
-}
-
-pub(crate) enum BatchValue {
-    Some { doc: RawDocumentBuf, is_last: bool },
-    Empty,
-    Exhausted,
-}
-
-impl<'s, S: ClientSessionHandle<'s>> CursorStream for GenericCursor<'s, S> {
-    fn poll_next_in_batch(&mut self, cx: &mut Context<'_>) -> Poll<Result<BatchValue>> {
-        // If there is a get more in flight, check on its status.
-        if let Some(future) = self.provider.executing_future() {
-            match Pin::new(future).poll(cx) {
-                // If a result is ready, retrieve the buffer and update the exhausted status.
-                Poll::Ready(get_more_result_and_session) => {
-                    let output = self.handle_get_more_result(get_more_result_and_session.result);
-                    self.provider.clear_execution(
-                        get_more_result_and_session.session,
-                        self.state().exhausted,
-                    );
-                    output?;
-                }
-                Poll::Pending => return Poll::Pending,
-            }
-        }
-
-        match self.state_mut().buffer.next() {
-            Some(doc) => {
-                let is_last = self.state().buffer.is_empty();
-
-                Poll::Ready(Ok(BatchValue::Some { doc, is_last }))
-            }
-            None if !self.state().exhausted && !self.state().pinned_connection.is_invalid() => {
-                let info = self.info.clone();
-                let client = self.client.clone();
-                let state = self.state.as_mut().unwrap();
-                self.provider
-                    .start_execution(info, client, state.pinned_connection.handle());
-                Poll::Ready(Ok(BatchValue::Empty))
-            }
-            None => Poll::Ready(Ok(BatchValue::Exhausted)),
-        }
-    }
-}
-
-// To avoid a private trait (`CursorStream`) in a public interface (`impl Stream`), this is provided
-// as a free function rather than a blanket impl.
-pub(crate) fn stream_poll_next<S, V>(this: &mut S, cx: &mut Context<'_>) -> Poll<Option<Result<V>>>
-where
-    S: CursorStream,
-    V: for<'a> serde::Deserialize<'a>,
-{
-    loop {
-        match this.poll_next_in_batch(cx) {
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(bv) => match bv? {
-                BatchValue::Some { doc, .. } => {
-                    return Poll::Ready(Some(Ok(crate::bson_compat::deserialize_from_slice(
-                        doc.as_bytes(),
-                    )?)))
-                }
-                BatchValue::Empty => continue,
-                BatchValue::Exhausted => return Poll::Ready(None),
-            },
-        }
-    }
-}
-
-pub(crate) struct NextInBatchFuture<'a, T>(&'a mut T);
-
-impl<'a, T> NextInBatchFuture<'a, T>
-where
-    T: CursorStream,
-{
-    pub(crate) fn new(stream: &'a mut T) -> Self {
-        Self(stream)
-    }
-}
-
-impl<C> Future for NextInBatchFuture<'_, C>
-where
-    C: CursorStream,
-{
-    type Output = Result<BatchValue>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.0.poll_next_in_batch(cx)
-    }
-}
-
-/// Provides batches of documents to a cursor via the `getMore` command.
-enum GetMoreProvider<'s, S> {
-    Executing(BoxFuture<'s, GetMoreResultAndSession<S>>),
-    // `Box` is used to make the size of `Idle` similar to that of the other variants.
-    Idle(Box<S>),
-    Done,
-}
-
-impl GetMoreProvider<'static, ImplicitClientSessionHandle> {
-    /// Extracts the stored implicit [`ClientSession`], if any.
-    /// The provider cannot be started again after this call.
-    fn take_implicit_session(&mut self) -> Option<ClientSession> {
-        match self {
-            Self::Idle(session) => session.take_implicit_session(),
-            Self::Executing(..) | Self::Done => None,
-        }
-    }
-}
-
-impl<'s, S: ClientSessionHandle<'s>> GetMoreProvider<'s, S> {
-    /// Get the future being evaluated, if there is one.
-    fn executing_future(&mut self) -> Option<&mut BoxFuture<'s, GetMoreResultAndSession<S>>> {
-        if let Self::Executing(future) = self {
-            Some(future)
-        } else {
-            None
-        }
-    }
-
-    /// Clear out any state remaining from previous `getMore` executions.
-    fn clear_execution(&mut self, session: S, exhausted: bool) {
-        if exhausted && session.is_implicit() {
-            *self = Self::Done
-        } else {
-            *self = Self::Idle(Box::new(session))
-        }
-    }
-
-    /// Start executing a new `getMore` if one is not already in flight.
-    fn start_execution(
-        &mut self,
-        info: CursorInformation,
-        client: Client,
-        pinned_connection: Option<&PinnedConnectionHandle>,
-    ) {
-        take_mut::take(self, |self_| {
-            if let Self::Idle(mut session) = self_ {
-                let pinned_connection = pinned_connection.map(|c| c.replicate());
-                let future = Box::pin(async move {
-                    let get_more = GetMore::new(info, pinned_connection.as_ref());
-                    let get_more_result = client
-                        .execute_operation(get_more, session.borrow_mut())
-                        .await;
-                    GetMoreResultAndSession {
-                        result: get_more_result,
-                        session: *session,
-                    }
-                });
-                Self::Executing(future)
-            } else {
-                self_
-            }
-        })
-    }
-
-    /// Return a future that will execute the `getMore` when polled.
-    /// This is useful in `async` functions that can `.await` the entire `getMore` process.
-    /// [`GetMoreProvider::start_execution`] and [`GetMoreProvider::clear_execution`]
-    /// should be used for contexts where the futures need to be [`poll`](Future::poll)ed manually.
-    fn execute(
-        &mut self,
-        info: CursorInformation,
-        client: Client,
-        pinned_connection: PinnedConnection,
-    ) -> BoxFuture<'_, Result<GetMoreResult>> {
-        match self {
-            Self::Idle(ref mut session) => Box::pin(async move {
-                let get_more = GetMore::new(info, pinned_connection.handle());
-                client
-                    .execute_operation(get_more, session.borrow_mut())
-                    .await
-            }),
-            Self::Executing(_fut) => Box::pin(async {
-                Err(Error::internal(
-                    "streaming the cursor was cancelled while a request was in progress and must \
-                     be continued before iterating manually",
-                ))
-            }),
-            Self::Done => {
-                // this should never happen
-                Box::pin(async { Err(Error::internal("cursor iterated after already exhausted")) })
-            }
-        }
-    }
-}
-
-struct GetMoreResultAndSession<S> {
-    result: Result<GetMoreResult>,
-    session: S,
-}
 
 /// Specification used to create a new cursor.
 #[derive(Debug, Clone)]
@@ -425,7 +24,7 @@ pub(crate) struct CursorSpecification {
 
 impl CursorSpecification {
     pub(crate) fn new(
-        response: RawCommandResponse,
+        response: crate::cmap::RawCommandResponse,
         address: ServerAddress,
         batch_size: impl Into<Option<u32>>,
         max_time: impl Into<Option<Duration>>,
@@ -456,6 +55,7 @@ impl CursorSpecification {
         })
     }
 
+    #[cfg(feature = "opentelemetry")]
     pub(crate) fn id(&self) -> i64 {
         self.info.id
     }
@@ -478,8 +78,7 @@ impl CursorReply {
             .get("postBatchResumeToken")?
             .and_then(crate::bson::RawBsonRef::as_document)
             .map(|d| d.to_owned());
-        let post_batch_resume_token =
-            crate::change_stream::event::ResumeToken::from_raw(post_token_raw);
+        let post_batch_resume_token = ResumeToken::from_raw(post_token_raw);
         Ok(Self {
             id,
             ns,
@@ -536,7 +135,7 @@ impl PinnedConnection {
         matches!(self, Self::Invalid(_))
     }
 
-    fn invalidate(&mut self) {
+    pub(super) fn invalidate(&mut self) {
         take_mut::take(self, |self_| {
             if let Self::Valid(c) = self_ {
                 Self::Invalid(c)
@@ -549,7 +148,7 @@ impl PinnedConnection {
 
 pub(super) fn kill_cursor(
     client: Client,
-    drop_token: &mut AsyncDropToken,
+    drop_token: &mut crate::client::AsyncDropToken,
     ns: &Namespace,
     cursor_id: i64,
     pinned_conn: PinnedConnection,
@@ -572,122 +171,6 @@ pub(super) fn kill_cursor(
     });
 }
 
-#[derive(Debug)]
-pub(crate) struct CursorState {
-    pub(crate) buffer: CursorBuffer,
-    pub(crate) exhausted: bool,
-    pub(crate) post_batch_resume_token: Option<ResumeToken>,
-    pub(crate) pinned_connection: PinnedConnection,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CursorBuffer {
-    docs: VecDeque<RawDocumentBuf>,
-    /// whether the buffer is at the front or not
-    fresh: bool,
-}
-
-impl CursorBuffer {
-    pub(crate) fn new(initial_buffer: VecDeque<RawDocumentBuf>) -> Self {
-        Self {
-            docs: initial_buffer,
-            fresh: true,
-        }
-    }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.docs.is_empty()
-    }
-
-    /// Removes and returns the document in the front of the buffer.
-    pub(crate) fn next(&mut self) -> Option<RawDocumentBuf> {
-        self.fresh = false;
-        self.docs.pop_front()
-    }
-
-    /// Advances the buffer to the next document. Returns whether there are any documents remaining
-    /// in the buffer after advancing.
-    pub(crate) fn advance(&mut self) -> bool {
-        // If at the front of the buffer, don't move forward as the first document hasn't been
-        // consumed yet.
-        if self.fresh {
-            self.fresh = false;
-        } else {
-            self.docs.pop_front();
-        }
-        !self.is_empty()
-    }
-
-    /// Returns the item at the front of the buffer, if there is one. This method does not change
-    /// the state of the buffer.
-    pub(crate) fn current(&self) -> Option<&RawDocument> {
-        self.docs.front().map(|d| d.as_ref())
-    }
-}
-
-impl AsRef<VecDeque<RawDocumentBuf>> for CursorBuffer {
-    fn as_ref(&self) -> &VecDeque<RawDocumentBuf> {
-        &self.docs
-    }
-}
-
-#[test]
-fn test_buffer() {
-    use crate::bson::rawdoc;
-
-    let queue: VecDeque<RawDocumentBuf> =
-        [rawdoc! { "x": 1 }, rawdoc! { "x": 2 }, rawdoc! { "x": 3 }].into();
-    let mut buffer = CursorBuffer::new(queue);
-
-    assert!(buffer.advance());
-    assert_eq!(buffer.current(), Some(rawdoc! { "x": 1 }.as_ref()));
-
-    assert!(buffer.advance());
-    assert_eq!(buffer.current(), Some(rawdoc! { "x": 2 }.as_ref()));
-
-    assert!(buffer.advance());
-    assert_eq!(buffer.current(), Some(rawdoc! { "x": 3 }.as_ref()));
-
-    assert!(!buffer.advance());
-    assert_eq!(buffer.current(), None);
-}
-
-pub(super) struct ImplicitClientSessionHandle(pub(super) Option<ClientSession>);
-
-impl ImplicitClientSessionHandle {
-    fn take_implicit_session(&mut self) -> Option<ClientSession> {
-        self.0.take()
-    }
-}
-
-impl ClientSessionHandle<'_> for ImplicitClientSessionHandle {
-    fn is_implicit(&self) -> bool {
-        true
-    }
-
-    fn borrow_mut(&mut self) -> Option<&mut ClientSession> {
-        self.0.as_mut()
-    }
-}
-
-pub(super) struct ExplicitClientSessionHandle<'a>(pub(super) &'a mut ClientSession);
-
-impl<'a> ClientSessionHandle<'a> for ExplicitClientSessionHandle<'a> {
-    fn is_implicit(&self) -> bool {
-        false
-    }
-
-    fn borrow_mut(&mut self) -> Option<&mut ClientSession> {
-        Some(self.0)
-    }
-}
-
-pub(super) trait ClientSessionHandle<'a>: Send + 'a {
-    fn is_implicit(&self) -> bool;
-
-    fn borrow_mut(&mut self) -> Option<&mut ClientSession>;
-}
-
 pub(crate) fn reply_batch(
     reply: &RawDocument,
 ) -> Result<VecDeque<crate::bson::raw::RawDocumentBuf>> {
@@ -700,16 +183,11 @@ pub(crate) fn reply_batch(
     };
     let mut out = VecDeque::new();
     for elt in docs {
-        let elt = elt?;
-        let doc = match elt.as_document() {
-            Some(doc) => doc.to_owned(),
-            None => {
-                return Err(crate::error::Error::invalid_response(
-                    "invalid batch element",
-                ))
-            }
-        };
-        out.push_back(doc);
+        out.push_back(
+            elt?.as_document()
+                .ok_or_else(|| Error::invalid_response("invalid cursor batch item"))?
+                .to_owned(),
+        );
     }
     Ok(out)
 }

--- a/driver/src/cursor/stream.rs
+++ b/driver/src/cursor/stream.rs
@@ -1,0 +1,226 @@
+use std::{collections::VecDeque, task::Poll};
+
+use derive_where::derive_where;
+use futures_core::Stream as AsyncStream;
+use futures_util::{stream::StreamExt, FutureExt};
+use serde::{de::DeserializeOwned, Deserialize};
+
+use crate::{
+    bson::{RawDocument, RawDocumentBuf},
+    error::{Error, Result},
+    BoxFuture,
+};
+
+use super::raw_batch::RawBatch;
+
+/// `Stream` represents an "introspectable" cursor stream - an implementation of an async `Stream`
+/// with a buffer that's available for external use when the stream isn't actively being polled.
+///
+/// If the buffer *is* queried during a poll, it will cause a panic.  This will only happen if a
+/// future is dropped without being fully polled, which is documented as unsupported by the driver.
+#[derive_where(Debug)]
+pub(super) struct Stream<'a, Raw, T> {
+    state: StreamState<'a, Raw>,
+    _phantom: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<'a, Raw, T> Stream<'a, Raw, T> {
+    pub(super) fn new(raw: Raw) -> Self {
+        Self::from_cursor(BatchBuffer::new(raw))
+    }
+
+    pub(super) fn from_cursor(cs: BatchBuffer<Raw>) -> Self {
+        Self {
+            state: StreamState::Idle(cs),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub(super) fn buffer(&self) -> &BatchBuffer<Raw> {
+        match &self.state {
+            StreamState::Idle(state) => state,
+            _ => panic!("state access while streaming"),
+        }
+    }
+
+    pub(super) fn buffer_mut(&mut self) -> &mut BatchBuffer<Raw> {
+        match &mut self.state {
+            StreamState::Idle(state) => state,
+            _ => panic!("state access while streaming"),
+        }
+    }
+
+    pub(super) fn take_buffer(&mut self) -> BatchBuffer<Raw> {
+        match std::mem::replace(&mut self.state, StreamState::Polling) {
+            StreamState::Idle(state) => state,
+            _ => panic!("state access while streaming"),
+        }
+    }
+
+    pub(super) fn with_type<D>(self) -> Stream<'a, Raw, D> {
+        Stream {
+            state: self.state,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[derive_where(Debug)]
+enum StreamState<'a, Raw> {
+    Idle(BatchBuffer<Raw>),
+    Polling,
+    Advance(#[derive_where(skip)] BoxFuture<'a, AdvanceDone<Raw>>),
+}
+
+#[derive_where(Debug)]
+struct AdvanceDone<Raw> {
+    buffer: BatchBuffer<Raw>,
+    out: Result<bool>,
+}
+
+#[derive_where(Debug)]
+pub(super) struct BatchBuffer<Raw> {
+    #[derive_where(skip)]
+    pub(super) raw: Raw,
+    batch: VecDeque<RawDocumentBuf>,
+}
+
+impl<Raw> BatchBuffer<Raw> {
+    pub(super) fn new(raw: Raw) -> Self {
+        Self {
+            raw,
+            batch: VecDeque::new(),
+        }
+    }
+
+    pub(super) fn current(&self) -> &RawDocument {
+        self.batch.front().unwrap()
+    }
+
+    pub(super) fn deserialize_current<'a, V>(&'a self) -> Result<V>
+    where
+        V: Deserialize<'a>,
+    {
+        crate::bson_compat::deserialize_from_slice(self.current().as_bytes()).map_err(Error::from)
+    }
+
+    pub(super) fn map<G>(self, f: impl FnOnce(Raw) -> G) -> BatchBuffer<G> {
+        BatchBuffer {
+            raw: f(self.raw),
+            batch: self.batch,
+        }
+    }
+
+    pub(crate) fn batch(&self) -> &VecDeque<RawDocumentBuf> {
+        &self.batch
+    }
+}
+
+impl<Raw: AsyncStream<Item = Result<RawBatch>> + Unpin> BatchBuffer<Raw> {
+    /// Attempt to advance the cursor forward to the next item. If there are no items cached
+    /// locally, perform getMores until the cursor is exhausted or the buffer has been refilled.
+    /// Return whether or not the cursor has been advanced.
+    pub(super) async fn advance(&mut self) -> Result<bool> {
+        loop {
+            match self.advance_internal().await? {
+                AdvanceResult::Advanced => return Ok(true),
+                AdvanceResult::Exhausted => return Ok(false),
+                AdvanceResult::Waiting => continue,
+            }
+        }
+    }
+
+    /// Attempt to advance the cursor forward to the next item. If there are no items cached
+    /// locally, perform a single getMore to attempt to retrieve more.
+    pub(super) async fn try_advance(&mut self) -> Result<bool> {
+        self.advance_internal()
+            .await
+            .map(|ar| matches!(ar, AdvanceResult::Advanced))
+    }
+
+    async fn advance_internal(&mut self) -> Result<AdvanceResult> {
+        // Next stored batch item
+        self.batch.pop_front();
+        if !self.batch.is_empty() {
+            return Ok(AdvanceResult::Advanced);
+        }
+
+        // Batch is empty, need a new one
+        let Some(raw_batch) = self.raw.next().await else {
+            return Ok(AdvanceResult::Exhausted);
+        };
+        let raw_batch = raw_batch?;
+        for item in raw_batch.doc_slices()? {
+            self.batch.push_back(
+                item?
+                    .as_document()
+                    .ok_or_else(|| Error::invalid_response("invalid cursor batch item"))?
+                    .to_owned(),
+            );
+        }
+        return Ok(if self.batch.is_empty() {
+            AdvanceResult::Waiting
+        } else {
+            AdvanceResult::Advanced
+        });
+    }
+}
+
+/// The result of one attempt to advance a cursor.
+#[derive(Debug)]
+enum AdvanceResult {
+    /// The cursor was successfully advanced and the buffer has at least one item.
+    Advanced,
+    /// The cursor does not have any more items and will not return any more in the future.
+    Exhausted,
+    /// The cursor does not currently have any items, but future calls to getMore may yield more.
+    Waiting,
+}
+
+impl<'a, Raw: 'a + AsyncStream<Item = Result<RawBatch>> + Send + Unpin, T: DeserializeOwned>
+    AsyncStream for Stream<'a, Raw, T>
+{
+    type Item = Result<T>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        loop {
+            match std::mem::replace(&mut self.state, StreamState::Polling) {
+                StreamState::Idle(mut buffer) => {
+                    self.state = StreamState::Advance(
+                        async move {
+                            let out = buffer.advance().await;
+                            AdvanceDone { buffer, out }
+                        }
+                        .boxed(),
+                    );
+                    continue;
+                }
+                StreamState::Advance(mut fut) => {
+                    return match fut.poll_unpin(cx) {
+                        Poll::Pending => {
+                            self.state = StreamState::Advance(fut);
+                            Poll::Pending
+                        }
+                        Poll::Ready(ar) => {
+                            let out = match ar.out {
+                                Err(e) => Some(Err(e)),
+                                Ok(false) => None,
+                                Ok(true) => Some(ar.buffer.deserialize_current()),
+                            };
+                            self.state = StreamState::Idle(ar.buffer);
+                            return Poll::Ready(out);
+                        }
+                    }
+                }
+                StreamState::Polling => {
+                    return Poll::Ready(Some(Err(Error::internal(
+                        "attempt to poll cursor already in polling state",
+                    ))))
+                }
+            }
+        }
+    }
+}

--- a/driver/src/cursor/sync.rs
+++ b/driver/src/cursor/sync.rs
@@ -1,13 +1,15 @@
 use futures_util::stream::StreamExt;
 use serde::de::{Deserialize, DeserializeOwned};
 
-use super::ClientSession;
 use crate::{
     bson::{Document, RawDocument},
     error::Result,
+    sync::ClientSession,
+};
+
+use super::{
+    session::{SessionCursor as AsyncSessionCursor, SessionCursorStream},
     Cursor as AsyncCursor,
-    SessionCursor as AsyncSessionCursor,
-    SessionCursorStream,
 };
 
 /// A `Cursor` streams the result of a query. When a query is made, a `Cursor` will be returned with
@@ -354,9 +356,10 @@ where
     async_stream: SessionCursorStream<'cursor, 'session, T>,
 }
 
-impl<T> Iterator for SessionCursorIter<'_, '_, T>
+impl<'cursor, 'session, T> Iterator for SessionCursorIter<'cursor, 'session, T>
 where
     T: DeserializeOwned + Unpin + Send + Sync,
+    'session: 'cursor,
 {
     type Item = Result<T>;
 

--- a/driver/src/event/cmap.rs
+++ b/driver/src/event/cmap.rs
@@ -176,6 +176,8 @@ pub struct ConnectionClosedEvent {
     #[serde(skip)]
     #[derive_where(skip)]
     pub(crate) error: Option<crate::error::Error>,
+
+    pub(crate) service_id: Option<ObjectId>,
 }
 
 /// The reasons that a connection may be closed.

--- a/driver/src/operation/aggregate.rs
+++ b/driver/src/operation/aggregate.rs
@@ -5,7 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     error::Result,
     operation::{append_options, OperationTarget, Retryability},
     options::{AggregateOptions, ReadPreference, SelectionCriteria, WriteConcern},

--- a/driver/src/operation/aggregate/change_stream.rs
+++ b/driver/src/operation/aggregate/change_stream.rs
@@ -1,8 +1,11 @@
 use crate::{
     bson::{doc, Document},
-    change_stream::{event::ResumeToken, ChangeStreamData, WatchArgs},
+    change_stream::{
+        common::{ChangeStreamData, WatchArgs},
+        event::ResumeToken,
+    },
     cmap::{Command, RawCommandResponse, StreamDescription},
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     error::Result,
     operation::{append_options, ExecutionContext, Operation, Retryability},
     options::{ChangeStreamOptions, SelectionCriteria, WriteConcern},

--- a/driver/src/operation/find.rs
+++ b/driver/src/operation/find.rs
@@ -2,7 +2,7 @@ use crate::{
     bson::{rawdoc, Document, RawDocumentBuf},
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     error::{Error, Result},
     operation::{OperationWithDefaults, Retryability, SERVER_4_4_0_WIRE_VERSION},
     options::{CursorType, FindOptions, SelectionCriteria},

--- a/driver/src/operation/get_more.rs
+++ b/driver/src/operation/get_more.rs
@@ -5,7 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     checked::Checked,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
-    cursor::{CursorInformation, CursorReply},
+    cursor::common::{CursorInformation, CursorReply},
     error::Result,
     operation::OperationWithDefaults,
     options::SelectionCriteria,

--- a/driver/src/operation/list_collections.rs
+++ b/driver/src/operation/list_collections.rs
@@ -2,7 +2,7 @@ use crate::{
     bson::rawdoc,
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     error::Result,
     operation::{OperationWithDefaults, Retryability},
     options::{ListCollectionsOptions, ReadPreference, SelectionCriteria},

--- a/driver/src/operation/list_indexes.rs
+++ b/driver/src/operation/list_indexes.rs
@@ -3,7 +3,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     checked::Checked,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     error::Result,
     operation::OperationWithDefaults,
     options::ListIndexesOptions,

--- a/driver/src/operation/run_cursor_command.rs
+++ b/driver/src/operation/run_cursor_command.rs
@@ -4,7 +4,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     concern::WriteConcern,
-    cursor::CursorSpecification,
+    cursor::common::CursorSpecification,
     error::{Error, Result},
     operation::{run_command::RunCommand, Operation, SERVER_4_4_0_WIRE_VERSION},
     options::{RunCursorCommandOptions, SelectionCriteria},

--- a/driver/src/sync.rs
+++ b/driver/src/sync.rs
@@ -3,17 +3,16 @@
 mod change_stream;
 mod client;
 mod coll;
-mod cursor;
 mod db;
 pub mod gridfs;
 
 #[cfg(test)]
 mod test;
 
+pub use crate::cursor::sync::{Cursor, SessionCursor, SessionCursorIter};
 pub use change_stream::{ChangeStream, SessionChangeStream};
 pub use client::{session::ClientSession, Client};
 pub use coll::Collection;
-pub use cursor::{Cursor, SessionCursor, SessionCursorIter};
 pub use db::Database;
 
 #[cfg(feature = "sync")]

--- a/driver/src/test/client.rs
+++ b/driver/src/test/client.rs
@@ -861,6 +861,8 @@ async fn find_one_and_delete_serde_consistency() {
         .database("find_one_and_delete_serde_consistency")
         .collection("test");
 
+    coll.drop().await.unwrap();
+
     #[derive(Debug, Serialize, Deserialize)]
     struct Foo {
         #[serde(with = "serde_hex::SerHexSeq::<serde_hex::StrictPfx>")]

--- a/driver/src/test/spec/unified_runner/entity.rs
+++ b/driver/src/test/spec/unified_runner/entity.rs
@@ -101,12 +101,12 @@ impl TestCursor {
         match self {
             Self::Normal(cursor) => {
                 let (tx, rx) = oneshot::channel();
-                cursor.lock().await.set_kill_watcher(tx);
+                cursor.lock().await.raw_mut().set_kill_watcher(tx);
                 rx
             }
             Self::Session { cursor, .. } => {
                 let (tx, rx) = oneshot::channel();
-                cursor.set_kill_watcher(tx);
+                cursor.raw_mut().set_kill_watcher(tx);
                 rx
             }
             Self::ChangeStream(stream) => {
@@ -509,8 +509,10 @@ impl Entity {
             Entity::Session(session) => Some(session.client().topology().id),
             Entity::Bucket(bucket) => Some(bucket.client().topology().id),
             Entity::Cursor(cursor) => match cursor {
-                TestCursor::Normal(cursor) => Some(cursor.lock().await.client().topology().id),
-                TestCursor::Session { cursor, .. } => Some(cursor.client().topology().id),
+                TestCursor::Normal(cursor) => {
+                    Some(cursor.lock().await.raw().client().topology().id)
+                }
+                TestCursor::Session { cursor, .. } => Some(cursor.raw().client().topology().id),
                 TestCursor::ChangeStream(cs) => Some(cs.lock().await.client().topology().id),
                 TestCursor::Closed => None,
             },


### PR DESCRIPTION
RUST-2324

This uses `RawBatchCursor` to handle the underlying commands and batch fetches, `Cursor` to break up those batches into buffers and iterate over individual items, and `ChangeStream` to handle resume tokens and automatic resume.  The code in each layer is (subjectively) simpler and easier to understand in isolation, and (objectively) has much less duplication of functionality.