### PR TITLE
RUST-2342 Skip flaky timing-based tests on macos

### DIFF
--- a/driver/src/sdam/test.rs
+++ b/driver/src/sdam/test.rs
@@ -30,6 +30,10 @@ use crate::{
 
 #[tokio::test(flavor = "multi_thread")]
 async fn min_heartbeat_frequency() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping min_heartbeat_frequency: flaky on macos");
+        return;
+    }
     if topology_is_load_balanced().await {
         log_uncaptured("skipping min_heartbeat_frequency test due to load-balanced topology");
         return;
@@ -87,6 +91,10 @@ async fn min_heartbeat_frequency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sdam_pool_management() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping sdam_pool_management: flaky on macos");
+        return;
+    }
     if !server_version_matches(">= 4.2.9").await {
         log_uncaptured(
             "skipping sdam_pool_management test due to server not supporting appName failCommand",

--- a/driver/src/test/change_stream.rs
+++ b/driver/src/test/change_stream.rs
@@ -67,6 +67,10 @@ async fn init_stream(
 /// Prose test 1: ChangeStream must continuously track the last seen resumeToken
 #[tokio::test]
 async fn tracks_resume_token() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping tracks_resume_token: flaky on macos");
+        return Ok(());
+    }
     let (client, coll, mut stream) = match init_stream("track_resume_token", false).await? {
         Some(t) => t,
         None => return Ok(()),

--- a/driver/src/test/client.rs
+++ b/driver/src/test/client.rs
@@ -1084,6 +1084,10 @@ async fn backpressure_run_unified() {
 // backpressure prose test #1
 #[tokio::test(flavor = "multi_thread")]
 async fn operation_retry_uses_exponential_backoff() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping operation_retry_uses_exponential_backoff: flaky on macos");
+        return;
+    }
     if server_version_lt(4, 4).await {
         log_uncaptured("skipping operation_retry_uses_exponential_backoff: requires 4.4+");
         return;

--- a/driver/src/test/cursor.rs
+++ b/driver/src/test/cursor.rs
@@ -7,12 +7,17 @@ use crate::{
     bson::doc,
     options::{CreateCollectionOptions, CursorType, FindOptions},
     runtime,
+    test::log_uncaptured,
     Client,
 };
 
 #[tokio::test]
 #[function_name::named]
 async fn tailable_cursor() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping tailable_cursor: flaky on macos");
+        return;
+    }
     let client = Client::for_test().await;
     let coll = client
         .create_fresh_collection(

--- a/driver/src/test/spec/retryable_reads.rs
+++ b/driver/src/test/spec/retryable_reads.rs
@@ -41,6 +41,11 @@ async fn run_unified() {
 /// pool before the second attempt.
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_releases_connection() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping retry_releases_connection: flaky on macos");
+        return;
+    }
+
     let mut client_options = get_client_options().await.clone();
     client_options.hosts.drain(1..);
     client_options.retry_reads = Some(true);

--- a/driver/src/test/spec/sdam.rs
+++ b/driver/src/test/spec/sdam.rs
@@ -37,23 +37,33 @@ async fn run_unified() {
         ]);
     }
 
+    let mut skipped_tests = vec![
+        // The driver does not support socketTimeoutMS.
+        "Reset server and pool after network timeout error during authentication",
+        "Ignore network timeout error on find",
+        "apply backpressure on network timeout error during connection establishment",
+        // TODO RUST-2068: unskip these tests
+        "Pool is cleared on handshake error during minPoolSize population",
+        "Pool is cleared on authentication error during minPoolSize population",
+    ];
+    if cfg!(target_os = "macos") {
+        skipped_tests
+            .extend_from_slice(&["Topology lifecycle", "Command error on Monitor handshake"]);
+    }
+
     run_unified_tests(&["server-discovery-and-monitoring", "unified"])
         .skip_files(&skipped_files)
-        .skip_tests(&[
-            // The driver does not support socketTimeoutMS.
-            "Reset server and pool after network timeout error during authentication",
-            "Ignore network timeout error on find",
-            "apply backpressure on network timeout error during connection establishment",
-            // TODO RUST-2068: unskip these tests
-            "Pool is cleared on handshake error during minPoolSize population",
-            "Pool is cleared on authentication error during minPoolSize population",
-        ])
+        .skip_tests(&skipped_tests)
         .await;
 }
 
 /// Streaming protocol prose test 1 from SDAM spec tests.
 #[tokio::test(flavor = "multi_thread")]
 async fn streaming_min_heartbeat_frequency() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping streaming_min_heartbeat_frequency: flaky on macos");
+        return;
+    }
     if topology_is_load_balanced().await {
         log_uncaptured("skipping streaming_min_heartbeat_frequency due to load balanced topology");
         return;

--- a/driver/src/test/spec/transactions.rs
+++ b/driver/src/test/spec/transactions.rs
@@ -280,6 +280,10 @@ async fn write_concern_not_inherited() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn convenient_api_retry_backoff_is_enforced() {
+    if cfg!(target_os = "macos") {
+        log_uncaptured("skipping convenient_api_retry_backoff_is_enforced: flaky on macos");
+        return;
+    }
     if !transactions_supported().await {
         log_uncaptured("skipping convenient_retry_backoff_is_enforced: transactions not supported");
         return;


### PR DESCRIPTION
RUST-2342

I went back through a week of waterfall runs; these tests were the cause of all of the failures on macos runs in that span ("Topology lifecycle" spec test by far the most).