### PR TITLE
RUST-1820 Use raw documents and smart truncation for tracing and otel

### DIFF
--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -75,7 +75,7 @@ tracing-unstable = ["dep:tracing", "log", "bson3?/serde_json-1", "dep:serde_json
 text-indexes-unstable = []
 
 # Enable support for opentelemetry instrumentation
-opentelemetry = ["dep:opentelemetry"]
+opentelemetry = ["dep:opentelemetry", "bson3?/serde_json-1", "dep:serde_json"]
 
 # Capture backtraces in errors.  This can be slow, memory intensive, and very verbose.
 error-backtrace = []

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -68,7 +68,7 @@ in-use-encryption-unstable = ["in-use-encryption"]
 # Enables support for emitting tracing events.
 # The tracing API is unstable and may have backwards-incompatible changes in minor version updates.
 # TODO: pending https://github.com/tokio-rs/tracing/issues/2036 stop depending directly on log.
-tracing-unstable = ["dep:tracing", "log", "bson3?/serde_json-1"]
+tracing-unstable = ["dep:tracing", "log", "bson3?/serde_json-1", "dep:serde_json"]
 
 # Backwards compatibility feature; this previously enabled Queryable Encryption text indexes, but
 # those are now GA and require no special feature flag.
@@ -115,6 +115,7 @@ pkcs8 = { version = "0.11.0", features = ["encryption", "pkcs5"], optional = tru
 rand = { version = "0.9", features = ["small_rng"] }
 rayon = { version = "1.5.3", optional = true }
 rustc_version_runtime = "0.3.0"
+serde_json = { version = "1.0", optional = true }
 serde_with = { version = "3.8.1", default-features = false, features = ["macros"] }
 sha1 = "0.11.0"
 sha2 = "0.11.0"

--- a/driver/src/bson_compat.rs
+++ b/driver/src/bson_compat.rs
@@ -29,6 +29,17 @@ pub(crate) fn cstr_to_str(cs: &CStr) -> &str {
     }
 }
 
+pub(crate) fn str_to_cstr(s: &str) -> crate::error::Result<&CStr> {
+    #[cfg(feature = "bson-3")]
+    {
+        Ok(s.try_into()?)
+    }
+    #[cfg(not(feature = "bson-3"))]
+    {
+        Ok(s)
+    }
+}
+
 #[cfg(feature = "bson-3")]
 pub(crate) trait RawDocumentBufExt: Sized {
     fn append_ref<'a>(

--- a/driver/src/bson_util.rs
+++ b/driver/src/bson_util.rs
@@ -410,7 +410,7 @@ fn rawdoc_to_json_str_inner(
     let mut current = doc.iter_elements();
     let mut is_array = false;
     let mut is_first = true;
-    push_trunc!(out, max_length_bytes, "{ ");
+    push_trunc!(out, max_length_bytes, "{");
     'outer: loop {
         while let Some(elt) = current.next() {
             let elt = elt?;
@@ -431,7 +431,7 @@ fn rawdoc_to_json_str_inner(
             }
 
             if !is_first {
-                push_trunc!(out, max_length_bytes, ", ");
+                push_trunc!(out, max_length_bytes, ",");
             }
             is_first = false;
 
@@ -441,11 +441,11 @@ fn rawdoc_to_json_str_inner(
                 )
                 .to_string();
                 push_trunc!(out, max_length_bytes, &key);
-                push_trunc!(out, max_length_bytes, ": ");
+                push_trunc!(out, max_length_bytes, ":");
             }
             match value {
                 RawBsonRef::Document(d) => {
-                    push_trunc!(out, max_length_bytes, "{ ");
+                    push_trunc!(out, max_length_bytes, "{");
                     let mut tmp = d.iter_elements();
                     std::mem::swap(&mut current, &mut tmp);
                     stack.push((tmp, is_array));
@@ -454,7 +454,7 @@ fn rawdoc_to_json_str_inner(
                     continue 'outer;
                 }
                 RawBsonRef::Array(a) => {
-                    push_trunc!(out, max_length_bytes, "[ ");
+                    push_trunc!(out, max_length_bytes, "[");
                     // bson 2.x doesn't have .iter_elements() on RawArray, so we have to jump
                     // through some hoops...
                     let mut tmp =
@@ -475,14 +475,7 @@ fn rawdoc_to_json_str_inner(
                 }
             }
         }
-        if is_first {
-            // nothing was emitted for this container, so drop the space from the opener to
-            // produce "{}" rather than "{  }".
-            out.pop();
-            push_trunc!(out, max_length_bytes, if is_array { "]" } else { "}" });
-        } else {
-            push_trunc!(out, max_length_bytes, if is_array { " ]" } else { " }" });
-        }
+        push_trunc!(out, max_length_bytes, if is_array { "]" } else { "}" });
         let Some(outer) = stack.pop() else {
             break;
         };

--- a/driver/src/bson_util.rs
+++ b/driver/src/bson_util.rs
@@ -325,33 +325,143 @@ pub(crate) mod option_u64_as_i64 {
 /// Truncates the given string at the closest UTF-8 character boundary >= the provided length.
 /// If the new length is >= the current length, does nothing.
 #[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
-pub(crate) fn truncate_on_char_boundary(s: &mut String, new_len: usize) {
+#[must_use]
+pub(crate) fn truncate_on_char_boundary(s: &mut String, new_len: usize) -> bool {
     let original_len = s.len();
-    if original_len > new_len {
-        // to avoid generating invalid UTF-8, find the first index >= max_length_bytes that is
-        // the end of a character.
-        // TODO: RUST-1496 we should use ceil_char_boundary here but it's currently nightly-only.
-        // see: https://doc.rust-lang.org/std/string/struct.String.html#method.ceil_char_boundary
-        let mut truncate_index = new_len;
-        // is_char_boundary returns true when the provided value == the length of the string, so
-        // if we reach the end of the string this loop will terminate.
-        while !s.is_char_boundary(truncate_index) {
-            truncate_index += 1;
-        }
-        s.truncate(truncate_index);
-        // due to the "rounding up" behavior we might not actually end up truncating anything.
-        // if we did, spec requires we add a trailing "...".
-        if truncate_index < original_len {
-            s.push_str("...")
-        }
+    if new_len >= original_len {
+        return false;
     }
+
+    // to avoid generating invalid UTF-8, find the first index >= max_length_bytes that is
+    // the end of a character.
+    // TODO: RUST-1496 we should use ceil_char_boundary here but it's currently nightly-only.
+    // see: https://doc.rust-lang.org/std/string/struct.String.html#method.ceil_char_boundary
+    let mut truncate_index = new_len;
+    // is_char_boundary returns true when the provided value == the length of the string, so
+    // if we reach the end of the string this loop will terminate.
+    while !s.is_char_boundary(truncate_index) {
+        truncate_index += 1;
+    }
+    s.truncate(truncate_index);
+    // due to the "rounding up" behavior we might not actually end up truncating anything.
+    truncate_index < original_len
 }
 
 #[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
 pub(crate) fn doc_to_json_str(doc: crate::bson::Document, max_length_bytes: usize) -> String {
     let mut ext_json = Bson::Document(doc).into_relaxed_extjson().to_string();
-    truncate_on_char_boundary(&mut ext_json, max_length_bytes);
+    if truncate_on_char_boundary(&mut ext_json, max_length_bytes) {
+        ext_json.push_str("...");
+    }
     ext_json
+}
+
+#[cfg(feature = "tracing-unstable")]
+macro_rules! push_trunc {
+    ($out:ident, $max:ident, $s:expr) => {{
+        let s = $s;
+        let new_len = $out.len().saturating_add(s.len());
+        if new_len > $max {
+            let delta = $max.abs_diff(new_len);
+            let new_len = s.len().saturating_sub(delta);
+            let mut s = s.to_owned();
+            let _ = truncate_on_char_boundary(&mut s, new_len);
+            $out.push_str(&s);
+            $out.push_str("...");
+            return $out;
+        }
+        $out.push_str(s);
+    }};
+}
+
+#[cfg(feature = "tracing-unstable")]
+macro_rules! ok_or_invalid {
+    ($r:expr) => {{
+        match $r {
+            Ok(v) => v,
+            Err(e) => return format!("<invalid document: {e}>"),
+        }
+    }};
+}
+
+#[cfg(feature = "tracing-unstable")]
+pub(crate) fn rawdoc_to_json_str(
+    doc: &crate::bson::RawDocument,
+    max_length_bytes: usize,
+) -> String {
+    let mut out = String::new();
+    let mut stack = vec![]; // [(iter, is_array)]
+    let mut current = doc.iter_elements();
+    let mut is_array = false;
+    let mut is_first = true;
+    push_trunc!(out, max_length_bytes, "{ ");
+    'outer: loop {
+        while let Some(elt) = current.next() {
+            use crate::bson_compat::cstr_to_str;
+
+            if !is_first {
+                push_trunc!(out, max_length_bytes, ", ");
+            }
+            is_first = false;
+
+            let elt = ok_or_invalid!(elt);
+            let value = ok_or_invalid!(elt.value());
+
+            if !is_array {
+                let key = ok_or_invalid!(serde_json::to_string(cstr_to_str(elt.key())));
+                push_trunc!(out, max_length_bytes, &key);
+                push_trunc!(out, max_length_bytes, ": ");
+            }
+            match value {
+                RawBsonRef::Document(d) => {
+                    push_trunc!(out, max_length_bytes, "{ ");
+                    let mut tmp = d.iter_elements();
+                    std::mem::swap(&mut current, &mut tmp);
+                    stack.push((tmp, is_array));
+                    is_array = false;
+                    is_first = true;
+                    continue 'outer;
+                }
+                RawBsonRef::Array(a) => {
+                    push_trunc!(out, max_length_bytes, "[ ");
+                    // bson 2.x doesn't have .iter_elements() on RawArray, so we have to jump
+                    // through some hoops...
+                    let mut tmp =
+                        ok_or_invalid!(crate::bson::RawDocument::from_bytes(a.as_bytes()))
+                            .iter_elements();
+                    std::mem::swap(&mut current, &mut tmp);
+                    stack.push((tmp, is_array));
+                    is_array = true;
+                    is_first = true;
+                    continue 'outer;
+                }
+                _ => {
+                    let parsed: Bson = ok_or_invalid!(value.try_into());
+                    push_trunc!(
+                        out,
+                        max_length_bytes,
+                        &parsed.into_relaxed_extjson().to_string()
+                    );
+                }
+            }
+        }
+        if is_first {
+            // nothing was emitted for this container, so drop the space from the opener to
+            // produce "{}" rather than "{  }".
+            out.pop();
+            push_trunc!(out, max_length_bytes, if is_array { "]" } else { "}" });
+        } else {
+            push_trunc!(out, max_length_bytes, if is_array { " ]" } else { " }" });
+        }
+        let Some(outer) = stack.pop() else {
+            break;
+        };
+        current = outer.0;
+        is_array = outer.1;
+        is_first = false;
+    }
+
+    out
 }
 
 #[cfg(test)]

--- a/driver/src/bson_util.rs
+++ b/driver/src/bson_util.rs
@@ -347,16 +347,23 @@ pub(crate) fn truncate_on_char_boundary(s: &mut String, new_len: usize) -> bool 
     truncate_index < original_len
 }
 
-#[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
-pub(crate) fn doc_to_json_str(doc: crate::bson::Document, max_length_bytes: usize) -> String {
-    let mut ext_json = Bson::Document(doc).into_relaxed_extjson().to_string();
-    if truncate_on_char_boundary(&mut ext_json, max_length_bytes) {
-        ext_json.push_str("...");
-    }
-    ext_json
+#[cfg(feature = "tracing-unstable")]
+pub(crate) fn rawdoc_to_json_str(
+    doc: &crate::bson::RawDocument,
+    max_length_bytes: usize,
+) -> Result<String> {
+    rawdoc_to_json_str_inner(doc, max_length_bytes, false)
 }
 
-#[cfg(feature = "tracing-unstable")]
+#[cfg(feature = "opentelemetry")]
+pub(crate) fn rawdoc_to_json_str_otel(
+    doc: &crate::bson::RawDocument,
+    max_length_bytes: usize,
+) -> Result<String> {
+    rawdoc_to_json_str_inner(doc, max_length_bytes, true)
+}
+
+#[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
 macro_rules! push_trunc {
     ($out:ident, $max:ident, $s:expr) => {{
         let s = $s;
@@ -368,27 +375,20 @@ macro_rules! push_trunc {
             let _ = truncate_on_char_boundary(&mut s, new_len);
             $out.push_str(&s);
             $out.push_str("...");
-            return $out;
+            return Ok($out);
         }
         $out.push_str(s);
     }};
 }
 
-#[cfg(feature = "tracing-unstable")]
-macro_rules! ok_or_invalid {
-    ($r:expr) => {{
-        match $r {
-            Ok(v) => v,
-            Err(e) => return format!("<invalid document: {e}>"),
-        }
-    }};
-}
-
-#[cfg(feature = "tracing-unstable")]
-pub(crate) fn rawdoc_to_json_str(
+#[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
+fn rawdoc_to_json_str_inner(
     doc: &crate::bson::RawDocument,
     max_length_bytes: usize,
-) -> String {
+    otel: bool,
+) -> Result<String> {
+    use crate::bson_compat::cstr;
+
     let mut out = String::new();
     let mut stack = vec![]; // [(iter, is_array)]
     let mut current = doc.iter_elements();
@@ -399,16 +399,31 @@ pub(crate) fn rawdoc_to_json_str(
         while let Some(elt) = current.next() {
             use crate::bson_compat::cstr_to_str;
 
+            let elt = elt?;
+            let value = elt.value()?;
+            // The opentelemetry spec requires omitting some toplevel fields.
+            if otel && stack.is_empty() {
+                if [
+                    cstr!("lsid"),
+                    cstr!("$db"),
+                    cstr!("$clusterTime"),
+                    cstr!("signature"),
+                ]
+                .iter()
+                .any(|k| *k == elt.key())
+                {
+                    continue;
+                }
+            }
+
             if !is_first {
                 push_trunc!(out, max_length_bytes, ", ");
             }
             is_first = false;
 
-            let elt = ok_or_invalid!(elt);
-            let value = ok_or_invalid!(elt.value());
-
             if !is_array {
-                let key = ok_or_invalid!(serde_json::to_string(cstr_to_str(elt.key())));
+                let key = serde_json::to_string(cstr_to_str(elt.key()))
+                    .map_err(|e| Error::internal(format!("invalid document key: {e}")))?;
                 push_trunc!(out, max_length_bytes, &key);
                 push_trunc!(out, max_length_bytes, ": ");
             }
@@ -427,8 +442,7 @@ pub(crate) fn rawdoc_to_json_str(
                     // bson 2.x doesn't have .iter_elements() on RawArray, so we have to jump
                     // through some hoops...
                     let mut tmp =
-                        ok_or_invalid!(crate::bson::RawDocument::from_bytes(a.as_bytes()))
-                            .iter_elements();
+                        crate::bson::RawDocument::from_bytes(a.as_bytes())?.iter_elements();
                     std::mem::swap(&mut current, &mut tmp);
                     stack.push((tmp, is_array));
                     is_array = true;
@@ -436,7 +450,7 @@ pub(crate) fn rawdoc_to_json_str(
                     continue 'outer;
                 }
                 _ => {
-                    let parsed: Bson = ok_or_invalid!(value.try_into());
+                    let parsed: Bson = value.try_into()?;
                     push_trunc!(
                         out,
                         max_length_bytes,
@@ -461,7 +475,7 @@ pub(crate) fn rawdoc_to_json_str(
         is_first = false;
     }
 
-    out
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/driver/src/bson_util.rs
+++ b/driver/src/bson_util.rs
@@ -364,20 +364,36 @@ pub(crate) fn rawdoc_to_json_str_otel(
 }
 
 #[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
+pub(crate) fn doc_err(e: Error) -> String {
+    serde_json::json!({
+        "serialization error": e.to_string()
+    })
+    .to_string()
+}
+
+#[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
+fn push_trunc(out: &mut String, max: usize, s: &str) -> bool {
+    let new_len = out.len().saturating_add(s.len());
+    if new_len <= max {
+        out.push_str(s);
+        return false;
+    }
+
+    let delta = max.abs_diff(new_len);
+    let new_len = s.len().saturating_sub(delta);
+    let mut s = s.to_owned();
+    let _ = truncate_on_char_boundary(&mut s, new_len);
+    out.push_str(&s);
+    out.push_str("...");
+    true
+}
+
+#[cfg(any(feature = "tracing-unstable", feature = "opentelemetry"))]
 macro_rules! push_trunc {
-    ($out:ident, $max:ident, $s:expr) => {{
-        let s = $s;
-        let new_len = $out.len().saturating_add(s.len());
-        if new_len > $max {
-            let delta = $max.abs_diff(new_len);
-            let new_len = s.len().saturating_sub(delta);
-            let mut s = s.to_owned();
-            let _ = truncate_on_char_boundary(&mut s, new_len);
-            $out.push_str(&s);
-            $out.push_str("...");
+    ($out:expr, $max:expr, $s:expr) => {{
+        if push_trunc(&mut $out, $max, $s) {
             return Ok($out);
         }
-        $out.push_str(s);
     }};
 }
 
@@ -397,8 +413,6 @@ fn rawdoc_to_json_str_inner(
     push_trunc!(out, max_length_bytes, "{ ");
     'outer: loop {
         while let Some(elt) = current.next() {
-            use crate::bson_compat::cstr_to_str;
-
             let elt = elt?;
             let value = elt.value()?;
             // The opentelemetry spec requires omitting some toplevel fields.
@@ -422,8 +436,10 @@ fn rawdoc_to_json_str_inner(
             is_first = false;
 
             if !is_array {
-                let key = serde_json::to_string(cstr_to_str(elt.key()))
-                    .map_err(|e| Error::internal(format!("invalid document key: {e}")))?;
+                let key = serde_json::Value::String(
+                    crate::bson_compat::cstr_to_str(elt.key()).to_owned(),
+                )
+                .to_string();
                 push_trunc!(out, max_length_bytes, &key);
                 push_trunc!(out, max_length_bytes, ": ");
             }

--- a/driver/src/client.rs
+++ b/driver/src/client.rs
@@ -34,7 +34,6 @@ use crate::{
     db::Database,
     error::{Error, ErrorKind, Result},
     event::command::{raw::RawCommandEvent, CommandEvent},
-    log_warning,
     operation::OverrideCriteriaFn,
     options::{
         ClientOptions,
@@ -360,26 +359,20 @@ impl Client {
         }
 
         let raw_event = generate_event();
-        let mut event: Option<Result<CommandEvent>> = None;
+        let mut event: Option<CommandEvent> = None;
         if let Some(tx) = test_channel {
-            if let Ok(event) = event.get_or_insert_with(|| raw_event.clone().try_into()) {
-                let (msg, ack) = crate::runtime::AcknowledgedMessage::package(event.clone());
-                let _ = tx.send(msg).await;
-                ack.wait_for_acknowledgment().await;
-            } else {
-                log_warning!("failed to parse raw event");
-            };
+            let event = event.get_or_insert_with(|| raw_event.clone().into());
+            let (msg, ack) = crate::runtime::AcknowledgedMessage::package(event.clone());
+            let _ = tx.send(msg).await;
+            ack.wait_for_acknowledgment().await;
         }
         #[cfg(feature = "tracing-unstable")]
         if let Some(ref tracing_emitter) = tracing_emitter {
             tracing_emitter.handle(raw_event.clone());
         }
         if let Some(handler) = &self.options().command_event_handler {
-            if let Ok(event) = event.unwrap_or_else(|| raw_event.try_into()) {
-                handler.handle(event);
-            } else {
-                log_warning!("failed to parse raw event");
-            }
+            let event = event.unwrap_or_else(|| raw_event.into());
+            handler.handle(event);
         }
     }
 

--- a/driver/src/client.rs
+++ b/driver/src/client.rs
@@ -33,7 +33,8 @@ use crate::{
     concern::{ReadConcern, WriteConcern},
     db::Database,
     error::{Error, ErrorKind, Result},
-    event::command::CommandEvent,
+    event::command::{raw::RawCommandEvent, CommandEvent},
+    log_warning,
     operation::OverrideCriteriaFn,
     options::{
         ClientOptions,
@@ -326,7 +327,10 @@ impl Client {
         }
     }
 
-    pub(crate) async fn emit_command_event(&self, generate_event: impl FnOnce() -> CommandEvent) {
+    pub(crate) async fn emit_command_event(
+        &self,
+        generate_event: impl FnOnce() -> RawCommandEvent,
+    ) {
         #[cfg(test)]
         if self
             .inner
@@ -355,18 +359,27 @@ impl Client {
             return;
         }
 
-        let event = generate_event();
+        let raw_event = generate_event();
+        let mut event: Option<Result<CommandEvent>> = None;
         if let Some(tx) = test_channel {
-            let (msg, ack) = crate::runtime::AcknowledgedMessage::package(event.clone());
-            let _ = tx.send(msg).await;
-            ack.wait_for_acknowledgment().await;
+            if let Ok(event) = event.get_or_insert_with(|| raw_event.clone().try_into()) {
+                let (msg, ack) = crate::runtime::AcknowledgedMessage::package(event.clone());
+                let _ = tx.send(msg).await;
+                ack.wait_for_acknowledgment().await;
+            } else {
+                log_warning!("failed to parse raw event");
+            };
         }
         #[cfg(feature = "tracing-unstable")]
         if let Some(ref tracing_emitter) = tracing_emitter {
-            tracing_emitter.handle(event.clone());
+            tracing_emitter.handle(raw_event.clone());
         }
         if let Some(handler) = &self.options().command_event_handler {
-            handler.handle(event);
+            if let Ok(event) = event.unwrap_or_else(|| raw_event.try_into()) {
+                handler.handle(event);
+            } else {
+                log_warning!("failed to parse raw event");
+            }
         }
     }
 

--- a/driver/src/client/executor.rs
+++ b/driver/src/client/executor.rs
@@ -11,10 +11,8 @@ use std::{
 use futures_core::future::BoxFuture;
 use serde::de::DeserializeOwned;
 
-#[cfg(feature = "in-use-encryption")]
-use crate::bson::RawDocumentBuf;
 use crate::{
-    bson::{doc, Document, RawBsonRef, RawDocument, Timestamp},
+    bson::{Document, RawBsonRef, RawDocument, RawDocumentBuf, Timestamp},
     change_stream::{
         common::{ChangeStreamData, WatchArgs},
         event::ChangeStreamEvent,
@@ -47,10 +45,8 @@ use crate::{
         UNKNOWN_TRANSACTION_COMMIT_RESULT,
     },
     event::command::{
-        CommandEvent,
+        raw::{RawCommandEvent, RawCommandStartedEvent, RawCommandSucceededEvent},
         CommandFailedEvent,
-        CommandStartedEvent,
-        CommandSucceededEvent,
     },
     hello::LEGACY_HELLO_COMMAND_NAME_LOWERCASE,
     operation::{
@@ -643,11 +639,11 @@ impl Client {
 
             self.emit_command_event(|| {
                 let command_body = if should_redact {
-                    Document::new()
+                    RawDocumentBuf::new()
                 } else {
-                    message.get_command_document()
+                    message.get_raw_command_document()
                 };
-                CommandEvent::Started(CommandStartedEvent {
+                RawCommandEvent::Started(RawCommandStartedEvent {
                     command: command_body,
                     db: target_db.clone(),
                     command_name: cmd_name.clone(),
@@ -682,7 +678,7 @@ impl Client {
                             err.redact();
                         }
 
-                        CommandEvent::Failed(CommandFailedEvent {
+                        RawCommandEvent::Failed(CommandFailedEvent {
                             duration,
                             command_name: cmd_name.clone(),
                             failure: err,
@@ -709,14 +705,12 @@ impl Client {
                 Ok(response) => {
                     self.emit_command_event(|| {
                         let reply = if should_redact {
-                            Document::new()
+                            RawDocumentBuf::new()
                         } else {
-                            response
-                                .body()
-                                .unwrap_or_else(|e| doc! { "deserialization error": e.to_string() })
+                            response.raw_body().to_owned()
                         };
 
-                        CommandEvent::Succeeded(CommandSucceededEvent {
+                        RawCommandEvent::Succeeded(RawCommandSucceededEvent {
                             duration,
                             reply,
                             command_name: cmd_name.clone(),

--- a/driver/src/cmap/conn/wire/message.rs
+++ b/driver/src/cmap/conn/wire/message.rs
@@ -113,12 +113,6 @@ impl Message {
         command
     }
 
-    #[cfg(feature = "opentelemetry")]
-    pub(crate) fn get_command_document(&self) -> crate::bson::Document {
-        crate::bson::Document::try_from(self.get_raw_command_document())
-            .unwrap_or_else(|e| doc! { "serialization error": e.to_string() })
-    }
-
     /// Reads bytes from `reader` and deserializes them into a Message.
     pub(crate) async fn read_from<T: AsyncRead + Unpin + Send>(
         mut reader: T,

--- a/driver/src/cmap/conn/wire/message.rs
+++ b/driver/src/cmap/conn/wire/message.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-use crate::bson::{doc, Array, Document};
+use crate::bson::doc;
 use bitflags::bitflags;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -11,7 +11,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 ))]
 use crate::options::Compressor;
 use crate::{
-    bson::RawDocumentBuf,
+    bson::{RawArrayBuf, RawDocumentBuf},
     bson_util,
     checked::Checked,
     cmap::{conn::wire::util::SyncCountReader, Command},
@@ -95,24 +95,28 @@ impl TryFrom<Command> for Message {
 impl Message {
     /// Gets this message's command as a Document. If serialization fails, returns a document
     /// containing the error.
-    pub(crate) fn get_command_document(&self) -> Document {
-        let mut command = match Document::try_from(self.document_payload.as_ref()) {
-            Ok(document) => document,
-            Err(error) => return doc! { "serialization error": error.to_string() },
-        };
+    pub(crate) fn get_raw_command_document(&self) -> RawDocumentBuf {
+        let mut command = self.document_payload.clone();
 
         for document_sequence in &self.document_sequences {
-            let mut documents = Array::new();
+            let ident_cstr = match crate::bson_compat::str_to_cstr(&document_sequence.identifier) {
+                Ok(cs) => cs,
+                Err(e) => return crate::bson::rawdoc! { "serialization error": e.to_string() },
+            };
+            let mut documents = RawArrayBuf::new();
             for document in &document_sequence.documents {
-                match Document::try_from(document.as_ref()) {
-                    Ok(document) => documents.push(document.into()),
-                    Err(error) => return doc! { "serialization error": error.to_string() },
-                }
+                documents.push(document.to_owned());
             }
-            command.insert(document_sequence.identifier.clone(), documents);
+            command.append(ident_cstr, documents);
         }
 
         command
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    pub(crate) fn get_command_document(&self) -> crate::bson::Document {
+        crate::bson::Document::try_from(self.get_raw_command_document())
+            .unwrap_or_else(|e| doc! { "serialization error": e.to_string() })
     }
 
     /// Reads bytes from `reader` and deserializes them into a Message.

--- a/driver/src/cmap/conn/wire/message.rs
+++ b/driver/src/cmap/conn/wire/message.rs
@@ -93,7 +93,7 @@ impl TryFrom<Command> for Message {
 }
 
 impl Message {
-    /// Gets this message's command as a Document. If serialization fails, returns a document
+    /// Gets this message's command as a RawDocumentBuf. If serialization fails, returns a document
     /// containing the error.
     pub(crate) fn get_raw_command_document(&self) -> RawDocumentBuf {
         let mut command = self.document_payload.clone();

--- a/driver/src/event/command.rs
+++ b/driver/src/event/command.rs
@@ -1,6 +1,8 @@
 //! Contains the events and functionality to monitor the commands and responses that a `Client`
 //! sends and receives from the server.
 
+pub(crate) mod raw;
+
 use std::time::Duration;
 
 use serde::Serialize;

--- a/driver/src/event/command/raw.rs
+++ b/driver/src/event/command/raw.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use crate::{
+    bson::{oid::ObjectId, RawDocumentBuf},
+    event::command::{CommandEvent, CommandFailedEvent, CommandSucceededEvent},
+};
+
+pub use crate::cmap::ConnectionInfo;
+
+use super::CommandStartedEvent;
+
+#[derive(Debug, Clone)]
+pub(crate) enum RawCommandEvent {
+    Started(RawCommandStartedEvent),
+    Succeeded(RawCommandSucceededEvent),
+    Failed(CommandFailedEvent),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RawCommandStartedEvent {
+    pub(crate) command: RawDocumentBuf,
+    pub(crate) db: String,
+    pub(crate) command_name: String,
+    pub(crate) request_id: i32,
+    pub(crate) connection: ConnectionInfo,
+    pub(crate) service_id: Option<ObjectId>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RawCommandSucceededEvent {
+    pub(crate) duration: Duration,
+    pub(crate) reply: RawDocumentBuf,
+    pub(crate) command_name: String,
+    pub(crate) request_id: i32,
+    pub(crate) connection: ConnectionInfo,
+    pub(crate) service_id: Option<ObjectId>,
+}
+
+impl TryInto<CommandEvent> for RawCommandEvent {
+    type Error = crate::error::Error;
+
+    fn try_into(self) -> Result<CommandEvent, Self::Error> {
+        Ok(match self {
+            RawCommandEvent::Started(ev) => CommandEvent::Started(CommandStartedEvent {
+                command: ev.command.try_into()?,
+                db: ev.db,
+                command_name: ev.command_name,
+                request_id: ev.request_id,
+                connection: ev.connection,
+                service_id: ev.service_id,
+            }),
+            RawCommandEvent::Succeeded(ev) => CommandEvent::Succeeded(CommandSucceededEvent {
+                duration: ev.duration,
+                reply: ev.reply.try_into()?,
+                command_name: ev.command_name,
+                request_id: ev.request_id,
+                connection: ev.connection,
+                service_id: ev.service_id,
+            }),
+            RawCommandEvent::Failed(ev) => CommandEvent::Failed(ev),
+        })
+    }
+}

--- a/driver/src/event/command/raw.rs
+++ b/driver/src/event/command/raw.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use crate::{
-    bson::{oid::ObjectId, RawDocumentBuf},
+    bson::{doc, oid::ObjectId, RawDocumentBuf},
+    bson_compat::RawError,
     event::command::{CommandEvent, CommandFailedEvent, CommandSucceededEvent},
 };
 
@@ -36,13 +37,13 @@ pub(crate) struct RawCommandSucceededEvent {
     pub(crate) service_id: Option<ObjectId>,
 }
 
-impl TryInto<CommandEvent> for RawCommandEvent {
-    type Error = crate::error::Error;
-
-    fn try_into(self) -> Result<CommandEvent, Self::Error> {
-        Ok(match self {
+impl Into<CommandEvent> for RawCommandEvent {
+    fn into(self) -> CommandEvent {
+        match self {
             RawCommandEvent::Started(ev) => CommandEvent::Started(CommandStartedEvent {
-                command: ev.command.try_into()?,
+                command: ev.command.try_into().unwrap_or_else(
+                    |e: RawError| doc! { "invalid command document": e.to_string() },
+                ),
                 db: ev.db,
                 command_name: ev.command_name,
                 request_id: ev.request_id,
@@ -51,13 +52,16 @@ impl TryInto<CommandEvent> for RawCommandEvent {
             }),
             RawCommandEvent::Succeeded(ev) => CommandEvent::Succeeded(CommandSucceededEvent {
                 duration: ev.duration,
-                reply: ev.reply.try_into()?,
+                reply: ev
+                    .reply
+                    .try_into()
+                    .unwrap_or_else(|e: RawError| doc! { "invalid reply document": e.to_string() }),
                 command_name: ev.command_name,
                 request_id: ev.request_id,
                 connection: ev.connection,
                 service_id: ev.service_id,
             }),
             RawCommandEvent::Failed(ev) => CommandEvent::Failed(ev),
-        })
+        }
     }
 }

--- a/driver/src/otel.rs
+++ b/driver/src/otel.rs
@@ -192,13 +192,12 @@ impl Client {
         }
         let text_max_len = self.options().otel_query_text_max_length();
         if text_max_len > 0 {
-            let mut doc = message.get_command_document();
-            for key in ["lsid", "$db", "$clusterTime", "signature"] {
-                doc.remove(key);
-            }
+            let doc = message.get_raw_command_document();
+
             attrs.push(KeyValue::new(
                 "db.query.text",
-                crate::bson_util::doc_to_json_str(doc, text_max_len),
+                crate::bson_util::rawdoc_to_json_str_otel(&doc, text_max_len)
+                    .unwrap_or_else(|e| format!("<invalid document: {e}>")),
             ));
         }
         if let Some(cursor_id) = op.cursor_id() {

--- a/driver/src/otel.rs
+++ b/driver/src/otel.rs
@@ -197,7 +197,7 @@ impl Client {
             attrs.push(KeyValue::new(
                 "db.query.text",
                 crate::bson_util::rawdoc_to_json_str_otel(&doc, text_max_len)
-                    .unwrap_or_else(|e| format!("<invalid document: {e}>")),
+                    .unwrap_or_else(crate::bson_util::doc_err),
             ));
         }
         if let Some(cursor_id) = op.cursor_id() {

--- a/driver/src/test.rs
+++ b/driver/src/test.rs
@@ -9,6 +9,7 @@ mod atlas_search;
 #[path = "test/atlas_sfp.rs"]
 mod atlas_sfp_skip_ci; // requires SFP environment variables set
 mod auth;
+mod bson_util;
 mod bulk_write;
 mod change_stream;
 mod client;

--- a/driver/src/test/bson_util.rs
+++ b/driver/src/test/bson_util.rs
@@ -4,11 +4,11 @@ fn rawdoc_to_json_str_sanity() {
     use crate::{bson::rawdoc, bson_util::rawdoc_to_json_str};
 
     assert_eq!(
-        r#"{ "hello": "world" }"#,
+        r#"{"hello":"world"}"#,
         rawdoc_to_json_str(&(rawdoc! {"hello": "world"}), 1000).unwrap()
     );
     assert_eq!(
-        r#"{ "hello": 1, "world": 2 }"#,
+        r#"{"hello":1,"world":2}"#,
         rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": 2}), 1000).unwrap()
     )
 }
@@ -19,19 +19,19 @@ fn rawdoc_to_json_str_nesting() {
     use crate::{bson::rawdoc, bson_util::rawdoc_to_json_str};
 
     assert_eq!(
-        r#"{ "hello": { "world": 1 } }"#,
+        r#"{"hello":{"world":1}}"#,
         rawdoc_to_json_str(&(rawdoc! {"hello": { "world": 1 }}), 1000).unwrap()
     );
     assert_eq!(
-        r#"{ "hello": 1, "world": [ 2 ] }"#,
+        r#"{"hello":1,"world":[2]}"#,
         rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": [ 2 ]}), 1000).unwrap()
     );
     assert_eq!(
-        r#"{ "hello": {}, "world": 2 }"#,
+        r#"{"hello":{},"world":2}"#,
         rawdoc_to_json_str(&(rawdoc! {"hello": { }, "world": 2 }), 1000).unwrap()
     );
     assert_eq!(
-        r#"{ "hello": [], "world": 2 }"#,
+        r#"{"hello":[],"world":2}"#,
         rawdoc_to_json_str(&(rawdoc! {"hello": [], "world": 2 }), 1000).unwrap()
     );
     assert_eq!("{}", rawdoc_to_json_str(&rawdoc! {}, 1000).unwrap());
@@ -43,15 +43,15 @@ fn rawdoc_to_json_str_truncation() {
     use crate::{bson::rawdoc, bson_util::rawdoc_to_json_str};
 
     assert_eq!(
-        r#"{ "he..."#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 5).unwrap()
+        r#"{"he..."#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 4).unwrap()
     );
     assert_eq!(
-        r#"{ "hello": ..."#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 11).unwrap()
+        r#"{"hello":..."#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 9).unwrap()
     );
     assert_eq!(
-        r#"{ "hello": "wor..."#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 15).unwrap()
+        r#"{"hello":"wor..."#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 13).unwrap()
     );
 }

--- a/driver/src/test/bson_util.rs
+++ b/driver/src/test/bson_util.rs
@@ -5,11 +5,11 @@ fn rawdoc_to_json_str_sanity() {
 
     assert_eq!(
         r#"{ "hello": "world" }"#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world"}), 1000)
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world"}), 1000).unwrap()
     );
     assert_eq!(
         r#"{ "hello": 1, "world": 2 }"#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": 2}), 1000)
+        rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": 2}), 1000).unwrap()
     )
 }
 
@@ -20,21 +20,21 @@ fn rawdoc_to_json_str_nesting() {
 
     assert_eq!(
         r#"{ "hello": { "world": 1 } }"#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": { "world": 1 }}), 1000)
+        rawdoc_to_json_str(&(rawdoc! {"hello": { "world": 1 }}), 1000).unwrap()
     );
     assert_eq!(
         r#"{ "hello": 1, "world": [ 2 ] }"#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": [ 2 ]}), 1000)
+        rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": [ 2 ]}), 1000).unwrap()
     );
     assert_eq!(
         r#"{ "hello": {}, "world": 2 }"#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": { }, "world": 2 }), 1000)
+        rawdoc_to_json_str(&(rawdoc! {"hello": { }, "world": 2 }), 1000).unwrap()
     );
     assert_eq!(
         r#"{ "hello": [], "world": 2 }"#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": [], "world": 2 }), 1000)
+        rawdoc_to_json_str(&(rawdoc! {"hello": [], "world": 2 }), 1000).unwrap()
     );
-    assert_eq!("{}", rawdoc_to_json_str(&rawdoc! {}, 1000));
+    assert_eq!("{}", rawdoc_to_json_str(&rawdoc! {}, 1000).unwrap());
 }
 
 #[cfg(feature = "tracing-unstable")]
@@ -44,14 +44,14 @@ fn rawdoc_to_json_str_truncation() {
 
     assert_eq!(
         r#"{ "he..."#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 5)
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 5).unwrap()
     );
     assert_eq!(
         r#"{ "hello": ..."#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 11)
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 11).unwrap()
     );
     assert_eq!(
         r#"{ "hello": "wor..."#,
-        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 15)
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 15).unwrap()
     );
 }

--- a/driver/src/test/bson_util.rs
+++ b/driver/src/test/bson_util.rs
@@ -1,0 +1,57 @@
+#[cfg(feature = "tracing-unstable")]
+#[test]
+fn rawdoc_to_json_str_sanity() {
+    use crate::{bson::rawdoc, bson_util::rawdoc_to_json_str};
+
+    assert_eq!(
+        r#"{ "hello": "world" }"#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world"}), 1000)
+    );
+    assert_eq!(
+        r#"{ "hello": 1, "world": 2 }"#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": 2}), 1000)
+    )
+}
+
+#[cfg(feature = "tracing-unstable")]
+#[test]
+fn rawdoc_to_json_str_nesting() {
+    use crate::{bson::rawdoc, bson_util::rawdoc_to_json_str};
+
+    assert_eq!(
+        r#"{ "hello": { "world": 1 } }"#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": { "world": 1 }}), 1000)
+    );
+    assert_eq!(
+        r#"{ "hello": 1, "world": [ 2 ] }"#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": 1, "world": [ 2 ]}), 1000)
+    );
+    assert_eq!(
+        r#"{ "hello": {}, "world": 2 }"#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": { }, "world": 2 }), 1000)
+    );
+    assert_eq!(
+        r#"{ "hello": [], "world": 2 }"#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": [], "world": 2 }), 1000)
+    );
+    assert_eq!("{}", rawdoc_to_json_str(&rawdoc! {}, 1000));
+}
+
+#[cfg(feature = "tracing-unstable")]
+#[test]
+fn rawdoc_to_json_str_truncation() {
+    use crate::{bson::rawdoc, bson_util::rawdoc_to_json_str};
+
+    assert_eq!(
+        r#"{ "he..."#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 5)
+    );
+    assert_eq!(
+        r#"{ "hello": ..."#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 11)
+    );
+    assert_eq!(
+        r#"{ "hello": "wor..."#,
+        rawdoc_to_json_str(&(rawdoc! {"hello": "world" }), 15)
+    );
+}

--- a/driver/src/test/spec/trace.rs
+++ b/driver/src/test/spec/trace.rs
@@ -46,32 +46,32 @@ fn tracing_truncation() {
     assert_eq!(s.len(), 8);
 
     // start of string is a boundary, so we should truncate there
-    truncate_on_char_boundary(&mut s, 0);
-    assert_eq!(s, String::from("..."));
+    assert!(truncate_on_char_boundary(&mut s, 0));
+    assert_eq!(s, String::from(""));
 
     // we should "round up" to the end of the first emoji
     s.clone_from(&two_emoji);
-    truncate_on_char_boundary(&mut s, 1);
-    assert_eq!(s, String::from("🤔..."));
+    assert!(truncate_on_char_boundary(&mut s, 1));
+    assert_eq!(s, String::from("🤔"));
 
     // 4 is a boundary, so we should truncate there
     s.clone_from(&two_emoji);
-    truncate_on_char_boundary(&mut s, 4);
-    assert_eq!(s, String::from("🤔..."));
+    assert!(truncate_on_char_boundary(&mut s, 4));
+    assert_eq!(s, String::from("🤔"));
 
     // we should round up to the full string
     s.clone_from(&two_emoji);
-    truncate_on_char_boundary(&mut s, 5);
+    assert!(!truncate_on_char_boundary(&mut s, 5));
     assert_eq!(s, two_emoji);
 
     // end of string is a boundary, so we should truncate there
     s.clone_from(&two_emoji);
-    truncate_on_char_boundary(&mut s, 8);
+    assert!(!truncate_on_char_boundary(&mut s, 8));
     assert_eq!(s, two_emoji);
 
     // we should get the full string back if the new length is longer than the original
     s.clone_from(&two_emoji);
-    truncate_on_char_boundary(&mut s, 10);
+    assert!(!truncate_on_char_boundary(&mut s, 10));
     assert_eq!(s, two_emoji);
 }
 

--- a/driver/src/test/spec/trace.rs
+++ b/driver/src/test/spec/trace.rs
@@ -212,7 +212,7 @@ async fn command_logging_truncation_mid_codepoint() {
 
     // 215 falls in the middle of an emoji (each is 4 bytes), so we should round up to 218, + 3 for
     // trailing "..."
-    assert_eq!(command.len(), 221);
+    assert_eq!(command.len(), 221, "truncated: {command:?}");
 
     coll.find(doc! {})
         .projection(doc! { "_id": 0, "🤔": 1 })

--- a/driver/src/trace.rs
+++ b/driver/src/trace.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "bson-3")]
-use crate::bson_compat::RawDocumentBufExt;
 use crate::{
-    bson_util::{doc_to_json_str, truncate_on_char_boundary},
+    bson_util::{rawdoc_to_json_str, truncate_on_char_boundary},
     client::options::{ServerAddress, DEFAULT_PORT},
 };
 
@@ -40,16 +39,17 @@ impl crate::error::Error {
             self.source
         );
         if let Some(server_response) = self.server_response() {
-            let server_response_string = match server_response.to_document() {
-                Ok(document) => doc_to_json_str(document, max_document_length),
-                Err(_) => {
-                    let mut hex_string = hex::encode(server_response.as_bytes());
-                    if truncate_on_char_boundary(&mut hex_string, max_document_length) {
-                        hex_string.push_str("...");
+            let server_response_string =
+                match rawdoc_to_json_str(server_response, max_document_length) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        let mut hex_string = hex::encode(server_response.as_bytes());
+                        if truncate_on_char_boundary(&mut hex_string, max_document_length) {
+                            hex_string.push_str("...");
+                        }
+                        hex_string
                     }
-                    hex_string
-                }
-            };
+                };
             error_string.push_str(", server response: ");
             error_string.push_str(&server_response_string);
         }

--- a/driver/src/trace.rs
+++ b/driver/src/trace.rs
@@ -44,7 +44,9 @@ impl crate::error::Error {
                 Ok(document) => doc_to_json_str(document, max_document_length),
                 Err(_) => {
                     let mut hex_string = hex::encode(server_response.as_bytes());
-                    truncate_on_char_boundary(&mut hex_string, max_document_length);
+                    if truncate_on_char_boundary(&mut hex_string, max_document_length) {
+                        hex_string.push_str("...");
+                    }
                     hex_string
                 }
             };

--- a/driver/src/trace.rs
+++ b/driver/src/trace.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "bson-3")]
 use crate::{
     bson_util::{rawdoc_to_json_str, truncate_on_char_boundary},
     client::options::{ServerAddress, DEFAULT_PORT},

--- a/driver/src/trace/command.rs
+++ b/driver/src/trace/command.rs
@@ -33,7 +33,8 @@ impl CommandTracingEventEmitter {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),
-                    command = rawdoc_to_json_str(&event.command, self.max_document_length_bytes),
+                    command = rawdoc_to_json_str(&event.command, self.max_document_length_bytes)
+                        .unwrap_or_else(|e| format!("<invalid document: {e}>")),
                     databaseName = event.db,
                     commandName = event.command_name,
                     requestId = event.request_id,
@@ -49,7 +50,8 @@ impl CommandTracingEventEmitter {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),
-                    reply = rawdoc_to_json_str(&event.reply, self.max_document_length_bytes),
+                    reply = rawdoc_to_json_str(&event.reply, self.max_document_length_bytes)
+                        .unwrap_or_else(|e| format!("<invalid document: {e}>")),
                     commandName = event.command_name,
                     requestId = event.request_id,
                     driverConnectionId = event.connection.id,

--- a/driver/src/trace/command.rs
+++ b/driver/src/trace/command.rs
@@ -1,8 +1,8 @@
 use crate::bson::oid::ObjectId;
 
 use crate::{
-    bson_util::doc_to_json_str,
-    event::command::CommandEvent,
+    bson_util::rawdoc_to_json_str,
+    event::command::raw::RawCommandEvent,
     trace::{TracingRepresentation, COMMAND_TRACING_EVENT_TARGET},
 };
 
@@ -27,13 +27,13 @@ impl CommandTracingEventEmitter {
         }
     }
 
-    pub(crate) fn handle(&self, event: CommandEvent) {
+    pub(crate) fn handle(&self, event: RawCommandEvent) {
         match event {
-            CommandEvent::Started(event) => {
+            RawCommandEvent::Started(event) => {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),
-                    command = doc_to_json_str(event.command, self.max_document_length_bytes),
+                    command = rawdoc_to_json_str(&event.command, self.max_document_length_bytes),
                     databaseName = event.db,
                     commandName = event.command_name,
                     requestId = event.request_id,
@@ -45,11 +45,11 @@ impl CommandTracingEventEmitter {
                     "Command started"
                 );
             }
-            CommandEvent::Succeeded(event) => {
+            RawCommandEvent::Succeeded(event) => {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),
-                    reply = doc_to_json_str(event.reply, self.max_document_length_bytes),
+                    reply = rawdoc_to_json_str(&event.reply, self.max_document_length_bytes),
                     commandName = event.command_name,
                     requestId = event.request_id,
                     driverConnectionId = event.connection.id,
@@ -61,7 +61,7 @@ impl CommandTracingEventEmitter {
                     "Command succeeded"
                 );
             }
-            CommandEvent::Failed(event) => {
+            RawCommandEvent::Failed(event) => {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),

--- a/driver/src/trace/command.rs
+++ b/driver/src/trace/command.rs
@@ -1,7 +1,7 @@
 use crate::bson::oid::ObjectId;
 
 use crate::{
-    bson_util::rawdoc_to_json_str,
+    bson_util::{doc_err, rawdoc_to_json_str},
     event::command::raw::RawCommandEvent,
     trace::{TracingRepresentation, COMMAND_TRACING_EVENT_TARGET},
 };
@@ -33,8 +33,7 @@ impl CommandTracingEventEmitter {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),
-                    command = rawdoc_to_json_str(&event.command, self.max_document_length_bytes)
-                        .unwrap_or_else(|e| format!("<invalid document: {e}>")),
+                    command = rawdoc_to_json_str(&event.command, self.max_document_length_bytes).unwrap_or_else(doc_err),
                     databaseName = event.db,
                     commandName = event.command_name,
                     requestId = event.request_id,
@@ -50,8 +49,7 @@ impl CommandTracingEventEmitter {
                 tracing::debug!(
                     target: COMMAND_TRACING_EVENT_TARGET,
                     topologyId = self.topology_id.tracing_representation(),
-                    reply = rawdoc_to_json_str(&event.reply, self.max_document_length_bytes)
-                        .unwrap_or_else(|e| format!("<invalid document: {e}>")),
+                    reply = rawdoc_to_json_str(&event.reply, self.max_document_length_bytes).unwrap_or_else(doc_err),
                     commandName = event.command_name,
                     requestId = event.request_id,
                     driverConnectionId = event.connection.id,

--- a/driver/src/trace/topology.rs
+++ b/driver/src/trace/topology.rs
@@ -1,7 +1,7 @@
 use crate::bson::oid::ObjectId;
 
 use crate::{
-    bson_util::rawdoc_to_json_str,
+    bson_util::{doc_err, rawdoc_to_json_str},
     event::sdam::{
         SdamEvent,
         ServerClosedEvent,
@@ -167,14 +167,13 @@ impl TopologyTracingEventEmitter {
             target: TOPOLOGY_TRACING_EVENT_TARGET,
             TracingOrLogLevel::Debug
         ) {
-            let reply = event
-                .reply
+            let reply = (&event.reply)
                 .try_into()
                 .map_err(crate::error::Error::from)
                 .and_then(|r: crate::bson::RawDocumentBuf| {
                     rawdoc_to_json_str(&r, self.max_document_length_bytes)
                 })
-                .unwrap_or_else(|e| format!("<invalid document: {e}>"));
+                .unwrap_or_else(doc_err);
             tracing::debug!(
                 target: TOPOLOGY_TRACING_EVENT_TARGET,
                 topologyId = self.topology_id.tracing_representation(),

--- a/driver/src/trace/topology.rs
+++ b/driver/src/trace/topology.rs
@@ -1,7 +1,7 @@
 use crate::bson::oid::ObjectId;
 
 use crate::{
-    bson_util::doc_to_json_str,
+    bson_util::rawdoc_to_json_str,
     event::sdam::{
         SdamEvent,
         ServerClosedEvent,
@@ -167,6 +167,14 @@ impl TopologyTracingEventEmitter {
             target: TOPOLOGY_TRACING_EVENT_TARGET,
             TracingOrLogLevel::Debug
         ) {
+            let reply = event
+                .reply
+                .try_into()
+                .map_err(crate::error::Error::from)
+                .and_then(|r: crate::bson::RawDocumentBuf| {
+                    rawdoc_to_json_str(&r, self.max_document_length_bytes)
+                })
+                .unwrap_or_else(|e| format!("<invalid document: {e}>"));
             tracing::debug!(
                 target: TOPOLOGY_TRACING_EVENT_TARGET,
                 topologyId = self.topology_id.tracing_representation(),
@@ -175,7 +183,7 @@ impl TopologyTracingEventEmitter {
                 driverConnectionId = event.driver_connection_id,
                 serverConnectionId = event.server_connection_id,
                 awaited = event.awaited,
-                reply = doc_to_json_str(event.reply, self.max_document_length_bytes),
+                reply = reply,
                 durationMS = event.duration.as_millis(),
                 "Server heartbeat succeeded"
             )


### PR DESCRIPTION
RUST-1820

This fixes the problem of large command documents causing extreme performance degradation when logging is enabled by skipping the `RawDocument` -> `Document` conversion step and truncating within the string formatting step rather than after.

Large doc insertMany benchmarks before this change:

without tracing: 217.224 MB/s
with tracing: 61.941 MB/s (~3.5x slower)

After this change:

without tracing: 217.057 MB/s
with tracing: 199.361 MB/s (~1.1x slower)