### PR TITLE
minor: use ready! macro in poll impls

### DIFF
--- a/driver/src/cursor/raw_batch.rs
+++ b/driver/src/cursor/raw_batch.rs
@@ -41,7 +41,7 @@
 
 use std::{
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use crate::{
@@ -227,44 +227,40 @@ impl Stream for RawBatchCursor {
         loop {
             // If a getMore is in flight, poll it and update state.
             if let Some(future) = self.state.provider.executing_future() {
-                match Pin::new(future).poll(cx) {
-                    Poll::Pending => return Poll::Pending,
-                    Poll::Ready(get_more_out) => {
-                        match get_more_out.result {
-                            Ok(out) => {
-                                self.state.initial_reply = Some(out.raw_reply);
-                                self.state.post_batch_resume_token = out.post_batch_resume_token;
-                                if out.exhausted {
-                                    self.mark_exhausted();
-                                }
-                                if out.id != 0 {
-                                    self.info.id = out.id;
-                                }
-                                self.info.ns = out.ns;
-                            }
-                            Err(e) => {
-                                if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
-                                {
-                                    self.mark_exhausted();
-                                }
-                                if e.is_network_error() {
-                                    // Flag the connection as invalid, preventing a killCursors
-                                    // command, but leave the connection pinned.
-                                    self.state.pinned_connection.invalidate();
-                                }
-                                let exhausted_now = self.state.exhausted;
-                                self.state
-                                    .provider
-                                    .clear_execution(get_more_out.session, exhausted_now);
-                                return Poll::Ready(Some(Err(e)));
-                            }
+                let get_more_out = ready!(Pin::new(future).poll(cx));
+                match get_more_out.result {
+                    Ok(out) => {
+                        self.state.initial_reply = Some(out.raw_reply);
+                        self.state.post_batch_resume_token = out.post_batch_resume_token;
+                        if out.exhausted {
+                            self.mark_exhausted();
+                        }
+                        if out.id != 0 {
+                            self.info.id = out.id;
+                        }
+                        self.info.ns = out.ns;
+                    }
+                    Err(e) => {
+                        if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
+                        {
+                            self.mark_exhausted();
+                        }
+                        if e.is_network_error() {
+                            // Flag the connection as invalid, preventing a killCursors
+                            // command, but leave the connection pinned.
+                            self.state.pinned_connection.invalidate();
                         }
                         let exhausted_now = self.state.exhausted;
                         self.state
                             .provider
                             .clear_execution(get_more_out.session, exhausted_now);
+                        return Poll::Ready(Some(Err(e)));
                     }
                 }
+                let exhausted_now = self.state.exhausted;
+                self.state
+                    .provider
+                    .clear_execution(get_more_out.session, exhausted_now);
             }
 
             // Yield any buffered reply.
@@ -435,43 +431,39 @@ impl Stream for SessionRawBatchCursorStream<'_, '_> {
         loop {
             // If a getMore is in flight, poll it and update state.
             if let Some(future) = self.provider.executing_future() {
-                match Pin::new(future).poll(cx) {
-                    Poll::Pending => return Poll::Pending,
-                    Poll::Ready(get_more_out) => {
-                        match get_more_out.result {
-                            Ok(out) => {
-                                if out.exhausted {
-                                    self.parent.mark_exhausted();
-                                }
-                                if out.id != 0 {
-                                    self.parent.info.id = out.id;
-                                }
-                                self.parent.info.ns = out.ns;
-                                self.parent.post_batch_resume_token = out.post_batch_resume_token;
-                                // Buffer next reply to yield on following polls.
-                                self.parent.buffered_reply = Some(out.raw_reply);
-                            }
-                            Err(e) => {
-                                if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
-                                {
-                                    self.parent.mark_exhausted();
-                                }
-                                if e.is_network_error() {
-                                    // Flag the connection as invalid, preventing a killCursors
-                                    // command, but leave the connection pinned.
-                                    self.parent.pinned_connection.invalidate();
-                                }
-                                let exhausted_now = self.parent.exhausted;
-                                self.provider
-                                    .clear_execution(get_more_out.session, exhausted_now);
-                                return Poll::Ready(Some(Err(e)));
-                            }
+                let get_more_out = ready!(Pin::new(future).poll(cx));
+                match get_more_out.result {
+                    Ok(out) => {
+                        if out.exhausted {
+                            self.parent.mark_exhausted();
+                        }
+                        if out.id != 0 {
+                            self.parent.info.id = out.id;
+                        }
+                        self.parent.info.ns = out.ns;
+                        self.parent.post_batch_resume_token = out.post_batch_resume_token;
+                        // Buffer next reply to yield on following polls.
+                        self.parent.buffered_reply = Some(out.raw_reply);
+                    }
+                    Err(e) => {
+                        if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
+                        {
+                            self.parent.mark_exhausted();
+                        }
+                        if e.is_network_error() {
+                            // Flag the connection as invalid, preventing a killCursors
+                            // command, but leave the connection pinned.
+                            self.parent.pinned_connection.invalidate();
                         }
                         let exhausted_now = self.parent.exhausted;
                         self.provider
                             .clear_execution(get_more_out.session, exhausted_now);
+                        return Poll::Ready(Some(Err(e)));
                     }
                 }
+                let exhausted_now = self.parent.exhausted;
+                self.provider
+                    .clear_execution(get_more_out.session, exhausted_now);
             }
 
             // Yield any buffered reply.

--- a/driver/src/gridfs/download.rs
+++ b/driver/src/gridfs/download.rs
@@ -1,7 +1,7 @@
 use std::{
     ops::Range,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use futures_util::{
@@ -145,17 +145,10 @@ impl AsyncRead for GridFsDownloadStream {
                         .boxed(),
                     );
 
-                    match new_future.poll_unpin(cx) {
-                        Poll::Ready(result) => result,
-                        Poll::Pending => return Poll::Pending,
-                    }
+                    ready!(new_future.poll_unpin(cx))
                 }
             }
-
-            State::Busy(future) => match future.poll_unpin(cx) {
-                Poll::Ready(result) => result,
-                Poll::Pending => return Poll::Pending,
-            },
+            State::Busy(future) => ready!(future.poll_unpin(cx)),
             State::Done => return Poll::Ready(Ok(0)),
         };
 

--- a/driver/src/gridfs/upload.rs
+++ b/driver/src/gridfs/upload.rs
@@ -1,7 +1,7 @@
 use std::{
     pin::Pin,
     sync::atomic::Ordering,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use futures_util::{
@@ -303,12 +303,7 @@ impl AsyncWrite for GridFsUploadStream {
             State::Closing(_) | State::Closed => return Poll::Ready(Err(get_closed_error())),
         };
 
-        let result = match future.poll_unpin(cx) {
-            Poll::Ready(result) => result,
-            Poll::Pending => return Poll::Pending,
-        };
-
-        match result {
+        match ready!(future.poll_unpin(cx)) {
             Ok((chunks_written, buffer)) => {
                 stream.current_n += chunks_written;
                 stream.state = State::Idle(Some(buffer));
@@ -364,11 +359,7 @@ impl AsyncWrite for GridFsUploadStream {
             State::Closed => return Poll::Ready(Err(get_closed_error())),
         };
 
-        let result = match future.poll_unpin(cx) {
-            Poll::Ready(result) => result,
-            Poll::Pending => return Poll::Pending,
-        };
-
+        let result = ready!(future.poll_unpin(cx));
         stream.state = State::Closed;
         match result {
             Ok(()) => Poll::Ready(Ok(())),

--- a/driver/src/runtime/acknowledged_message.rs
+++ b/driver/src/runtime/acknowledged_message.rs
@@ -72,9 +72,8 @@ impl<R> Future for AcknowledgmentReceiver<R> {
     type Output = Option<R>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
-        match Pin::new(&mut self.get_mut().receiver).poll(cx) {
-            Poll::Ready(r) => Poll::Ready(r.ok()),
-            Poll::Pending => Poll::Pending,
-        }
+        Pin::new(&mut self.get_mut().receiver)
+            .poll(cx)
+            .map(Result::ok)
     }
 }


### PR DESCRIPTION
Found this handy macro to propagate `Poll::Pending` status similar to `Result::Err`, it makes manual `poll` implementations a little easier to read.