### PR TITLE
minor: update fastrand dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"


### PR DESCRIPTION
cargo-deny flagged the version we had pinned as yanked.