### PR TITLE
RUST-2275 Update change streams spec test

### DIFF
--- a/driver/src/change_stream/event.rs
+++ b/driver/src/change_stream/event.rs
@@ -129,6 +129,7 @@ pub struct ChangeStreamEvent<T> {
 }
 
 /// Describes which fields have been updated or removed from a document.
+#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]

--- a/spec/change-streams/README.md
+++ b/spec/change-streams/README.md
@@ -56,7 +56,7 @@ Each YAML file has the following keys:
 The definition of MATCH or MATCHES in the Spec Test Runner is as follows:
 
 - MATCH takes two values, `expected` and `actual`
-- Notation is "Assert \[actual\] MATCHES \[expected\]
+- Notation is "Assert [actual] MATCHES [expected]
 - Assertion passes if `expected` is a subset of `actual`, with the value `42` acting as placeholders for "any value"
 
 Pseudocode implementation of `actual` MATCHES `expected`:
@@ -167,7 +167,7 @@ and sharded clusters unless otherwise specified:
 
 1. `ChangeStream` must continuously track the last seen `resumeToken`
 
-2. `ChangeStream` will throw an exception if the server response is missing the resume token (if wire version is \< 8,
+2. `ChangeStream` will throw an exception if the server response is missing the resume token (if wire version is < 8,
     this is a driver-side error; for 8+, this is a server-side error)
 
 3. After receiving a `resumeToken`, `ChangeStream` will automatically resume one time on a resumable error with the
@@ -194,23 +194,13 @@ and sharded clusters unless otherwise specified:
 
 11. For a `ChangeStream` under these conditions:
 
-    - Running against a server `>=4.0.7`.
     - The batch is empty or has been iterated to the last document.
 
     Expected result:
 
     - `getResumeToken` must return the `postBatchResumeToken` from the current command response.
 
-12. For a `ChangeStream` under these conditions:
-
-    - Running against a server `<4.0.7`.
-    - The batch is empty or has been iterated to the last document.
-
-    Expected result:
-
-    - `getResumeToken` must return the `_id` of the last document returned if one exists.
-    - `getResumeToken` must return `resumeAfter` from the initial aggregate if the option was specified.
-    - If `resumeAfter` was not specified, the `getResumeToken` result must be empty.
+12. **Removed**
 
 13. For a `ChangeStream` under these conditions:
 

--- a/spec/change-streams/unified/change-streams-disambiguatedPaths.json
+++ b/spec/change-streams/unified/change-streams-disambiguatedPaths.json
@@ -43,6 +43,91 @@
   ],
   "tests": [
     {
+      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.1.0",
+          "maxServerVersion": "8.1.99",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        },
+        {
+          "minServerVersion": "8.2.1",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "$$exists": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
       "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
       "operations": [
         {

--- a/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
+++ b/spec/change-streams/unified/change-streams-disambiguatedPaths.yml
@@ -24,6 +24,41 @@ initialData:
     documents: []
 
 tests:
+  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
+    # skip server version 8.2.0, which emits disambiguatedPaths unconditionally
+    runOnRequirements:
+      - minServerVersion: "6.1.0"
+        maxServerVersion: "8.1.99"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+      - minServerVersion: "8.2.1"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { $$exists: false }
+
   - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
     operations:
       - name: insertOne


### PR DESCRIPTION
RUST-2275

This required adding `#[skip_serializing_none]` to the relevant struct, which we probably should have had there in the first place; otherwise the test fails because `None` gets interpreted as bson `null`, which is different from "field not present".