### PR TITLE
RUST-2008 Remove and forbid `add_expansions_to_env`

### DIFF
--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -24,7 +24,7 @@
 #
 # Make sure to uncomment the call before merging!
 
-exec_timeout_secs: 3600 
+exec_timeout_secs: 3600
 
 functions:
   "fetch source":
@@ -94,6 +94,9 @@ functions:
       params:
         working_dir: src
         include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
           - PROJECT_DIRECTORY
           - DRIVERS_TOOLS
           - DRY_RUN
@@ -205,8 +208,7 @@ tasks:
     commands:
       - func: "fetch source"
       - func: "install dependencies"
-      # TEMPORARY: commented out for main-branch dry run; UNCOMMENT before merging!
-      # - func: "fetch tag"
+      - func: "fetch tag"
       - func: "build vars"
       - func: "publish release"
       - func: "publish papertrail"

--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -94,6 +94,7 @@ functions:
       params:
         working_dir: src
         include_expansions_in_env:
+          - PROJECT_DIRECTORY
           - DRIVERS_TOOLS
           - DRY_RUN
         binary: bash
@@ -125,6 +126,7 @@ functions:
       params:
         working_dir: "src"
         include_expansions_in_env:
+          - PROJECT_DIRECTORY
           - CARGO_REGISTRY_TOKEN
           - DRY_RUN
           - PACKAGE_ONLY
@@ -203,7 +205,8 @@ tasks:
     commands:
       - func: "fetch source"
       - func: "install dependencies"
-      - func: "fetch tag"
+      # TEMPORARY: commented out for main-branch dry run; UNCOMMENT before merging!
+      # - func: "fetch tag"
       - func: "build vars"
       - func: "publish release"
       - func: "publish papertrail"

--- a/.evergreen/releases.yml
+++ b/.evergreen/releases.yml
@@ -93,7 +93,9 @@ functions:
     - command: subprocess.exec
       params:
         working_dir: src
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - DRIVERS_TOOLS
+          - DRY_RUN
         binary: bash
         args:
           - .evergreen/release-build-vars.sh
@@ -122,7 +124,10 @@ functions:
       type: test
       params:
         working_dir: "src"
-        add_expansions_to_env: true
+        include_expansions_in_env:
+          - CARGO_REGISTRY_TOKEN
+          - DRY_RUN
+          - PACKAGE_ONLY
         binary: bash
         args:
           - .evergreen/release-danger-do-not-run-manually.sh

--- a/.github/workflows/check-forbidden-strings.yml
+++ b/.github/workflows/check-forbidden-strings.yml
@@ -1,0 +1,19 @@
+name: Check for forbidden strings
+
+on: pull_request
+
+jobs:
+  check-for-add-expansions-to-env:
+    name: Check for "add_expansions_to_env"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: |
+          FORBIDDEN="add_expansions_to_env"
+
+          if git grep -F "$FORBIDDEN" -- ':(glob).evergreen/**/*.yml'; then
+            echo "$FORBIDDEN should not be used. Replace with include_expansions_in_env and specify a precise list of expansions needed."
+            exit 1
+          else
+            echo "$FORBIDDEN not found."
+          fi

--- a/.github/workflows/check-forbidden-strings.yml
+++ b/.github/workflows/check-forbidden-strings.yml
@@ -1,11 +1,11 @@
-name: Check for forbidden strings
-
+name: Grep checks
 on: pull_request
 
 jobs:
-  check-for-add-expansions-to-env:
+  add-expansions-to-env:
     name: Check for "add_expansions_to_env"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
       - run: |


### PR DESCRIPTION
release dry run patch: https://spruce.corp.mongodb.com/version/6a6b53620bee4300075d44b3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

The check is implemented as a Github action because it is more lightweight - so far, it appears to take ~5 seconds to run.