### PR TITLE
RUST-2465 Simplify cursor/changestream internals

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,6 +19,7 @@ if [ "Windows_NT" == "$OS" ]; then
   export SSL_CERT_DIR=$(cygpath /etc/ssl/certs --windows)
 fi
 
-cargo_test ""
+#cargo_test ""
+cargo_test "change_stream"
 
 exit $CARGO_RESULT

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -19,7 +19,6 @@ if [ "Windows_NT" == "$OS" ]; then
   export SSL_CERT_DIR=$(cygpath /etc/ssl/certs --windows)
 fi
 
-#cargo_test ""
-cargo_test "change_stream"
+cargo_test ""
 
 exit $CARGO_RESULT

--- a/driver/src/change_stream.rs
+++ b/driver/src/change_stream.rs
@@ -7,7 +7,6 @@ pub mod session;
 #[cfg(test)]
 use std::collections::VecDeque;
 use std::{
-    ops::ControlFlow,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -21,10 +20,7 @@ use tokio::sync::oneshot;
 
 use crate::{
     change_stream::event::ResumeToken,
-    cursor::{
-        poll_state::{poll_panic, PollState},
-        stream::AdvanceResult,
-    },
+    cursor::poll_state::{poll_panic, PollState},
     error::Result,
     Cursor,
 };
@@ -180,24 +176,19 @@ where
             cx,
             |mut state| {
                 async move {
-                    let out = state.next_if_any(&mut ()).await;
+                    let out = state.next_event(&mut ()).await;
                     (state, out)
                 }
                 .boxed()
             },
-            |_, out| match out {
-                Ok(AdvanceResult::Advanced(v)) => ControlFlow::Break(Some(Ok(v))),
-                Ok(AdvanceResult::Waiting) => ControlFlow::Continue(()),
-                Ok(AdvanceResult::Exhausted) => ControlFlow::Break(None),
-                Err(e) => ControlFlow::Break(Some(Err(e))),
-            },
+            |_, out| out.transpose(),
         )
     }
 }
 
 type CursorWrapper = common::CursorWrapper<Cursor<()>>;
 
-type ChangeStreamState<T> = PollState<'static, Box<CursorWrapper>, Result<AdvanceResult<T>>>;
+type ChangeStreamState<T> = PollState<'static, Box<CursorWrapper>, Result<Option<T>>>;
 
 impl common::InnerCursor for Cursor<()> {
     type Session = ();

--- a/driver/src/change_stream.rs
+++ b/driver/src/change_stream.rs
@@ -7,19 +7,27 @@ pub mod session;
 #[cfg(test)]
 use std::collections::VecDeque;
 use std::{
+    ops::ControlFlow,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use crate::{cursor::stream::AdvanceResult, error::Error};
 use derive_where::derive_where;
-use futures_core::{future::BoxFuture, Stream};
+use futures_core::Stream;
 use futures_util::FutureExt;
 use serde::de::DeserializeOwned;
 #[cfg(test)]
 use tokio::sync::oneshot;
 
-use crate::{change_stream::event::ResumeToken, error::Result, Cursor};
+use crate::{
+    change_stream::event::ResumeToken,
+    cursor::{
+        poll_state::{poll_panic, PollState},
+        stream::AdvanceResult,
+    },
+    error::Result,
+    Cursor,
+};
 use common::{ChangeStreamData, WatchArgs};
 
 /// A `ChangeStream` streams the ongoing changes of its associated collection, database or
@@ -72,7 +80,7 @@ pub struct ChangeStream<T>
 where
     T: DeserializeOwned,
 {
-    inner: StreamState<T>,
+    inner: ChangeStreamState<T>,
 }
 
 impl<T> ChangeStream<T>
@@ -81,7 +89,7 @@ where
 {
     pub(crate) fn new(cursor: Cursor<()>, args: WatchArgs, data: ChangeStreamData) -> Self {
         Self {
-            inner: StreamState::Idle(Box::new(CursorWrapper::new(cursor, args, data))),
+            inner: PollState::new(Box::new(CursorWrapper::new(cursor, args, data))),
         }
     }
 
@@ -92,19 +100,19 @@ where
     /// [here](https://www.mongodb.com/docs/manual/changeStreams/#change-stream-resume-token) for more
     /// information on change stream resume tokens.
     pub fn resume_token(&self) -> Option<ResumeToken> {
-        self.inner.state().data.resume_token.clone()
+        poll_panic!(self.inner.state()).data.resume_token.clone()
     }
 
     /// Update the type streamed values will be parsed as.
     pub fn with_type<D: DeserializeOwned>(self) -> ChangeStream<D> {
         ChangeStream {
-            inner: StreamState::Idle(self.inner.take_state()),
+            inner: PollState::new(poll_panic!(self.inner.into_state())),
         }
     }
 
     /// Returns whether the change stream will continue to receive events.
     pub fn is_alive(&self) -> bool {
-        !self.inner.state().cursor.raw().is_exhausted()
+        !poll_panic!(self.inner.state().and_then(|state| state.cursor.raw())).is_exhausted()
     }
 
     /// Retrieves the next result from the change stream, if any.
@@ -134,25 +142,30 @@ where
     pub async fn next_if_any(&mut self) -> Result<Option<T>> {
         Ok(self
             .inner
-            .state_mut()
+            .state_mut()?
             .next_if_any(&mut ())
             .await?
             .into_option())
     }
 
     #[cfg(test)]
-    pub(crate) fn set_kill_watcher(&mut self, tx: oneshot::Sender<()>) {
-        self.inner.state_mut().cursor.raw_mut().set_kill_watcher(tx);
+    pub(crate) fn set_kill_watcher(&mut self, tx: oneshot::Sender<()>) -> Result<()> {
+        self.inner
+            .state_mut()?
+            .cursor
+            .raw_mut()?
+            .set_kill_watcher(tx);
+        Ok(())
     }
 
     #[cfg(test)]
-    pub(crate) fn current_batch(&self) -> &VecDeque<crate::bson::RawDocumentBuf> {
-        self.inner.state().cursor.batch()
+    pub(crate) fn current_batch(&self) -> Result<&VecDeque<crate::bson::RawDocumentBuf>> {
+        self.inner.state()?.cursor.batch()
     }
 
     #[cfg(test)]
-    pub(crate) fn client(&self) -> &crate::Client {
-        self.inner.state().cursor.raw().client()
+    pub(crate) fn client(&self) -> Result<&crate::Client> {
+        Ok(self.inner.state()?.cursor.raw()?.client())
     }
 }
 
@@ -162,91 +175,29 @@ where
 {
     type Item = Result<T>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.inner).poll_next(cx)
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.poll_next_step(
+            cx,
+            |mut state| {
+                async move {
+                    let out = state.next_if_any(&mut ()).await;
+                    (state, out)
+                }
+                .boxed()
+            },
+            |_, out| match out {
+                Ok(AdvanceResult::Advanced(v)) => ControlFlow::Break(Some(Ok(v))),
+                Ok(AdvanceResult::Waiting) => ControlFlow::Continue(()),
+                Ok(AdvanceResult::Exhausted) => ControlFlow::Break(None),
+                Err(e) => ControlFlow::Break(Some(Err(e))),
+            },
+        )
     }
 }
 
 type CursorWrapper = common::CursorWrapper<Cursor<()>>;
 
-// This is almost entirely the same as `crate::cursor::stream::Stream`.  However, making a generic
-// version to underlie both has the side effect of changing the variance on `T` from covariant to
-// invariant, which breaks cursor zero-copy deserialization :(
-#[derive_where(Debug)]
-enum StreamState<T: DeserializeOwned> {
-    Idle(Box<CursorWrapper>),
-    Polling,
-    Next(#[derive_where(skip)] BoxFuture<'static, NextDone<T>>),
-}
-
-struct NextDone<T> {
-    state: CursorWrapper,
-    out: Result<AdvanceResult<T>>,
-}
-
-impl<T: DeserializeOwned> StreamState<T> {
-    fn state(&self) -> &CursorWrapper {
-        match self {
-            Self::Idle(st) => st,
-            _ => panic!("invalid change stream state access"),
-        }
-    }
-
-    fn state_mut(&mut self) -> &mut CursorWrapper {
-        match self {
-            Self::Idle(st) => st,
-            _ => panic!("invalid change stream state access"),
-        }
-    }
-
-    fn take_state(self) -> Box<CursorWrapper> {
-        match self {
-            Self::Idle(st) => st,
-            _ => panic!("invalid change stream state access"),
-        }
-    }
-}
-
-impl<T: DeserializeOwned> Stream for StreamState<T> {
-    type Item = Result<T>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
-            match std::mem::replace(&mut *self, StreamState::Polling) {
-                StreamState::Idle(mut state) => {
-                    *self = StreamState::Next(
-                        async move {
-                            let out = state.next_if_any(&mut ()).await;
-                            NextDone { state: *state, out }
-                        }
-                        .boxed(),
-                    );
-                    continue;
-                }
-                StreamState::Next(mut fut) => match fut.poll_unpin(cx) {
-                    Poll::Pending => {
-                        *self = StreamState::Next(fut);
-                        return Poll::Pending;
-                    }
-                    Poll::Ready(NextDone { state, out }) => {
-                        *self = StreamState::Idle(Box::new(state));
-                        match out {
-                            Ok(AdvanceResult::Advanced(v)) => return Poll::Ready(Some(Ok(v))),
-                            Ok(AdvanceResult::Waiting) => continue,
-                            Ok(AdvanceResult::Exhausted) => return Poll::Ready(None),
-                            Err(e) => return Poll::Ready(Some(Err(e))),
-                        }
-                    }
-                },
-                StreamState::Polling => {
-                    return Poll::Ready(Some(Err(Error::internal(
-                        "attempt to poll change stream already in polling state",
-                    ))))
-                }
-            }
-        }
-    }
-}
+type ChangeStreamState<T> = PollState<'static, Box<CursorWrapper>, Result<AdvanceResult<T>>>;
 
 impl common::InnerCursor for Cursor<()> {
     type Session = ();
@@ -259,7 +210,7 @@ impl common::InnerCursor for Cursor<()> {
     }
 
     fn get_resume_token(&self) -> Result<Option<ResumeToken>> {
-        common::get_resume_token(self.batch(), self.raw().post_batch_resume_token())
+        common::get_resume_token(self.batch()?, self.raw()?.post_batch_resume_token())
     }
 
     fn current(&self) -> &crate::bson::RawDocument {
@@ -272,18 +223,18 @@ impl common::InnerCursor for Cursor<()> {
         mut data: ChangeStreamData,
         _session: &mut Self::Session,
     ) -> Result<(Self, WatchArgs)> {
-        data.implicit_session = self.raw_mut().take_implicit_session();
-        let new_stream: ChangeStream<event::ChangeStreamEvent<()>> = self
-            .raw()
-            .client()
+        data.implicit_session = self.raw_mut()?.take_implicit_session();
+        let client = self.raw()?.client().clone();
+        let new_stream: ChangeStream<event::ChangeStreamEvent<()>> = client
             .execute_watch(args.pipeline, args.options, args.target, Some(data))
             .await?;
-        let new_wrapper = new_stream.inner.take_state();
+        let new_wrapper = new_stream.inner.into_state()?;
         Ok((new_wrapper.cursor, new_wrapper.args))
     }
 
-    fn set_drop_address(&mut self, from: &Self) {
-        self.raw_mut()
-            .set_drop_address(from.raw().address().clone());
+    fn set_drop_address(&mut self, from: &Self) -> Result<()> {
+        self.raw_mut()?
+            .set_drop_address(from.raw()?.address().clone());
+        Ok(())
     }
 }

--- a/driver/src/change_stream/common.rs
+++ b/driver/src/change_stream/common.rs
@@ -100,7 +100,7 @@ impl<Inner> CursorWrapper<Inner> {
                         .execute_watch(self.args.clone(), self.data.take(), session)
                         .await?;
                     // Ensure that the old cursor is killed on the server selected for the new one.
-                    self.cursor.set_drop_address(&new_cursor);
+                    self.cursor.set_drop_address(&new_cursor)?;
                     self.cursor = new_cursor;
                     self.args = new_args;
                     continue;
@@ -138,5 +138,5 @@ pub(super) trait InnerCursor: Sized {
         data: ChangeStreamData,
         session: &mut Self::Session,
     ) -> Result<(Self, WatchArgs)>;
-    fn set_drop_address(&mut self, from: &Self);
+    fn set_drop_address(&mut self, from: &Self) -> Result<()>;
 }

--- a/driver/src/change_stream/common.rs
+++ b/driver/src/change_stream/common.rs
@@ -75,6 +75,24 @@ impl<Inner> CursorWrapper<Inner> {
         Self { cursor, args, data }
     }
 
+    /// Retrieve the next event, waiting through batches that arrive empty.  Returns `None` only
+    /// when the cursor is exhausted and no further events can arrive.
+    pub(super) async fn next_event<T: DeserializeOwned>(
+        &mut self,
+        session: &mut Inner::Session,
+    ) -> Result<Option<T>>
+    where
+        Inner: InnerCursor,
+    {
+        loop {
+            match self.next_if_any(session).await? {
+                AdvanceResult::Advanced(event) => return Ok(Some(event)),
+                AdvanceResult::Waiting => continue,
+                AdvanceResult::Exhausted => return Ok(None),
+            }
+        }
+    }
+
     pub(super) async fn next_if_any<T: DeserializeOwned>(
         &mut self,
         session: &mut Inner::Session,

--- a/driver/src/change_stream/session.rs
+++ b/driver/src/change_stream/session.rs
@@ -1,7 +1,7 @@
 //! Types for change streams using sessions.
 use serde::de::DeserializeOwned;
 
-use crate::{cursor::stream::AdvanceResult, error::Result, ClientSession, SessionCursor};
+use crate::{error::Result, ClientSession, SessionCursor};
 
 use super::{
     event::{ChangeStreamEvent, ResumeToken},
@@ -92,13 +92,7 @@ where
     /// # }
     /// ```
     pub async fn next(&mut self, session: &mut ClientSession) -> Result<Option<T>> {
-        loop {
-            match self.inner.next_if_any(session).await? {
-                AdvanceResult::Advanced(t) => return Ok(Some(t)),
-                AdvanceResult::Waiting => continue,
-                AdvanceResult::Exhausted => return Ok(None),
-            }
-        }
+        self.inner.next_event(session).await
     }
 
     /// Returns whether the change stream will continue to receive events.

--- a/driver/src/change_stream/session.rs
+++ b/driver/src/change_stream/session.rs
@@ -147,7 +147,7 @@ impl super::common::InnerCursor for SessionCursor<()> {
     }
 
     fn get_resume_token(&self) -> Result<Option<ResumeToken>> {
-        super::common::get_resume_token(self.batch(), self.raw().post_batch_resume_token())
+        super::common::get_resume_token(self.batch()?, self.raw().post_batch_resume_token())
     }
 
     fn current(&self) -> &crate::bson::RawDocument {
@@ -175,8 +175,9 @@ impl super::common::InnerCursor for SessionCursor<()> {
         Ok((new_inner.cursor, new_inner.args))
     }
 
-    fn set_drop_address(&mut self, from: &Self) {
+    fn set_drop_address(&mut self, from: &Self) -> Result<()> {
         self.raw_mut()
             .set_drop_address(from.raw().address().clone());
+        Ok(())
     }
 }

--- a/driver/src/cursor.rs
+++ b/driver/src/cursor.rs
@@ -1,4 +1,5 @@
 pub(crate) mod common;
+pub(crate) mod poll_state;
 pub mod raw_batch;
 pub(crate) mod session;
 pub(crate) mod stream;
@@ -15,6 +16,7 @@ use serde::{de::DeserializeOwned, Deserialize};
 use crate::{
     bson::RawDocument,
     cmap::conn::PinnedConnectionHandle,
+    cursor::poll_state::poll_panic,
     error::Result,
     Client,
     ClientSession,
@@ -86,6 +88,16 @@ pub struct Cursor<T> {
     stream: stream::Stream<'static, raw_batch::RawBatchCursor, T>,
 }
 
+#[allow(dead_code)]
+const _: fn() = || {
+    /// `Cursor<T>` must stay covariant in `T` for zero-copy deserialization to work: a cursor
+    /// yielding a type that borrows for a long lifetime has to be usable where one borrowing for a
+    /// shorter lifetime is expected.
+    fn assert_covariant<'long: 'short, 'short>(cursor: Cursor<&'long str>) -> Cursor<&'short str> {
+        cursor
+    }
+};
+
 impl<T> Cursor<T> {
     /// Move the cursor forward, potentially triggering requests to the database for more results
     /// if the local buffer has been exhausted.
@@ -113,7 +125,7 @@ impl<T> Cursor<T> {
     /// # }
     /// ```
     pub async fn advance(&mut self) -> Result<bool> {
-        self.stream.buffer_mut().advance().await
+        self.stream.buffer_mut()?.advance().await
     }
 
     /// Returns a reference to the current result in the cursor.
@@ -136,12 +148,12 @@ impl<T> Cursor<T> {
     /// # }
     /// ```
     pub fn current(&self) -> &RawDocument {
-        self.stream.buffer().current()
+        poll_panic!(self.stream.buffer()).current()
     }
 
     /// Returns true if the cursor has any additional items to return and false otherwise.
     pub fn has_next(&self) -> bool {
-        let state = self.stream.buffer();
+        let state = poll_panic!(self.stream.buffer());
         !state.batch().is_empty() || state.raw.has_next()
     }
 
@@ -177,7 +189,7 @@ impl<T> Cursor<T> {
     where
         T: Deserialize<'a>,
     {
-        self.stream.buffer().deserialize_current()
+        self.stream.buffer()?.deserialize_current()
     }
 
     /// Update the type streamed values will be parsed as.
@@ -190,20 +202,20 @@ impl<T> Cursor<T> {
         }
     }
 
-    pub(crate) fn raw(&self) -> &raw_batch::RawBatchCursor {
-        &self.stream.buffer().raw
+    pub(crate) fn raw(&self) -> Result<&raw_batch::RawBatchCursor> {
+        Ok(&self.stream.buffer()?.raw)
     }
 
-    pub(crate) fn raw_mut(&mut self) -> &mut raw_batch::RawBatchCursor {
-        &mut self.stream.buffer_mut().raw
+    pub(crate) fn raw_mut(&mut self) -> Result<&mut raw_batch::RawBatchCursor> {
+        Ok(&mut self.stream.buffer_mut()?.raw)
     }
 
     pub(crate) async fn try_advance(&mut self) -> Result<stream::AdvanceResult> {
-        self.stream.buffer_mut().try_advance().await
+        self.stream.buffer_mut()?.try_advance().await
     }
 
-    pub(crate) fn batch(&self) -> &std::collections::VecDeque<crate::bson::RawDocumentBuf> {
-        self.stream.buffer().batch()
+    pub(crate) fn batch(&self) -> Result<&std::collections::VecDeque<crate::bson::RawDocumentBuf>> {
+        Ok(self.stream.buffer()?.batch())
     }
 }
 

--- a/driver/src/cursor/poll_state.rs
+++ b/driver/src/cursor/poll_state.rs
@@ -1,0 +1,104 @@
+use std::{
+    ops::ControlFlow,
+    task::{Context, Poll},
+};
+
+use derive_where::derive_where;
+use futures_util::FutureExt;
+
+use crate::{
+    error::{Error, Result},
+    BoxFuture,
+};
+
+/// Message used if the state is accessed while a step is in progress.
+const STREAMING_ERR: &str = "cursor state access while streaming";
+
+/// The state of an "introspectable" async stream
+#[derive_where(Debug; S)]
+pub(crate) enum PollState<'a, S, O> {
+    Idle(S),
+    Running(#[derive_where(skip)] BoxFuture<'a, (S, O)>),
+    Polling,
+}
+
+impl<'a, S, O> PollState<'a, S, O> {
+    pub(crate) fn new(state: S) -> Self {
+        Self::Idle(state)
+    }
+
+    pub(crate) fn state(&self) -> Result<&S> {
+        match self {
+            Self::Idle(state) => Ok(state),
+            _ => Err(Error::internal(STREAMING_ERR)),
+        }
+    }
+
+    pub(crate) fn state_mut(&mut self) -> Result<&mut S> {
+        match self {
+            Self::Idle(state) => Ok(state),
+            _ => Err(Error::internal(STREAMING_ERR)),
+        }
+    }
+
+    pub(crate) fn into_state(self) -> Result<S> {
+        match self {
+            Self::Idle(state) => Ok(state),
+            _ => Err(Error::internal(STREAMING_ERR)),
+        }
+    }
+
+    pub(crate) fn take_state(&mut self) -> Option<S> {
+        match std::mem::replace(self, Self::Polling) {
+            Self::Idle(state) => Some(state),
+            _ => None,
+        }
+    }
+
+    /// Drive the machine.
+    /// * `start` builds the future for the Idle -> Running state transition.
+    /// * `finish` inspects future output and either yields a value or keeps looping.
+    pub(crate) fn poll_next_step<T>(
+        &mut self,
+        cx: &mut Context<'_>,
+        mut start: impl FnMut(S) -> BoxFuture<'a, (S, O)>,
+        mut finish: impl FnMut(&mut S, O) -> ControlFlow<Option<Result<T>>>,
+    ) -> Poll<Option<Result<T>>> {
+        loop {
+            match std::mem::replace(self, Self::Polling) {
+                Self::Idle(state) => {
+                    *self = Self::Running(start(state));
+                    continue;
+                }
+                Self::Running(mut future) => match future.poll_unpin(cx) {
+                    Poll::Pending => {
+                        *self = Self::Running(future);
+                        return Poll::Pending;
+                    }
+                    Poll::Ready((mut state, out)) => {
+                        let step = finish(&mut state, out);
+                        *self = Self::Idle(state);
+                        match step {
+                            ControlFlow::Break(item) => return Poll::Ready(item),
+                            ControlFlow::Continue(()) => continue,
+                        }
+                    }
+                },
+                Self::Polling => {
+                    return Poll::Ready(Some(Err(Error::internal(
+                        "attempt to poll stream already in polling state",
+                    ))))
+                }
+            }
+        }
+    }
+}
+
+/// Various public API methods downstream of `PollState` accessors require infallibility; this makes
+/// them more searchable than a raw `unwrap`.
+macro_rules! poll_panic {
+    ($r:expr) => {
+        $r.unwrap()
+    };
+}
+pub(crate) use poll_panic;

--- a/driver/src/cursor/poll_state.rs
+++ b/driver/src/cursor/poll_state.rs
@@ -1,7 +1,4 @@
-use std::{
-    ops::ControlFlow,
-    task::{Context, Poll},
-};
+use std::task::{Context, Poll};
 
 use derive_where::derive_where;
 use futures_util::FutureExt;
@@ -55,14 +52,14 @@ impl<'a, S, O> PollState<'a, S, O> {
         }
     }
 
-    /// Drive the machine.
+    /// Drive the machine as a [`futures_core::Stream::poll_next`].
     /// * `start` builds the future for the Idle -> Running state transition.
-    /// * `finish` inspects future output and either yields a value or keeps looping.
+    /// * `finish` turns that future's output into a stream item, with `None` ending the stream.
     pub(crate) fn poll_next_step<T>(
         &mut self,
         cx: &mut Context<'_>,
         mut start: impl FnMut(S) -> BoxFuture<'a, (S, O)>,
-        mut finish: impl FnMut(&mut S, O) -> ControlFlow<Option<Result<T>>>,
+        mut finish: impl FnMut(&mut S, O) -> Option<Result<T>>,
     ) -> Poll<Option<Result<T>>> {
         loop {
             match std::mem::replace(self, Self::Polling) {
@@ -76,12 +73,9 @@ impl<'a, S, O> PollState<'a, S, O> {
                         return Poll::Pending;
                     }
                     Poll::Ready((mut state, out)) => {
-                        let step = finish(&mut state, out);
+                        let item = finish(&mut state, out);
                         *self = Self::Idle(state);
-                        match step {
-                            ControlFlow::Break(item) => return Poll::Ready(item),
-                            ControlFlow::Continue(()) => continue,
-                        }
+                        return Poll::Ready(item);
                     }
                 },
                 Self::Polling => {

--- a/driver/src/cursor/raw_batch.rs
+++ b/driver/src/cursor/raw_batch.rs
@@ -118,8 +118,8 @@ impl RawBatch {
 pub struct RawBatchCursor {
     client: Client,
     drop_token: AsyncDropToken,
-    info: CursorInformation,
-    state: RawBatchCursorState,
+    state: CursorState,
+    provider: GetMoreRawProvider<'static, ImplicitClientSessionHandle>,
     drop_address: Option<ServerAddress>,
     #[cfg(test)]
     kill_watcher: Option<oneshot::Sender<()>>,
@@ -133,12 +133,113 @@ const _: fn() = || {
     assert_unpin(_rb);
 };
 
-struct RawBatchCursorState {
+/// The state of a server-side cursor, shared by [`RawBatchCursor`] and [`SessionRawBatchCursor`].
+#[derive(Debug)]
+struct CursorState {
+    info: CursorInformation,
     exhausted: bool,
     pinned_connection: PinnedConnection,
     post_batch_resume_token: Option<ResumeToken>,
-    provider: GetMoreRawProvider<'static, ImplicitClientSessionHandle>,
     buffered_reply: Option<RawDocumentBuf>,
+}
+
+impl CursorState {
+    fn new(spec: CursorSpecification, pin: Option<PinnedConnectionHandle>) -> Self {
+        Self {
+            exhausted: spec.info.id == 0,
+            info: spec.info,
+            pinned_connection: PinnedConnection::new(pin),
+            post_batch_resume_token: spec.post_batch_resume_token,
+            buffered_reply: Some(spec.initial_reply),
+        }
+    }
+
+    fn mark_exhausted(&mut self) {
+        self.exhausted = true;
+        self.pinned_connection = PinnedConnection::Unpinned;
+    }
+
+    fn has_next(&self) -> bool {
+        if !self.exhausted {
+            return true;
+        }
+        let Some(batch) = self
+            .buffered_reply
+            .as_ref()
+            .and_then(|reply| reply.get_document(CURSOR).ok())
+            .and_then(|cursor| {
+                cursor
+                    .get_array(FIRST_BATCH)
+                    .or_else(|_| cursor.get_array(NEXT_BATCH))
+                    .ok()
+            })
+        else {
+            return false;
+        };
+        !batch.is_empty()
+    }
+
+    fn poll_next_batch<'s, S: ClientSessionHandle<'s>>(
+        &mut self,
+        provider: &mut GetMoreRawProvider<'s, S>,
+        client: &Client,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<RawBatch>>> {
+        loop {
+            // If a getMore is in flight, poll it and update state.
+            if let Some(future) = provider.executing_future() {
+                let get_more_out = ready!(Pin::new(future).poll(cx));
+                let error = match get_more_out.result {
+                    Ok(out) => {
+                        self.buffered_reply = Some(out.raw_reply);
+                        self.post_batch_resume_token = out.post_batch_resume_token;
+                        if out.exhausted {
+                            self.mark_exhausted();
+                        }
+                        if out.id != 0 {
+                            self.info.id = out.id;
+                        }
+                        self.info.ns = out.ns;
+                        None
+                    }
+                    Err(e) => {
+                        if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
+                        {
+                            self.mark_exhausted();
+                        }
+                        if e.is_network_error() {
+                            // Flag the connection as invalid, preventing a killCursors
+                            // command, but leave the connection pinned.
+                            self.pinned_connection.invalidate();
+                        }
+                        Some(e)
+                    }
+                };
+                provider.clear_execution(get_more_out.session, self.exhausted);
+                if let Some(e) = error {
+                    return Poll::Ready(Some(Err(e)));
+                }
+            }
+
+            // Yield any buffered reply.
+            if let Some(reply) = self.buffered_reply.take() {
+                return Poll::Ready(Some(Ok(RawBatch::new(reply))));
+            }
+
+            // If not exhausted and the connection is valid, start a getMore and iterate.
+            if !self.exhausted && !matches!(self.pinned_connection, PinnedConnection::Invalid(_)) {
+                provider.start_execution(
+                    self.info.clone(),
+                    client.clone(),
+                    self.pinned_connection.handle(),
+                );
+                continue;
+            }
+
+            // Otherwise, we're done.
+            return Poll::Ready(None);
+        }
+    }
 }
 
 impl crate::cursor::NewCursor for RawBatchCursor {
@@ -163,20 +264,14 @@ impl RawBatchCursor {
         Self {
             client: client.clone(),
             drop_token: client.register_async_drop(),
-            info: spec.info,
             drop_address: None,
             #[cfg(test)]
             kill_watcher: None,
-            state: RawBatchCursorState {
-                exhausted,
-                pinned_connection: PinnedConnection::new(pin),
-                post_batch_resume_token: spec.post_batch_resume_token,
-                provider: if exhausted {
-                    GetMoreRawProvider::Done
-                } else {
-                    GetMoreRawProvider::Idle(Box::new(ImplicitClientSessionHandle(session)))
-                },
-                buffered_reply: Some(spec.initial_reply),
+            state: CursorState::new(spec, pin),
+            provider: if exhausted {
+                GetMoreRawProvider::Done
+            } else {
+                GetMoreRawProvider::Idle(Box::new(ImplicitClientSessionHandle(session)))
             },
         }
     }
@@ -186,24 +281,7 @@ impl RawBatchCursor {
     }
 
     pub(crate) fn has_next(&self) -> bool {
-        if !self.is_exhausted() {
-            return true;
-        }
-        let Some(batch) = self
-            .state
-            .buffered_reply
-            .as_ref()
-            .and_then(|reply| reply.get_document(CURSOR).ok())
-            .and_then(|cursor| {
-                cursor
-                    .get_array(FIRST_BATCH)
-                    .or_else(|_| cursor.get_array(NEXT_BATCH))
-                    .ok()
-            })
-        else {
-            return false;
-        };
-        !batch.is_empty()
+        self.state.has_next()
     }
 
     pub(crate) fn post_batch_resume_token(&self) -> Option<&ResumeToken> {
@@ -211,7 +289,7 @@ impl RawBatchCursor {
     }
 
     pub(crate) fn address(&self) -> &ServerAddress {
-        &self.info.address
+        &self.state.info.address
     }
 
     pub(crate) fn set_drop_address(&mut self, address: ServerAddress) {
@@ -220,11 +298,6 @@ impl RawBatchCursor {
 
     pub(crate) fn client(&self) -> &Client {
         &self.client
-    }
-
-    fn mark_exhausted(&mut self) {
-        self.state.exhausted = true;
-        self.state.pinned_connection = PinnedConnection::Unpinned;
     }
 
     #[cfg(test)]
@@ -238,74 +311,17 @@ impl RawBatchCursor {
 
     /// Extracts the stored implicit [`ClientSession`], if any.
     pub(crate) fn take_implicit_session(&mut self) -> Option<ClientSession> {
-        self.state.provider.take_implicit_session()
+        self.provider.take_implicit_session()
     }
 }
 
 impl Stream for RawBatchCursor {
     type Item = Result<RawBatch>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
-            // If a getMore is in flight, poll it and update state.
-            if let Some(future) = self.state.provider.executing_future() {
-                let get_more_out = ready!(Pin::new(future).poll(cx));
-                match get_more_out.result {
-                    Ok(out) => {
-                        self.state.buffered_reply = Some(out.raw_reply);
-                        self.state.post_batch_resume_token = out.post_batch_resume_token;
-                        if out.exhausted {
-                            self.mark_exhausted();
-                        }
-                        if out.id != 0 {
-                            self.info.id = out.id;
-                        }
-                        self.info.ns = out.ns;
-                    }
-                    Err(e) => {
-                        if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
-                        {
-                            self.mark_exhausted();
-                        }
-                        if e.is_network_error() {
-                            // Flag the connection as invalid, preventing a killCursors
-                            // command, but leave the connection pinned.
-                            self.state.pinned_connection.invalidate();
-                        }
-                        let exhausted_now = self.state.exhausted;
-                        self.state
-                            .provider
-                            .clear_execution(get_more_out.session, exhausted_now);
-                        return Poll::Ready(Some(Err(e)));
-                    }
-                }
-                let exhausted_now = self.state.exhausted;
-                self.state
-                    .provider
-                    .clear_execution(get_more_out.session, exhausted_now);
-            }
-
-            // Yield any buffered reply.
-            if let Some(reply) = self.state.buffered_reply.take() {
-                return Poll::Ready(Some(Ok(RawBatch::new(reply))));
-            }
-
-            // If not exhausted and the connection is valid, start a getMore and iterate.
-            if !self.state.exhausted
-                && !matches!(self.state.pinned_connection, PinnedConnection::Invalid(_))
-            {
-                let info = self.info.clone();
-                let client = self.client.clone();
-                let state = &mut self.state;
-                state
-                    .provider
-                    .start_execution(info, client, state.pinned_connection.handle());
-                continue;
-            }
-
-            // Otherwise, we're done.
-            return Poll::Ready(None);
-        }
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        this.state
+            .poll_next_batch(&mut this.provider, &this.client, cx)
     }
 }
 
@@ -317,8 +333,8 @@ impl Drop for RawBatchCursor {
         kill_cursor(
             self.client.clone(),
             &mut self.drop_token,
-            &self.info.ns,
-            self.info.id,
+            &self.state.info.ns,
+            self.state.info.id,
             self.state.pinned_connection.replicate(),
             self.drop_address.take(),
             #[cfg(test)]
@@ -332,11 +348,7 @@ impl Drop for RawBatchCursor {
 pub struct SessionRawBatchCursor {
     client: Client,
     drop_token: AsyncDropToken,
-    info: CursorInformation,
-    exhausted: bool,
-    pinned_connection: PinnedConnection,
-    post_batch_resume_token: Option<ResumeToken>,
-    buffered_reply: Option<RawDocumentBuf>,
+    state: CursorState,
     drop_address: Option<ServerAddress>,
     #[cfg(test)]
     kill_watcher: Option<oneshot::Sender<()>>,
@@ -359,15 +371,10 @@ impl SessionRawBatchCursor {
         spec: CursorSpecification,
         pinned: Option<PinnedConnectionHandle>,
     ) -> Self {
-        let exhausted = spec.info.id == 0;
         Self {
             drop_token: client.register_async_drop(),
             client,
-            info: spec.info,
-            exhausted,
-            pinned_connection: PinnedConnection::new(pinned),
-            post_batch_resume_token: spec.post_batch_resume_token,
-            buffered_reply: Some(spec.initial_reply),
+            state: CursorState::new(spec, pinned),
             drop_address: None,
             #[cfg(test)]
             kill_watcher: None,
@@ -387,24 +394,19 @@ impl SessionRawBatchCursor {
     }
 
     pub(crate) fn address(&self) -> &ServerAddress {
-        &self.info.address
+        &self.state.info.address
     }
 
     pub(crate) fn set_drop_address(&mut self, address: ServerAddress) {
         self.drop_address = Some(address);
     }
 
-    fn mark_exhausted(&mut self) {
-        self.exhausted = true;
-        self.pinned_connection = PinnedConnection::Unpinned;
-    }
-
     pub(crate) fn is_exhausted(&self) -> bool {
-        self.exhausted
+        self.state.exhausted
     }
 
     pub(crate) fn post_batch_resume_token(&self) -> Option<&ResumeToken> {
-        self.post_batch_resume_token.as_ref()
+        self.state.post_batch_resume_token.as_ref()
     }
 
     #[cfg(test)]
@@ -429,9 +431,9 @@ impl Drop for SessionRawBatchCursor {
         kill_cursor(
             self.client.clone(),
             &mut self.drop_token,
-            &self.info.ns,
-            self.info.id,
-            self.pinned_connection.replicate(),
+            &self.state.info.ns,
+            self.state.info.id,
+            self.state.pinned_connection.replicate(),
             self.drop_address.take(),
             #[cfg(test)]
             self.kill_watcher.take(),
@@ -449,69 +451,11 @@ pub struct SessionRawBatchCursorStream<'cursor, 'session> {
 impl Stream for SessionRawBatchCursorStream<'_, '_> {
     type Item = Result<RawBatch>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
-            // If a getMore is in flight, poll it and update state.
-            if let Some(future) = self.provider.executing_future() {
-                let get_more_out = ready!(Pin::new(future).poll(cx));
-                match get_more_out.result {
-                    Ok(out) => {
-                        if out.exhausted {
-                            self.parent.mark_exhausted();
-                        }
-                        if out.id != 0 {
-                            self.parent.info.id = out.id;
-                        }
-                        self.parent.info.ns = out.ns;
-                        self.parent.post_batch_resume_token = out.post_batch_resume_token;
-                        // Buffer next reply to yield on following polls.
-                        self.parent.buffered_reply = Some(out.raw_reply);
-                    }
-                    Err(e) => {
-                        if matches!(*e.kind, ErrorKind::Command(ref ce) if ce.code == 43 || ce.code == 237)
-                        {
-                            self.parent.mark_exhausted();
-                        }
-                        if e.is_network_error() {
-                            // Flag the connection as invalid, preventing a killCursors
-                            // command, but leave the connection pinned.
-                            self.parent.pinned_connection.invalidate();
-                        }
-                        let exhausted_now = self.parent.exhausted;
-                        self.provider
-                            .clear_execution(get_more_out.session, exhausted_now);
-                        return Poll::Ready(Some(Err(e)));
-                    }
-                }
-                let exhausted_now = self.parent.exhausted;
-                self.provider
-                    .clear_execution(get_more_out.session, exhausted_now);
-            }
-
-            // Yield any buffered reply.
-            if let Some(reply) = self.parent.buffered_reply.take() {
-                return Poll::Ready(Some(Ok(RawBatch::new(reply))));
-            }
-
-            // If not exhausted and the connection is valid, start a getMore and iterate.
-            if !self.parent.exhausted
-                && !matches!(self.parent.pinned_connection, PinnedConnection::Invalid(_))
-            {
-                let info = self.parent.info.clone();
-                let client = self.parent.client.clone();
-                let pinned_owned = self
-                    .parent
-                    .pinned_connection
-                    .handle()
-                    .map(|c| c.replicate());
-                let pinned_ref = pinned_owned.as_ref();
-                self.provider.start_execution(info, client, pinned_ref);
-                continue;
-            }
-
-            // Otherwise, we're done.
-            return Poll::Ready(None);
-        }
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        this.parent
+            .state
+            .poll_next_batch(&mut this.provider, &this.parent.client, cx)
     }
 }
 

--- a/driver/src/cursor/raw_batch.rs
+++ b/driver/src/cursor/raw_batch.rs
@@ -140,7 +140,7 @@ struct CursorState {
     exhausted: bool,
     pinned_connection: PinnedConnection,
     post_batch_resume_token: Option<ResumeToken>,
-    buffered_reply: Option<RawDocumentBuf>,
+    buffered_reply: Option<BufferedReply>,
 }
 
 impl CursorState {
@@ -150,7 +150,7 @@ impl CursorState {
             info: spec.info,
             pinned_connection: PinnedConnection::new(pin),
             post_batch_resume_token: spec.post_batch_resume_token,
-            buffered_reply: Some(spec.initial_reply),
+            buffered_reply: Some(BufferedReply::new(spec.initial_reply)),
         }
     }
 
@@ -160,23 +160,11 @@ impl CursorState {
     }
 
     fn has_next(&self) -> bool {
-        if !self.exhausted {
-            return true;
-        }
-        let Some(batch) = self
-            .buffered_reply
-            .as_ref()
-            .and_then(|reply| reply.get_document(CURSOR).ok())
-            .and_then(|cursor| {
-                cursor
-                    .get_array(FIRST_BATCH)
-                    .or_else(|_| cursor.get_array(NEXT_BATCH))
-                    .ok()
-            })
-        else {
-            return false;
-        };
-        !batch.is_empty()
+        !self.exhausted
+            || self
+                .buffered_reply
+                .as_ref()
+                .is_some_and(|buffered| buffered.has_docs)
     }
 
     fn poll_next_batch<'s, S: ClientSessionHandle<'s>>(
@@ -191,7 +179,7 @@ impl CursorState {
                 let get_more_out = ready!(Pin::new(future).poll(cx));
                 let error = match get_more_out.result {
                     Ok(out) => {
-                        self.buffered_reply = Some(out.raw_reply);
+                        self.buffered_reply = Some(BufferedReply::new(out.raw_reply));
                         self.post_batch_resume_token = out.post_batch_resume_token;
                         if out.exhausted {
                             self.mark_exhausted();
@@ -222,8 +210,8 @@ impl CursorState {
             }
 
             // Yield any buffered reply.
-            if let Some(reply) = self.buffered_reply.take() {
-                return Poll::Ready(Some(Ok(RawBatch::new(reply))));
+            if let Some(buffered) = self.buffered_reply.take() {
+                return Poll::Ready(Some(Ok(RawBatch::new(buffered.reply))));
             }
 
             // If not exhausted and the connection is valid, start a getMore and iterate.
@@ -239,6 +227,29 @@ impl CursorState {
             // Otherwise, we're done.
             return Poll::Ready(None);
         }
+    }
+}
+
+/// A server reply along with cached "has documents" status.
+#[derive(Debug)]
+struct BufferedReply {
+    reply: RawDocumentBuf,
+    has_docs: bool,
+}
+
+impl BufferedReply {
+    fn new(reply: RawDocumentBuf) -> Self {
+        let has_docs = reply
+            .get_document(CURSOR)
+            .ok()
+            .and_then(|cursor| {
+                cursor
+                    .get_array(FIRST_BATCH)
+                    .or_else(|_| cursor.get_array(NEXT_BATCH))
+                    .ok()
+            })
+            .is_some_and(|batch| !batch.is_empty());
+        Self { reply, has_docs }
     }
 }
 

--- a/driver/src/cursor/session.rs
+++ b/driver/src/cursor/session.rs
@@ -262,7 +262,7 @@ impl<T> SessionCursor<T> {
     where
         T: Deserialize<'a>,
     {
-        poll_panic!(self.buffer()).deserialize_current()
+        self.buffer()?.deserialize_current()
     }
 
     /// Update the type streamed values will be parsed as.

--- a/driver/src/cursor/session.rs
+++ b/driver/src/cursor/session.rs
@@ -5,8 +5,8 @@ use futures_util::StreamExt;
 
 use crate::{
     bson::{Document, RawDocument},
-    cursor::raw_batch::SessionRawBatchCursor,
-    error::Result,
+    cursor::{poll_state::poll_panic, raw_batch::SessionRawBatchCursor},
+    error::{Error, Result},
     raw_batch_cursor::SessionRawBatchCursorStream,
     ClientSession,
 };
@@ -180,22 +180,28 @@ impl<T> SessionCursor<T> {
     /// # }
     /// ```
     pub async fn advance(&mut self, session: &mut ClientSession) -> Result<bool> {
-        self.stream(session).stream.buffer_mut().advance().await
+        self.stream(session).stream.buffer_mut()?.advance().await
     }
 
     pub(crate) async fn try_advance(
         &mut self,
         session: &mut ClientSession,
     ) -> Result<stream::AdvanceResult> {
-        self.stream(session).stream.buffer_mut().try_advance().await
+        self.stream(session)
+            .stream
+            .buffer_mut()?
+            .try_advance()
+            .await
     }
 
-    fn buffer(&self) -> &stream::BatchBuffer<()> {
-        self.buffer.as_ref().unwrap()
+    fn buffer(&self) -> Result<&stream::BatchBuffer<()>> {
+        self.buffer
+            .as_ref()
+            .ok_or_else(|| Error::internal("cursor buffer lost"))
     }
 
-    pub(crate) fn batch(&self) -> &std::collections::VecDeque<crate::bson::RawDocumentBuf> {
-        self.buffer().batch()
+    pub(crate) fn batch(&self) -> Result<&std::collections::VecDeque<crate::bson::RawDocumentBuf>> {
+        Ok(self.buffer()?.batch())
     }
 
     /// Returns a reference to the current result in the cursor.
@@ -219,7 +225,7 @@ impl<T> SessionCursor<T> {
     /// # }
     /// ```
     pub fn current(&self) -> &RawDocument {
-        self.buffer().current()
+        poll_panic!(self.buffer()).current()
     }
 
     /// Deserialize the current result to the generic type associated with this cursor.
@@ -256,7 +262,7 @@ impl<T> SessionCursor<T> {
     where
         T: Deserialize<'a>,
     {
-        self.buffer().deserialize_current()
+        poll_panic!(self.buffer()).deserialize_current()
     }
 
     /// Update the type streamed values will be parsed as.
@@ -292,7 +298,7 @@ pub struct SessionCursorStream<'cursor, 'session, T = Document> {
 
 impl<T> Drop for SessionCursorStream<'_, '_, T> {
     fn drop(&mut self) {
-        *self.parent = Some(self.stream.take_buffer().map(|_| ()));
+        *self.parent = self.stream.take_buffer().map(|b| b.map(|_| ()));
     }
 }
 

--- a/driver/src/cursor/stream.rs
+++ b/driver/src/cursor/stream.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, ops::ControlFlow, task::Poll};
+use std::{collections::VecDeque, task::Poll};
 
 use derive_where::derive_where;
 use futures_core::Stream as AsyncStream;
@@ -193,12 +193,10 @@ impl<'a, Raw: 'a + AsyncStream<Item = Result<RawBatch>> + Send + Unpin, T: Deser
                 }
                 .boxed()
             },
-            |buffer, out| {
-                ControlFlow::Break(match out {
-                    Err(e) => Some(Err(e)),
-                    Ok(false) => None,
-                    Ok(true) => Some(buffer.deserialize_current()),
-                })
+            |buffer, out| match out {
+                Err(e) => Some(Err(e)),
+                Ok(false) => None,
+                Ok(true) => Some(buffer.deserialize_current()),
             },
         )
     }

--- a/driver/src/cursor/stream.rs
+++ b/driver/src/cursor/stream.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, task::Poll};
+use std::{collections::VecDeque, ops::ControlFlow, task::Poll};
 
 use derive_where::derive_where;
 use futures_core::Stream as AsyncStream;
@@ -8,10 +8,9 @@ use serde::{de::DeserializeOwned, Deserialize};
 use crate::{
     bson::{RawDocument, RawDocumentBuf},
     error::{Error, Result},
-    BoxFuture,
 };
 
-use super::raw_batch::RawBatch;
+use super::{poll_state::PollState, raw_batch::RawBatch};
 
 /// `Stream` represents an "introspectable" cursor stream - an implementation of an async `Stream`
 /// with a buffer that's available for external use when the stream isn't actively being polled.
@@ -20,7 +19,7 @@ use super::raw_batch::RawBatch;
 /// future is dropped without being fully polled, which is documented as unsupported by the driver.
 #[derive_where(Debug)]
 pub(super) struct Stream<'a, Raw, T> {
-    state: StreamState<'a, Raw>,
+    state: PollState<'a, BatchBuffer<Raw>, Result<bool>>,
     _phantom: std::marker::PhantomData<fn() -> T>,
 }
 
@@ -31,30 +30,21 @@ impl<'a, Raw, T> Stream<'a, Raw, T> {
 
     pub(super) fn from_cursor(cs: BatchBuffer<Raw>) -> Self {
         Self {
-            state: StreamState::Idle(cs),
+            state: PollState::new(cs),
             _phantom: std::marker::PhantomData,
         }
     }
 
-    pub(super) fn buffer(&self) -> &BatchBuffer<Raw> {
-        match &self.state {
-            StreamState::Idle(state) => state,
-            _ => panic!("state access while streaming"),
-        }
+    pub(super) fn buffer(&self) -> Result<&BatchBuffer<Raw>> {
+        self.state.state()
     }
 
-    pub(super) fn buffer_mut(&mut self) -> &mut BatchBuffer<Raw> {
-        match &mut self.state {
-            StreamState::Idle(state) => state,
-            _ => panic!("state access while streaming"),
-        }
+    pub(super) fn buffer_mut(&mut self) -> Result<&mut BatchBuffer<Raw>> {
+        self.state.state_mut()
     }
 
-    pub(super) fn take_buffer(&mut self) -> BatchBuffer<Raw> {
-        match std::mem::replace(&mut self.state, StreamState::Polling) {
-            StreamState::Idle(state) => state,
-            _ => panic!("state access while streaming"),
-        }
+    pub(super) fn take_buffer(&mut self) -> Option<BatchBuffer<Raw>> {
+        self.state.take_state()
     }
 
     pub(super) fn with_type<D>(self) -> Stream<'a, Raw, D> {
@@ -63,19 +53,6 @@ impl<'a, Raw, T> Stream<'a, Raw, T> {
             _phantom: std::marker::PhantomData,
         }
     }
-}
-
-#[derive_where(Debug)]
-enum StreamState<'a, Raw> {
-    Idle(BatchBuffer<Raw>),
-    Polling,
-    Advance(#[derive_where(skip)] BoxFuture<'a, AdvanceDone<Raw>>),
-}
-
-#[derive_where(Debug)]
-struct AdvanceDone<Raw> {
-    buffer: BatchBuffer<Raw>,
-    out: Result<bool>,
 }
 
 #[derive_where(Debug)]
@@ -207,41 +184,22 @@ impl<'a, Raw: 'a + AsyncStream<Item = Result<RawBatch>> + Send + Unpin, T: Deser
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        loop {
-            match std::mem::replace(&mut self.state, StreamState::Polling) {
-                StreamState::Idle(mut buffer) => {
-                    self.state = StreamState::Advance(
-                        async move {
-                            let out = buffer.advance().await;
-                            AdvanceDone { buffer, out }
-                        }
-                        .boxed(),
-                    );
-                    continue;
+        self.state.poll_next_step(
+            cx,
+            |mut buffer| {
+                async move {
+                    let out = buffer.advance().await;
+                    (buffer, out)
                 }
-                StreamState::Advance(mut fut) => {
-                    return match fut.poll_unpin(cx) {
-                        Poll::Pending => {
-                            self.state = StreamState::Advance(fut);
-                            Poll::Pending
-                        }
-                        Poll::Ready(ar) => {
-                            let out = match ar.out {
-                                Err(e) => Some(Err(e)),
-                                Ok(false) => None,
-                                Ok(true) => Some(ar.buffer.deserialize_current()),
-                            };
-                            self.state = StreamState::Idle(ar.buffer);
-                            return Poll::Ready(out);
-                        }
-                    }
-                }
-                StreamState::Polling => {
-                    return Poll::Ready(Some(Err(Error::internal(
-                        "attempt to poll cursor already in polling state",
-                    ))))
-                }
-            }
-        }
+                .boxed()
+            },
+            |buffer, out| {
+                ControlFlow::Break(match out {
+                    Err(e) => Some(Err(e)),
+                    Ok(false) => None,
+                    Ok(true) => Some(buffer.deserialize_current()),
+                })
+            },
+        )
     }
 }

--- a/driver/src/test/change_stream.rs
+++ b/driver/src/test/change_stream.rs
@@ -337,7 +337,7 @@ async fn batch_mid_resume_token() -> Result<()> {
 
         // if after iterating the stream last time there's one document left,
         // then we're done here and can continue to the assertions.
-        if stream.current_batch().len() == 1 {
+        if stream.current_batch()?.len() == 1 {
             break;
         }
     }

--- a/driver/src/test/spec/unified_runner/entity.rs
+++ b/driver/src/test/spec/unified_runner/entity.rs
@@ -97,11 +97,11 @@ pub(crate) enum TestCursor {
 }
 
 impl TestCursor {
-    pub(crate) async fn make_kill_watcher(&mut self) -> oneshot::Receiver<()> {
-        match self {
+    pub(crate) async fn make_kill_watcher(&mut self) -> Result<oneshot::Receiver<()>> {
+        Ok(match self {
             Self::Normal(cursor) => {
                 let (tx, rx) = oneshot::channel();
-                cursor.lock().await.raw_mut().set_kill_watcher(tx);
+                cursor.lock().await.raw_mut()?.set_kill_watcher(tx);
                 rx
             }
             Self::Session { cursor, .. } => {
@@ -111,11 +111,11 @@ impl TestCursor {
             }
             Self::ChangeStream(stream) => {
                 let (tx, rx) = oneshot::channel();
-                stream.lock().await.set_kill_watcher(tx);
+                stream.lock().await.set_kill_watcher(tx)?;
                 rx
             }
             Self::Closed => panic!("cannot set a kill_watcher on a closed cursor"),
-        }
+        })
     }
 }
 
@@ -126,13 +126,14 @@ pub(crate) enum TestChangeStream {
 }
 
 impl TestChangeStream {
-    pub(crate) fn set_kill_watcher(&mut self, tx: oneshot::Sender<()>) {
+    pub(crate) fn set_kill_watcher(&mut self, tx: oneshot::Sender<()>) -> Result<()> {
         match self {
-            Self::Event(cse) => cse.set_kill_watcher(tx),
-            Self::Doc(csd) => csd.set_kill_watcher(tx),
+            Self::Event(cse) => cse.set_kill_watcher(tx)?,
+            Self::Doc(csd) => csd.set_kill_watcher(tx)?,
         }
+        Ok(())
     }
-    pub(crate) fn client(&self) -> &crate::Client {
+    pub(crate) fn client(&self) -> Result<&crate::Client> {
         match self {
             Self::Event(cse) => cse.client(),
             Self::Doc(csd) => csd.client(),
@@ -510,10 +511,10 @@ impl Entity {
             Entity::Bucket(bucket) => Some(bucket.client().topology().id),
             Entity::Cursor(cursor) => match cursor {
                 TestCursor::Normal(cursor) => {
-                    Some(cursor.lock().await.raw().client().topology().id)
+                    Some(cursor.lock().await.raw().ok()?.client().topology().id)
                 }
                 TestCursor::Session { cursor, .. } => Some(cursor.raw().client().topology().id),
-                TestCursor::ChangeStream(cs) => Some(cs.lock().await.client().topology().id),
+                TestCursor::ChangeStream(cs) => Some(cs.lock().await.client().ok()?.topology().id),
                 TestCursor::Closed => None,
             },
             _ => None,

--- a/driver/src/test/spec/unified_runner/operation/connection.rs
+++ b/driver/src/test/spec/unified_runner/operation/connection.rs
@@ -55,7 +55,7 @@ impl TestOperation for Close {
                 }
                 Entity::Cursor(_) => {
                     let cursor = entities.get_mut(id).unwrap().as_mut_cursor();
-                    let rx = cursor.make_kill_watcher().await;
+                    let rx = cursor.make_kill_watcher().await?;
                     *cursor = TestCursor::Closed;
                     drop(entities);
                     let _ = rx.await;


### PR DESCRIPTION
RUST-2465

This adds a `PollState` helper that handles the "stream but also expose inner state" logic, used for both cursors and change streams; unlike my previous attempts, this one dodges the variance issues primarily by not attempting to be a stream itself and being parameterized on the stream _output_. I also took this opportunity to make the state access (which is technically fallible) propagate the failure and only panic on public APIs that can't be changed before 4.0.  If this seems reasonable, I'll file a ticket to make those APIs return `Result` in 4.0.

This also takes the logic for raw batch cursors that was duplicated across the session/no boundary and pulls it into a `CursorState` struct, making `RawBatchCursor` and `SessionRawBatchCursor` thin wrappers around common logic.