### PR TITLE
RUST-2465 Fix an infinite loop in ChangeStream iteration

### DIFF
--- a/driver/src/change_stream.rs
+++ b/driver/src/change_stream.rs
@@ -227,6 +227,9 @@ impl<T: DeserializeOwned> Stream for StreamState<T> {
                         *self = StreamState::Idle(Box::new(state));
                         match out {
                             Ok(Some(v)) => return Poll::Ready(Some(Ok(v))),
+                            Ok(None) if self.state().cursor.raw().is_exhausted() => {
+                                return Poll::Ready(None)
+                            }
                             Ok(None) => continue,
                             Err(e) => return Poll::Ready(Some(Err(e))),
                         }

--- a/driver/src/change_stream.rs
+++ b/driver/src/change_stream.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use crate::error::Error;
+use crate::{cursor::stream::AdvanceResult, error::Error};
 use derive_where::derive_where;
 use futures_core::{future::BoxFuture, Stream};
 use futures_util::FutureExt;
@@ -132,7 +132,12 @@ where
     /// # }
     /// ```
     pub async fn next_if_any(&mut self) -> Result<Option<T>> {
-        self.inner.state_mut().next_if_any(&mut ()).await
+        Ok(self
+            .inner
+            .state_mut()
+            .next_if_any(&mut ())
+            .await?
+            .into_option())
     }
 
     #[cfg(test)]
@@ -176,7 +181,7 @@ enum StreamState<T: DeserializeOwned> {
 
 struct NextDone<T> {
     state: CursorWrapper,
-    out: Result<Option<T>>,
+    out: Result<AdvanceResult<T>>,
 }
 
 impl<T: DeserializeOwned> StreamState<T> {
@@ -226,11 +231,9 @@ impl<T: DeserializeOwned> Stream for StreamState<T> {
                     Poll::Ready(NextDone { state, out }) => {
                         *self = StreamState::Idle(Box::new(state));
                         match out {
-                            Ok(Some(v)) => return Poll::Ready(Some(Ok(v))),
-                            Ok(None) if self.state().cursor.raw().is_exhausted() => {
-                                return Poll::Ready(None)
-                            }
-                            Ok(None) => continue,
+                            Ok(AdvanceResult::Advanced(v)) => return Poll::Ready(Some(Ok(v))),
+                            Ok(AdvanceResult::Waiting) => continue,
+                            Ok(AdvanceResult::Exhausted) => return Poll::Ready(None),
                             Err(e) => return Poll::Ready(Some(Err(e))),
                         }
                     }
@@ -248,7 +251,10 @@ impl<T: DeserializeOwned> Stream for StreamState<T> {
 impl common::InnerCursor for Cursor<()> {
     type Session = ();
 
-    async fn try_advance(&mut self, _session: &mut Self::Session) -> Result<bool> {
+    async fn try_advance(
+        &mut self,
+        _session: &mut Self::Session,
+    ) -> Result<crate::cursor::stream::AdvanceResult> {
         self.try_advance().await
     }
 

--- a/driver/src/change_stream/common.rs
+++ b/driver/src/change_stream/common.rs
@@ -12,6 +12,7 @@ use serde::de::DeserializeOwned;
 use crate::bson_compat::RawBsonRefExt as _;
 use crate::{
     change_stream::event::ResumeToken,
+    cursor::stream::AdvanceResult,
     error::{ErrorKind, Result},
     ClientSession,
 };
@@ -77,22 +78,21 @@ impl<Inner> CursorWrapper<Inner> {
     pub(super) async fn next_if_any<T: DeserializeOwned>(
         &mut self,
         session: &mut Inner::Session,
-    ) -> Result<Option<T>>
+    ) -> Result<AdvanceResult<T>>
     where
         Inner: InnerCursor,
     {
         loop {
             match self.cursor.try_advance(session).await {
-                Ok(has) => {
+                Ok(advanced) => {
                     self.data.resume_token = self.cursor.get_resume_token()?;
-                    return if has {
-                        self.data.document_returned = true;
-                        deserialize_from_slice(self.cursor.current().as_bytes())
-                            .map(Some)
-                            .map_err(Error::from)
-                    } else {
-                        Ok(None)
-                    };
+                    return advanced
+                        .map(|()| {
+                            self.data.document_returned = true;
+                            deserialize_from_slice(self.cursor.current().as_bytes())
+                                .map_err(Error::from)
+                        })
+                        .transpose();
                 }
                 Err(e) if e.is_resumable() => {
                     let (new_cursor, new_args) = self
@@ -129,7 +129,7 @@ pub(super) fn get_resume_token(
 pub(super) trait InnerCursor: Sized {
     type Session;
 
-    async fn try_advance(&mut self, session: &mut Self::Session) -> Result<bool>;
+    async fn try_advance(&mut self, session: &mut Self::Session) -> Result<AdvanceResult>;
     fn get_resume_token(&self) -> Result<Option<ResumeToken>>;
     fn current(&self) -> &RawDocument;
     async fn execute_watch(

--- a/driver/src/change_stream/session.rs
+++ b/driver/src/change_stream/session.rs
@@ -1,7 +1,7 @@
 //! Types for change streams using sessions.
 use serde::de::DeserializeOwned;
 
-use crate::{error::Result, ClientSession, SessionCursor};
+use crate::{cursor::stream::AdvanceResult, error::Result, ClientSession, SessionCursor};
 
 use super::{
     event::{ChangeStreamEvent, ResumeToken},
@@ -93,11 +93,10 @@ where
     /// ```
     pub async fn next(&mut self, session: &mut ClientSession) -> Result<Option<T>> {
         loop {
-            let maybe_next = self.next_if_any(session).await?;
-            match maybe_next {
-                Some(t) => return Ok(Some(t)),
-                None if self.is_alive() => continue,
-                None => return Ok(None),
+            match self.inner.next_if_any(session).await? {
+                AdvanceResult::Advanced(t) => return Ok(Some(t)),
+                AdvanceResult::Waiting => continue,
+                AdvanceResult::Exhausted => return Ok(None),
             }
         }
     }
@@ -133,14 +132,17 @@ where
     /// # }
     /// ```
     pub async fn next_if_any(&mut self, session: &mut ClientSession) -> Result<Option<T>> {
-        self.inner.next_if_any(session).await
+        Ok(self.inner.next_if_any(session).await?.into_option())
     }
 }
 
 impl super::common::InnerCursor for SessionCursor<()> {
     type Session = ClientSession;
 
-    async fn try_advance(&mut self, session: &mut Self::Session) -> Result<bool> {
+    async fn try_advance(
+        &mut self,
+        session: &mut Self::Session,
+    ) -> Result<crate::cursor::stream::AdvanceResult> {
         self.try_advance(session).await
     }
 

--- a/driver/src/cursor.rs
+++ b/driver/src/cursor.rs
@@ -1,7 +1,7 @@
 pub(crate) mod common;
 pub mod raw_batch;
 pub(crate) mod session;
-mod stream;
+pub(crate) mod stream;
 #[cfg(feature = "sync")]
 pub(crate) mod sync;
 
@@ -198,7 +198,7 @@ impl<T> Cursor<T> {
         &mut self.stream.buffer_mut().raw
     }
 
-    pub(crate) async fn try_advance(&mut self) -> Result<bool> {
+    pub(crate) async fn try_advance(&mut self) -> Result<stream::AdvanceResult> {
         self.stream.buffer_mut().try_advance().await
     }
 

--- a/driver/src/cursor/session.rs
+++ b/driver/src/cursor/session.rs
@@ -183,7 +183,10 @@ impl<T> SessionCursor<T> {
         self.stream(session).stream.buffer_mut().advance().await
     }
 
-    pub(crate) async fn try_advance(&mut self, session: &mut ClientSession) -> Result<bool> {
+    pub(crate) async fn try_advance(
+        &mut self,
+        session: &mut ClientSession,
+    ) -> Result<stream::AdvanceResult> {
         self.stream(session).stream.buffer_mut().try_advance().await
     }
 

--- a/driver/src/cursor/stream.rs
+++ b/driver/src/cursor/stream.rs
@@ -122,8 +122,8 @@ impl<Raw: AsyncStream<Item = Result<RawBatch>> + Unpin> BatchBuffer<Raw> {
     /// Return whether or not the cursor has been advanced.
     pub(super) async fn advance(&mut self) -> Result<bool> {
         loop {
-            match self.advance_internal().await? {
-                AdvanceResult::Advanced => return Ok(true),
+            match self.try_advance().await? {
+                AdvanceResult::Advanced(_) => return Ok(true),
                 AdvanceResult::Exhausted => return Ok(false),
                 AdvanceResult::Waiting => continue,
             }
@@ -132,17 +132,11 @@ impl<Raw: AsyncStream<Item = Result<RawBatch>> + Unpin> BatchBuffer<Raw> {
 
     /// Attempt to advance the cursor forward to the next item. If there are no items cached
     /// locally, perform a single getMore to attempt to retrieve more.
-    pub(super) async fn try_advance(&mut self) -> Result<bool> {
-        self.advance_internal()
-            .await
-            .map(|ar| matches!(ar, AdvanceResult::Advanced))
-    }
-
-    async fn advance_internal(&mut self) -> Result<AdvanceResult> {
+    pub(crate) async fn try_advance(&mut self) -> Result<AdvanceResult> {
         // Next stored batch item
         self.batch.pop_front();
         if !self.batch.is_empty() {
-            return Ok(AdvanceResult::Advanced);
+            return Ok(AdvanceResult::Advanced(()));
         }
 
         // Batch is empty, need a new one
@@ -161,20 +155,47 @@ impl<Raw: AsyncStream<Item = Result<RawBatch>> + Unpin> BatchBuffer<Raw> {
         Ok(if self.batch.is_empty() {
             AdvanceResult::Waiting
         } else {
-            AdvanceResult::Advanced
+            AdvanceResult::Advanced(())
         })
     }
 }
 
 /// The result of one attempt to advance a cursor.
-#[derive(Debug)]
-enum AdvanceResult {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AdvanceResult<T = ()> {
     /// The cursor was successfully advanced and the buffer has at least one item.
-    Advanced,
+    Advanced(T),
     /// The cursor does not have any more items and will not return any more in the future.
     Exhausted,
     /// The cursor does not currently have any items, but future calls to getMore may yield more.
     Waiting,
+}
+
+impl<T> AdvanceResult<T> {
+    pub(crate) fn map<U>(self, f: impl FnOnce(T) -> U) -> AdvanceResult<U> {
+        match self {
+            Self::Advanced(t) => AdvanceResult::Advanced(f(t)),
+            Self::Exhausted => AdvanceResult::Exhausted,
+            Self::Waiting => AdvanceResult::Waiting,
+        }
+    }
+
+    pub(crate) fn into_option(self) -> Option<T> {
+        match self {
+            Self::Advanced(t) => Some(t),
+            Self::Exhausted | Self::Waiting => None,
+        }
+    }
+}
+
+impl<T, E> AdvanceResult<std::result::Result<T, E>> {
+    pub(crate) fn transpose(self) -> std::result::Result<AdvanceResult<T>, E> {
+        match self {
+            Self::Advanced(rt) => rt.map(AdvanceResult::Advanced),
+            Self::Exhausted => Ok(AdvanceResult::Exhausted),
+            Self::Waiting => Ok(AdvanceResult::Waiting),
+        }
+    }
 }
 
 impl<'a, Raw: 'a + AsyncStream<Item = Result<RawBatch>> + Send + Unpin, T: DeserializeOwned>

--- a/driver/src/test/change_stream.rs
+++ b/driver/src/test/change_stream.rs
@@ -595,3 +595,30 @@ async fn _collection_watch_typed() {
     let _: Option<crate::error::Result<ChangeStreamEvent<crate::bson::RawDocumentBuf>>> =
         stream.next().await;
 }
+
+// Regression test: dropping a watched collection could cause an infinite loop.
+#[tokio::test]
+async fn drop_infinite_loop() -> Result<()> {
+    if !(topology_is_replica_set().await || topology_is_sharded().await) {
+        log_uncaptured("skipping change stream test on unsupported topology");
+        return Ok(());
+    }
+    let client = Client::for_test().await;
+    let coll = client
+        .database("changestream_drop_spin")
+        .collection::<Document>("watched");
+
+    coll.drop().await.ok();
+    coll.insert_one(doc! { "x": 1 }).await?;
+
+    let mut stream = coll.watch().await?;
+    coll.drop().await?;
+
+    for _ in 1..=10 {
+        if let None = stream.try_next().await? {
+            break;
+        }
+    }
+
+    return Ok(());
+}


### PR DESCRIPTION
RUST-2465

The immediate cause was that we forgot to check for exhaustion in the non-session path - `StreamState::poll_next` would `continue` for any `Ok(None)` case, which could be either "waiting for next result" or "exhausted".  In the latter, the next layers down would early-exit and `poll_next` would keep looping.

The root cause (IMO) is that flattening the trinary `AdvanceResult` into a binary `bool`/`Option` was done way too early and made this sort of mistake very easy to make - it was just a forgotten `if` guard in a match.  This PR extends `AdvanceResult` with an optional payload and makes it the data carrier all the way through the layers up to the public API so hopefully it's less of a footgun.