### PR TITLE
minor: fix update-spec-tests.sh

### DIFF
--- a/etc/update-spec-tests.sh
+++ b/etc/update-spec-tests.sh
@@ -28,11 +28,11 @@ tmpdir=`perl -MFile::Temp=tempdir -wle 'print tempdir(TMPDIR => 1, CLEANUP => 0)
 curl -sL "https://github.com/mongodb/specifications/archive/$REF.zip" -o "$tmpdir/specs.zip"
 unzip -q -d "$tmpdir" "$tmpdir/specs.zip"
 mkdir -p "${DEST}/$1"
-EXCLUDE=""
+EXCLUDE=()
 if [ "$1" = "client-side-encryption" ]; then
-  EXCLUDE="--exclude=legacy/"
+  EXCLUDE=(--exclude=legacy/)
 fi
-rsync -ah "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1" --delete "${EXCLUDE}"
+rsync -ah "${EXCLUDE[@]}" --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
 
 if [ "$1" = "client-side-encryption" ]; then
     mkdir -p "${DEST}/testdata/$1/data"

--- a/etc/update-spec-tests.sh
+++ b/etc/update-spec-tests.sh
@@ -28,11 +28,11 @@ tmpdir=`perl -MFile::Temp=tempdir -wle 'print tempdir(TMPDIR => 1, CLEANUP => 0)
 curl -sL "https://github.com/mongodb/specifications/archive/$REF.zip" -o "$tmpdir/specs.zip"
 unzip -q -d "$tmpdir" "$tmpdir/specs.zip"
 mkdir -p "${DEST}/$1"
-EXCLUDE=()
+EXCLUDE=""
 if [ "$1" = "client-side-encryption" ]; then
-  EXCLUDE=(--exclude=legacy/)
+  EXCLUDE="--exclude=legacy/"
 fi
-rsync -ah "${EXCLUDE[@]}" --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
+rsync -ah ${EXCLUDE} --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
 
 if [ "$1" = "client-side-encryption" ]; then
     mkdir -p "${DEST}/testdata/$1/data"


### PR DESCRIPTION
So, it turns out that `rsync` is particular about positional parameters.  Its general invocation form is `rsync [OPTS] SRC.. DEST`; it's smart enough to include anything with `--` in `OPTS` but otherwise everything goes into the "list of sources followed by single destination".

It _further_ turns out that `"${EXCLUDE}"`, when `EXCLUDE` is `""`, will still be passed as an empty string in the args.

And finally, as it happens, `rsync` treats an empty-string destination as meaning "current working directory".

The upshot of all of that is that my change to add an exclusion for `client-side-encryption` mean that when the script argument _wasn't_ that, rsync would see the current working directory as the target and, because nothing in cwd matched anything in the sources list, would happily delete everything 🙃 

The fix here unquotes `${EXCLUDE}` so that when empty it's treated as not existing rather than present-but-empty, and also moves all of the options to before the positional parameters to hopefully make this kind of mistake less likely in the future.