### PR TITLE
RUST-2418 bump to use hickory-* 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -651,7 +651,7 @@ dependencies = [
  "hex",
  "indexmap",
  "js-sys",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -724,6 +724,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -802,6 +813,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "console"
@@ -1177,18 +1198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1451,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1511,23 +1521,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1536,21 +1545,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec 1.15.0",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1754,7 +1788,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1930,6 +1964,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1951,6 +1988,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2250,6 +2336,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "hmac 0.12.1",
@@ -2271,7 +2358,7 @@ dependencies = [
  "percent-encoding",
  "pkcs8",
  "pretty_assertions",
- "rand",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "reqwest",
@@ -2331,6 +2418,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nodrop"
@@ -2502,7 +2595,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2661,6 +2754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,7 +2825,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2737,7 +2841,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2758,7 +2862,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2795,6 +2899,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,6 +2933,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -3082,6 +3203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3443,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -3966,6 +4106,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,6 +4296,15 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.0",
+]
 
 [[package]]
 name = "windows"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -33,7 +33,7 @@ sync = []
 rustls-tls = ["dep:rustls", "rustls/ring", "dep:tokio-rustls", "tokio-rustls/ring", "dep:webpki-roots"]
 rustls-tls-aws-lc = ["dep:rustls", "rustls/aws_lc_rs", "dep:tokio-rustls", "tokio-rustls/aws_lc_rs", "dep:webpki-roots"]
 openssl-tls = ["dep:openssl", "dep:openssl-probe", "dep:tokio-openssl"]
-dns-resolver = ["dep:hickory-resolver", "dep:hickory-proto"]
+dns-resolver = ["dep:hickory-net", "dep:hickory-resolver", "dep:hickory-proto"]
 cert-key-password = ["dep:pem", "dep:pkcs8"]
 socks5-proxy = ["dep:fast-socks5"]
 
@@ -96,8 +96,9 @@ futures-io = "0.3.21"
 futures-core = "0.3.14"
 futures-util = { version = "0.3.14", features = ["io"] }
 hex = "0.4.0"
-hickory-proto = { version = "0.25", optional = true }
-hickory-resolver = { version = "0.25", optional = true }
+hickory-net = { version = "0.26", optional = true }
+hickory-proto = { version = "0.26", optional = true }
+hickory-resolver = { version = "0.26", optional = true }
 hmac = "0.12.1"
 log = { version = "0.4.17", optional = true }
 md-5 = "0.10.1"

--- a/driver/src/client/auth/gssapi.rs
+++ b/driver/src/client/auth/gssapi.rs
@@ -4,6 +4,8 @@ mod windows;
 #[cfg(not(target_os = "windows"))]
 mod nix;
 
+use hickory_proto::rr::RData;
+
 use crate::{
     bson::Bson,
     client::{
@@ -240,7 +242,7 @@ async fn canonicalize_hostname(
         CanonicalizeHostName::Forward => {
             let lookup_records = resolver.cname_lookup(hostname).await?;
 
-            if !lookup_records.records().is_empty() {
+            if !lookup_records.answers().is_empty() {
                 // As long as there is a record, we can return the original hostname.
                 // Although the spec says to return the canonical name, this is not
                 // done by any drivers in practice since the majority of them use
@@ -264,7 +266,12 @@ async fn canonicalize_hostname(
                 // reverse lookup
                 match resolver.reverse_lookup(first_address).await {
                     Ok(reverse_lookup) => {
-                        if let Some(name) = reverse_lookup.iter().next() {
+                        if let Some(name) =
+                            reverse_lookup.answers().iter().find_map(|r| match &r.data {
+                                RData::PTR(ptr) => Some(ptr),
+                                _ => None,
+                            })
+                        {
                             name.to_lowercase().to_string()
                         } else {
                             hostname.to_lowercase()

--- a/driver/src/client/options/resolver_config.rs
+++ b/driver/src/client/options/resolver_config.rs
@@ -25,12 +25,12 @@ impl PartialEq for ResolverConfig {
         }
 
         for (a, b) in std::iter::zip(left.name_servers(), right.name_servers()) {
-            if !(a.socket_addr == b.socket_addr
-                && a.protocol == b.protocol
-                && a.tls_dns_name == b.tls_dns_name
-                && a.http_endpoint == b.http_endpoint
+            if !(a.ip == b.ip
                 && a.trust_negative_responses == b.trust_negative_responses
-                && a.bind_addr == b.bind_addr)
+                && a.connections.len() == b.connections.len()
+                && std::iter::zip(&a.connections, &b.connections).all(|(ca, cb)| {
+                    ca.port == cb.port && ca.protocol == cb.protocol && ca.bind_addr == cb.bind_addr
+                }))
             {
                 return false;
             }
@@ -48,7 +48,7 @@ impl ResolverConfig {
     /// Please see: <https://www.cloudflare.com/dns/>
     pub fn cloudflare() -> Self {
         ResolverConfig {
-            inner: HickoryResolverConfig::cloudflare(),
+            inner: HickoryResolverConfig::udp_and_tcp(&hickory_resolver::config::CLOUDFLARE),
         }
     }
 
@@ -59,7 +59,7 @@ impl ResolverConfig {
     /// ISP’s track similar information in DNS.
     pub fn google() -> Self {
         ResolverConfig {
-            inner: HickoryResolverConfig::google(),
+            inner: HickoryResolverConfig::udp_and_tcp(&hickory_resolver::config::GOOGLE),
         }
     }
 
@@ -69,7 +69,7 @@ impl ResolverConfig {
     /// Please see: <https://www.quad9.net/faq/>
     pub fn quad9() -> Self {
         ResolverConfig {
-            inner: HickoryResolverConfig::quad9(),
+            inner: HickoryResolverConfig::udp_and_tcp(&hickory_resolver::config::QUAD9),
         }
     }
 }

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -338,7 +338,7 @@ impl Error {
     }
 
     #[cfg(feature = "dns-resolver")]
-    pub(crate) fn from_resolve_error(error: hickory_resolver::ResolveError) -> Self {
+    pub(crate) fn from_resolve_error(error: hickory_net::NetError) -> Self {
         ErrorKind::DnsResolve {
             message: error.to_string(),
         }

--- a/driver/src/runtime/resolver.rs
+++ b/driver/src/runtime/resolver.rs
@@ -1,13 +1,12 @@
 use crate::error::{Error, Result};
 use hickory_resolver::{
     config::ResolverConfig,
-    lookup::{SrvLookup, TxtLookup},
-    Name,
+    lookup::Lookup,
+    proto::rr::Name,
 };
 
 #[cfg(feature = "gssapi-auth")]
 use hickory_resolver::{
-    lookup::{Lookup, ReverseLookup},
     lookup_ip::LookupIp,
     proto::rr::RecordType,
 };
@@ -28,7 +27,8 @@ impl AsyncResolver {
             None => hickory_resolver::TokioResolver::builder_tokio()
                 .map_err(Error::from_resolve_error)?,
         }
-        .build();
+        .build()
+        .map_err(Error::from_resolve_error)?;
 
         Ok(Self { resolver })
     }
@@ -58,7 +58,7 @@ impl AsyncResolver {
     }
 
     #[cfg(feature = "gssapi-auth")]
-    pub async fn reverse_lookup(&self, ip_addr: IpAddr) -> Result<ReverseLookup> {
+    pub async fn reverse_lookup(&self, ip_addr: IpAddr) -> Result<Lookup> {
         let lookup = self
             .resolver
             .reverse_lookup(ip_addr)
@@ -67,7 +67,7 @@ impl AsyncResolver {
         Ok(lookup)
     }
 
-    pub async fn srv_lookup(&self, query: &str) -> Result<SrvLookup> {
+    pub async fn srv_lookup(&self, query: &str) -> Result<Lookup> {
         let name = Name::from_str_relaxed(query).map_err(Error::from_resolve_proto_error)?;
         let lookup = self
             .resolver
@@ -77,7 +77,7 @@ impl AsyncResolver {
         Ok(lookup)
     }
 
-    pub async fn txt_lookup(&self, query: &str) -> Result<Option<TxtLookup>> {
+    pub async fn txt_lookup(&self, query: &str) -> Result<Option<Lookup>> {
         let name = Name::from_str_relaxed(query).map_err(Error::from_resolve_proto_error)?;
         let lookup_result = self.resolver.txt_lookup(name).await;
         match lookup_result {

--- a/driver/src/runtime/resolver.rs
+++ b/driver/src/runtime/resolver.rs
@@ -1,15 +1,8 @@
 use crate::error::{Error, Result};
-use hickory_resolver::{
-    config::ResolverConfig,
-    lookup::Lookup,
-    proto::rr::Name,
-};
+use hickory_resolver::{config::ResolverConfig, lookup::Lookup, proto::rr::Name};
 
 #[cfg(feature = "gssapi-auth")]
-use hickory_resolver::{
-    lookup_ip::LookupIp,
-    proto::rr::RecordType,
-};
+use hickory_resolver::{lookup_ip::LookupIp, proto::rr::RecordType};
 #[cfg(feature = "gssapi-auth")]
 use std::net::IpAddr;
 

--- a/driver/src/srv.rs
+++ b/driver/src/srv.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 #[cfg(feature = "dns-resolver")]
 use crate::error::ErrorKind;
+#[cfg(feature = "dns-resolver")]
+use hickory_proto::rr::RData;
 use crate::{client::options::ResolverConfig, error::Result, options::ServerAddress};
 
 #[derive(Debug)]
@@ -127,23 +129,21 @@ impl SrvResolver {
     }
 
     async fn get_srv_hosts_unvalidated(&self, lookup_hostname: &str) -> Result<LookupHosts> {
-        use hickory_proto::rr::RData;
-
         let srv_lookup = self.resolver.srv_lookup(lookup_hostname).await?;
         let mut hosts = vec![];
         let mut min_ttl = u32::MAX;
-        for record in srv_lookup.as_lookup().record_iter() {
-            let RData::SRV(srv) = record.data() else {
+        for record in srv_lookup.answers() {
+            let RData::SRV(srv) = &record.data else {
                 continue;
             };
-            let mut host = srv.target().to_utf8();
+            let mut host = srv.target.to_utf8();
             // Remove the trailing '.'
             if host.ends_with('.') {
                 host.pop();
             }
-            let port = Some(srv.port());
+            let port = Some(srv.port);
             hosts.push(ServerAddress::Tcp { host, port });
-            min_ttl = std::cmp::min(min_ttl, record.ttl());
+            min_ttl = std::cmp::min(min_ttl, record.ttl);
         }
         Ok(LookupHosts {
             hosts,
@@ -175,7 +175,13 @@ impl SrvResolver {
             Some(response) => response,
             None => return Ok(()),
         };
-        let mut txt_records = txt_records_response.iter();
+        let mut txt_records = txt_records_response
+            .answers()
+            .iter()
+            .filter_map(|record| match &record.data {
+                RData::TXT(txt) => Some(txt),
+                _ => None,
+            });
 
         let txt_record = match txt_records.next() {
             Some(record) => record,
@@ -193,7 +199,7 @@ impl SrvResolver {
         }
 
         let txt_data: Vec<_> = txt_record
-            .txt_data()
+            .txt_data
             .iter()
             .map(|bytes| String::from_utf8_lossy(bytes.as_ref()).into_owned())
             .collect();

--- a/driver/src/srv.rs
+++ b/driver/src/srv.rs
@@ -2,9 +2,9 @@ use std::time::Duration;
 
 #[cfg(feature = "dns-resolver")]
 use crate::error::ErrorKind;
+use crate::{client::options::ResolverConfig, error::Result, options::ServerAddress};
 #[cfg(feature = "dns-resolver")]
 use hickory_proto::rr::RData;
-use crate::{client::options::ResolverConfig, error::Result, options::ServerAddress};
 
 #[derive(Debug)]
 pub(crate) struct ResolvedConfig {
@@ -175,13 +175,14 @@ impl SrvResolver {
             Some(response) => response,
             None => return Ok(()),
         };
-        let mut txt_records = txt_records_response
-            .answers()
-            .iter()
-            .filter_map(|record| match &record.data {
-                RData::TXT(txt) => Some(txt),
-                _ => None,
-            });
+        let mut txt_records =
+            txt_records_response
+                .answers()
+                .iter()
+                .filter_map(|record| match &record.data {
+                    RData::TXT(txt) => Some(txt),
+                    _ => None,
+                });
 
         let txt_record = match txt_records.next() {
             Some(record) => record,


### PR DESCRIPTION
Hey folks!
There's an [advisory](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465) that we want to fix in our software and need mongodb crate to bump hickory to solve that.
I used Claude to do the update, then manually reviewed it. 