### PR TITLE
add asp commands

### DIFF
--- a/driver/examples/stream_processing_example.rs
+++ b/driver/examples/stream_processing_example.rs
@@ -1,0 +1,177 @@
+//! Demonstrates the full lifecycle of an Atlas Stream Processing (ASP) stream
+//! processor using [`mongodb::stream_processing::StreamProcessingClient`].
+//! It creates, starts, samples, stops, and drops a processor.
+//!
+//! Requirements:
+//!
+//!   - An Atlas Stream Processing workspace with a hostname matching the
+//!     pattern `atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net`
+//!     (or `.mongodb-<env>.net` for staging).
+//!   - A user with the `atlasAdmin` role.
+//!   - Two connections registered in the workspace:
+//!       - `sample_stream_solar`  (built-in sample source)
+//!       - `__testLog`            (built-in test sink)
+//!
+//! Use the `MONGODB_STREAM_PROCESSING_URI` environment variable to specify
+//! the workspace connection string (including username/password). Run with:
+//!
+//! ```text
+//! MONGODB_STREAM_PROCESSING_URI='mongodb://user:pass@atlas-stream-….a.query.mongodb.net/' \
+//!     cargo run -p mongodb --example stream_processing_example
+//! ```
+
+use std::{
+    process::ExitCode,
+    time::{Duration, Instant},
+};
+
+use mongodb::{
+    bson::{doc, oid::ObjectId},
+    error::Result,
+    stream_processing::{GetStreamProcessorSamplesOptions, StreamProcessingClient, StreamProcessors},
+};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let uri = match std::env::var("MONGODB_STREAM_PROCESSING_URI") {
+        Ok(uri) if !uri.is_empty() => uri,
+        _ => {
+            eprintln!(
+                "This example requires an Atlas Stream Processing workspace endpoint."
+            );
+            eprintln!(
+                "Set MONGODB_STREAM_PROCESSING_URI to the workspace connection string."
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    if !StreamProcessingClient::is_workspace_uri(&uri) {
+        eprintln!("MONGODB_STREAM_PROCESSING_URI does not look like a workspace endpoint.");
+        eprintln!(
+            "Expected hostname pattern: atlas-stream-*.<region>.a.query.mongodb.net \
+             (or .mongodb-stage.net for Atlas staging)"
+        );
+        return ExitCode::from(1);
+    }
+
+    let client = match StreamProcessingClient::with_uri_str(&uri).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("StreamProcessingClient::with_uri_str failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let processors = client.stream_processors();
+    let name = format!("rustdriver_demo_{}", ObjectId::new().to_hex());
+
+    println!("Workspace: {uri}");
+    println!("Processor: {name}\n");
+
+    match run_lifecycle(&processors, &name).await {
+        Ok(()) => {
+            println!("OK.");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("\nFAILED: {e}");
+            // Best-effort cleanup so we don't leave processors behind.
+            if processors.get(&name).drop().await.is_ok() {
+                eprintln!("(cleaned up processor {name})");
+            }
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run_lifecycle(processors: &StreamProcessors, name: &str) -> Result<()> {
+    let pipeline = vec![
+        doc! { "$source": { "connectionName": "sample_stream_solar" } },
+        doc! { "$emit": { "connectionName": "__testLog", "topic": "rust-driver-demo" } },
+    ];
+
+    // 1. create
+    println!("[1/6] create({name})");
+    processors.create(name, pipeline, None).await?;
+    let info = processors.get_info(name).await?;
+    println!("      state={}\n", info.state);
+
+    // 2. start
+    println!("[2/6] start()");
+    let processor = processors.get(name);
+    processor.start(None).await?;
+    let state = wait_for_state(processors, name, "STARTED", Duration::from_secs(30)).await?;
+    println!("      state={state}\n");
+    if state != "STARTED" {
+        return Err(mongodb::error::Error::custom(format!(
+            "processor did not reach STARTED within 30s (got {state})"
+        )));
+    }
+
+    // 3. stats
+    println!("[3/6] stats()");
+    let stats = processor.stats(None).await?;
+    println!("      {stats:?}\n");
+
+    // 4. sample
+    println!("[4/6] samples()");
+    let opened = processor
+        .samples(GetStreamProcessorSamplesOptions::builder().limit(5).build())
+        .await?;
+    println!(
+        "      open  cursorId={} docs={}",
+        opened.cursor_id,
+        opened.documents.len()
+    );
+
+    if !opened.is_exhausted() {
+        // Give the stream a moment to produce something.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let batch = processor
+            .samples(
+                GetStreamProcessorSamplesOptions::builder()
+                    .cursor_id(opened.cursor_id)
+                    .batch_size(5)
+                    .build(),
+            )
+            .await?;
+        println!(
+            "      batch cursorId={} docs={}",
+            batch.cursor_id,
+            batch.documents.len()
+        );
+        for (i, doc) in batch.documents.iter().enumerate() {
+            println!("          [{i}] {doc:?}");
+        }
+    }
+    println!();
+
+    // 5. stop
+    println!("[5/6] stop()");
+    processor.stop().await?;
+    let state = processors.get_info(name).await?.state;
+    println!("      state={state}\n");
+
+    // 6. drop
+    println!("[6/6] drop()");
+    processor.drop().await?;
+    println!("      dropped\n");
+
+    Ok(())
+}
+
+async fn wait_for_state(
+    processors: &StreamProcessors,
+    name: &str,
+    target: &str,
+    timeout: Duration,
+) -> Result<String> {
+    let deadline = Instant::now() + timeout;
+    let mut state = processors.get_info(name).await?.state;
+    while state != target && Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        state = processors.get_info(name).await?.state;
+    }
+    Ok(state)
+}

--- a/driver/examples/stream_processing_example.rs
+++ b/driver/examples/stream_processing_example.rs
@@ -4,9 +4,9 @@
 //!
 //! Requirements:
 //!
-//!   - An Atlas Stream Processing workspace with a hostname matching the
-//!     pattern `atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net`
-//!     (or `.mongodb-<env>.net` for staging).
+//!   - An Atlas Stream Processing workspace with a hostname matching the pattern
+//!     `atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net` (or `.mongodb-<env>.net`
+//!     for staging).
 //!   - A user with the `atlasAdmin` role.
 //!   - Two connections registered in the workspace:
 //!       - `sample_stream_solar`  (built-in sample source)
@@ -28,7 +28,11 @@ use std::{
 use mongodb::{
     bson::{doc, oid::ObjectId},
     error::Result,
-    stream_processing::{GetStreamProcessorSamplesOptions, StreamProcessingClient, StreamProcessors},
+    stream_processing::{
+        GetStreamProcessorSamplesOptions,
+        StreamProcessingClient,
+        StreamProcessors,
+    },
 };
 
 #[tokio::main]
@@ -36,12 +40,8 @@ async fn main() -> ExitCode {
     let uri = match std::env::var("MONGODB_STREAM_PROCESSING_URI") {
         Ok(uri) if !uri.is_empty() => uri,
         _ => {
-            eprintln!(
-                "This example requires an Atlas Stream Processing workspace endpoint."
-            );
-            eprintln!(
-                "Set MONGODB_STREAM_PROCESSING_URI to the workspace connection string."
-            );
+            eprintln!("This example requires an Atlas Stream Processing workspace endpoint.");
+            eprintln!("Set MONGODB_STREAM_PROCESSING_URI to the workspace connection string.");
             return ExitCode::from(1);
         }
     };
@@ -49,8 +49,8 @@ async fn main() -> ExitCode {
     if !StreamProcessingClient::is_workspace_uri(&uri) {
         eprintln!("MONGODB_STREAM_PROCESSING_URI does not look like a workspace endpoint.");
         eprintln!(
-            "Expected hostname pattern: atlas-stream-*.<region>.a.query.mongodb.net \
-             (or .mongodb-stage.net for Atlas staging)"
+            "Expected hostname pattern: atlas-stream-*.<region>.a.query.mongodb.net (or \
+             .mongodb-stage.net for Atlas staging)"
         );
         return ExitCode::from(1);
     }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -53,6 +53,7 @@ mod search_index;
 mod selection_criteria;
 mod serde_util;
 mod srv;
+pub mod stream_processing;
 #[cfg(feature = "sync")]
 pub mod sync;
 #[cfg(test)]

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -23,6 +23,7 @@ pub(crate) mod raw_output;
 pub(crate) mod run_command;
 pub(crate) mod run_cursor_command;
 mod search_index;
+pub(crate) mod stream_processing;
 mod update;
 
 use std::{borrow::Cow, fmt::Debug, ops::Deref};

--- a/driver/src/operation/stream_processing.rs
+++ b/driver/src/operation/stream_processing.rs
@@ -1,0 +1,10 @@
+//! Operation implementations for Atlas Stream Processing commands.
+
+pub(crate) mod create_stream_processor;
+pub(crate) mod drop_stream_processor;
+pub(crate) mod get_more_sample_stream_processor;
+pub(crate) mod get_stream_processor;
+pub(crate) mod get_stream_processor_stats;
+pub(crate) mod start_sample_stream_processor;
+pub(crate) mod start_stream_processor;
+pub(crate) mod stop_stream_processor;

--- a/driver/src/operation/stream_processing/create_stream_processor.rs
+++ b/driver/src/operation/stream_processing/create_stream_processor.rs
@@ -1,0 +1,76 @@
+use crate::{
+    bson::{doc, Document},
+    bson_compat::{cstr, cstr_to_str, CStr},
+    bson_util,
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+    operation::{append_options, ExecutionContext, OperationWithDefaults},
+    stream_processing::options::CreateStreamProcessorOptions,
+    Client,
+};
+
+#[derive(Debug)]
+pub(crate) struct CreateStreamProcessor {
+    client: Client,
+    name: String,
+    pipeline: Vec<Document>,
+    options: Option<CreateStreamProcessorOptions>,
+}
+
+impl CreateStreamProcessor {
+    pub(crate) fn new(
+        client: Client,
+        name: String,
+        pipeline: Vec<Document>,
+        options: Option<CreateStreamProcessorOptions>,
+    ) -> Self {
+        Self {
+            client,
+            name,
+            pipeline,
+            options,
+        }
+    }
+}
+
+impl OperationWithDefaults for CreateStreamProcessor {
+    type O = ();
+
+    const NAME: &'static CStr = cstr!("createStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        let mut body = doc! {
+            cstr_to_str(Self::NAME): self.name.as_str(),
+            "pipeline": bson_util::to_bson_array(&self.pipeline),
+        };
+
+        if let Some(opts) = self.options.as_ref() {
+            let mut sub = Document::new();
+            append_options(&mut sub, Some(opts))?;
+            if !sub.is_empty() {
+                body.insert("options", sub);
+            }
+        }
+
+        Ok(Command::from_operation(self, (&body).try_into()?))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        _response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        // { ok: 1 }
+        Ok(())
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for CreateStreamProcessor {}

--- a/driver/src/operation/stream_processing/drop_stream_processor.rs
+++ b/driver/src/operation/stream_processing/drop_stream_processor.rs
@@ -1,0 +1,51 @@
+use crate::{
+    bson::rawdoc,
+    bson_compat::{cstr, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+    operation::{ExecutionContext, OperationWithDefaults},
+    Client,
+};
+
+#[derive(Debug)]
+pub(crate) struct DropStreamProcessor {
+    client: Client,
+    name: String,
+}
+
+impl DropStreamProcessor {
+    pub(crate) fn new(client: Client, name: String) -> Self {
+        Self { client, name }
+    }
+}
+
+impl OperationWithDefaults for DropStreamProcessor {
+    type O = ();
+
+    const NAME: &'static CStr = cstr!("dropStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        Ok(Command::from_operation(
+            self,
+            rawdoc! { Self::NAME: self.name.as_str() },
+        ))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        _response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        Ok(())
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for DropStreamProcessor {}

--- a/driver/src/operation/stream_processing/get_more_sample_stream_processor.rs
+++ b/driver/src/operation/stream_processing/get_more_sample_stream_processor.rs
@@ -1,0 +1,101 @@
+use crate::{
+    bson::{rawdoc, Bson, Document},
+    bson_compat::{cstr, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::{Error, Result},
+    operation::{ExecutionContext, OperationWithDefaults},
+    stream_processing::types::StreamProcessorSamples,
+    Client,
+};
+
+/// Retrieves the next batch from a sample cursor. MUST be called with the
+/// `cursor_id` returned by `startSampleStreamProcessor` (or a prior call to
+/// this command).
+#[derive(Debug)]
+pub(crate) struct GetMoreSampleStreamProcessor {
+    client: Client,
+    name: String,
+    cursor_id: i64,
+    batch_size: Option<i32>,
+}
+
+impl GetMoreSampleStreamProcessor {
+    pub(crate) fn new(
+        client: Client,
+        name: String,
+        cursor_id: i64,
+        batch_size: Option<i32>,
+    ) -> Self {
+        Self {
+            client,
+            name,
+            cursor_id,
+            batch_size,
+        }
+    }
+}
+
+impl OperationWithDefaults for GetMoreSampleStreamProcessor {
+    type O = StreamProcessorSamples;
+
+    const NAME: &'static CStr = cstr!("getMoreSampleStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        let mut body = rawdoc! {
+            Self::NAME: self.name.as_str(),
+            "cursorId": self.cursor_id,
+        };
+        if let Some(bs) = self.batch_size {
+            body.append(cstr!("batchSize"), bs);
+        }
+        Ok(Command::from_operation(self, body))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        let mut doc: Document = response.body()?;
+
+        let cursor_id = match doc.remove("cursorId") {
+            Some(Bson::Int64(n)) => n,
+            Some(Bson::Int32(n)) => n as i64,
+            _ => {
+                return Err(Error::custom(
+                    "getMoreSampleStreamProcessor response missing cursorId",
+                ))
+            }
+        };
+
+        // Dev-server deviation: some server builds use "messages" instead of
+        // "nextBatch". Prefer the spec-defined "nextBatch" but fall back to
+        // "messages" when present.
+        let batch_bson = doc.remove("nextBatch").or_else(|| doc.remove("messages"));
+        let documents = match batch_bson {
+            Some(Bson::Array(arr)) => arr
+                .into_iter()
+                .filter_map(|b| match b {
+                    Bson::Document(d) => Some(d),
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+
+        Ok(StreamProcessorSamples {
+            cursor_id,
+            documents,
+        })
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for GetMoreSampleStreamProcessor {}

--- a/driver/src/operation/stream_processing/get_stream_processor.rs
+++ b/driver/src/operation/stream_processing/get_stream_processor.rs
@@ -46,8 +46,7 @@ impl OperationWithDefaults for GetStreamProcessor {
             doc = inner;
         }
 
-        let info: StreamProcessorInfo =
-            crate::bson::from_document(doc).map_err(crate::error::Error::custom)?;
+        let info: StreamProcessorInfo = crate::bson_compat::deserialize_from_document(doc)?;
         Ok(info)
     }
 

--- a/driver/src/operation/stream_processing/get_stream_processor.rs
+++ b/driver/src/operation/stream_processing/get_stream_processor.rs
@@ -1,0 +1,67 @@
+use crate::{
+    bson::{rawdoc, Document},
+    bson_compat::{cstr, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+    operation::{ExecutionContext, OperationWithDefaults, Retryability},
+    options::ClientOptions,
+    stream_processing::types::StreamProcessorInfo,
+    Client,
+};
+
+#[derive(Debug)]
+pub(crate) struct GetStreamProcessor {
+    client: Client,
+    name: String,
+}
+
+impl GetStreamProcessor {
+    pub(crate) fn new(client: Client, name: String) -> Self {
+        Self { client, name }
+    }
+}
+
+impl OperationWithDefaults for GetStreamProcessor {
+    type O = StreamProcessorInfo;
+
+    const NAME: &'static CStr = cstr!("getStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        Ok(Command::from_operation(
+            self,
+            rawdoc! { Self::NAME: self.name.as_str() },
+        ))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        // Dev-server deviation: some server builds wrap the processor document
+        // in a top-level "result" key. Decode the response as a Document first
+        // so we can unwrap it before deserializing into StreamProcessorInfo.
+        let mut doc: Document = response.body()?;
+        if let Some(crate::bson::Bson::Document(inner)) = doc.remove("result") {
+            doc = inner;
+        }
+
+        let info: StreamProcessorInfo =
+            crate::bson::from_document(doc).map_err(crate::error::Error::custom)?;
+        Ok(info)
+    }
+
+    fn retryability(&self, options: &ClientOptions) -> Retryability {
+        Retryability::read(options)
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for GetStreamProcessor {}

--- a/driver/src/operation/stream_processing/get_stream_processor_stats.rs
+++ b/driver/src/operation/stream_processing/get_stream_processor_stats.rs
@@ -1,0 +1,72 @@
+use crate::{
+    bson::{rawdoc, Document},
+    bson_compat::{cstr, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+    operation::{ExecutionContext, OperationWithDefaults, Retryability},
+    options::ClientOptions,
+    stream_processing::options::GetStreamProcessorStatsOptions,
+    Client,
+};
+
+#[derive(Debug)]
+pub(crate) struct GetStreamProcessorStats {
+    client: Client,
+    name: String,
+    options: Option<GetStreamProcessorStatsOptions>,
+}
+
+impl GetStreamProcessorStats {
+    pub(crate) fn new(
+        client: Client,
+        name: String,
+        options: Option<GetStreamProcessorStatsOptions>,
+    ) -> Self {
+        Self {
+            client,
+            name,
+            options,
+        }
+    }
+}
+
+impl OperationWithDefaults for GetStreamProcessorStats {
+    type O = Document;
+
+    const NAME: &'static CStr = cstr!("getStreamProcessorStats");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        let mut body = rawdoc! { Self::NAME: self.name.as_str() };
+
+        if let Some(opts) = self.options.as_ref() {
+            if let Some(verbose) = opts.verbose {
+                body.append(cstr!("options"), rawdoc! { "verbose": verbose });
+            }
+        }
+
+        Ok(Command::from_operation(self, body))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        let doc: Document = response.body()?;
+        Ok(doc)
+    }
+
+    fn retryability(&self, options: &ClientOptions) -> Retryability {
+        Retryability::read(options)
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for GetStreamProcessorStats {}

--- a/driver/src/operation/stream_processing/start_sample_stream_processor.rs
+++ b/driver/src/operation/stream_processing/start_sample_stream_processor.rs
@@ -1,0 +1,69 @@
+use serde::Deserialize;
+
+use crate::{
+    bson::rawdoc,
+    bson_compat::{cstr, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+    operation::{ExecutionContext, OperationWithDefaults},
+    Client,
+};
+
+/// Returns the int64 `cursorId` used by `getMoreSampleStreamProcessor` to
+/// retrieve the first batch of sampled documents. `startSampleStreamProcessor`
+/// itself does not return any documents.
+#[derive(Debug)]
+pub(crate) struct StartSampleStreamProcessor {
+    client: Client,
+    name: String,
+    limit: Option<i32>,
+}
+
+impl StartSampleStreamProcessor {
+    pub(crate) fn new(client: Client, name: String, limit: Option<i32>) -> Self {
+        Self {
+            client,
+            name,
+            limit,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Response {
+    #[serde(rename = "cursorId")]
+    cursor_id: i64,
+}
+
+impl OperationWithDefaults for StartSampleStreamProcessor {
+    type O = i64;
+
+    const NAME: &'static CStr = cstr!("startSampleStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        let mut body = rawdoc! { Self::NAME: self.name.as_str() };
+        if let Some(limit) = self.limit {
+            body.append(cstr!("limit"), limit);
+        }
+        Ok(Command::from_operation(self, body))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        let r: Response = response.body()?;
+        Ok(r.cursor_id)
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for StartSampleStreamProcessor {}

--- a/driver/src/operation/stream_processing/start_stream_processor.rs
+++ b/driver/src/operation/stream_processing/start_stream_processor.rs
@@ -1,0 +1,105 @@
+use crate::{
+    bson::{doc, Bson, Document},
+    bson_compat::{cstr, cstr_to_str, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::{Error, Result},
+    operation::{ExecutionContext, OperationWithDefaults},
+    stream_processing::options::StartStreamProcessorOptions,
+    Client,
+};
+
+const VALID_FAILOVER_MODES: &[&str] = &["GRACEFUL", "FORCED"];
+
+#[derive(Debug)]
+pub(crate) struct StartStreamProcessor {
+    client: Client,
+    name: String,
+    options: Option<StartStreamProcessorOptions>,
+}
+
+impl StartStreamProcessor {
+    pub(crate) fn new(
+        client: Client,
+        name: String,
+        options: Option<StartStreamProcessorOptions>,
+    ) -> Self {
+        Self {
+            client,
+            name,
+            options,
+        }
+    }
+}
+
+impl OperationWithDefaults for StartStreamProcessor {
+    type O = ();
+
+    const NAME: &'static CStr = cstr!("startStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        let mut body = doc! { cstr_to_str(Self::NAME): self.name.as_str() };
+
+        if let Some(opts) = self.options.as_ref() {
+            if let Some(workers) = opts.workers {
+                body.insert("workers", workers);
+            }
+
+            // Spec puts these option fields under a nested `options` document.
+            let mut sub = Document::new();
+            if let Some(clear) = opts.clear_checkpoints {
+                sub.insert("clearCheckpoints", clear);
+            }
+            if let Some(ts) = opts.start_at_operation_time {
+                sub.insert("startAtOperationTime", Bson::Timestamp(ts));
+            }
+            if let Some(tier) = opts.tier.as_deref() {
+                sub.insert("tier", tier);
+            }
+            if let Some(auto_scaling) = opts.enable_auto_scaling {
+                sub.insert("enableAutoScaling", auto_scaling);
+            }
+            if !sub.is_empty() {
+                body.insert("options", sub);
+            }
+
+            if let Some(failover) = opts.failover.as_ref() {
+                if let Some(mode) = failover.mode.as_deref() {
+                    if !VALID_FAILOVER_MODES.contains(&mode) {
+                        return Err(Error::invalid_argument(format!(
+                            "invalid failover.mode \"{mode}\"; expected one of: {}",
+                            VALID_FAILOVER_MODES.join(", "),
+                        )));
+                    }
+                }
+                let mut f = doc! { "region": failover.region.as_str() };
+                if let Some(mode) = failover.mode.as_deref() {
+                    f.insert("mode", mode);
+                }
+                if let Some(dry) = failover.dry_run {
+                    f.insert("dryRun", dry);
+                }
+                body.insert("failover", f);
+            }
+        }
+
+        Ok(Command::from_operation(self, (&body).try_into()?))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        _response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        Ok(())
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for StartStreamProcessor {}

--- a/driver/src/operation/stream_processing/stop_stream_processor.rs
+++ b/driver/src/operation/stream_processing/stop_stream_processor.rs
@@ -1,0 +1,51 @@
+use crate::{
+    bson::rawdoc,
+    bson_compat::{cstr, CStr},
+    cmap::{Command, RawCommandResponse, StreamDescription},
+    error::Result,
+    operation::{ExecutionContext, OperationWithDefaults},
+    Client,
+};
+
+#[derive(Debug)]
+pub(crate) struct StopStreamProcessor {
+    client: Client,
+    name: String,
+}
+
+impl StopStreamProcessor {
+    pub(crate) fn new(client: Client, name: String) -> Self {
+        Self { client, name }
+    }
+}
+
+impl OperationWithDefaults for StopStreamProcessor {
+    type O = ();
+
+    const NAME: &'static CStr = cstr!("stopStreamProcessor");
+
+    fn build(&mut self, _description: &StreamDescription) -> Result<Command> {
+        Ok(Command::from_operation(
+            self,
+            rawdoc! { Self::NAME: self.name.as_str() },
+        ))
+    }
+
+    fn handle_response<'a>(
+        &'a self,
+        _response: &'a RawCommandResponse,
+        _context: ExecutionContext<'a>,
+    ) -> Result<Self::O> {
+        Ok(())
+    }
+
+    fn target(&self) -> super::super::OperationTarget {
+        super::super::OperationTarget::admin(&self.client)
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    type Otel = crate::otel::Witness<Self>;
+}
+
+#[cfg(feature = "opentelemetry")]
+impl crate::otel::OtelInfoDefaults for StopStreamProcessor {}

--- a/driver/src/stream_processing.rs
+++ b/driver/src/stream_processing.rs
@@ -1,0 +1,382 @@
+//! Atlas Stream Processing client and helpers.
+//!
+//! Atlas Stream Processing (ASP) workspaces share the `mongodb://` URI scheme
+//! with standard MongoDB clusters but use a distinct hostname pattern:
+//!
+//! ```text
+//! mongodb://atlas-stream-<workspaceId>-<suffix>.<region>.a.query.mongodb.net/
+//! ```
+//!
+//! Atlas staging endpoints use `.a.query.mongodb-stage.net` instead; both are
+//! accepted.
+//!
+//! Per the ASP spec, TLS is required and `authSource` defaults to `"admin"`.
+
+pub mod options;
+pub mod types;
+
+pub use options::*;
+pub use types::*;
+
+use crate::{
+    bson::Document,
+    error::{Error, Result},
+    operation::stream_processing::{
+        create_stream_processor::CreateStreamProcessor,
+        drop_stream_processor::DropStreamProcessor,
+        get_more_sample_stream_processor::GetMoreSampleStreamProcessor,
+        get_stream_processor::GetStreamProcessor,
+        get_stream_processor_stats::GetStreamProcessorStats,
+        start_sample_stream_processor::StartSampleStreamProcessor,
+        start_stream_processor::StartStreamProcessor,
+        stop_stream_processor::StopStreamProcessor,
+    },
+    options::{ClientOptions, Tls},
+    Client,
+};
+
+/// Client for an Atlas Stream Processing workspace.
+///
+/// Distinct from [`Client`] so that connection intent is explicit and ASP
+/// commands cannot be accidentally routed to a standard `mongod`. Drivers MAY
+/// still use [`Client`] directly with `run_command` for any commands not yet
+/// modeled here.
+#[derive(Clone, Debug)]
+pub struct StreamProcessingClient {
+    client: Client,
+}
+
+impl StreamProcessingClient {
+    /// Creates a new [`StreamProcessingClient`] connected to the workspace
+    /// specified by `uri`. The URI must point at a workspace endpoint —
+    /// see [`is_workspace_uri`](Self::is_workspace_uri).
+    pub async fn with_uri_str(uri: impl AsRef<str>) -> Result<Self> {
+        let uri = uri.as_ref();
+
+        if !Self::is_workspace_uri(uri) {
+            return Err(Error::invalid_argument(
+                "StreamProcessingClient requires a workspace endpoint URI \
+                 (atlas-stream-*.a.query.mongodb.net or .mongodb-<env>.net). For standard MongoDB \
+                 clusters, use mongodb::Client instead.",
+            ));
+        }
+
+        if uri.to_ascii_lowercase().starts_with("mongodb+srv://") {
+            return Err(Error::invalid_argument(
+                "mongodb+srv:// is not supported for workspace endpoints; use mongodb://",
+            ));
+        }
+
+        let mut options = ClientOptions::parse(uri).await?;
+        Self::apply_workspace_defaults(&mut options)?;
+
+        Ok(Self {
+            client: Client::with_options(options)?,
+        })
+    }
+
+    /// Creates a new [`StreamProcessingClient`] from pre-parsed options.
+    ///
+    /// Workspace defaults — TLS enabled, `authSource=admin` — are applied if
+    /// not already set. Returns an error if TLS has been explicitly disabled.
+    pub fn with_options(mut options: ClientOptions) -> Result<Self> {
+        Self::apply_workspace_defaults(&mut options)?;
+        Ok(Self {
+            client: Client::with_options(options)?,
+        })
+    }
+
+    /// Returns the underlying [`Client`] for advanced uses such as
+    /// [`Client::database`] followed by `run_command`.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
+
+    /// Returns a handle for managing stream processors in this workspace.
+    pub fn stream_processors(&self) -> StreamProcessors {
+        StreamProcessors {
+            client: self.client.clone(),
+        }
+    }
+
+    /// Returns `true` when the supplied URI targets an Atlas Stream Processing
+    /// workspace endpoint.
+    ///
+    /// Matches hostnames that begin with `atlas-stream-` and end with
+    /// `.a.query.mongodb.net` (production) or `.a.query.mongodb-<env>.net`
+    /// (e.g. `mongodb-stage.net` for Atlas staging).
+    pub fn is_workspace_uri(uri: &str) -> bool {
+        // Lower-case host comparison; URI scheme is case-insensitive.
+        let lower = uri.to_ascii_lowercase();
+        if !lower.starts_with("mongodb://") {
+            return false;
+        }
+        // Strip scheme + optional userinfo.
+        let after_scheme = &lower["mongodb://".len()..];
+        let after_userinfo = match after_scheme.rfind('@') {
+            Some(idx) if idx < after_scheme.find(['/', '?']).unwrap_or(after_scheme.len()) => {
+                &after_scheme[idx + 1..]
+            }
+            _ => after_scheme,
+        };
+        // Strip path/query/port — we only need the host.
+        let end = after_userinfo
+            .find(['/', '?', ':'])
+            .unwrap_or(after_userinfo.len());
+        let host = &after_userinfo[..end];
+
+        if !host.starts_with("atlas-stream-") {
+            return false;
+        }
+
+        // Accept .a.query.mongodb.net or .a.query.mongodb-<env>.net
+        if host.ends_with(".a.query.mongodb.net") {
+            return true;
+        }
+        if let Some(rest) = host.strip_suffix(".net") {
+            if let Some(prefix) = rest.rsplit_once(".a.query.mongodb-") {
+                // prefix.1 must be a non-empty environment suffix containing
+                // only ascii letters/digits/dashes.
+                let env = prefix.1;
+                if !env.is_empty() && env.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn apply_workspace_defaults(options: &mut ClientOptions) -> Result<()> {
+        match &options.tls {
+            Some(Tls::Disabled) => {
+                return Err(Error::invalid_argument(
+                    "TLS cannot be disabled for an Atlas Stream Processing workspace connection",
+                ));
+            }
+            Some(Tls::Enabled(_)) => {}
+            None => {
+                options.tls = Some(Tls::Enabled(Default::default()));
+            }
+        }
+
+        if let Some(cred) = options.credential.as_mut() {
+            if cred.source.is_none() {
+                cred.source = Some("admin".into());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Handle for managing stream processors in a workspace.
+///
+/// Obtained from [`StreamProcessingClient::stream_processors`].
+#[derive(Clone, Debug)]
+pub struct StreamProcessors {
+    client: Client,
+}
+
+impl StreamProcessors {
+    /// Creates a new stream processor.
+    pub async fn create(
+        &self,
+        name: impl Into<String>,
+        pipeline: Vec<Document>,
+        options: impl Into<Option<CreateStreamProcessorOptions>>,
+    ) -> Result<()> {
+        let op =
+            CreateStreamProcessor::new(self.client.clone(), name.into(), pipeline, options.into());
+        self.client.execute_operation(op, None).await
+    }
+
+    /// Returns a handle for the named processor. Does not imply that the
+    /// processor currently exists on the server.
+    pub fn get(&self, name: impl Into<String>) -> StreamProcessor {
+        StreamProcessor {
+            client: self.client.clone(),
+            name: name.into(),
+        }
+    }
+
+    /// Returns information about a single stream processor.
+    pub async fn get_info(&self, name: impl Into<String>) -> Result<StreamProcessorInfo> {
+        let op = GetStreamProcessor::new(self.client.clone(), name.into());
+        self.client.execute_operation(op, None).await
+    }
+}
+
+/// Handle for a specific named stream processor.
+///
+/// Holding a handle does not imply the processor currently exists on the
+/// server.
+#[derive(Clone, Debug)]
+pub struct StreamProcessor {
+    client: Client,
+    name: String,
+}
+
+impl StreamProcessor {
+    /// Returns the processor name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Starts the processor. The processor MUST be in `STOPPED` or `FAILED`;
+    /// starting a `STARTED` processor returns an error from the server.
+    pub async fn start(
+        &self,
+        options: impl Into<Option<StartStreamProcessorOptions>>,
+    ) -> Result<()> {
+        let op = StartStreamProcessor::new(self.client.clone(), self.name.clone(), options.into());
+        self.client.execute_operation(op, None).await
+    }
+
+    /// Stops the processor. The processor remains in the `STOPPED` state and
+    /// can be restarted.
+    pub async fn stop(&self) -> Result<()> {
+        let op = StopStreamProcessor::new(self.client.clone(), self.name.clone());
+        self.client.execute_operation(op, None).await
+    }
+
+    /// Drops the processor permanently. A dropped processor cannot be
+    /// recovered.
+    #[allow(clippy::should_implement_trait)] // `drop` here is the ASP command, not Drop::drop
+    pub async fn drop(&self) -> Result<()> {
+        let op = DropStreamProcessor::new(self.client.clone(), self.name.clone());
+        self.client.execute_operation(op, None).await
+    }
+
+    /// Returns runtime statistics for the processor. Returns an error if the
+    /// processor is not in the `STARTED` state.
+    pub async fn stats(
+        &self,
+        options: impl Into<Option<GetStreamProcessorStatsOptions>>,
+    ) -> Result<Document> {
+        let op =
+            GetStreamProcessorStats::new(self.client.clone(), self.name.clone(), options.into());
+        self.client.execute_operation(op, None).await
+    }
+
+    /// Retrieves a batch of sampled documents.
+    ///
+    /// Routes to `startSampleStreamProcessor` when no `cursor_id` is supplied
+    /// (or `cursor_id` is 0); otherwise routes to `getMoreSampleStreamProcessor`
+    /// with the supplied `cursor_id`. The caller MUST stop iterating when the
+    /// returned [`cursor_id`](StreamProcessorSamples::cursor_id) is 0.
+    pub async fn samples(
+        &self,
+        options: impl Into<Option<GetStreamProcessorSamplesOptions>>,
+    ) -> Result<StreamProcessorSamples> {
+        let options = options.into().unwrap_or_default();
+        let cursor_id = options.cursor_id.unwrap_or(0);
+
+        if cursor_id == 0 {
+            let op = StartSampleStreamProcessor::new(
+                self.client.clone(),
+                self.name.clone(),
+                options.limit,
+            );
+            let cursor_id = self.client.execute_operation(op, None).await?;
+            return Ok(StreamProcessorSamples {
+                cursor_id,
+                documents: Vec::new(),
+            });
+        }
+
+        let op = GetMoreSampleStreamProcessor::new(
+            self.client.clone(),
+            self.name.clone(),
+            cursor_id,
+            options.batch_size,
+        );
+        self.client.execute_operation(op, None).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StreamProcessingClient;
+
+    #[test]
+    fn is_workspace_uri_accepts_production_endpoint() {
+        assert!(StreamProcessingClient::is_workspace_uri(
+            "mongodb://atlas-stream-699c842ef433fe6001480b17-etif1.virginia-usa.a.query.mongodb.\
+             net/"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_accepts_with_credentials_and_port() {
+        assert!(StreamProcessingClient::is_workspace_uri(
+            "mongodb://user:pass@atlas-stream-xyz.us-east-1.a.query.mongodb.net:27017/?\
+             retryWrites=true"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_accepts_staging_endpoint() {
+        assert!(StreamProcessingClient::is_workspace_uri(
+            "mongodb://user:pass@atlas-stream-699c842ef433fe6001480b17-etif1.virginia-usa.a.query.\
+             mongodb-stage.net"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_rejects_standard_cluster() {
+        assert!(!StreamProcessingClient::is_workspace_uri(
+            "mongodb://localhost:27017/"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_rejects_srv_scheme() {
+        assert!(!StreamProcessingClient::is_workspace_uri(
+            "mongodb+srv://cluster0.example.mongodb.net/"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_rejects_similar_looking_host() {
+        assert!(!StreamProcessingClient::is_workspace_uri(
+            "mongodb://atlas-stream-x.example.com/"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_rejects_missing_prefix() {
+        assert!(!StreamProcessingClient::is_workspace_uri(
+            "mongodb://abc.virginia-usa.a.query.mongodb.net/"
+        ));
+    }
+
+    #[test]
+    fn is_workspace_uri_is_case_insensitive_on_scheme() {
+        assert!(StreamProcessingClient::is_workspace_uri(
+            "MONGODB://atlas-stream-xyz.us-east-1.a.query.mongodb.net/"
+        ));
+    }
+
+    #[tokio::test]
+    async fn with_uri_str_rejects_non_workspace_uri() {
+        let err = StreamProcessingClient::with_uri_str("mongodb://localhost:27017/")
+            .await
+            .expect_err("expected error for non-workspace URI");
+        assert!(err.to_string().contains("workspace endpoint URI"));
+    }
+
+    #[tokio::test]
+    async fn with_uri_str_rejects_srv_scheme() {
+        let err = StreamProcessingClient::with_uri_str(
+            "mongodb+srv://atlas-stream-x.us-east-1.a.query.mongodb.net/",
+        )
+        .await
+        .expect_err("expected error for SRV URI");
+        // Either the workspace check or the srv check should reject; both are valid.
+        let msg = err.to_string();
+        assert!(
+            msg.contains("workspace endpoint URI") || msg.contains("mongodb+srv://"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/driver/src/stream_processing/options.rs
+++ b/driver/src/stream_processing/options.rs
@@ -1,0 +1,111 @@
+//! Options for Atlas Stream Processing commands.
+
+use macro_magic::export_tokens;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use typed_builder::TypedBuilder;
+
+use crate::bson::{Document, Timestamp};
+
+/// Options for [`StreamProcessors::create`](super::StreamProcessors::create).
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+#[export_tokens]
+pub struct CreateStreamProcessorOptions {
+    /// Dead letter queue configuration.
+    pub dlq: Option<Document>,
+
+    /// Field name used for stream metadata.
+    pub stream_meta_field_name: Option<String>,
+
+    /// Compute tier (e.g. `"SP2"`, `"SP5"`, `"SP10"`, `"SP30"`, `"SP50"`).
+    pub tier: Option<String>,
+
+    /// Whether failover is enabled.
+    pub failover: Option<bool>,
+}
+
+/// Failover configuration for [`StartStreamProcessorOptions`].
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct FailoverOptions {
+    /// Target region for failover. Required when failover is sent.
+    #[builder(setter(into))]
+    pub region: String,
+
+    /// Failover mode. Valid values: `"GRACEFUL"` (default), `"FORCED"`.
+    #[builder(default, setter(into))]
+    pub mode: Option<String>,
+
+    /// If true, validates the failover request without executing it.
+    #[builder(default, setter(into))]
+    pub dry_run: Option<bool>,
+}
+
+/// Options for [`StreamProcessor::start`](super::StreamProcessor::start).
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+#[export_tokens]
+pub struct StartStreamProcessorOptions {
+    /// Number of workers.
+    pub workers: Option<i32>,
+
+    /// Clear checkpoints before starting.
+    pub clear_checkpoints: Option<bool>,
+
+    /// Resume from a specific operation time.
+    pub start_at_operation_time: Option<Timestamp>,
+
+    /// Compute tier. Valid values: `"SP2"`, `"SP5"`, `"SP10"`, `"SP30"`, `"SP50"`.
+    pub tier: Option<String>,
+
+    /// Enable auto-scaling.
+    pub enable_auto_scaling: Option<bool>,
+
+    /// Failover configuration. The `region` is required when failover is sent.
+    pub failover: Option<FailoverOptions>,
+    // Note: the spec's `startAfter` option is RESERVED for future use and is
+    // not yet accepted by the server; this driver MUST NOT send it.
+}
+
+/// Options for [`StreamProcessor::stats`](super::StreamProcessor::stats).
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+#[export_tokens]
+pub struct GetStreamProcessorStatsOptions {
+    /// If true, includes per-operator statistics.
+    pub verbose: Option<bool>,
+}
+
+/// Options for [`StreamProcessor::samples`](super::StreamProcessor::samples).
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(into)))]
+#[non_exhaustive]
+#[export_tokens]
+pub struct GetStreamProcessorSamplesOptions {
+    /// The cursor id from a previous call. If absent or 0, a new sample cursor
+    /// is opened via `startSampleStreamProcessor`. If non-zero, the next batch
+    /// is fetched via `getMoreSampleStreamProcessor`.
+    pub cursor_id: Option<i64>,
+
+    /// Maximum number of documents to sample. Only sent on the initial call
+    /// (when `cursor_id` is absent or 0). Ignored on subsequent calls.
+    pub limit: Option<i32>,
+
+    /// Number of documents to return per batch. Only sent on subsequent calls
+    /// (when `cursor_id` is non-zero). Ignored on the initial call.
+    pub batch_size: Option<i32>,
+}

--- a/driver/src/stream_processing/types.rs
+++ b/driver/src/stream_processing/types.rs
@@ -1,0 +1,101 @@
+//! Result types for Atlas Stream Processing commands.
+
+use serde::{Deserialize, Serialize};
+
+use crate::bson::{DateTime, Document};
+
+/// Information about a single stream processor, returned by `getStreamProcessor`.
+///
+/// Fields the spec marks as optional may be absent depending on server version
+/// and are deserialized as `None`.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct StreamProcessorInfo {
+    /// Processor id. Optional: not returned by all server versions.
+    pub id: Option<String>,
+
+    /// Processor name.
+    pub name: String,
+
+    /// Current state. Drivers MUST surface unknown state values as-is rather
+    /// than mapping them to a known state, so this is intentionally a plain
+    /// `String` rather than an enum.
+    pub state: String,
+
+    /// Aggregation pipeline of the processor.
+    #[serde(default)]
+    pub pipeline: Vec<Document>,
+
+    /// Pipeline version. Optional: not returned by all server versions.
+    pub pipeline_version: Option<i32>,
+
+    /// Compute tier.
+    pub tier: Option<String>,
+
+    /// Dead letter queue configuration.
+    pub dlq: Option<Document>,
+
+    /// Field name used for stream metadata.
+    pub stream_meta_field_name: Option<String>,
+
+    /// Whether auto-scaling is enabled.
+    #[serde(default)]
+    pub enable_auto_scaling: bool,
+
+    /// Whether failover is enabled.
+    #[serde(default)]
+    pub failover_enabled: bool,
+
+    /// Active region for the processor.
+    pub active_region: Option<String>,
+
+    /// Workspace default region.
+    pub workspace_default_region: Option<String>,
+
+    /// Timestamp of the last state change.
+    pub last_state_change: Option<DateTime>,
+
+    /// Timestamp of the last modification.
+    pub last_modified_at: Option<DateTime>,
+
+    /// User who last modified the processor.
+    pub modified_by: Option<String>,
+
+    /// Whether the processor has been started at least once.
+    #[serde(default)]
+    pub has_started: bool,
+
+    /// Error message. Always present; empty when no error has occurred.
+    #[serde(default)]
+    pub error_msg: String,
+
+    /// Whether the most recent error is retryable.
+    #[serde(default)]
+    pub error_retryable: bool,
+
+    /// Error code from the most recent error.
+    pub error_code: Option<i32>,
+}
+
+/// A batch of sampled documents from a running stream processor.
+///
+/// Callers MUST stop iterating when [`cursor_id`](Self::cursor_id) is `0` —
+/// the cursor is exhausted and no further calls should be made.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct StreamProcessorSamples {
+    /// The cursor id to pass to the next call. A value of `0` means the cursor
+    /// is exhausted.
+    pub cursor_id: i64,
+
+    /// The batch of sampled documents returned by this call.
+    pub documents: Vec<Document>,
+}
+
+impl StreamProcessorSamples {
+    /// Returns `true` when the cursor is exhausted (cursor id is 0).
+    pub fn is_exhausted(&self) -> bool {
+        self.cursor_id == 0
+    }
+}

--- a/driver/src/test.rs
+++ b/driver/src/test.rs
@@ -28,6 +28,7 @@ mod happy_eyeballs_skip_ci; // requires happy eyeballs server
 mod index_management;
 mod lambda_examples;
 pub(crate) mod spec;
+mod stream_processing;
 mod timeseries;
 pub(crate) mod util;
 

--- a/driver/src/test/stream_processing.rs
+++ b/driver/src/test/stream_processing.rs
@@ -1,0 +1,129 @@
+//! Functional smoke test for Atlas Stream Processing.
+//!
+//! Skipped unless `MONGODB_STREAM_PROCESSING_URI` is set to a workspace
+//! endpoint (`atlas-stream-*.<region>.a.query.mongodb{,-stage}.net`) with
+//! valid credentials.
+//!
+//! Exercises the full lifecycle: create -> start -> stats -> sample -> stop -> drop.
+
+use std::time::Duration;
+
+use crate::{
+    bson::{doc, oid::ObjectId, Document},
+    stream_processing::StreamProcessingClient,
+};
+
+use super::log_uncaptured;
+
+fn skip_msg() -> Option<String> {
+    match std::env::var("MONGODB_STREAM_PROCESSING_URI") {
+        Ok(uri) if !uri.is_empty() => {
+            if StreamProcessingClient::is_workspace_uri(&uri) {
+                None
+            } else {
+                Some(format!(
+                    "MONGODB_STREAM_PROCESSING_URI=\"{uri}\" is not a workspace endpoint"
+                ))
+            }
+        }
+        _ => Some("MONGODB_STREAM_PROCESSING_URI is not configured".to_string()),
+    }
+}
+
+async fn wait_for_state(
+    processors: &crate::stream_processing::StreamProcessors,
+    name: &str,
+    target: &str,
+    timeout: Duration,
+) -> crate::error::Result<String> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut state = processors.get_info(name).await?.state;
+    while state != target && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        state = processors.get_info(name).await?.state;
+    }
+    Ok(state)
+}
+
+#[tokio::test]
+async fn lifecycle() {
+    if let Some(reason) = skip_msg() {
+        log_uncaptured(format!("Skipping stream_processing::lifecycle: {reason}"));
+        return;
+    }
+
+    let uri = std::env::var("MONGODB_STREAM_PROCESSING_URI").unwrap();
+    let client = StreamProcessingClient::with_uri_str(&uri)
+        .await
+        .expect("StreamProcessingClient::with_uri_str");
+    let processors = client.stream_processors();
+
+    let name = format!("rustdriver_test_{}", ObjectId::new().to_hex());
+    let pipeline = vec![
+        doc! { "$source": { "connectionName": "sample_stream_solar" } },
+        doc! { "$emit": { "connectionName": "__testLog", "topic": "rust-driver-demo" } },
+    ];
+
+    let cleanup = async {
+        let _ = processors.get(&name).drop().await;
+    };
+
+    // create
+    processors
+        .create(&name, pipeline, None)
+        .await
+        .expect("create should succeed");
+
+    let info = processors.get_info(&name).await.expect("get_info");
+    assert_eq!(info.name, name);
+    assert!(
+        ["CREATED", "VALIDATING", "CREATING"]
+            .iter()
+            .any(|s| *s == info.state),
+        "unexpected post-create state: {}",
+        info.state
+    );
+
+    // start
+    let processor = processors.get(&name);
+    processor.start(None).await.expect("start should succeed");
+    let state = wait_for_state(&processors, &name, "STARTED", Duration::from_secs(30))
+        .await
+        .expect("get_info while waiting");
+    assert_eq!(state, "STARTED", "processor did not reach STARTED");
+
+    // stats
+    let stats: Document = processor.stats(None).await.expect("stats should succeed");
+    assert!(!stats.is_empty());
+
+    // sample: open + fetch one batch
+    let samples = processor
+        .samples(
+            crate::stream_processing::GetStreamProcessorSamplesOptions::builder()
+                .limit(5)
+                .build(),
+        )
+        .await
+        .expect("startSample");
+    assert!(samples.cursor_id > 0, "expected non-zero cursor id");
+
+    let batch = processor
+        .samples(
+            crate::stream_processing::GetStreamProcessorSamplesOptions::builder()
+                .cursor_id(samples.cursor_id)
+                .batch_size(5)
+                .build(),
+        )
+        .await
+        .expect("getMore");
+    assert!(batch.cursor_id >= 0);
+
+    // stop + drop
+    processor.stop().await.expect("stop should succeed");
+    processor.drop().await.expect("drop should succeed");
+
+    // Cleanup is a best-effort no-op now that drop already ran; intentionally
+    // run it regardless to make sure failures earlier in the test don't leak
+    // a processor.
+    cleanup.await;
+}


### PR DESCRIPTION
  ## Summary

  Adds first-class driver support for Atlas Stream Processing (ASP), implementing the [ASP driver spec](https://docs.google.com/document/d/1ORSCgQCwB0wo54egVPUwvuY6egcvjaJpYf965IywKjs/edit). Today users have to drop down to `Database::run_command` against a workspace endpoint; this PR adds a dedicated client/handles/operations layer.

  ## What's new

  **Public module** (`driver/src/stream_processing.rs`, `driver/src/stream_processing/`)
  - `StreamProcessingClient` — workspace-scoped client distinct from `Client`. Validates the workspace URI (`atlas-stream-*.<region>.a.query.mongodb.net` and the `.mongodb-<env>.net` staging variants), enforces TLS, defaults `authSource=admin`. Constructor pair: `with_uri_str` and `with_options`. Static `is_workspace_uri(&str) -> bool` is exposed for callers that want to gate before connecting.
  - `StreamProcessors` — `create()` / `get()` / `get_info()` for managing processors in a workspace.
  - `StreamProcessor` — `start()` / `stop()` / `drop()` / `stats()` / `samples()` for a named processor.
  - `StreamProcessorInfo` — typed deserialization target for `getStreamProcessor`. Fields the spec marks as Optional (e.g. `id`, `pipeline_version`) are `Option<T>`.
  - `StreamProcessorSamples` — result of `samples()`, exposes `cursor_id`, `documents`, `is_exhausted()`.                                                                                                                              - Options: `CreateStreamProcessorOptions`, `StartStreamProcessorOptions`, `FailoverOptions`, `GetStreamProcessorStatsOptions`, `GetStreamProcessorSamplesOptions`. All `#[derive(TypedBuilder, Serialize, Deserialize)]` with `#[skip_serializing_none]` to match the rest of the driver's options pattern.

  **Operation layer** (`driver/src/operation/stream_processing/`)
  One `OperationWithDefaults` impl per wire command: `createStreamProcessor`, `startStreamProcessor`, `stopStreamProcessor`, `dropStreamProcessor`, `getStreamProcessor`, `getStreamProcessorStats`, `startSampleStreamProcessor`, `getMoreSampleStreamProcessor`. All target the `admin` database via `OperationTarget::admin(client)`. Retryable reads (`getStreamProcessor`, `getStreamProcessorStats`) declare
  `Retryability::read(options)` per the spec's retryability matrix.

  ## Notable spec / server alignment

  - **`startAfter` (in `StartStreamProcessorOptions`) is intentionally not exposed** — the spec marks it RESERVED for future use and explicitly forbids drivers from sending it.                                                       - **Dev-server response shape deviations are accommodated**, matching the workarounds in the Python POC and PHP PR:
    - `GetStreamProcessor` unwraps a top-level `result` wrapper when the server returns `{ ok: 1, result: { … } }`.
    - `GetMoreSampleStreamProcessor` accepts both `nextBatch` (spec) and `messages` (current dev server).                                                                                                                                - `StreamProcessorInfo::id` and `pipeline_version` are `Option<T>` rather than required.
  - **`samples()` is a single-command dispatch:** absent / zero `cursor_id` → `startSampleStreamProcessor` (returns `cursor_id`, empty docs); non-zero `cursor_id` → `getMoreSampleStreamProcessor`. Callers stop when `cursor_id ==0`.
  - **State strings are returned as plain `String`**, not an enum — per the spec, drivers MUST surface unknown state values as-is rather than mapping to a closed set.
  - **Internal-only fields** (`tenantID`, `projectId`, `processorId`) are not surfaced in the user-facing API.

  ## Test plan

  - [x] `cargo check -p mongodb` clean
  - [x] `cargo clippy -p mongodb --all-targets -- -D warnings` — no new warnings on the new code (only pre-existing CSFLE-feature-gated dead-code warnings in `client.rs` / `tracking_arc.rs` that are present on `main`)
  - [x] `cargo +nightly fmt --check -- --unstable-features` clean
  - [x] `cargo test -p mongodb --lib stream_processing::tests` — 10 unit tests pass (URI detection for prod / staging / creds-and-port / case-insensitivity / four reject cases; async rejection paths for non-workspace URI and SRVscheme)
  - [ ] Functional smoke test `stream_processing::lifecycle` in `driver/src/test/stream_processing.rs` runs the full `create → start → stats → sample → stop → drop` lifecycle. Self-skips via `log_uncaptured` unless `MONGODB_STREAM_PROCESSING_URI` is set to a real workspace endpoint — needs an Evergreen variant configured with workspace creds before it actually exercises in CI.

