### PR TITLE
RUST-2376 Optionally redact errors containing URI elements

### DIFF
--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -29,6 +29,7 @@ compat-3-3-0 = []
 bson-2 = ["dep:bson2", "mongocrypt?/bson-2"]
 bson-3 = ["dep:bson3", "mongocrypt?/bson-3"]
 sync = []
+redact-errors = []
 
 rustls-tls = ["dep:rustls", "rustls/ring", "dep:tokio-rustls", "tokio-rustls/ring", "dep:webpki-roots"]
 rustls-tls-aws-lc = ["dep:rustls", "rustls/aws_lc_rs", "dep:tokio-rustls", "tokio-rustls/aws_lc_rs", "dep:webpki-roots"]

--- a/driver/src/client.rs
+++ b/driver/src/client.rs
@@ -628,6 +628,7 @@ impl Client {
         }
     }
 
+    #[cfg(feature = "in-use-encryption")]
     pub(crate) fn weak(&self) -> WeakClient {
         WeakClient {
             inner: TrackingArc::downgrade(&self.inner),
@@ -688,11 +689,13 @@ impl Client {
     }
 }
 
+#[cfg(feature = "in-use-encryption")]
 #[derive(Clone, Debug)]
 pub(crate) struct WeakClient {
     inner: crate::tracking_arc::Weak<ClientInner>,
 }
 
+#[cfg(feature = "in-use-encryption")]
 impl WeakClient {
     pub(crate) fn upgrade(&self) -> Option<Client> {
         self.inner.upgrade().map(|inner| Client { inner })

--- a/driver/src/client/auth/gssapi.rs
+++ b/driver/src/client/auth/gssapi.rs
@@ -17,7 +17,7 @@ use crate::{
         options::ServerApi,
     },
     cmap::Connection,
-    error::{Error, Result},
+    error::{Error, Redact, Result},
     options::ResolverConfig,
 };
 
@@ -254,7 +254,7 @@ async fn canonicalize_hostname(
             } else {
                 return Err(Error::authentication_error(
                     GSSAPI_STR,
-                    &format!("No addresses found for hostname: {hostname}"),
+                    &format!("No addresses found for hostname: {}", Redact(hostname)),
                 ));
             }
         }
@@ -282,7 +282,7 @@ async fn canonicalize_hostname(
             } else {
                 return Err(Error::authentication_error(
                     GSSAPI_STR,
-                    &format!("No addresses found for hostname: {hostname}"),
+                    &format!("No addresses found for hostname: {}", Redact(hostname)),
                 ));
             }
         }

--- a/driver/src/client/options.rs
+++ b/driver/src/client/options.rs
@@ -37,7 +37,7 @@ use crate::{
     bson::{doc, Bson, Document, Timestamp, UuidRepresentation},
     client::auth::{AuthMechanism, Credential},
     concern::{Acknowledgment, ReadConcern, WriteConcern},
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind, Redact, Result},
     event::EventHandler,
     options::ReadConcernLevel,
     sdam::{verify_max_staleness, DEFAULT_HEARTBEAT_FREQUENCY, MIN_HEARTBEAT_FREQUENCY},
@@ -252,8 +252,8 @@ impl ServerAddress {
             let Some((hostname, port)) = ip_literal.split_once("]") else {
                 return Err(ErrorKind::InvalidArgument {
                     message: format!(
-                        "invalid server address {address}: missing closing ']' in IP literal \
-                         hostname"
+                        "invalid server address {}: missing closing ']' in IP literal hostname",
+                        Redact(address),
                     ),
                 }
                 .into());
@@ -261,7 +261,7 @@ impl ServerAddress {
 
             if let Err(parse_error) = Ipv6Addr::from_str(hostname) {
                 return Err(ErrorKind::InvalidArgument {
-                    message: format!("invalid server address {address}: {parse_error}"),
+                    message: format!("invalid server address {}: {parse_error}", Redact(address)),
                 }
                 .into());
             }
@@ -273,8 +273,9 @@ impl ServerAddress {
             } else {
                 return Err(ErrorKind::InvalidArgument {
                     message: format!(
-                        "invalid server address {address}: the hostname can only be followed by a \
-                         port prefixed with ':', got {port}"
+                        "invalid server address {}: the hostname can only be followed by a port \
+                         prefixed with ':', got {port}",
+                        Redact(address)
                     ),
                 }
                 .into());
@@ -290,7 +291,10 @@ impl ServerAddress {
 
         if hostname.is_empty() {
             return Err(ErrorKind::InvalidArgument {
-                message: format!("invalid server address {address}: the hostname cannot be empty"),
+                message: format!(
+                    "invalid server address {}: the hostname cannot be empty",
+                    Redact(address)
+                ),
             }
             .into());
         }
@@ -308,8 +312,9 @@ impl ServerAddress {
                 Ok(0) | Err(_) => {
                     return Err(ErrorKind::InvalidArgument {
                         message: format!(
-                            "invalid server address {address}: the port must be an integer \
-                             between 1 and 65535, got {port}"
+                            "invalid server address {}: the port must be an integer between 1 and \
+                             65535, got {port}",
+                            Redact(address)
                         ),
                     }
                     .into());

--- a/driver/src/cmap/conn.rs
+++ b/driver/src/cmap/conn.rs
@@ -21,7 +21,7 @@ use super::{conn::pooled::PooledConnection, manager::PoolManager};
 use crate::{
     bson::oid::ObjectId,
     cmap::PoolGeneration,
-    error::{load_balanced_mode_mismatch, Error, ErrorKind, Result},
+    error::{load_balanced_mode_mismatch, Error, ErrorKind, Redact, Result},
     event::cmap::{CmapEventEmitter, ConnectionCreatedEvent},
     options::ServerAddress,
     runtime::AsyncStream,
@@ -192,7 +192,7 @@ impl Connection {
                 let error: Error = ErrorKind::ConnectionPoolCleared {
                     message: format!(
                         "Connection to {} interrupted due to server monitor timeout",
-                        self.address,
+                        Redact(&self.address),
                     )
                 }.into();
                 self.error = Some(error.clone());
@@ -216,7 +216,7 @@ impl Connection {
         if self.more_to_come {
             return Err(Error::internal(format!(
                 "attempted to send a new message to {} but moreToCome bit was set",
-                self.address()
+                Redact(self.address())
             )));
         }
 
@@ -276,7 +276,7 @@ impl Connection {
         if !self.more_to_come {
             return Err(Error::internal(format!(
                 "attempted to stream response from connection to {} but moreToCome bit was not set",
-                self.address()
+                Redact(self.address())
             )));
         }
 

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -145,8 +145,8 @@ impl Error {
     pub(crate) fn pool_cleared_error(address: &ServerAddress, cause: &Error) -> Self {
         ErrorKind::ConnectionPoolCleared {
             message: format!(
-                "Connection pool for {address} cleared because another operation failed with: \
-                 {cause}"
+                "Connection pool for {} cleared because another operation failed with: {cause}",
+                Redact(address)
             ),
         }
         .into()
@@ -1187,3 +1187,25 @@ macro_rules! load_balanced_mode_mismatch {
 }
 
 pub(crate) use load_balanced_mode_mismatch;
+
+pub(crate) struct Redact<T>(pub T);
+
+impl<T: std::fmt::Display> std::fmt::Display for Redact<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if cfg!(feature = "redact-errors") {
+            write!(f, "<redacted>")
+        } else {
+            write!(f, "{}", self.0)
+        }
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Redact<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if cfg!(feature = "redact-errors") {
+            write!(f, "<redacted>")
+        } else {
+            write!(f, "{:?}", self.0)
+        }
+    }
+}

--- a/driver/src/runtime/stream.rs
+++ b/driver/src/runtime/stream.rs
@@ -115,7 +115,10 @@ impl AsyncStream {
                 let resolved: Vec<_> = runtime::resolve_address(&address).await?.collect();
                 if resolved.is_empty() {
                     return Err(ErrorKind::DnsResolve {
-                        message: format!("No DNS results for domain {address}"),
+                        message: format!(
+                            "No DNS results for domain {}",
+                            crate::error::Redact(address)
+                        ),
                     }
                     .into());
                 }

--- a/driver/src/runtime/tls_rustls.rs
+++ b/driver/src/runtime/tls_rustls.rs
@@ -53,7 +53,7 @@ pub(super) async fn tls_connect<T: AsyncRead + AsyncWrite + Unpin>(
 ) -> Result<TlsStream<T>> {
     let name = ServerName::try_from(host)
         .map_err(|e| ErrorKind::DnsResolve {
-            message: format!("could not resolve {host:?}: {e}"),
+            message: format!("could not resolve {:?}: {e}", crate::error::Redact(host)),
         })?
         .to_owned();
 

--- a/driver/src/sdam/topology.rs
+++ b/driver/src/sdam/topology.rs
@@ -5,11 +5,6 @@ use std::{
     time::Duration,
 };
 
-use crate::{
-    bson::oid::ObjectId,
-    cmap::establish::handshake::ClientMetadata,
-    error::SYSTEM_OVERLOADED_ERROR,
-};
 use futures_util::{
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
@@ -21,14 +16,15 @@ use tokio::sync::{
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use crate::{
+    bson::oid::ObjectId,
     client::options::{ClientOptions, ServerAddress},
     cmap::{
         conn::{pooled::PooledConnection, ConnectionGeneration},
-        establish::{ConnectionEstablisher, EstablisherOptions},
+        establish::{handshake::ClientMetadata, ConnectionEstablisher, EstablisherOptions},
         Command,
         PoolGeneration,
     },
-    error::{load_balanced_mode_mismatch, Error, Result},
+    error::{load_balanced_mode_mismatch, Error, Redact, Result, SYSTEM_OVERLOADED_ERROR},
     event::sdam::{
         SdamEvent,
         ServerClosedEvent,
@@ -520,7 +516,8 @@ impl TopologyWorker {
                 let removed_server = self.servers.remove(address);
                 debug_assert!(
                     removed_server.is_some(),
-                    "tried to remove non-existent address from topology: {address}"
+                    "tried to remove non-existent address from topology: {}",
+                    Redact(address)
                 );
 
                 self.emit_event(|| {
@@ -557,7 +554,8 @@ impl TopologyWorker {
                 if self.servers.contains_key(address) {
                     debug_assert!(
                         false,
-                        "adding address that already exists in topology: {address}"
+                        "adding address that already exists in topology: {}",
+                        Redact(address)
                     );
                     continue;
                 }

--- a/driver/src/srv.rs
+++ b/driver/src/srv.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 #[cfg(feature = "dns-resolver")]
-use crate::error::ErrorKind;
+use crate::error::{ErrorKind, Redact};
 use crate::{client::options::ResolverConfig, error::Result, options::ServerAddress};
 #[cfg(feature = "dns-resolver")]
 use hickory_proto::rr::RData;
@@ -69,7 +69,10 @@ impl LookupHosts {
 
         if self.hosts.is_empty() {
             return Err(ErrorKind::DnsResolve {
-                message: format!("SRV lookup for {original_hostname} returned no records"),
+                message: format!(
+                    "SRV lookup for {} returned no records",
+                    Redact(original_hostname)
+                ),
             }
             .into());
         }
@@ -192,8 +195,9 @@ impl SrvResolver {
         if txt_records.next().is_some() {
             return Err(ErrorKind::DnsResolve {
                 message: format!(
-                    "TXT lookup for {original_hostname} returned more than one record, but more \
-                     than one are not allowed with 'mongodb+srv'",
+                    "TXT lookup for {} returned more than one record, but more than one are not \
+                     allowed with 'mongodb+srv'",
+                    Redact(original_hostname),
                 ),
             }
             .into());

--- a/driver/src/test/error.rs
+++ b/driver/src/test/error.rs
@@ -1,5 +1,6 @@
 use crate::error::{
     Error,
+    Redact,
     NOTWRITABLEPRIMARY_CODES,
     RECOVERING_CODES,
     RETRYABLE_READ_CODES,
@@ -64,4 +65,38 @@ fn retryable_read_codes_differ_from_write_codes_by_exactly_134() {
         "RETRYABLE_READ_CODES should differ from RETRYABLE_WRITE_CODES only by code 134 \
          (ReadConcernMajorityNotAvailableYet)"
     );
+}
+
+#[test]
+fn redacted_display() {
+    let value = "test";
+    let actual = format!("{}", Redact(value));
+    if cfg!(feature = "redact-errors") {
+        assert!(
+            !actual.contains(value),
+            "value: {value:?} actual: {actual:?}"
+        );
+    } else {
+        assert!(
+            actual.contains(value),
+            "value: {value:?} actual: {actual:?}"
+        );
+    }
+}
+
+#[test]
+fn redacted_debug() {
+    let value = "test";
+    let actual = format!("{:?}", Redact(value));
+    if cfg!(feature = "redact-errors") {
+        assert!(
+            !actual.contains(value),
+            "value: {value:?} actual: {actual:?}"
+        );
+    } else {
+        assert!(
+            actual.contains(value),
+            "value: {value:?} actual: {actual:?}"
+        );
+    }
 }

--- a/driver/src/tracking_arc.rs
+++ b/driver/src/tracking_arc.rs
@@ -51,6 +51,7 @@ impl<T> TrackingArc<T> {
         }
     }
 
+    #[cfg(feature = "in-use-encryption")]
     pub(crate) fn downgrade(tracked: &Self) -> Weak<T> {
         Weak {
             inner: Arc::downgrade(&tracked.inner),
@@ -114,11 +115,13 @@ impl<T> std::ops::Deref for TrackingArc<T> {
     }
 }
 
+#[cfg(feature = "in-use-encryption")]
 #[derive(Debug)]
 pub(crate) struct Weak<T> {
     inner: std::sync::Weak<Inner<T>>,
 }
 
+#[cfg(feature = "in-use-encryption")]
 impl<T> Clone for Weak<T> {
     fn clone(&self) -> Self {
         Self {
@@ -127,6 +130,7 @@ impl<T> Clone for Weak<T> {
     }
 }
 
+#[cfg(feature = "in-use-encryption")]
 impl<T> Weak<T> {
     pub(crate) fn upgrade(&self) -> Option<TrackingArc<T>> {
         self.inner.upgrade().map(|inner| {


### PR DESCRIPTION
RUST-2376

This adds a new `redact-errors` feature flag that will cause URI components contained in error messages to be replaced with `"<redacted>"`.

There's also a minor unrelated cleanup - some code didn't have the proper `#[cfg(feature = "in-use-encryption")]` gating, causing warnings when compiling with default features.