### PR TITLE
fix: support nested bevy asset paths and prevent azure imds overflow panic

### DIFF
--- a/bevy/src/reader.rs
+++ b/bevy/src/reader.rs
@@ -221,7 +221,6 @@ enum AssetPath {
         name: String,
     },
 }
-
 impl AssetPath {
     fn parse(path: &Path) -> std::io::Result<Self> {
         let Some(parts) = path.iter().map(|p| p.to_str()).collect::<Option<Vec<_>>>() else {
@@ -230,28 +229,34 @@ impl AssetPath {
                 "non-utf8 path",
             ));
         };
-        return match parts.as_slice() {
-            ["document", db, coll, name] => Ok(Self::Document {
-                namespace: mongodb::Namespace::new(*db, *coll),
-                name: name.to_string(),
-            }),
-            ["gridfs", db, bucket, name] => Ok(Self::GridFs {
-                db: db.to_string(),
-                bucket: bucket.to_string(),
-                name: name.to_string(),
-            }),
-            _ => Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidFilename,
-                format!(
-                    "expected \"document/<database>/<collection>/<asset>\" or \
-                     \"gridfs/<database>/<bucket>/<asset>\", got {:?}",
-                    path
-                ),
-            )),
-        };
+        if parts.len() >= 4 {
+            let prefix = parts[0];
+            let db = parts[1].to_string();
+            let secondary = parts[2].to_string();
+            let name = parts[3..].join("/");
+            if prefix == "document" {
+                return Ok(Self::Document {
+                    namespace: mongodb::Namespace::new(db, secondary),
+                    name,
+                });
+            } else if prefix == "gridfs" {
+                return Ok(Self::GridFs {
+                    db,
+                    bucket: secondary,
+                    name,
+                });
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidFilename,
+            format!(
+                "expected \"document/<database>/<collection>/<asset>\" or \
+                 \"gridfs/<database>/<bucket>/<asset>\", got {:?}",
+                path
+            ),
+        ))
     }
 }
-
 impl std::fmt::Display for AssetPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/bevy/src/tests.rs
+++ b/bevy/src/tests.rs
@@ -62,6 +62,34 @@ fn load_image_document() {
 }
 
 #[test]
+fn load_image_document_nested() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let plugin = rt.block_on(async {
+        let client = mongodb::Client::with_uri_str(&*MONGODB_URI).await.unwrap();
+        let db = client.database("bevy_test");
+
+        let doc = rawdoc! {
+            "name": "textures/player/pixel.pbm",
+            "data": mongodb::bson::Binary {
+                subtype: BinarySubtype::Generic,
+                bytes: PNM_IMAGE_DATA.to_owned(),
+            },
+        };
+        let coll = db.collection::<RawDocumentBuf>("doc_images_nested");
+        coll.drop().await.unwrap();
+        coll.insert_one(doc.clone()).await.unwrap();
+
+        let meta_coll = db.collection::<RawDocumentBuf>("doc_images_nested.meta");
+        meta_coll.drop().await.unwrap();
+
+        MongodbAssetPlugin::new(&client).await
+    });
+
+    let result = test_load_image(plugin, "mongodb://document/bevy_test/doc_images_nested/textures/player/pixel.pbm");
+    assert!(result.is_ok(), "{:?}", result);
+}
+
+#[test]
 fn load_image_document_with_meta() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let plugin = rt.block_on(async {

--- a/driver/src/client/csfle/state_machine.rs
+++ b/driver/src/client/csfle/state_machine.rs
@@ -531,10 +531,14 @@ pub(crate) mod azure {
                     &format!("invalid `expires_in` response field: {e}"),
                 )
             })?;
+            let expires_in = Duration::from_secs(expires_in_secs);
+            let expire_time = now.checked_add(expires_in).ok_or_else(|| {
+                Error::authentication_error("azure imds", "expires_in response is too large")
+            })?;
             #[allow(clippy::redundant_clone)]
             Ok(CachedAccessToken {
                 token_doc: rawdoc! { "accessToken": server_response.access_token.clone() },
-                expire_time: now + Duration::from_secs(expires_in_secs),
+                expire_time,
                 #[cfg(test)]
                 server_response,
             })


### PR DESCRIPTION
## Overview
This PR resolves two distinct issues in the MongoDB Rust Driver repository:
1. **Bevy Integration**: A path parsing bug in the Bevy asset reader (`bevy/src/reader.rs`) that prevented loading assets located in nested subdirectories.
2. **Core Driver (CSFLE)**: A potential crash/panic vector in the Azure KMS credentials fetcher (`driver/src/client/csfle/state_machine.rs`) caused by direct addition overflow on `Instant` using an unvalidated server-provided duration.

---

## 1. Bevy Nested Asset Path Resolution

### The Bug
In `bevy/src/reader.rs`, `AssetPath::parse` parses incoming asset reader paths by mapping path components to a slice and matching against an exact list of 4 components:
```rust
return match parts.as_slice() {
    ["document", db, coll, name] => Ok(Self::Document {
        namespace: mongodb::Namespace::new(*db, *coll),
        name: name.to_string(),
    }),
    ["gridfs", db, bucket, name] => Ok(Self::GridFs {
        db: db.to_string(),
        bucket: bucket.to_string(),
        name: name.to_string(),
    }),
    _ => Err(std::io::Error::new(
        std::io::ErrorKind::InvalidFilename,
        ...
    )),
};
```
When Bevy attempts to load an asset in a nested subdirectory (e.g. `document/bevy_test/doc_images/textures/player/pixel.pbm`), `parts` yields 6 components: `["document", "bevy_test", "doc_images", "textures", "player", "pixel.pbm"]`. 

Because the slice contains more than 4 items, it falls back to the `_` error match arm and fails with an `InvalidFilename` error.

### The Fix
We redesigned the `AssetPath::parse` function to match paths of length 4 or greater. It extracts the prefix, database, and secondary identifier (collection/bucket) and then joins all remaining path components using `/` to reconstruct the nested name.

```rust
if parts.len() >= 4 {
    let prefix = parts[0];
    let db = parts[1].to_string();
    let secondary = parts[2].to_string();
    let name = parts[3..].join("/");
    if prefix == "document" {
        return Ok(Self::Document {
            namespace: mongodb::Namespace::new(db, secondary),
            name,
        });
    } else if prefix == "gridfs" {
        return Ok(Self::GridFs {
            db,
            bucket: secondary,
            name,
        });
    }
}
```

### Verification
- Added a new unit test, `load_image_document_nested`, in `bevy/src/tests.rs` that registers a document asset with a nested name (`textures/player/pixel.pbm`) and verifies successful retrieval and loading via the Bevy asset server.
- Verified successful compilation of the Bevy tests workspace via `cargo check --manifest-path bevy/Cargo.toml --tests`.

---

## 2. Robust Azure KMS Credentials Token Expiry Calculations

### The Bug
In `driver/src/client/csfle/state_machine.rs`, during Azure KMS credential retrieval from the IMDS service, the token `expires_in` string field is parsed as an unsigned 64-bit integer:
```rust
let expires_in_secs: u64 = server_response.expires_in.parse().map_err(|e| { ... })?;
```
The driver then calculated the expiration time by performing direct addition on `Instant::now()`:
```rust
expire_time: now + Duration::from_secs(expires_in_secs)
```
In Rust, the operator `+` on `Instant` panics if the resulting time overflows the internal platform-dependent range of `Instant`. If the Azure IMDS service (or a malicious proxy/server) returns an extremely large value (e.g., `18446744073709551615`), the driver will crash immediately due to thread panic.

### The Fix
We replaced the direct addition operator `+` with `Instant::checked_add` to handle potential duration overflows gracefully:
```rust
let expires_in = Duration::from_secs(expires_in_secs);
let expire_time = now.checked_add(expires_in).ok_or_else(|| {
    Error::authentication_error("azure imds", "expires_in response is too large")
})?;
```
This safely intercepts oversized intervals and returns a descriptive authentication error instead of a catastrophic thread panic.

### Verification
- Verified compilation and static check of the core driver crate via `cargo check --manifest-path driver/Cargo.toml`.