### PR TITLE
RUST-2299 Remove warnings about hickory performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ A simple CRUD API example using Axum and MongoDB can be found [here](https://git
 
 The Rocket web framework provides built-in support for MongoDB via the Rust driver. The documentation for the [`rocket_db_pools`](https://api.rocket.rs/v0.5/rocket_db_pools/index.html) crate contains instructions for using MongoDB with your Rocket application.
 
-## Windows DNS note
-
-On Windows, there is a known issue in the `hickory-resolver` crate, which the driver uses to perform DNS lookups, that causes severe performance degradation in resolvers that use the system configuration. Since the driver uses the system configuration by default, users are recommended to specify an alternate resolver configuration on Windows (e.g. `ResolverConfig::cloudflare()`) until that issue is resolved. This only has an effect when connecting to deployments using a `mongodb+srv` connection string.
-
 ## Warning about timeouts / cancellation
 
 In async Rust, it is common to implement cancellation and timeouts by dropping a future after a

--- a/driver/src/client/options.rs
+++ b/driver/src/client/options.rs
@@ -709,9 +709,6 @@ pub struct ClientOptions {
 
     /// Configuration of the DNS resolver used for SRV and TXT lookups.
     /// By default, the host system's resolver configuration will be used.
-    ///
-    /// On Windows, there is a known performance issue in [hickory_resolver] with using the default
-    /// system configuration, so a custom configuration is recommended.
     #[builder(setter(skip))]
     #[serde(skip)]
     #[derive_where(skip(Debug))]


### PR DESCRIPTION
RUST-2299

It turns out the reason I was having trouble making a repro case is because ... it doesn't repro any more.  Happily, it _does_ repro with the version of hickory (then trust-dns) that was current at the time the bug originally was filed, so I was able to validate the repro and behavior change.