### PR TITLE
RUST-2397 fix semgrep check

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -62,9 +62,9 @@ buildvariants:
   - name: lint
     display_name: "Lint"
     run_on:
-      - rhel8-latest-small
+      - ubuntu2404-small
     expansions:
-      LIBMONGOCRYPT_OS: rhel-80-64-bit
+      LIBMONGOCRYPT_OS: ubuntu2404-64
     tasks:
       - name: .lint
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -64,7 +64,7 @@ buildvariants:
     run_on:
       - ubuntu2404-small
     expansions:
-      LIBMONGOCRYPT_OS: ubuntu2404-64
+      LIBMONGOCRYPT_OS: ubuntu2204-64
     tasks:
       - name: .lint
 


### PR DESCRIPTION
RUST-2397

It turns out that [semgrep 1.158.0](https://github.com/semgrep/semgrep/releases/tag/v1.158.0), released on Friday, introduced a new requirement on glibc >=2.35; RHEL8 doesn't satisfy this requirement.  RHEL10 does, but we don't have evergreen test hosts for that yet AFAICT.