### PR TITLE
RUST-2483 Deserialize FindOptions maxTimeMS from milliseconds

### DIFF
--- a/driver/src/coll/options.rs
+++ b/driver/src/coll/options.rs
@@ -842,7 +842,9 @@ pub struct FindOptions {
     /// across the wire as an integer number of milliseconds.
     #[serde(
         rename = "maxTimeMS",
-        serialize_with = "serde_util::serialize_duration_option_as_int_millis"
+        serialize_with = "serde_util::serialize_duration_option_as_int_millis",
+        deserialize_with = "serde_util::deserialize_duration_option_from_u64_millis",
+        default
     )]
     pub max_time: Option<Duration>,
 
@@ -1215,5 +1217,45 @@ impl<'de> Deserialize<'de> for CommitQuorum {
             }
             IntOrString::Int(i) => Ok(CommitQuorum::Nodes(i)),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use super::{AggregateOptions, FindOptions};
+    use crate::bson::doc;
+
+    #[test]
+    fn max_time_deserializes_from_millis() {
+        let options: FindOptions =
+            crate::bson_compat::deserialize_from_document(doc! { "maxTimeMS": 5000 }).unwrap();
+        assert_eq!(options.max_time, Some(Duration::from_millis(5000)));
+
+        // `FindOptions` and `AggregateOptions` should accept the same representation.
+        let aggregate: AggregateOptions =
+            crate::bson_compat::deserialize_from_document(doc! { "maxTimeMS": 5000 }).unwrap();
+        assert_eq!(aggregate.max_time, options.max_time);
+    }
+
+    #[test]
+    fn max_time_round_trips() {
+        let options = FindOptions::builder()
+            .max_time(Duration::from_millis(5000))
+            .build();
+        let document = crate::bson_compat::serialize_to_document(&options).unwrap();
+        assert_eq!(document.get_i32("maxTimeMS").unwrap(), 5000);
+
+        let round_tripped: FindOptions =
+            crate::bson_compat::deserialize_from_document(document).unwrap();
+        assert_eq!(round_tripped.max_time, options.max_time);
+    }
+
+    #[test]
+    fn max_time_is_optional() {
+        let options: FindOptions =
+            crate::bson_compat::deserialize_from_document(doc! { "limit": 1_i64 }).unwrap();
+        assert_eq!(options.max_time, None);
     }
 }


### PR DESCRIPTION
[RUST-2483](https://jira.mongodb.org/browse/RUST-2483)

`FindOptions::max_time` serializes to an integer number of milliseconds via `serialize_duration_option_as_int_millis`, but it has no matching `deserialize_with`. Deserialization falls back to the default serde representation of `std::time::Duration` and rejects the very value the driver itself emits:

```
invalid type: integer `5000`, expected struct Duration
```

It only accepts `{ "secs": 5, "nanos": 0 }`, an internal representation that no MongoDB document would ever carry.

Every other option type in `driver/src/coll/options.rs` that carries `max_time` already applies `deserialize_duration_option_from_u64_millis`: `AggregateOptions`, `CountOptions`, `DistinctOptions`, `EstimatedDocumentCountOptions`, `CreateIndexOptions`, `DropIndexOptions` and `ListIndexesOptions`. `FindOptions` is the only one missing it.

The test suite shows the same expectation: `driver/src/test/spec/unified_runner/operation/find.rs` replicates `FindOptions`' fields because serde cannot combine `flatten` with `deny_unknown_fields`, and it applies that helper to `max_time` by hand.

This reaches end users through Prisma, whose MongoDB connector deserializes the `options` argument of `findRaw` straight into `FindOptions`. Passing `{ maxTimeMS: 25000 }` to `findRaw` fails, while the identical value passed to `aggregateRaw` succeeds because `AggregateOptions` has the helper.

## Changes

Apply the helper (with `default`, matching `AggregateOptions`) and add three tests: deserialization from milliseconds, a serialize/deserialize round trip, and the field remaining optional.

## Testing

The new tests pass with the fix; two of the three fail without it.

`cargo nextest run --no-fail-fast` against a local three-node replica set gives 318 passed / 47 failed on this branch, and 315 passed / 47 failed on `main` under the same setup. The failing sets are identical — the difference of three is the tests added here, all passing. Those 47 failures are an artifact of my local server not being started with `enableTestCommands=1`, so `configureFailPoint` is unavailable.

`cargo +nightly fmt --check` passes and `cargo clippy --lib --all-features --tests` reports nothing for the changed file.