### PR TITLE
RUST-2405 listIndexes returns root documents

### DIFF
--- a/driver/src/runtime.rs
+++ b/driver/src/runtime.rs
@@ -57,13 +57,6 @@ compile_error!(
     "At least one of the features 'rustls-tls', 'rustls-tls-aws-lc' or 'openssl-tls' must be \
      enabled."
 );
-#[cfg(all(feature = "rustls-tls", feature = "rustls-tls-aws-lc"))]
-#[allow(dead_code)]
-fn emit_double_rustls_warning() {
-    #[warn(dead_code)]
-    let w = "Warning: Only one of the features 'rustls-tls' or 'rustls-tls-aws-lc' should be \
-             enabled as 'rustls-tls' is ignored while adding extra dependencies";
-}
 
 pub(crate) use tls::TlsConfig;
 

--- a/driver/src/test/spec/unified_runner/operation/index.rs
+++ b/driver/src/test/spec/unified_runner/operation/index.rs
@@ -88,6 +88,10 @@ impl TestOperation for ListIndexes {
         }
         .boxed()
     }
+
+    fn returns_root_documents(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
RUST-2405

The rules for when extra fields are allowed in the spec are complicated and require flagging some specific operations as returning an array of root-level documents; we'd forgotten to tag `listIndexes` with this flag and that was causing the current batch of test failures.

I also removed the unrelated warning about having both `rustls-tls` and `rustls-tls-aws-lc` enabled because (a) it's annoying when developing with `--all-features` to have an unfixable warning and (b) we don't have a warning like that for the similar `rustls` vs `openssl` overlap.