### PR TITLE
RUST-2351 unskip BSON size limit tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -358,6 +358,7 @@ buildvariants:
 
   - name: in-use-encryption-disable-crypt-shared
     display_name: "In-Use Encryption (disable crypt_shared)"
+    patchable: false
     run_on:
       - rhel8-latest-small
     expansions:


### PR DESCRIPTION
Patch build: https://spruce.corp.mongodb.com/version/69b4539782ac400007427fab/

Reverts skips added in https://github.com/mongodb/mongo-rust-driver/pull/1604 since SERVER-118428 is now released.