### PR TITLE
RUST-2425 Document error code buckets

### DIFF
--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -25,7 +25,7 @@ pub use bulk_write::{BulkWriteError, PartialBulkWriteResult};
 /// SHUTTING_DOWN_CODES is a strict subset of these.
 pub(crate) const RECOVERING_CODES: [i32; 5] = [11600, 11602, 13436, 189, 91];
 /// Codes indicating the node is not a writable primary (per the SDAM spec).
-const NOTWRITABLEPRIMARY_CODES: [i32; 3] = [10107, 13435, 10058];
+pub(crate) const NOTWRITABLEPRIMARY_CODES: [i32; 3] = [10107, 13435, 10058];
 /// Codes indicating the node is shutting down. Strict subset of RECOVERING_CODES;
 /// both sets must be updated together if new codes are added.
 pub(crate) const SHUTTING_DOWN_CODES: [i32; 2] = [11600, 91];

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -21,17 +21,34 @@ use crate::{
 
 pub use bulk_write::{BulkWriteError, PartialBulkWriteResult};
 
-const RECOVERING_CODES: [i32; 5] = [11600, 11602, 13436, 189, 91];
+/// Codes indicating the node is in a recovering state (per the SDAM spec).
+/// SHUTTING_DOWN_CODES is a strict subset of these.
+pub(crate) const RECOVERING_CODES: [i32; 5] = [11600, 11602, 13436, 189, 91];
+/// Codes indicating the node is not a writable primary (per the SDAM spec).
 const NOTWRITABLEPRIMARY_CODES: [i32; 3] = [10107, 13435, 10058];
-const SHUTTING_DOWN_CODES: [i32; 2] = [11600, 91];
-const RETRYABLE_READ_CODES: [i32; 13] = [
+/// Codes indicating the node is shutting down. Strict subset of RECOVERING_CODES;
+/// both sets must be updated together if new codes are added.
+pub(crate) const SHUTTING_DOWN_CODES: [i32; 2] = [11600, 91];
+/// Codes that make a read operation retryable (wire version <= 8).
+/// Superset of RETRYABLE_WRITE_CODES — includes code 134 (ReadConcernMajorityNotAvailableYet).
+pub(crate) const RETRYABLE_READ_CODES: [i32; 13] = [
     11600, 11602, 10107, 13435, 13436, 189, 91, 7, 6, 89, 9001, 134, 262,
 ];
-const RETRYABLE_WRITE_CODES: [i32; 12] = [
+/// Codes that make a write operation retryable (wire version <= 8).
+/// Subset of RETRYABLE_READ_CODES.
+pub(crate) const RETRYABLE_WRITE_CODES: [i32; 12] = [
     11600, 11602, 10107, 13435, 13436, 189, 91, 7, 6, 89, 9001, 262,
 ];
 const UNKNOWN_TRANSACTION_COMMIT_RESULT_LABEL_CODES: [i32; 3] = [50, 64, 91];
 const REAUTHENTICATION_REQUIRED_CODE: i32 = 391;
+/// Code 43 is CursorNotFound, which is always resumable regardless of wire version.
+const CURSOR_NOT_FOUND_CODE: i32 = 43;
+/// Error codes indicating a change stream is resumable on servers with wire version < 9
+/// (MongoDB < 4.4). On wire version >= 9, the server instead sets the
+/// "ResumableChangeStreamError" label directly.
+const RESUMABLE_CHANGE_STREAM_CODES: [i32; 17] = [
+    6, 7, 89, 91, 189, 262, 9001, 10107, 11600, 11602, 13435, 13436, 63, 150, 13388, 234, 133,
+];
 
 /// Retryable write error label. This label will be added to an error when the error is
 /// write-retryable.
@@ -498,7 +515,7 @@ impl Error {
             return true;
         }
         let code = self.sdam_code();
-        if code == Some(43) {
+        if code == Some(CURSOR_NOT_FOUND_CODE) {
             return true;
         }
         if matches!(self.wire_version, Some(v) if v >= 9)
@@ -507,12 +524,7 @@ impl Error {
             return true;
         }
         if let (Some(code), true) = (code, matches!(self.wire_version, Some(v) if v < 9)) {
-            if [
-                6, 7, 89, 91, 189, 262, 9001, 10107, 11600, 11602, 13435, 13436, 63, 150, 13388,
-                234, 133,
-            ]
-            .contains(&code)
-            {
+            if RESUMABLE_CHANGE_STREAM_CODES.contains(&code) {
                 return true;
             }
         }

--- a/driver/src/test/error.rs
+++ b/driver/src/test/error.rs
@@ -1,5 +1,6 @@
 use crate::error::{
     Error,
+    NOTWRITABLEPRIMARY_CODES,
     RECOVERING_CODES,
     RETRYABLE_READ_CODES,
     RETRYABLE_WRITE_CODES,
@@ -30,6 +31,16 @@ fn shutting_down_codes_subset_of_recovering_codes() {
         "SHUTTING_DOWN_CODES must be a subset of RECOVERING_CODES; update both arrays together \
          when adding new codes"
     );
+}
+
+#[test]
+fn not_writeable_primary_codes_disjoint_from_recovering_codes() {
+    assert!(
+        NOTWRITABLEPRIMARY_CODES
+            .iter()
+            .all(|c| !RECOVERING_CODES.contains(c)),
+        "NOTWRITABLEPRIMARY_CODES must be disjoint from RECOVERING_CODES",
+    )
 }
 
 #[test]

--- a/driver/src/test/error.rs
+++ b/driver/src/test/error.rs
@@ -1,4 +1,10 @@
-use crate::error::Error;
+use crate::error::{
+    Error,
+    RECOVERING_CODES,
+    RETRYABLE_READ_CODES,
+    RETRYABLE_WRITE_CODES,
+    SHUTTING_DOWN_CODES,
+};
 
 #[test]
 fn custom_display() {
@@ -11,4 +17,40 @@ fn custom_display() {
     let display = error.to_string();
     let kind = display.split(",").next().unwrap();
     assert_eq!(kind, "Kind: Custom user error");
+}
+
+fn is_subset(subset: &[i32], superset: &[i32]) -> bool {
+    subset.iter().all(|c| superset.contains(c))
+}
+
+#[test]
+fn shutting_down_codes_subset_of_recovering_codes() {
+    assert!(
+        is_subset(&SHUTTING_DOWN_CODES, &RECOVERING_CODES),
+        "SHUTTING_DOWN_CODES must be a subset of RECOVERING_CODES; \
+         update both arrays together when adding new codes"
+    );
+}
+
+#[test]
+fn retryable_write_codes_subset_of_retryable_read_codes() {
+    assert!(
+        is_subset(&RETRYABLE_WRITE_CODES, &RETRYABLE_READ_CODES),
+        "RETRYABLE_WRITE_CODES must be a subset of RETRYABLE_READ_CODES"
+    );
+}
+
+#[test]
+fn retryable_read_codes_differ_from_write_codes_by_exactly_134() {
+    let read_only: Vec<i32> = RETRYABLE_READ_CODES
+        .iter()
+        .copied()
+        .filter(|c| !RETRYABLE_WRITE_CODES.contains(c))
+        .collect();
+    assert_eq!(
+        read_only,
+        vec![134],
+        "RETRYABLE_READ_CODES should differ from RETRYABLE_WRITE_CODES \
+         only by code 134 (ReadConcernMajorityNotAvailableYet)"
+    );
 }

--- a/driver/src/test/error.rs
+++ b/driver/src/test/error.rs
@@ -27,8 +27,8 @@ fn is_subset(subset: &[i32], superset: &[i32]) -> bool {
 fn shutting_down_codes_subset_of_recovering_codes() {
     assert!(
         is_subset(&SHUTTING_DOWN_CODES, &RECOVERING_CODES),
-        "SHUTTING_DOWN_CODES must be a subset of RECOVERING_CODES; \
-         update both arrays together when adding new codes"
+        "SHUTTING_DOWN_CODES must be a subset of RECOVERING_CODES; update both arrays together \
+         when adding new codes"
     );
 }
 
@@ -50,7 +50,7 @@ fn retryable_read_codes_differ_from_write_codes_by_exactly_134() {
     assert_eq!(
         read_only,
         vec![134],
-        "RETRYABLE_READ_CODES should differ from RETRYABLE_WRITE_CODES \
-         only by code 134 (ReadConcernMajorityNotAvailableYet)"
+        "RETRYABLE_READ_CODES should differ from RETRYABLE_WRITE_CODES only by code 134 \
+         (ReadConcernMajorityNotAvailableYet)"
     );
 }


### PR DESCRIPTION
RUST-2425

This adds documentation for the error code category constants, turns a few that were inline into named, and adds tests for the spec-defined relationships to make sure we don't accidentally break that later.