### PR TITLE
RUST-2347 Revert change to matcher behavior re. null/unset

### DIFF
--- a/driver/src/change_stream/event.rs
+++ b/driver/src/change_stream/event.rs
@@ -2,12 +2,16 @@
 #[cfg(test)]
 use std::convert::TryInto;
 
-use crate::{cursor::CursorSpecification, options::ChangeStreamOptions};
-
-use crate::bson::{DateTime, Document, RawBson, RawDocumentBuf, Timestamp};
 #[cfg(test)]
 use crate::{bson::Bson, bson_compat::RawError};
+use crate::{
+    bson::{DateTime, Document, RawBson, RawDocumentBuf, Timestamp},
+    cursor::CursorSpecification,
+    options::ChangeStreamOptions,
+};
+
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 /// An opaque token used for resuming an interrupted
 /// [`ChangeStream`](crate::change_stream::ChangeStream).
@@ -50,6 +54,7 @@ impl ResumeToken {
 
 /// A `ChangeStreamEvent` represents a
 /// [change event](https://www.mongodb.com/docs/manual/reference/change-events/) in the associated change stream.
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]

--- a/driver/src/test/spec/unified_runner/matcher.rs
+++ b/driver/src/test/spec/unified_runner/matcher.rs
@@ -462,7 +462,6 @@ fn results_match_inner(
         },
         _ => match actual {
             Some(actual) => match_eq(actual, expected),
-            None if *expected == Bson::Null => Ok(()),
             None => Err(format!("expected {expected:?}, got None")),
         },
     }
@@ -497,14 +496,7 @@ fn special_operator_matches(
     entities: Option<&EntityMap>,
 ) -> Result<(), String> {
     match key.as_ref() {
-        "$$exists" => {
-            let expected = value.as_bool().unwrap();
-            // Allow `Some(Bson::Null)` to count as not existing
-            if !expected && actual == Some(&Bson::Null) {
-                return Ok(());
-            }
-            match_eq(&actual.is_some(), &expected)
-        }
+        "$$exists" => match_eq(&actual.is_some(), &value.as_bool().unwrap()),
         "$$type" => {
             if let Some(actual) = actual {
                 type_matches(value, actual)

--- a/driver/src/test/spec/unified_runner/operation.rs
+++ b/driver/src/test/spec/unified_runner/operation.rs
@@ -509,12 +509,17 @@ impl TestOperation for CreateChangeStream {
                 }
                 _ => panic!("Invalid entity for createChangeStream"),
             };
-            // These particular tests require unknown fields to be passed through to the result.
+
             let tcs = if [
+                // These tests require unknown fields to be passed through to the result.
                 "Test newField added in response MUST NOT err",
                 "Test new structure in ns document MUST NOT err",
                 "Test modified structure in ns document MUST NOT err",
                 "Test projection in change stream returns expected fields",
+                // These tests require that a field set to null be passed through as null rather
+                // than unset.
+                "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+                "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled",
             ]
             .contains(&description)
             {


### PR DESCRIPTION
RUST-2347

This reverts the change from #1598 that allowed `null` to count as unset and vice versa.  It turns out that the spec is [specific](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.md#exists) on this point; this change was also masking a failure in the change stream tests.

This also adds the two tests that motivated that change to the "parse change stream events as untyped documents" list.  Those tests specifically look for a field to match `null` rather than being unset; the Rust driver doesn't preserve that information in the bson -> struct -> bson pipeline since both states are represented as `None` and it would be a hassle and maybe a breaking change to fix that.