### PR TITLE
RUST-2446 Make `base_backoff` error field public

### DIFF
--- a/driver/src/client/executor/retry.rs
+++ b/driver/src/client/executor/retry.rs
@@ -198,13 +198,13 @@ impl Retry {
         const DEFAULT_BASE_BACKOFF: Duration = Duration::from_millis(100);
         const MAX_BACKOFF: Duration = Duration::from_millis(10_000);
 
-        let jitter = rand::random_range(0f64..1f64);
+        let jitter = rand::random::<f32>();
         #[cfg(test)]
         let jitter = test_options.and_then(|o| o.jitter).unwrap_or(jitter);
 
         let base_backoff = self.base_backoff.unwrap_or(DEFAULT_BASE_BACKOFF);
         let backoff = std::cmp::min(base_backoff * 2u32.pow(self.attempt), MAX_BACKOFF);
-        backoff.mul_f64(jitter)
+        backoff.mul_f32(jitter)
     }
 }
 

--- a/driver/src/client/executor/retry.rs
+++ b/driver/src/client/executor/retry.rs
@@ -3,7 +3,6 @@ use std::{collections::HashSet, time::Duration};
 #[cfg(test)]
 use crate::options::TestOptions;
 use crate::{
-    bson_util::round_clamp,
     error::{Error, Result, NO_WRITES_PERFORMED, RETRYABLE_ERROR, SYSTEM_OVERLOADED_ERROR},
     operation::{Operation, Retryability},
     options::ServerAddress,
@@ -22,7 +21,7 @@ pub(crate) struct Retry {
     txn_number: Option<i64>,
     pub(crate) overloaded: bool,
     max_retries: u32,
-    base_backoff_ms: Option<f64>,
+    base_backoff: Option<Duration>,
 }
 
 struct Failure {
@@ -111,7 +110,7 @@ impl Retry {
                 || retryability.can_retry_error(error) && !is_transaction_op
         };
         let overloaded = error.contains_label(SYSTEM_OVERLOADED_ERROR);
-        let base_backoff_ms = error.base_backoff_ms().filter(|ms| *ms > 0f64);
+        let base_backoff = error.base_backoff().filter(|duration| !duration.is_zero());
 
         let max_adaptive_retries = overloaded.then_some(
             client
@@ -157,7 +156,7 @@ impl Retry {
                 if let Some(max_adaptive_retries) = max_adaptive_retries {
                     retry.max_retries = max_adaptive_retries;
                 }
-                retry.base_backoff_ms = base_backoff_ms;
+                retry.base_backoff = base_backoff;
                 Ok(retry)
             }
             None => {
@@ -173,7 +172,7 @@ impl Retry {
                     txn_number,
                     overloaded,
                     max_retries: max_adaptive_retries.unwrap_or(MAX_RW_RETRIES),
-                    base_backoff_ms,
+                    base_backoff,
                 })
             }
         }
@@ -196,18 +195,16 @@ impl Retry {
             return backoff;
         }
 
-        const DEFAULT_BASE_BACKOFF_MS: f64 = 100f64;
-        const MAX_BACKOFF_MS: f64 = 10_000f64;
+        const DEFAULT_BASE_BACKOFF: Duration = Duration::from_millis(100);
+        const MAX_BACKOFF: Duration = Duration::from_millis(10_000);
 
         let jitter = rand::random_range(0f64..1f64);
         #[cfg(test)]
         let jitter = test_options.and_then(|o| o.jitter).unwrap_or(jitter);
 
-        let base_backoff_ms = self.base_backoff_ms.unwrap_or(DEFAULT_BASE_BACKOFF_MS);
-        let computed_backoff = jitter * base_backoff_ms * 2f64.powf(f64::from(self.attempt));
-        let max_backoff = jitter * MAX_BACKOFF_MS;
-        let backoff: u64 = std::cmp::min(round_clamp(computed_backoff), round_clamp(max_backoff));
-        Duration::from_millis(backoff)
+        let base_backoff = self.base_backoff.unwrap_or(DEFAULT_BASE_BACKOFF);
+        let backoff = std::cmp::min(base_backoff * 2u32.pow(self.attempt), MAX_BACKOFF);
+        backoff.mul_f64(jitter)
     }
 }
 

--- a/driver/src/client/options.rs
+++ b/driver/src/client/options.rs
@@ -746,7 +746,7 @@ pub(crate) struct TestOptions {
     pub(crate) hello_cb: Option<EventHandler<crate::cmap::Command>>,
 
     /// The value to use for jitter when calculating retry backoff.
-    pub(crate) jitter: Option<f64>,
+    pub(crate) jitter: Option<f32>,
 
     /// The amount of time to use for all retry backoffs. Set to a large number to detect the
     /// absence/presence of backoff.

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -904,6 +904,7 @@ pub struct CommandError {
     #[serde(rename = "topologyVersion")]
     pub(crate) topology_version: Option<TopologyVersion>,
 
+    /// The base amount of time to back off before retrying an operation.
     #[serde(
         rename = "baseBackoffMS",
         deserialize_with = "deserialize_duration_option_from_u64_millis",

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -906,8 +906,8 @@ pub struct CommandError {
 
     #[serde(
         rename = "baseBackoffMS",
-        deserialize_with = "deserialize_duration_option_from_u64_millis"
-        default,
+        deserialize_with = "deserialize_duration_option_from_u64_millis",
+        default
     )]
     pub(crate) base_backoff: Option<Duration>,
 }

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -909,7 +909,7 @@ pub struct CommandError {
         deserialize_with = "deserialize_duration_option_from_u64_millis",
         default
     )]
-    pub(crate) base_backoff: Option<Duration>,
+    pub base_backoff: Option<Duration>,
 }
 
 impl CommandError {

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Debug},
     sync::Arc,
+    time::Duration,
 };
 
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,7 @@ use crate::{
     cmap::RawCommandResponse,
     options::ServerAddress,
     sdam::{ServerType, TopologyVersion},
+    serde_util::deserialize_duration_option_from_u64_millis,
 };
 
 pub use bulk_write::{BulkWriteError, PartialBulkWriteResult};
@@ -547,9 +549,10 @@ impl Error {
         }
     }
 
-    pub(crate) fn base_backoff_ms(&self) -> Option<f64> {
+    /// Returns the value for [`CommandError::base_backoff`] if this error is a command error.
+    pub fn base_backoff(&self) -> Option<Duration> {
         match self.kind.as_ref() {
-            ErrorKind::Command(command_error) => command_error.base_backoff_ms,
+            ErrorKind::Command(command_error) => command_error.base_backoff,
             _ => None,
         }
     }
@@ -901,8 +904,12 @@ pub struct CommandError {
     #[serde(rename = "topologyVersion")]
     pub(crate) topology_version: Option<TopologyVersion>,
 
-    #[serde(rename = "baseBackoffMS")]
-    pub(crate) base_backoff_ms: Option<f64>,
+    #[serde(
+        rename = "baseBackoffMS",
+        deserialize_with = "deserialize_duration_option_from_u64_millis"
+        default,
+    )]
+    pub(crate) base_backoff: Option<Duration>,
 }
 
 impl CommandError {

--- a/driver/src/sdam/description/topology/test/sdam.rs
+++ b/driver/src/sdam/description/topology/test/sdam.rs
@@ -300,7 +300,7 @@ async fn run_test(test_file: TestFile) {
                     code_name: "dummy error".to_string(),
                     message: "dummy".to_string(),
                     topology_version: None,
-                    base_backoff_ms: None,
+                    base_backoff: None,
                 })))
             } else if command_response == Default::default() {
                 Err(Error::from(ErrorKind::Io(Arc::new(

--- a/driver/src/test/client.rs
+++ b/driver/src/test/client.rs
@@ -1097,7 +1097,7 @@ async fn operation_retry_uses_exponential_backoff() {
     if topology_is_sharded().await {
         options.hosts.drain(1..);
     }
-    options.test_options_mut().jitter = Some(0f64);
+    options.test_options_mut().jitter = Some(0f32);
     let client = Client::for_test().options(options).await;
     let coll = client.database("db").collection("coll");
 
@@ -1114,7 +1114,7 @@ async fn operation_retry_uses_exponential_backoff() {
     if topology_is_sharded().await {
         options.hosts.drain(1..);
     }
-    options.test_options_mut().jitter = Some(1f64);
+    options.test_options_mut().jitter = Some(1f32);
     let client = Client::for_test().options(options).await;
     let coll = client.database("db").collection("coll");
 
@@ -1257,7 +1257,7 @@ async fn override_base_backoff_ms() {
     }
 
     let mut options = get_client_options().await.clone();
-    options.test_options_mut().jitter = Some(1f64);
+    options.test_options_mut().jitter = Some(1f32);
     let client = Client::for_test()
         .options(options)
         .use_single_mongos()

--- a/driver/src/test/client.rs
+++ b/driver/src/test/client.rs
@@ -1287,5 +1287,5 @@ async fn override_base_backoff_ms() {
     assert!(duration_secs >= 0.3);
     assert!(duration_secs < 0.6);
     let error = result.unwrap_err();
-    assert_eq!(error.base_backoff_ms(), Some(50f64));
+    assert_eq!(error.base_backoff(), Some(Duration::from_millis(50)));
 }

--- a/driver/src/test/spec/trace.rs
+++ b/driver/src/test/spec/trace.rs
@@ -318,7 +318,7 @@ fn error_redaction() {
             code_name: "CodeName".to_string(),
             message: "Hello".to_string(),
             topology_version: None,
-            base_backoff_ms: None,
+            base_backoff: None,
         }),
         labels.clone(),
     );


### PR DESCRIPTION
This field is used in the code examples for [RUST-2463](https://jira.mongodb.org/browse/RUST-2463).