### PR TITLE
RUST-2398 bump max wire version to 29

### DIFF
--- a/driver/src/sdam/description/server.rs
+++ b/driver/src/sdam/description/server.rs
@@ -15,7 +15,7 @@ use crate::{
 
 const DRIVER_MIN_DB_VERSION: &str = "4.2";
 const DRIVER_MIN_WIRE_VERSION: i32 = 8;
-const DRIVER_MAX_WIRE_VERSION: i32 = 25;
+const DRIVER_MAX_WIRE_VERSION: i32 = 29;
 
 /// Enum representing the possible types of servers that the driver can connect to.
 #[derive(Debug, Deserialize, Clone, Copy, Eq, PartialEq, Serialize, Default)]


### PR DESCRIPTION
RUST-2398

The answer to the in-person question of why existing tests aren't failing against 9.0 is that, per spec, the Rust driver checks the server's _min_ wire version against the driver's _max_.