### PR TITLE
RUST-2386 Fix EC2 auth test

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -237,11 +237,21 @@ buildvariants:
     display_name: "AWS Authentication"
     patchable: false
     run_on:
+      - rhel8-latest-small
+    expansions:
+      ORCHESTRATION_FILE: auth-aws.json
+    tasks:
+      - .aws-auth !test-aws-auth-ecs
+
+  - name: aws-auth-ecs
+    display_name: "AWS Authentication (ECS)"
+    patchable: false
+    run_on:
       - ubuntu2404-small
     expansions:
       ORCHESTRATION_FILE: auth-aws.json
     tasks:
-      - .aws-auth
+      - test-aws-auth-ecs
 
   - name: azure-kms
     display_name: "Azure KMS"


### PR DESCRIPTION
RUST-2386

[Passing run](https://spruce.corp.mongodb.com/version/69d8c8b6afd01a0007009a0b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

Turns out that it fails if run on ubuntu.  Why?  No idea.

The ECS test, on the other hand, _has_ to continue to run on ubuntu because one of the evergreen-tools scripts for it requires that, so it gets its own variant.

This doesn't fix the failing lambda test; that one has the same issue no matter the host's linux distro.