### PR TITLE
RUST-2412 Send afterClusterTime on writes in causally-consistent sessions

### DIFF
--- a/driver/src/client/executor.rs
+++ b/driver/src/client/executor.rs
@@ -839,7 +839,7 @@ impl Client {
                         session.transaction.state,
                         TransactionState::None | TransactionState::Starting
                     )
-                    && op.read_concern().supported()
+                    && (op.read_concern().supported() || op.is_after_cluster_time_write())
                 {
                     cmd.set_after_cluster_time(session);
                 }

--- a/driver/src/db/options.rs
+++ b/driver/src/db/options.rs
@@ -286,14 +286,14 @@ pub enum TimeseriesGranularity {
 }
 
 /// Specifies the options to a [`Database::drop`](crate::Database::drop) operation.
-#[derive(Clone, Debug, Default, TypedBuilder, Serialize)]
+#[derive(Clone, Debug, Default, TypedBuilder, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[builder(field_defaults(default, setter(into)))]
 #[non_exhaustive]
 #[export_tokens]
 pub struct DropDatabaseOptions {
     /// The write concern for the operation.
-    #[serde(skip_serializing)]
+    #[serde(skip)]
     pub write_concern: Option<WriteConcern>,
 }
 

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -118,4 +118,5 @@ macro_rules! log_warning {
     }
 }
 
+#[allow(unused)]
 use log_warning;

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -191,6 +191,9 @@ pub(crate) trait Operation {
     /// The noun to this operation's verb.
     fn target(&self) -> OperationTarget;
 
+    /// Whether this is a write operation that needs `afterClusterTime` set.
+    fn is_after_cluster_time_write(&self) -> bool;
+
     #[cfg(feature = "opentelemetry")]
     type Otel: crate::otel::OtelWitness<Op = Self>;
 
@@ -405,6 +408,10 @@ pub(crate) trait BaseOperation: Send + Sync {
 
     fn target(&self) -> OperationTarget;
 
+    fn is_after_cluster_time_write(&self) -> bool {
+        self.write_concern().supported()
+    }
+
     #[cfg(feature = "opentelemetry")]
     type Otel: crate::otel::OtelWitness<Op = Self>;
 }
@@ -442,6 +449,7 @@ pub(crate) trait OperationDispatch<Kind> {
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle>;
     fn name(&self) -> &CStr;
     fn target(&self) -> OperationTarget;
+    fn is_after_cluster_time_write(&self) -> bool;
     #[cfg(feature = "opentelemetry")]
     type Otel: crate::otel::OtelWitness<Op = Self>;
 }
@@ -507,6 +515,9 @@ macro_rules! operation_dispatch_body {
         }
         fn target(&self) -> OperationTarget {
             <T as $trait>::target(self)
+        }
+        fn is_after_cluster_time_write(&self) -> bool {
+            <T as $trait>::is_after_cluster_time_write(self)
         }
         #[cfg(feature = "opentelemetry")]
         type Otel = <T as $trait>::Otel;
@@ -589,6 +600,9 @@ pub(crate) trait WrappedOperation {
     }
     fn target(&self) -> OperationTarget {
         self.wrapped().target()
+    }
+    fn is_after_cluster_time_write(&self) -> bool {
+        self.wrapped().is_after_cluster_time_write()
     }
 }
 

--- a/driver/src/operation/abort_transaction.rs
+++ b/driver/src/operation/abort_transaction.rs
@@ -85,6 +85,10 @@ impl BaseOperation for AbortTransaction {
         crate::operation::OperationTarget::admin(&self.target)
     }
 
+    fn is_after_cluster_time_write(&self) -> bool {
+        false
+    }
+
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
 }

--- a/driver/src/operation/aggregate.rs
+++ b/driver/src/operation/aggregate.rs
@@ -168,6 +168,10 @@ impl BaseOperation for Aggregate {
         self.target.clone()
     }
 
+    fn is_after_cluster_time_write(&self) -> bool {
+        false
+    }
+
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
 }

--- a/driver/src/operation/commit_transaction.rs
+++ b/driver/src/operation/commit_transaction.rs
@@ -92,6 +92,10 @@ impl BaseOperation for CommitTransaction {
         super::OperationTarget::admin(&self.target)
     }
 
+    fn is_after_cluster_time_write(&self) -> bool {
+        false
+    }
+
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
 }

--- a/driver/src/operation/run_cursor_command.rs
+++ b/driver/src/operation/run_cursor_command.rs
@@ -7,7 +7,6 @@ use crate::{
     error::Result,
     operation::{
         run_command::RunCommand,
-        Operation,
         OperationImpl,
         Wrapped,
         WrappedOperation,
@@ -84,6 +83,9 @@ impl<'conn> WrappedOperation for RunCursorCommand<'conn> {
 impl OperationImpl for RunCursorCommand<'_> {
     type Kind = Wrapped;
 }
+
+#[cfg(feature = "opentelemetry")]
+use crate::operation::Operation;
 
 #[cfg(feature = "opentelemetry")]
 impl crate::otel::OtelInfo for RunCursorCommand<'_> {

--- a/driver/src/test/spec.rs
+++ b/driver/src/test/spec.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod causal_consistency;
 mod change_streams;
 mod collection_management;
 mod command_monitoring;

--- a/driver/src/test/spec/causal_consistency.rs
+++ b/driver/src/test/spec/causal_consistency.rs
@@ -1,0 +1,6 @@
+use crate::test::spec::unified_runner::run_unified_tests;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn run_unified() {
+    run_unified_tests(&["causal-consistency"]).await;
+}

--- a/driver/src/test/spec/unified_runner/operation.rs
+++ b/driver/src/test/spec/unified_runner/operation.rs
@@ -6,6 +6,7 @@ mod connection;
 mod count;
 #[cfg(feature = "in-use-encryption")]
 mod csfle;
+mod database;
 mod delete;
 mod failpoint;
 mod find;
@@ -48,6 +49,7 @@ use connection::*;
 use count::*;
 #[cfg(feature = "in-use-encryption")]
 use csfle::*;
+use database::*;
 use delete::*;
 use failpoint::*;
 use find::*;
@@ -120,6 +122,7 @@ pub(crate) trait TestOperation: Debug + Send + Sync {
 macro_rules! with_mut_session {
     ($test_runner:ident, $id:expr, |$session:ident| $body:expr) => {
         async {
+            use crate::test::spec::unified_runner::Entity;
             let id = $id;
             let entity = $test_runner.entities.write().await.remove(id).unwrap();
             match entity {
@@ -159,7 +162,12 @@ macro_rules! with_opt_session {
             let act = $act;
             match $id {
                 Some(id) => {
-                    with_mut_session!($test_runner, id, |session| act.session(session)).await
+                    crate::test::spec::unified_runner::operation::with_mut_session!(
+                        $test_runner,
+                        id,
+                        |session| act.session(session)
+                    )
+                    .await
                 }
                 None => act.await,
             }
@@ -339,6 +347,7 @@ impl<'de> Deserialize<'de> for Operation {
             }
             "createCollection" => deserialize_op::<CreateCollection>(definition.arguments),
             "dropCollection" => deserialize_op::<DropCollection>(definition.arguments),
+            "dropDatabase" => deserialize_op::<DropDatabase>(definition.arguments),
             "runCommand" => deserialize_op::<RunCommand>(definition.arguments),
             "runCursorCommand" => deserialize_op::<RunCursorCommand>(definition.arguments),
             "endSession" => deserialize_op::<EndSession>(definition.arguments),

--- a/driver/src/test/spec/unified_runner/operation/bulk_write.rs
+++ b/driver/src/test/spec/unified_runner/operation/bulk_write.rs
@@ -18,7 +18,7 @@ use crate::{
     test::spec::unified_runner::{Entity, TestRunner},
 };
 
-use super::{with_mut_session, with_opt_session, TestOperation};
+use super::{with_opt_session, TestOperation};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/driver/src/test/spec/unified_runner/operation/collection.rs
+++ b/driver/src/test/spec/unified_runner/operation/collection.rs
@@ -106,7 +106,7 @@ impl TestOperation for DropCollection {
     ) -> BoxFuture<'a, Result<Option<Entity>>> {
         async move {
             let database = test_runner.get_database(id).await;
-            let collection = database.collection::<Document>(&self.collection).clone();
+            let collection = database.collection::<Document>(&self.collection);
             with_opt_session!(
                 test_runner,
                 &self.session,

--- a/driver/src/test/spec/unified_runner/operation/count.rs
+++ b/driver/src/test/spec/unified_runner/operation/count.rs
@@ -3,7 +3,7 @@ use crate::{
     error::Result,
     options::{CountOptions, DistinctOptions, EstimatedDocumentCountOptions},
     test::spec::unified_runner::{
-        operation::{with_mut_session, with_opt_session, TestOperation},
+        operation::{with_opt_session, TestOperation},
         Entity,
         ExpectedEvent,
         TestRunner,

--- a/driver/src/test/spec/unified_runner/operation/database.rs
+++ b/driver/src/test/spec/unified_runner/operation/database.rs
@@ -1,0 +1,40 @@
+use futures::FutureExt;
+use serde::Deserialize;
+
+use crate::{
+    options::DropDatabaseOptions,
+    test::spec::unified_runner::operation::{with_opt_session, TestOperation},
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct DropDatabase {
+    database: String,
+    #[serde(flatten)]
+    options: DropDatabaseOptions,
+    session: Option<String>,
+}
+
+impl TestOperation for DropDatabase {
+    fn execute_entity_operation<'a>(
+        &'a self,
+        id: &'a str,
+        test_runner: &'a crate::test::spec::unified_runner::TestRunner,
+    ) -> futures::prelude::future::BoxFuture<
+        'a,
+        crate::error::Result<Option<crate::test::spec::unified_runner::Entity>>,
+    > {
+        async move {
+            let client = test_runner.get_client(id).await;
+            let db = client.database(&self.database);
+            with_opt_session!(
+                test_runner,
+                &self.session,
+                db.drop().with_options(self.options.clone()),
+            )
+            .await?;
+            Ok(None)
+        }
+        .boxed()
+    }
+}

--- a/driver/src/test/spec/unified_runner/operation/delete.rs
+++ b/driver/src/test/spec/unified_runner/operation/delete.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Result,
     options::DeleteOptions,
     test::spec::unified_runner::{
-        operation::{with_mut_session, with_opt_session, TestOperation},
+        operation::{with_opt_session, TestOperation},
         Entity,
         TestRunner,
     },

--- a/driver/src/test/spec/unified_runner/operation/failpoint.rs
+++ b/driver/src/test/spec/unified_runner/operation/failpoint.rs
@@ -1,7 +1,6 @@
 use crate::test::{
     spec::unified_runner::{
         operation::{with_mut_session, TestOperation},
-        Entity,
         TestRunner,
     },
     util::fail_point::FailPoint,

--- a/driver/src/test/spec/unified_runner/operation/insert.rs
+++ b/driver/src/test/spec/unified_runner/operation/insert.rs
@@ -10,7 +10,7 @@ use crate::{
     error::Result,
     options::{InsertManyOptions, InsertOneOptions},
     test::spec::unified_runner::{
-        operation::{with_mut_session, with_opt_session, TestOperation},
+        operation::{with_opt_session, TestOperation},
         Entity,
         TestRunner,
     },

--- a/driver/src/test/spec/unified_runner/operation/update.rs
+++ b/driver/src/test/spec/unified_runner/operation/update.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Result,
     options::{ReplaceOptions, UpdateModifications, UpdateOptions},
     test::spec::unified_runner::{
-        operation::{with_mut_session, with_opt_session, TestOperation},
+        operation::{with_opt_session, TestOperation},
         Entity,
         TestRunner,
     },

--- a/etc/update-spec-tests.sh
+++ b/etc/update-spec-tests.sh
@@ -32,7 +32,7 @@ EXCLUDE=""
 if [ "$1" = "client-side-encryption" ]; then
   EXCLUDE="--exclude=legacy/"
 fi
-rsync -ah $EXCLUDE --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
+rsync -ah ${EXCLUDE} --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
 
 if [ "$1" = "client-side-encryption" ]; then
     mkdir -p "${DEST}/testdata/$1/data"

--- a/etc/update-spec-tests.sh
+++ b/etc/update-spec-tests.sh
@@ -32,7 +32,7 @@ EXCLUDE=""
 if [ "$1" = "client-side-encryption" ]; then
   EXCLUDE="--exclude=legacy/"
 fi
-rsync -ah ${EXCLUDE} --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
+rsync -ah $EXCLUDE --delete "$tmpdir/specifications-$REF"*"/source/$1/tests/" "${DEST}/$1"
 
 if [ "$1" = "client-side-encryption" ]; then
     mkdir -p "${DEST}/testdata/$1/data"

--- a/spec/causal-consistency/causal-consistency-clientBulkWrite.json
+++ b/spec/causal-consistency/causal-consistency-clientBulkWrite.json
@@ -1,0 +1,151 @@
+{
+  "description": "causal consistency bulkWrite include afterClusterTime",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "causal-consistency-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": {
+          "causalConsistency": true
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "causal-consistency-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "clientBulkWrite includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "clientBulkWrite",
+          "object": "client0",
+          "arguments": {
+            "session": "session0",
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "causal-consistency-tests.test",
+                  "document": {
+                    "_id": 4
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "command": {
+                  "bulkWrite": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/causal-consistency/causal-consistency-clientBulkWrite.yml
+++ b/spec/causal-consistency/causal-consistency-clientBulkWrite.yml
@@ -1,0 +1,75 @@
+description: "causal consistency bulkWrite include afterClusterTime"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "8.0"
+    topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      uriOptions:
+        retryWrites: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName causal-consistency-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName test
+  - session:
+      id: &session0 session0
+      client: *client0
+      sessionOptions:
+        causalConsistency: true
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+# In a causally consistent session, once an operationTime has been established by a prior
+# operation, subsequent write commands MUST include readConcern.afterClusterTime so the
+# server can apply the write causally after the previously-observed data.
+
+tests:
+  - description: "clientBulkWrite includes afterClusterTime in causally consistent session"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult: [{ _id: 1, x: 11 }]
+      - name: clientBulkWrite
+        object: *client0
+        arguments:
+          session: *session0
+          models:
+          - insertOne:
+              namespace: causal-consistency-tests.test
+              document: { _id: 4 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: find
+              command:
+                find: *collectionName
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+          - commandStartedEvent:
+              commandName: bulkWrite
+              command:
+                bulkWrite: 1
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }

--- a/spec/causal-consistency/causal-consistency-write-commands.json
+++ b/spec/causal-consistency/causal-consistency-write-commands.json
@@ -1,0 +1,1396 @@
+{
+  "description": "causal consistency write commands include afterClusterTime",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "causal-consistency-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": {
+          "causalConsistency": true
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "causal-consistency-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "insertOne includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 4
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "command": {
+                  "insert": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertMany includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 4
+              },
+              {
+                "_id": 5
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "command": {
+                  "insert": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateOne includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 100
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "update",
+                "command": {
+                  "update": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateMany includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gt": 0
+              }
+            },
+            "update": {
+              "$set": {
+                "updated": true
+              }
+            }
+          },
+          "expectResult": {
+            "matchedCount": 3,
+            "modifiedCount": 3,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "update",
+                "command": {
+                  "update": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "replaceOne includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 100
+            }
+          },
+          "expectResult": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "update",
+                "command": {
+                  "update": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteOne includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": {
+            "deletedCount": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "delete",
+                "command": {
+                  "delete": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteMany includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "deleteMany",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gt": 0
+              }
+            }
+          },
+          "expectResult": {
+            "deletedCount": 3
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "delete",
+                "command": {
+                  "delete": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndUpdate includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 100
+              }
+            }
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "findAndModify",
+                "command": {
+                  "findAndModify": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndDelete includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "findAndModify",
+                "command": {
+                  "findAndModify": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndReplace includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 100
+            }
+          },
+          "expectResult": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "findAndModify",
+                "command": {
+                  "findAndModify": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "bulkWrite includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": 4
+                  }
+                }
+              },
+              {
+                "updateOne": {
+                  "filter": {
+                    "_id": 2
+                  },
+                  "update": {
+                    "$set": {
+                      "x": 100
+                    }
+                  }
+                }
+              },
+              {
+                "deleteOne": {
+                  "filter": {
+                    "_id": 3
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "command": {
+                  "insert": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "update",
+                "command": {
+                  "update": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "delete",
+                "command": {
+                  "delete": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "create includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "causal-consistency-createCollection-test"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "causal-consistency-createCollection-test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "drop",
+                "command": {
+                  "drop": "causal-consistency-createCollection-test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "create",
+                "command": {
+                  "create": "causal-consistency-createCollection-test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "createIndexes includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "keys": {
+              "x": 1
+            },
+            "name": "x_1"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "createIndexes",
+                "command": {
+                  "createIndexes": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "drop includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "drop",
+                "command": {
+                  "drop": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "dropDatabase includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "dropDatabase",
+          "object": "client0",
+          "arguments": {
+            "session": "session0",
+            "database": "causal-consistency-dropDatabase-test"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "dropDatabase",
+                "command": {
+                  "dropDatabase": 1,
+                  "$db": "causal-consistency-dropDatabase-test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "dropIndexes includes afterClusterTime in causally consistent session",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        },
+        {
+          "name": "dropIndexes",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "command": {
+                  "find": "test",
+                  "readConcern": {
+                    "$$exists": false
+                  },
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "dropIndexes",
+                "command": {
+                  "dropIndexes": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "first write command in a causally consistent session does not include afterClusterTime",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 4
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 4
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "command": {
+                  "insert": "test",
+                  "lsid": {
+                    "$$sessionLsid": "session0"
+                  },
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/causal-consistency/causal-consistency-write-commands.yml
+++ b/spec/causal-consistency/causal-consistency-write-commands.yml
@@ -1,0 +1,472 @@
+description: "causal consistency write commands include afterClusterTime"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      uriOptions:
+        retryWrites: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName causal-consistency-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName test
+  - session:
+      id: &session0 session0
+      client: *client0
+      sessionOptions:
+        causalConsistency: true
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+# In a causally consistent session, once an operationTime has been established by a prior
+# operation, subsequent write commands MUST include readConcern.afterClusterTime so the
+# server can apply the write causally after the previously-observed data.
+
+tests:
+  - description: "insertOne includes afterClusterTime in causally consistent session"
+    operations:
+      - &find
+        name: find
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult: [{ _id: 1, x: 11 }]
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectResult:
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 4 } }
+    expectEvents:
+      - client: *client0
+        events:
+          - &findEvent
+            commandStartedEvent:
+              commandName: find
+              command:
+                find: *collectionName
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "insertMany includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: insertMany
+        object: *collection0
+        arguments:
+          session: *session0
+          documents:
+            - { _id: 4 }
+            - { _id: 5 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "updateOne includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: updateOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          update: { $set: { x: 100 } }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "updateMany includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: updateMany
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: { $gt: 0 } }
+          update: { $set: { updated: true } }
+        expectResult:
+          matchedCount: 3
+          modifiedCount: 3
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "replaceOne includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          replacement: { x: 100 }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "deleteOne includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult:
+          deletedCount: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: delete
+              command:
+                delete: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "deleteMany includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: { $gt: 0 } }
+        expectResult:
+          deletedCount: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: delete
+              command:
+                delete: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "findOneAndUpdate includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          update: { $set: { x: 100 } }
+        expectResult: { _id: 1, x: 11 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: findAndModify
+              command:
+                findAndModify: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "findOneAndDelete includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult: { _id: 1, x: 11 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: findAndModify
+              command:
+                findAndModify: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "findOneAndReplace includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          replacement: { x: 100 }
+        expectResult: { _id: 1, x: 11 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: findAndModify
+              command:
+                findAndModify: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "bulkWrite includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          session: *session0
+          requests:
+            - insertOne:
+                document: { _id: 4 }
+            - updateOne:
+                filter: { _id: 2 }
+                update: { $set: { x: 100 } }
+            - deleteOne:
+                filter: { _id: 3 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+          - commandStartedEvent:
+              commandName: delete
+              command:
+                delete: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "create includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      # Drop the collection first to make sure there's no name conflict during
+      # createCollection.
+      - name: dropCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: &newCollectionName causal-consistency-createCollection-test
+      - name: createCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *newCollectionName
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: drop
+              command:
+                drop: *newCollectionName
+                lsid: { $$sessionLsid: *session0 }
+          - commandStartedEvent:
+              commandName: create
+              command:
+                create: *newCollectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "createIndexes includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: createIndex
+        object: *collection0
+        arguments:
+          session: *session0
+          keys: { x: 1 }
+          name: x_1
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: createIndexes
+              command:
+                createIndexes: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "drop includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: dropCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *collectionName
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: drop
+              command:
+                drop: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "dropDatabase includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: dropDatabase
+        object: *client0
+        arguments:
+          session: *session0
+          database: causal-consistency-dropDatabase-test
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: dropDatabase
+              command:
+                dropDatabase: 1
+                $db: causal-consistency-dropDatabase-test
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "dropIndexes includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: dropIndexes
+        object: *collection0
+        arguments:
+          session: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: dropIndexes
+              command:
+                dropIndexes: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  # Covers the same condition as Causal Consistency prose test #2, but for a write operation.
+  - description: "first write command in a causally consistent session does not include afterClusterTime"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectResult:
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 4 } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern: { $$exists: false }

--- a/spec/transactions-convenient-api/README.md
+++ b/spec/transactions-convenient-api/README.md
@@ -29,20 +29,97 @@ Write a callback that returns a custom value (e.g. boolean, string, object). Exe
 Drivers should test that `withTransaction` enforces a non-configurable timeout before retrying both commits and entire
 transactions. Specifically, three cases should be checked:
 
-- If the callback raises an error with the TransientTransactionError label and the retry timeout has been exceeded,
-    `withTransaction` should propagate the error to its caller.
-- If committing raises an error with the UnknownTransactionCommitResult label, and the retry timeout has been exceeded,
-    `withTransaction` should propagate the error to its caller.
-- If committing raises an error with the TransientTransactionError label and the retry timeout has been exceeded,
-    `withTransaction` should propagate the error to its caller. This case may occur if the commit was internally retried
-    against a new primary after a failover and the second primary returned a NoSuchTransaction error response.
+- If the callback raises an error with the `TransientTransactionError` label and the retry timeout has been exceeded,
+    `withTransaction` should propagate the error as described in the
+    [propagation mechanism](../transactions-convenient-api.md#timeout-error-propagation) to its caller.
+- If committing raises an error with the `UnknownTransactionCommitResult` label, and the retry timeout has been
+    exceeded, `withTransaction` should propagate the error as described in the
+    [propagation mechanism](../transactions-convenient-api.md#timeout-error-propagation) to its caller
+- If committing raises an error with the `TransientTransactionError` label and the retry timeout has been exceeded,
+    `withTransaction` should propagate the error as described in the
+    [propagation mechanism](../transactions-convenient-api.md#timeout-error-propagation) to its caller. This case may
+    occur if the commit was internally retried against a new primary after a failover and the second primary returned a
+    `NoSuchTransaction` error response.
 
 If possible, drivers should implement these tests without requiring the test runner to block for the full duration of
 the retry timeout. This might be done by internally modifying the timeout value used by `withTransaction` with some
 private API or using a mock timer.
 
+The drivers should assert that the timeout error propagated has the same labels as the error it wraps.
+
+### Retry Backoff is Enforced
+
+Drivers should test that retries within `withTransaction` do not occur immediately.
+
+1. let `client` be a `MongoClient`
+2. let `coll` be a collection
+3. Now, run transactions without backoff:
+    1. Configure the random number generator used for jitter to always return `0` -- this effectively disables backoff.
+
+    2. Configure a fail point that forces 13 retries like so:
+
+        ```python
+           set_fail_point(
+              {
+                  "configureFailPoint": "failCommand",
+                  "mode": {
+                      "times": 13
+                  },  # sufficiently high enough such that the time effect of backoff is noticeable
+                  "data": {
+                      "failCommands": ["commitTransaction"],
+                      "errorCode": 251,
+                  },
+              }
+           )
+        ```
+
+        > Note: errorCode 251 is NoSuchTransaction.
+
+    3. Define the callback for the transaction as follows:
+
+        ```python
+           def callback(session):
+              coll.insert_one({}, session=session)
+        ```
+
+    4. Let `no_backoff_time` be the duration of the withTransaction API call:
+
+        ```python
+           start = time.monotonic()
+           with client.start_session() as s:
+              s.with_transaction(callback)
+           end = time.monotonic()
+           no_backoff_time = end - start
+        ```
+4. Now run the command with backoff:
+    1. Configure the random number generator used for jitter to always return a number as close as possible to `1`.
+    2. Configure a fail point that forces 13 retries like in step 3.2.
+    3. Use the same callback defined in 3.3.
+    4. Let `with_backoff_time` be the duration of the withTransaction API call:
+        ```python
+           start = time.monotonic()
+           with client.start_session() as s:
+              s.with_transaction(callback)
+           end = time.monotonic()
+           no_backoff_time = end - start
+        ```
+5. Compare the durations of the two runs.
+    ```python
+    assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 3.6 seconds)) < 0.5 seconds)
+    ```
+    The sum of 13 backoffs is roughly 3.6 seconds. There is a half-second window to account for potential variance
+    between the two runs.
+
 ## Changelog
 
+- 2206-07-08: Update Backoff test to use updated exponential formula.
+- 2026-04-02: [DRIVERS-3436](https://github.com/mongodb/specifications/pull/1920) Refine withTransaction timeout error
+    wrapping semantics and label propagation in spec and prose tests
+- 2026-03-03: Clarify exponential backoff jitter upper bound.
+- 2026-02-17: Clarify expected error when timeout is reached
+    [DRIVERS-3391](https://jira.mongodb.org/browse/DRIVERS-3391).
+- 2026-01-07: Fixed Retry Backoff is Enforced test accordingly to the updated spec.
+- 2025-11-18: Added Backoff test.
 - 2024-09-06: Migrated from reStructuredText to Markdown.
 - 2024-02-08: Converted legacy tests to unified format.
 - 2021-04-29: Remove text about write concern timeouts from prose test.

--- a/spec/transactions-convenient-api/unified/callback-aborts.json
+++ b/spec/transactions-convenient-api/unified/callback-aborts.json
@@ -308,10 +308,12 @@
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
-                  "autocommit": {
-                    "$$exists": false
-                  },
                   "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    }
+                  },
+                  "autocommit": {
                     "$$exists": false
                   },
                   "startTransaction": {

--- a/spec/transactions-convenient-api/unified/callback-aborts.yml
+++ b/spec/transactions-convenient-api/unified/callback-aborts.yml
@@ -164,9 +164,10 @@ tests:
                   - { _id: 2 }
                 ordered: true
                 lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
                 # omitted fields
                 autocommit: { $$exists: false }
-                readConcern: { $$exists: false }
                 startTransaction: { $$exists: false }
                 writeConcern: { $$exists: false }
               commandName: insert

--- a/spec/transactions-convenient-api/unified/callback-commits.json
+++ b/spec/transactions-convenient-api/unified/callback-commits.json
@@ -381,10 +381,12 @@
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
-                  "autocommit": {
-                    "$$exists": false
-                  },
                   "readConcern": {
+                    "afterClusterTime": {
+                      "$$exists": true
+                    }
+                  },
+                  "autocommit": {
                     "$$exists": false
                   },
                   "startTransaction": {

--- a/spec/transactions-convenient-api/unified/callback-commits.yml
+++ b/spec/transactions-convenient-api/unified/callback-commits.yml
@@ -193,9 +193,10 @@ tests:
                   - { _id: 3 }
                 ordered: true
                 lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
                 # omitted fields
                 autocommit: { $$exists: false }
-                readConcern: { $$exists: false }
                 startTransaction: { $$exists: false }
                 writeConcern: { $$exists: false }
               commandName: insert

--- a/spec/transactions/unified/commit.json
+++ b/spec/transactions/unified/commit.json
@@ -209,6 +209,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -870,6 +873,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -1040,7 +1046,12 @@
                   ],
                   "ordered": true,
                   "readConcern": {
-                    "$$exists": false
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
                   },
                   "lsid": {
                     "$$sessionLsid": "session1"
@@ -1196,7 +1207,12 @@
                   ],
                   "ordered": true,
                   "readConcern": {
-                    "$$exists": false
+                    "afterClusterTime": {
+                      "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
+                    }
                   },
                   "lsid": {
                     "$$sessionLsid": "session1"

--- a/spec/transactions/unified/commit.yml
+++ b/spec/transactions/unified/commit.yml
@@ -136,6 +136,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '2' }
                 startTransaction: true
@@ -522,6 +523,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session0 }
                 # txnNumber 2 was skipped
                 txnNumber: { $numberLong: '3' }
@@ -615,7 +617,9 @@ tests:
                 documents:
                   - { _id: 2 }
                 ordered: true
-                readConcern: { $$exists: false }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session1 }
                 txnNumber: { $$exists: false }
                 startTransaction: { $$exists: false }
@@ -698,7 +702,9 @@ tests:
                 documents:
                   - { _id: 2 }
                 ordered: true
-                readConcern: { $$exists: false }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session1 }
                 txnNumber: { $$exists: false }
                 startTransaction: { $$exists: false }

--- a/spec/transactions/unified/retryable-writes.json
+++ b/spec/transactions/unified/retryable-writes.json
@@ -217,7 +217,9 @@
                   ],
                   "ordered": true,
                   "readConcern": {
-                    "$$exists": false
+                    "afterClusterTime": {
+                      "$$exists": true
+                    }
                   },
                   "lsid": {
                     "$$sessionLsid": "session0"
@@ -306,7 +308,9 @@
                   ],
                   "ordered": true,
                   "readConcern": {
-                    "$$exists": false
+                    "afterClusterTime": {
+                      "$$exists": true
+                    }
                   },
                   "lsid": {
                     "$$sessionLsid": "session0"

--- a/spec/transactions/unified/retryable-writes.yml
+++ b/spec/transactions/unified/retryable-writes.yml
@@ -132,7 +132,8 @@ tests:
                 documents:
                   - { _id: 2 }
                 ordered: true
-                readConcern: { $$exists: false }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '2' }
                 startTransaction: { $$exists: false }
@@ -175,7 +176,8 @@ tests:
                   - { _id: 4 }
                   - { _id: 5 }
                 ordered: true
-                readConcern: { $$exists: false }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '4' }
                 startTransaction: { $$exists: false }


### PR DESCRIPTION
RUST-2412

This one's a little fiddly because I didn't want to hardcode a list but the set of commands that need this isn't _quite_ "commands that support a write concern", there are a few in the latter that are excluded in the former.  Adding a new method with a default impl and specifically tagging those few operations seemed the least-bad option here.