### PR TITLE
RUST-2479 Report write concern errors for `findAndModify`

### DIFF
--- a/driver/src/bson_util.rs
+++ b/driver/src/bson_util.rs
@@ -99,6 +99,15 @@ pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
     }
 }
 
+pub(crate) fn get_u64_raw(val: &RawBsonRef) -> Option<u64> {
+    match val {
+        RawBsonRef::Int32(i) => get_u64(&Bson::Int32(*i)),
+        RawBsonRef::Int64(i) => get_u64(&Bson::Int64(*i)),
+        RawBsonRef::Double(i) => get_u64(&Bson::Double(*i)),
+        _ => None,
+    }
+}
+
 pub(crate) fn to_bson_array(docs: &[Document]) -> Bson {
     Bson::Array(docs.iter().map(|doc| Bson::Document(doc.clone())).collect())
 }

--- a/driver/src/cmap/conn.rs
+++ b/driver/src/cmap/conn.rs
@@ -26,7 +26,7 @@ use crate::{
     options::ServerAddress,
     runtime::AsyncStream,
 };
-pub(crate) use command::{Command, RawCommandResponse};
+pub(crate) use command::{Command, RawCommandResponse, WriteErrorBody};
 pub(crate) use stream_description::StreamDescription;
 
 #[cfg(any(

--- a/driver/src/cmap/conn/command.rs
+++ b/driver/src/cmap/conn/command.rs
@@ -1,10 +1,22 @@
+use std::collections::HashMap;
+
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::wire::{message::DocumentSequence, Message};
 use crate::{
     bson::{Document, RawDocument, RawDocumentBuf},
+    bson_compat::{deserialize_from_slice, Utf8Lossy},
+    bson_util::get_u64_raw,
     client::{options::ServerApi, ClusterTime},
-    error::{Error, ErrorKind, Result},
+    error::{
+        Error,
+        ErrorKind,
+        IndexedWriteError,
+        InsertManyError,
+        Result,
+        WriteConcernError,
+        WriteFailure,
+    },
     hello::{HelloCommandResponse, HelloReply},
     operation::{CommandErrorBody, CommandResponse, Feature, Operation},
     options::{ReadConcernInternal, ReadConcernLevel, ServerAddress, WriteConcern},
@@ -210,6 +222,17 @@ pub(crate) struct RawCommandResponse {
     raw: RawDocumentBuf,
 }
 
+/// A helper struct to deserialize write-error-specific fields from a server response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WriteErrorBody {
+    #[serde(rename = "writeErrors")]
+    pub(crate) write_errors: Option<Utf8Lossy<Vec<IndexedWriteError>>>,
+    #[serde(rename = "writeConcernError")]
+    pub(crate) write_concern_error: Option<Utf8Lossy<WriteConcernError>>,
+    #[serde(rename = "errorLabels")]
+    pub(crate) labels: Option<Vec<String>>,
+}
+
 impl RawCommandResponse {
     #[cfg(test)]
     pub(crate) fn with_document_and_address(source: ServerAddress, doc: Document) -> Result<Self> {
@@ -230,10 +253,59 @@ impl RawCommandResponse {
     }
 
     pub(crate) fn body<'a, T: Deserialize<'a>>(&'a self) -> Result<T> {
-        crate::bson_compat::deserialize_from_slice(self.raw.as_bytes()).map_err(|e| {
+        deserialize_from_slice(self.raw.as_bytes()).map_err(|e| {
             Error::from(ErrorKind::InvalidResponse {
                 message: format!("{e}"),
             })
+        })
+    }
+
+    pub(crate) fn extract_single_write_error(&self) -> Result<()> {
+        let body: WriteErrorBody = self.body()?;
+
+        if let Some(write_error) = body
+            .write_errors
+            .and_then(|write_errors| write_errors.0.into_iter().next())
+        {
+            Err(Error::new(
+                ErrorKind::Write(WriteFailure::WriteError(write_error.into())),
+                body.labels,
+            ))
+        } else if let Some(write_concern_error) = body.write_concern_error {
+            Err(Error::new(
+                ErrorKind::Write(WriteFailure::WriteConcernError(write_concern_error.0)),
+                body.labels,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn extract_insert_many_error(&self) -> Result<()> {
+        let body: WriteErrorBody = self.body()?;
+
+        if body.write_errors.is_none() && body.write_concern_error.is_none() {
+            return Ok(());
+        }
+
+        Err(Error::new(
+            ErrorKind::InsertMany(InsertManyError {
+                write_errors: body.write_errors.map(|lossy| lossy.0),
+                write_concern_error: body.write_concern_error.map(|lossy| lossy.0),
+                inserted_ids: HashMap::new(),
+            }),
+            body.labels,
+        ))
+    }
+
+    pub(crate) fn extract_n(&self) -> Result<u64> {
+        let Some(n) = self.raw.get("n")? else {
+            return Err(Error::invalid_response(
+                "expected n field in server response",
+            ));
+        };
+        get_u64_raw(&n).ok_or_else(|| {
+            Error::invalid_response(format!("expected numeric value for n, got {n:?}"))
         })
     }
 

--- a/driver/src/cmap/conn/command.rs
+++ b/driver/src/cmap/conn/command.rs
@@ -260,7 +260,7 @@ impl RawCommandResponse {
         })
     }
 
-    pub(crate) fn extract_single_write_error(&self) -> Result<()> {
+    pub(crate) fn validate_single_write(&self) -> Result<()> {
         let body: WriteErrorBody = self.body()?;
 
         if let Some(write_error) = body
@@ -281,7 +281,7 @@ impl RawCommandResponse {
         }
     }
 
-    pub(crate) fn extract_insert_many_error(&self) -> Result<()> {
+    pub(crate) fn validate_insert_many(&self) -> Result<()> {
         let body: WriteErrorBody = self.body()?;
 
         if body.write_errors.is_none() && body.write_concern_error.is_none() {

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -1032,6 +1032,24 @@ impl IndexedWriteError {
     }
 }
 
+impl From<IndexedWriteError> for WriteError {
+    fn from(error: IndexedWriteError) -> Self {
+        let IndexedWriteError {
+            index: _index,
+            code,
+            code_name,
+            message,
+            details,
+        } = error;
+        Self {
+            code,
+            code_name,
+            message,
+            details,
+        }
+    }
+}
+
 /// The set of errors that occurred during a call to
 /// [`insert_many`](crate::Collection::insert_many).
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -25,7 +25,7 @@ pub(crate) mod run_cursor_command;
 mod search_index;
 mod update;
 
-use std::{borrow::Cow, fmt::Debug, ops::Deref};
+use std::{borrow::Cow, fmt::Debug};
 
 use bson::{RawBsonRef, RawDocument, RawDocumentBuf, Timestamp};
 use futures_util::FutureExt;
@@ -42,16 +42,7 @@ use crate::{
         RawCommandResponse,
         StreamDescription,
     },
-    error::{
-        CommandError,
-        Error,
-        ErrorKind,
-        IndexedWriteError,
-        InsertManyError,
-        Result,
-        WriteConcernError,
-        WriteFailure,
-    },
+    error::{CommandError, Error, ErrorKind, Result},
     options::{ClientOptions, ReadConcern, WriteConcern},
     selection_criteria::SelectionCriteria,
     BoxFuture,
@@ -701,95 +692,6 @@ pub(crate) fn append_options_to_raw_document<T: Serialize>(
         extend_raw_document_buf(doc, options_raw_doc)?;
     }
     Ok(())
-}
-
-#[derive(Deserialize, Debug)]
-pub(crate) struct SingleWriteBody {
-    n: u64,
-}
-
-/// Body of a write response that could possibly have a write concern error but not write errors.
-#[derive(Debug, Deserialize, Default, Clone)]
-pub(crate) struct WriteConcernOnlyBody {
-    #[serde(rename = "writeConcernError")]
-    write_concern_error: Option<WriteConcernError>,
-
-    #[serde(rename = "errorLabels")]
-    labels: Option<Vec<String>>,
-}
-
-impl WriteConcernOnlyBody {
-    fn validate(&self) -> Result<()> {
-        match self.write_concern_error {
-            Some(ref wc_error) => Err(Error::new(
-                ErrorKind::Write(WriteFailure::WriteConcernError(wc_error.clone())),
-                self.labels.clone(),
-            )),
-            None => Ok(()),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct WriteResponseBody<T = SingleWriteBody> {
-    body: T,
-    write_errors: Option<Vec<IndexedWriteError>>,
-    write_concern_error: Option<WriteConcernError>,
-    labels: Option<Vec<String>>,
-}
-
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for WriteResponseBody<T> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use crate::bson_compat::Utf8Lossy;
-        #[derive(Deserialize)]
-        struct Helper<T> {
-            #[serde(flatten)]
-            body: T,
-            #[serde(rename = "writeErrors")]
-            write_errors: Option<Utf8Lossy<Vec<IndexedWriteError>>>,
-            #[serde(rename = "writeConcernError")]
-            write_concern_error: Option<Utf8Lossy<WriteConcernError>>,
-            #[serde(rename = "errorLabels")]
-            labels: Option<Vec<String>>,
-        }
-        let helper = Helper::deserialize(deserializer)?;
-        Ok(Self {
-            body: helper.body,
-            write_errors: helper.write_errors.map(|l| l.0),
-            write_concern_error: helper.write_concern_error.map(|l| l.0),
-            labels: helper.labels,
-        })
-    }
-}
-
-impl<T> WriteResponseBody<T> {
-    fn validate(&self) -> Result<()> {
-        if self.write_errors.is_none() && self.write_concern_error.is_none() {
-            return Ok(());
-        };
-
-        let failure = InsertManyError {
-            write_errors: self.write_errors.clone(),
-            write_concern_error: self.write_concern_error.clone(),
-            inserted_ids: Default::default(),
-        };
-
-        Err(Error::new(
-            ErrorKind::InsertMany(failure),
-            self.labels.clone(),
-        ))
-    }
-}
-
-impl<T> Deref for WriteResponseBody<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.body
-    }
 }
 
 fn cursor_get_at_cluster_time(response: &RawDocument) -> Result<Option<Timestamp>> {

--- a/driver/src/operation/abort_transaction.rs
+++ b/driver/src/operation/abort_transaction.rs
@@ -9,7 +9,7 @@ use crate::{
     Client,
 };
 
-use super::{BaseOperation, ExecutionContext, WriteConcernOnlyBody};
+use super::{BaseOperation, ExecutionContext};
 
 pub(crate) struct AbortTransaction {
     write_concern: Option<WriteConcern>,
@@ -49,8 +49,7 @@ impl BaseOperation for AbortTransaction {
         response: &RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.extract_single_write_error()
     }
 
     fn selection_criteria(&self) -> super::Feature<&SelectionCriteria> {

--- a/driver/src/operation/abort_transaction.rs
+++ b/driver/src/operation/abort_transaction.rs
@@ -49,7 +49,7 @@ impl BaseOperation for AbortTransaction {
         response: &RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()
+        response.validate_single_write()
     }
 
     fn selection_criteria(&self) -> super::Feature<&SelectionCriteria> {

--- a/driver/src/operation/aggregate.rs
+++ b/driver/src/operation/aggregate.rs
@@ -11,7 +11,7 @@ use crate::{
     options::{AggregateOptions, ClientOptions, ReadPreference, SelectionCriteria, WriteConcern},
 };
 
-use super::{BaseOperation, ExecutionContext, WriteConcernOnlyBody, SERVER_4_4_0_WIRE_VERSION};
+use super::{BaseOperation, ExecutionContext, SERVER_4_4_0_WIRE_VERSION};
 
 #[derive(Debug)]
 pub(crate) struct Aggregate {
@@ -84,8 +84,7 @@ impl BaseOperation for Aggregate {
         context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
         if self.is_out_or_merge {
-            let wc_error_info = response.body::<WriteConcernOnlyBody>()?;
-            wc_error_info.validate()?;
+            response.extract_single_write_error()?;
         };
 
         let description = context.connection.stream_description()?;

--- a/driver/src/operation/aggregate.rs
+++ b/driver/src/operation/aggregate.rs
@@ -84,7 +84,7 @@ impl BaseOperation for Aggregate {
         context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
         if self.is_out_or_merge {
-            response.extract_single_write_error()?;
+            response.validate_single_write()?;
         };
 
         let description = context.connection.stream_description()?;

--- a/driver/src/operation/bulk_write.rs
+++ b/driver/src/operation/bulk_write.rs
@@ -11,7 +11,7 @@ use crate::{
     bson_util::{self, RawDocumentCollection},
     checked::Checked,
     client::session::TransactionState,
-    cmap::{Command, RawCommandResponse, StreamDescription},
+    cmap::{conn::WriteErrorBody, Command, RawCommandResponse, StreamDescription},
     cursor::{common::CursorSpecification, NewCursor},
     error::{BulkWriteError, Error, ErrorKind, Result},
     operation::{
@@ -31,13 +31,7 @@ use crate::{
     SessionCursor,
 };
 
-use super::{
-    ExecutionContext,
-    Retryability,
-    WriteResponseBody,
-    OP_MSG_OVERHEAD_BYTES,
-    SERVER_8_0_0_WIRE_VERSION,
-};
+use super::{ExecutionContext, Retryability, OP_MSG_OVERHEAD_BYTES, SERVER_8_0_0_WIRE_VERSION};
 
 use server_responses::*;
 
@@ -405,22 +399,23 @@ where
         mut context: ExecutionContext<'b>,
     ) -> BoxFuture<'b, Result<Self::O>> {
         async move {
-            let response: WriteResponseBody<SummaryInfo> = raw_response.body()?;
-            let n_errors: usize = Checked::new(response.body.n_errors).try_into()?;
+            let write_error: WriteErrorBody = raw_response.body()?;
+            let summary_info: SummaryInfo = raw_response.body()?;
+            let n_errors: usize = Checked::new(summary_info.n_errors).try_into()?;
 
             let mut error: BulkWriteError = Default::default();
             let mut result: R = Default::default();
 
             result.populate_summary_info(
-                response.body.n_inserted,
-                response.body.n_matched,
-                response.body.n_modified,
-                response.body.n_upserted,
-                response.body.n_deleted,
+                summary_info.n_inserted,
+                summary_info.n_matched,
+                summary_info.n_modified,
+                summary_info.n_upserted,
+                summary_info.n_deleted,
             );
 
-            if let Some(write_concern_error) = response.write_concern_error {
-                error.write_concern_errors.push(write_concern_error);
+            if let Some(write_concern_error) = write_error.write_concern_error {
+                error.write_concern_errors.push(write_concern_error.0);
             }
 
             let specification = CursorSpecification::new(
@@ -495,7 +490,7 @@ where
                     error.partial_result = Some(result.into_partial_result());
                 }
 
-                let error = Error::new(ErrorKind::BulkWrite(error), response.labels)
+                let error = Error::new(ErrorKind::BulkWrite(error), write_error.labels)
                     .with_source(iteration_result.err());
                 Err(error)
             }

--- a/driver/src/operation/commit_transaction.rs
+++ b/driver/src/operation/commit_transaction.rs
@@ -11,7 +11,7 @@ use crate::{
     Client,
 };
 
-use super::{ExecutionContext, WriteConcernOnlyBody};
+use super::ExecutionContext;
 
 pub(crate) struct CommitTransaction {
     options: Option<TransactionOptions>,
@@ -47,8 +47,7 @@ impl BaseOperation for CommitTransaction {
         response: &RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.extract_single_write_error()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/commit_transaction.rs
+++ b/driver/src/operation/commit_transaction.rs
@@ -47,7 +47,7 @@ impl BaseOperation for CommitTransaction {
         response: &RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()
+        response.validate_single_write()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/create.rs
+++ b/driver/src/operation/create.rs
@@ -46,7 +46,7 @@ impl BaseOperation for Create {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()
+        response.validate_single_write()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/create.rs
+++ b/driver/src/operation/create.rs
@@ -5,13 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::{CreateCollectionOptions, WriteConcern},
 };
 
@@ -52,8 +46,7 @@ impl BaseOperation for Create {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.extract_single_write_error()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/create_indexes.rs
+++ b/driver/src/operation/create_indexes.rs
@@ -12,7 +12,7 @@ use crate::{
     results::CreateIndexesResult,
 };
 
-use super::{ExecutionContext, WriteConcernOnlyBody};
+use super::ExecutionContext;
 
 #[derive(Debug)]
 pub(crate) struct CreateIndexes {
@@ -72,8 +72,7 @@ impl BaseOperation for CreateIndexes {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()?;
+        response.extract_single_write_error()?;
         let index_names = self.indexes.iter().filter_map(|i| i.get_name()).collect();
         Ok(CreateIndexesResult { index_names })
     }

--- a/driver/src/operation/create_indexes.rs
+++ b/driver/src/operation/create_indexes.rs
@@ -72,7 +72,7 @@ impl BaseOperation for CreateIndexes {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()?;
+        response.validate_single_write()?;
         let index_names = self.indexes.iter().filter_map(|i| i.get_name()).collect();
         Ok(CreateIndexesResult { index_names })
     }

--- a/driver/src/operation/delete.rs
+++ b/driver/src/operation/delete.rs
@@ -3,15 +3,8 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     collation::Collation,
-    error::{convert_insert_many_error, Result},
-    operation::{
-        append_options,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        Retryability,
-        WriteResponseBody,
-    },
+    error::Result,
+    operation::{append_options, Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, DeleteOptions, Hint, WriteConcern},
     results::DeleteResult,
     Collection,
@@ -85,11 +78,9 @@ impl BaseOperation for Delete {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody = response.body()?;
-        response.validate().map_err(convert_insert_many_error)?;
-
+        response.extract_single_write_error()?;
         Ok(DeleteResult {
-            deleted_count: response.n,
+            deleted_count: response.extract_n()?,
         })
     }
 

--- a/driver/src/operation/delete.rs
+++ b/driver/src/operation/delete.rs
@@ -78,7 +78,7 @@ impl BaseOperation for Delete {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()?;
+        response.validate_single_write()?;
         Ok(DeleteResult {
             deleted_count: response.extract_n()?,
         })

--- a/driver/src/operation/drop_collection.rs
+++ b/driver/src/operation/drop_collection.rs
@@ -46,7 +46,7 @@ impl BaseOperation for DropCollection {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()
+        response.validate_single_write()
     }
 
     fn handle_error(&self, error: Error) -> Result<Self::O> {

--- a/driver/src/operation/drop_collection.rs
+++ b/driver/src/operation/drop_collection.rs
@@ -5,13 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
-    operation::{
-        append_options_to_raw_document,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::{DropCollectionOptions, WriteConcern},
 };
 
@@ -52,8 +46,7 @@ impl BaseOperation for DropCollection {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.extract_single_write_error()
     }
 
     fn handle_error(&self, error: Error) -> Result<Self::O> {

--- a/driver/src/operation/drop_database.rs
+++ b/driver/src/operation/drop_database.rs
@@ -5,13 +5,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::DropDatabaseOptions,
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::WriteConcern,
 };
 
@@ -49,8 +43,7 @@ impl BaseOperation for DropDatabase {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.extract_single_write_error()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/drop_database.rs
+++ b/driver/src/operation/drop_database.rs
@@ -43,7 +43,7 @@ impl BaseOperation for DropDatabase {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()
+        response.validate_single_write()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/find_and_modify.rs
+++ b/driver/src/operation/find_and_modify.rs
@@ -11,7 +11,7 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::options::UpdateModifications,
-    error::{convert_insert_many_error, Error, ErrorKind, Result},
+    error::{Error, ErrorKind, Result},
     operation::{
         append_options_to_raw_document,
         find_and_modify::options::Modification,
@@ -19,7 +19,6 @@ use crate::{
         BaseOperation,
         OperationImpl,
         Retryability,
-        WriteResponseBody,
     },
     options::{ClientOptions, WriteConcern},
     Collection,
@@ -96,13 +95,13 @@ impl<T: DeserializeOwned> BaseOperation for FindAndModify<T> {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
+        response.extract_single_write_error()?;
         #[derive(Debug, Deserialize)]
         struct Response {
             // deserializing directly into Option<T> doesn't report an error if `value` is missing
             value: RawBson,
         }
-        let body: WriteResponseBody<Response> = response.body()?;
-        body.validate().map_err(convert_insert_many_error)?;
+        let body = response.body::<Response>()?;
         match body.value {
             RawBson::Document(ref doc) => Ok(Some(deserialize_from_slice(doc.as_bytes())?)),
             RawBson::Null => Ok(None),

--- a/driver/src/operation/find_and_modify.rs
+++ b/driver/src/operation/find_and_modify.rs
@@ -95,7 +95,7 @@ impl<T: DeserializeOwned> BaseOperation for FindAndModify<T> {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()?;
+        response.validate_single_write()?;
         #[derive(Debug, Deserialize)]
         struct Response {
             // deserializing directly into Option<T> doesn't report an error if `value` is missing

--- a/driver/src/operation/find_and_modify.rs
+++ b/driver/src/operation/find_and_modify.rs
@@ -11,7 +11,7 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::options::UpdateModifications,
-    error::{ErrorKind, Result},
+    error::{convert_insert_many_error, Error, ErrorKind, Result},
     operation::{
         append_options_to_raw_document,
         find_and_modify::options::Modification,
@@ -19,6 +19,7 @@ use crate::{
         BaseOperation,
         OperationImpl,
         Retryability,
+        WriteResponseBody,
     },
     options::{ClientOptions, WriteConcern},
     Collection,
@@ -96,21 +97,19 @@ impl<T: DeserializeOwned> BaseOperation for FindAndModify<T> {
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
         #[derive(Debug, Deserialize)]
-        pub(crate) struct Response {
+        struct Response {
+            // deserializing directly into Option<T> doesn't report an error if `value` is missing
             value: RawBson,
         }
-        let response: Response = response.body()?;
-
-        match response.value {
-            RawBson::Document(doc) => Ok(Some(deserialize_from_slice(doc.as_bytes())?)),
+        let body: WriteResponseBody<Response> = response.body()?;
+        body.validate().map_err(convert_insert_many_error)?;
+        match body.value {
+            RawBson::Document(ref doc) => Ok(Some(deserialize_from_slice(doc.as_bytes())?)),
             RawBson::Null => Ok(None),
-            other => Err(ErrorKind::InvalidResponse {
-                message: format!(
-                    "expected document for value field of findAndModify response, but instead got \
-                     {other:?}"
-                ),
-            }
-            .into()),
+            ref other => Err(Error::invalid_response(format!(
+                "expected document for value field of findAndModify response, but instead got \
+                 {other:?}",
+            ))),
         }
     }
 

--- a/driver/src/operation/insert.rs
+++ b/driver/src/operation/insert.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     checked::Checked,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    error::{Error, ErrorKind, InsertManyError, Result},
-    operation::{Base, BaseOperation, OperationImpl, Retryability, WriteResponseBody},
+    error::{ErrorKind, Result},
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, InsertManyOptions, WriteConcern},
     results::InsertManyResult,
     Collection,
@@ -133,41 +133,39 @@ impl BaseOperation for Insert<'_> {
         response: &'b RawCommandResponse,
         _context: ExecutionContext<'b>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody = response.body()?;
-        let response_n = Checked::<usize>::try_from(response.n)?;
+        let n: usize = Checked::new(response.extract_n()?).try_into()?;
+        let inserted_ids = || {
+            self.inserted_ids
+                .iter()
+                .cloned()
+                .enumerate()
+                .take(n)
+                .collect()
+        };
 
-        let mut map = HashMap::new();
-        if self.options.ordered == Some(true) {
-            // in ordered inserts, only the first n were attempted.
-            for (i, id) in self.inserted_ids.iter().enumerate().take(response_n.get()?) {
-                map.insert(i, id.clone());
-            }
-        } else {
-            // for unordered, add all the attempted ids and then remove the ones that have
-            // associated write errors.
-            for (i, id) in self.inserted_ids.iter().enumerate() {
-                map.insert(i, id.clone());
-            }
-
-            if let Some(write_errors) = response.write_errors.as_ref() {
-                for err in write_errors {
-                    map.remove(&err.index);
-                }
+        match response.extract_insert_many_error() {
+            Ok(()) => Ok(InsertManyResult {
+                inserted_ids: inserted_ids(),
+            }),
+            Err(mut error) => {
+                if let ErrorKind::InsertMany(ref mut insert_many_error) = *error.kind {
+                    let inserted_ids = if self.options.ordered == Some(false) {
+                        let mut all_inserted_ids: HashMap<_, _> =
+                            self.inserted_ids.iter().cloned().enumerate().collect();
+                        if let Some(ref write_errors) = insert_many_error.write_errors {
+                            for write_error in write_errors {
+                                all_inserted_ids.remove(&write_error.index);
+                            }
+                        }
+                        all_inserted_ids
+                    } else {
+                        inserted_ids()
+                    };
+                    insert_many_error.inserted_ids = inserted_ids;
+                };
+                Err(error)
             }
         }
-
-        if response.write_errors.is_some() || response.write_concern_error.is_some() {
-            return Err(Error::new(
-                ErrorKind::InsertMany(InsertManyError {
-                    write_errors: response.write_errors,
-                    write_concern_error: response.write_concern_error,
-                    inserted_ids: map,
-                }),
-                response.labels,
-            ));
-        }
-
-        Ok(InsertManyResult { inserted_ids: map })
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/insert.rs
+++ b/driver/src/operation/insert.rs
@@ -143,7 +143,7 @@ impl BaseOperation for Insert<'_> {
                 .collect()
         };
 
-        match response.extract_insert_many_error() {
+        match response.validate_insert_many() {
             Ok(()) => Ok(InsertManyResult {
                 inserted_ids: inserted_ids(),
             }),

--- a/driver/src/operation/update.rs
+++ b/driver/src/operation/update.rs
@@ -7,8 +7,8 @@ use crate::{
     bson_compat::{cstr, CStr},
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    error::{convert_insert_many_error, Result},
-    operation::{Base, BaseOperation, OperationImpl, Retryability, WriteResponseBody},
+    error::Result,
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, UpdateModifications, UpdateOptions, WriteConcern},
     results::UpdateResult,
     Collection,
@@ -166,8 +166,8 @@ impl BaseOperation for Update {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody<UpdateBody> = response.body()?;
-        response.validate().map_err(convert_insert_many_error)?;
+        response.extract_single_write_error()?;
+        let response: UpdateBody = response.body()?;
 
         let modified_count = response.n_modified;
         let upserted_id = response
@@ -177,11 +177,7 @@ impl BaseOperation for Update {
             .and_then(|doc| doc.get("_id"))
             .cloned();
 
-        let matched_count = if upserted_id.is_some() {
-            0
-        } else {
-            response.body.n
-        };
+        let matched_count = if upserted_id.is_some() { 0 } else { response.n };
 
         Ok(UpdateResult {
             matched_count,

--- a/driver/src/operation/update.rs
+++ b/driver/src/operation/update.rs
@@ -166,7 +166,7 @@ impl BaseOperation for Update {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        response.extract_single_write_error()?;
+        response.validate_single_write()?;
         let response: UpdateBody = response.body()?;
 
         let modified_count = response.n_modified;

--- a/driver/src/test/coll.rs
+++ b/driver/src/test/coll.rs
@@ -1321,6 +1321,14 @@ async fn aggregate_with_generics() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn find_and_modify_write_concern_error() {
+    if server_version_lt(4, 4).await {
+        log_uncaptured(
+            "skipping find_and_modify_write_concern_error due to missing fail command error label \
+             support",
+        );
+        return;
+    }
+
     let client = Client::for_test().use_single_mongos().await;
 
     let coll = client

--- a/driver/src/test/coll.rs
+++ b/driver/src/test/coll.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use crate::{
     bson::{doc, rawdoc, serde_helpers::HumanReadable, Bson, Document, RawDocumentBuf},
     bson_compat::serialize_to_document,
-    error::{ErrorKind, Result, WriteFailure},
+    error::{ErrorKind, Result, WriteFailure, RETRYABLE_WRITE_ERROR},
     options::{
         Acknowledgment,
         CollectionOptions,
@@ -32,6 +32,7 @@ use crate::{
         server_version_lt,
         topology_is_replica_set,
         topology_is_standalone,
+        util::fail_point::{FailPoint, FailPointMode},
         EventClient,
     },
     Client,
@@ -1316,4 +1317,26 @@ async fn aggregate_with_generics() {
     let lens: Vec<B> = cursor.try_collect().await.unwrap();
     let first_len: usize = lens[0].len.try_into().unwrap();
     assert_eq!(first_len, len);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn find_and_modify_write_concern_error() {
+    let client = Client::for_test().use_single_mongos().await;
+
+    let coll = client
+        .database("db")
+        .collection("find_and_modify_write_concern_error");
+    coll.drop().await.unwrap();
+    coll.insert_one(doc! { "x": 1 }).await.unwrap();
+
+    let fail_point = FailPoint::fail_command(&["findAndModify"], FailPointMode::Times(2))
+        .write_concern_error(doc! { "code": 64 })
+        .error_labels(vec![RETRYABLE_WRITE_ERROR]);
+    let _guard = client.enable_fail_point(fail_point).await.unwrap();
+
+    let error = coll.find_one_and_delete(doc! { "x": 2 }).await.unwrap_err();
+    let ErrorKind::Write(WriteFailure::WriteConcernError(write_concern_error)) = *error.kind else {
+        panic!("expected write concern error, got {error}");
+    };
+    assert_eq!(write_concern_error.code, 64);
 }


### PR DESCRIPTION
Fixes the bug reported in RUST-2479. I also refactored how we parse write error fields out of server responses, which (IMO) ended up being a nice cleanup.