### PR TITLE
RUST-2386: Fix cargo-binstall in AWS Lambda

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -57,7 +57,7 @@ for arg; do
     fi
   elif [ $arg == "cargo-lambda" ]; then
     source ${CARGO_HOME}/env
-    cargo install cargo-binstall
+    cargo install cargo-binstall --locked
     cargo binstall cargo-lambda -y
   else
     echo Missing/unknown install option: "$arg"


### PR DESCRIPTION
* The main failure reason was incorrect role in EG variables ([DRIVERS-3250](https://jira.mongodb.org/browse/DRIVERS-3250))
* Fixing `cargo install cargo-binstall` failure to due to dependencies conflicts

[EG run](https://spruce.corp.mongodb.com/version/69ebd0f1c053830007e4d48c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).