### PR TITLE
RUST-2476 Additional cherrypicks for 3.8.1

### DIFF
--- a/driver/src/bson_util.rs
+++ b/driver/src/bson_util.rs
@@ -99,6 +99,15 @@ pub(crate) fn get_u64(val: &Bson) -> Option<u64> {
     }
 }
 
+pub(crate) fn get_u64_raw(val: &RawBsonRef) -> Option<u64> {
+    match val {
+        RawBsonRef::Int32(i) => get_u64(&Bson::Int32(*i)),
+        RawBsonRef::Int64(i) => get_u64(&Bson::Int64(*i)),
+        RawBsonRef::Double(i) => get_u64(&Bson::Double(*i)),
+        _ => None,
+    }
+}
+
 pub(crate) fn to_bson_array(docs: &[Document]) -> Bson {
     Bson::Array(docs.iter().map(|doc| Bson::Document(doc.clone())).collect())
 }

--- a/driver/src/cmap/conn.rs
+++ b/driver/src/cmap/conn.rs
@@ -26,7 +26,7 @@ use crate::{
     options::ServerAddress,
     runtime::AsyncStream,
 };
-pub(crate) use command::{Command, RawCommandResponse};
+pub(crate) use command::{Command, RawCommandResponse, WriteErrorBody};
 pub(crate) use stream_description::StreamDescription;
 
 #[cfg(any(

--- a/driver/src/cmap/conn/command.rs
+++ b/driver/src/cmap/conn/command.rs
@@ -1,10 +1,22 @@
+use std::collections::HashMap;
+
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use super::wire::{message::DocumentSequence, Message};
 use crate::{
     bson::{Document, RawDocument, RawDocumentBuf},
+    bson_compat::{deserialize_from_slice, Utf8Lossy},
+    bson_util::get_u64_raw,
     client::{options::ServerApi, ClusterTime},
-    error::{Error, ErrorKind, Result},
+    error::{
+        Error,
+        ErrorKind,
+        IndexedWriteError,
+        InsertManyError,
+        Result,
+        WriteConcernError,
+        WriteFailure,
+    },
     hello::{HelloCommandResponse, HelloReply},
     operation::{CommandErrorBody, CommandResponse, Feature, Operation},
     options::{ReadConcernInternal, ReadConcernLevel, ServerAddress, WriteConcern},
@@ -210,6 +222,17 @@ pub(crate) struct RawCommandResponse {
     raw: RawDocumentBuf,
 }
 
+/// A helper struct to deserialize write-error-specific fields from a server response.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WriteErrorBody {
+    #[serde(rename = "writeErrors")]
+    pub(crate) write_errors: Option<Utf8Lossy<Vec<IndexedWriteError>>>,
+    #[serde(rename = "writeConcernError")]
+    pub(crate) write_concern_error: Option<Utf8Lossy<WriteConcernError>>,
+    #[serde(rename = "errorLabels")]
+    pub(crate) labels: Option<Vec<String>>,
+}
+
 impl RawCommandResponse {
     #[cfg(test)]
     pub(crate) fn with_document_and_address(source: ServerAddress, doc: Document) -> Result<Self> {
@@ -230,10 +253,59 @@ impl RawCommandResponse {
     }
 
     pub(crate) fn body<'a, T: Deserialize<'a>>(&'a self) -> Result<T> {
-        crate::bson_compat::deserialize_from_slice(self.raw.as_bytes()).map_err(|e| {
+        deserialize_from_slice(self.raw.as_bytes()).map_err(|e| {
             Error::from(ErrorKind::InvalidResponse {
                 message: format!("{e}"),
             })
+        })
+    }
+
+    pub(crate) fn validate_single_write(&self) -> Result<()> {
+        let body: WriteErrorBody = self.body()?;
+
+        if let Some(write_error) = body
+            .write_errors
+            .and_then(|write_errors| write_errors.0.into_iter().next())
+        {
+            Err(Error::new(
+                ErrorKind::Write(WriteFailure::WriteError(write_error.into())),
+                body.labels,
+            ))
+        } else if let Some(write_concern_error) = body.write_concern_error {
+            Err(Error::new(
+                ErrorKind::Write(WriteFailure::WriteConcernError(write_concern_error.0)),
+                body.labels,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn validate_insert_many(&self) -> Result<()> {
+        let body: WriteErrorBody = self.body()?;
+
+        if body.write_errors.is_none() && body.write_concern_error.is_none() {
+            return Ok(());
+        }
+
+        Err(Error::new(
+            ErrorKind::InsertMany(InsertManyError {
+                write_errors: body.write_errors.map(|lossy| lossy.0),
+                write_concern_error: body.write_concern_error.map(|lossy| lossy.0),
+                inserted_ids: HashMap::new(),
+            }),
+            body.labels,
+        ))
+    }
+
+    pub(crate) fn extract_n(&self) -> Result<u64> {
+        let Some(n) = self.raw.get("n")? else {
+            return Err(Error::invalid_response(
+                "expected n field in server response",
+            ));
+        };
+        get_u64_raw(&n).ok_or_else(|| {
+            Error::invalid_response(format!("expected numeric value for n, got {n:?}"))
         })
     }
 

--- a/driver/src/error.rs
+++ b/driver/src/error.rs
@@ -1027,6 +1027,24 @@ impl IndexedWriteError {
     }
 }
 
+impl From<IndexedWriteError> for WriteError {
+    fn from(error: IndexedWriteError) -> Self {
+        let IndexedWriteError {
+            index: _index,
+            code,
+            code_name,
+            message,
+            details,
+        } = error;
+        Self {
+            code,
+            code_name,
+            message,
+            details,
+        }
+    }
+}
+
 /// The set of errors that occurred during a call to
 /// [`insert_many`](crate::Collection::insert_many).
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -126,10 +126,8 @@ impl Retryability {
     }
 }
 
-/// A trait modeling the behavior of a server side operation.
-///
-/// No methods in this trait should have default behaviors to ensure that wrapper operations
-/// replicate all behavior.  Default behavior is provided by the `OperationDefault` trait.
+/// A trait modeling the behavior of a server side operation.  This should not be implemented
+/// directly; use either the `BaseOperation` or `WrappedOperation` traits.
 pub(crate) trait Operation {
     /// The output type of this operation.
     type O;
@@ -291,9 +289,9 @@ impl<T: Send + Sync> From<&Collection<T>> for OperationTarget {
     }
 }
 
-// A mirror of the `Operation` trait, with default behavior where appropriate.  Should only be
+// A mirror of the `Operation` trait, with default behavior where appropriate.  Should be
 // implemented by operation types that do not delegate to other operations.
-pub(crate) trait OperationWithDefaults: Send + Sync {
+pub(crate) trait BaseOperation: Send + Sync {
     /// The output type of this operation.
     type O;
 
@@ -411,65 +409,192 @@ pub(crate) trait OperationWithDefaults: Send + Sync {
     type Otel: crate::otel::OtelWitness<Op = Self>;
 }
 
-impl<T: OperationWithDefaults> Operation for T
-where
-    T: Send + Sync,
-{
-    type O = T::O;
-    const NAME: &'static CStr = T::NAME;
-    const ZERO_COPY: bool = T::ZERO_COPY;
-    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
-        self.build(description)
-    }
-    fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
-        self.extract_at_cluster_time(response)
-    }
+/// We'd like both `BaseOperation` and `WrappedOperation` to automatically implement `Operation`.
+/// However, Rust only allows one blanket impl per trait, so we can't do both
+/// `impl<T: BaseOperation> Operation for T` and `impl<T: WrappedOperation> Operation for T`.
+///
+/// To work around this, `OperationDispatch` provides an indirection: the one blanket impl for
+/// `Operation` is a generic `OperationDispatch<K>`, and each specialized version of the trait
+/// has a blanket impl for `OperationDispatch` with a specific type parameter.
+///
+/// `OperationImpl` is a helper trait for this setup that binds specific impls to the appropriate
+/// dispatch type.
+pub(crate) trait OperationDispatch<Kind> {
+    type O;
+    const NAME: &'static CStr;
+    const ZERO_COPY: bool;
+    fn build(&mut self, description: &StreamDescription) -> Result<Command>;
+    fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>>;
     fn handle_response<'a>(
         &'a self,
         response: Cow<'a, RawCommandResponse>,
         context: ExecutionContext<'a>,
-    ) -> BoxFuture<'a, Result<Self::O>> {
-        self.handle_response_async(response, context)
+    ) -> BoxFuture<'a, Result<Self::O>>;
+    fn handle_error(&self, error: Error) -> Result<Self::O>;
+    fn selection_criteria(&self) -> Feature<&SelectionCriteria>;
+    fn read_concern(&self) -> Feature<&ReadConcern>;
+    fn write_concern(&self) -> Feature<&WriteConcern>;
+    fn supports_sessions(&self) -> bool;
+    fn retryability(&self, options: &ClientOptions) -> Retryability;
+    fn is_backpressure_retryable(&self, options: &ClientOptions) -> bool;
+    fn update_for_retry(&mut self, retry: Option<&Retry>);
+    fn override_criteria(&self) -> OverrideCriteriaFn;
+    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle>;
+    fn name(&self) -> &CStr;
+    fn target(&self) -> OperationTarget;
+    #[cfg(feature = "opentelemetry")]
+    type Otel: crate::otel::OtelWitness<Op = Self>;
+}
+
+macro_rules! operation_dispatch {
+    ($trait:path, $tag:ty, $handle_response:ident) => {
+        impl<T: $trait> OperationDispatch<$tag> for T {
+            operation_dispatch_body! { $trait, $handle_response }
+        }
+    };
+}
+
+macro_rules! operation_dispatch_body {
+    ($trait:path, $handle_response:ident) => {
+        type O = <T as $trait>::O;
+        const NAME: &'static CStr = <T as $trait>::NAME;
+        const ZERO_COPY: bool = <T as $trait>::ZERO_COPY;
+        fn build(&mut self, description: &StreamDescription) -> Result<Command> {
+            <T as $trait>::build(self, description)
+        }
+        fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
+            <T as $trait>::extract_at_cluster_time(self, response)
+        }
+        fn handle_response<'a>(
+            &'a self,
+            response: Cow<'a, RawCommandResponse>,
+            context: ExecutionContext<'a>,
+        ) -> BoxFuture<'a, Result<Self::O>> {
+            <T as $trait>::$handle_response(self, response, context)
+        }
+        fn handle_error(&self, error: Error) -> Result<Self::O> {
+            <T as $trait>::handle_error(self, error)
+        }
+        fn selection_criteria(&self) -> Feature<&SelectionCriteria> {
+            <T as $trait>::selection_criteria(self)
+        }
+        fn read_concern(&self) -> Feature<&ReadConcern> {
+            <T as $trait>::read_concern(self)
+        }
+        fn write_concern(&self) -> Feature<&WriteConcern> {
+            <T as $trait>::write_concern(self)
+        }
+        fn supports_sessions(&self) -> bool {
+            <T as $trait>::supports_sessions(self)
+        }
+        fn retryability(&self, options: &ClientOptions) -> Retryability {
+            <T as $trait>::retryability(self, options)
+        }
+        fn is_backpressure_retryable(&self, options: &ClientOptions) -> bool {
+            <T as $trait>::is_backpressure_retryable(self, options)
+        }
+        fn update_for_retry(&mut self, retry: Option<&Retry>) {
+            <T as $trait>::update_for_retry(self, retry)
+        }
+        fn override_criteria(&self) -> OverrideCriteriaFn {
+            <T as $trait>::override_criteria(self)
+        }
+        fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
+            <T as $trait>::pinned_connection(self)
+        }
+        fn name(&self) -> &CStr {
+            <T as $trait>::name(self)
+        }
+        fn target(&self) -> OperationTarget {
+            <T as $trait>::target(self)
+        }
+        #[cfg(feature = "opentelemetry")]
+        type Otel = <T as $trait>::Otel;
+    };
+}
+
+pub(crate) trait OperationImpl {
+    type Kind;
+}
+
+impl<K, T> Operation for T
+where
+    T: OperationImpl<Kind = K> + OperationDispatch<K> + Send + Sync,
+{
+    operation_dispatch_body! { OperationDispatch<K>, handle_response }
+}
+
+pub(crate) struct Base;
+
+operation_dispatch! { BaseOperation, Base, handle_response_async }
+
+/// A trait for operations that delegate most behavior to another wrapped operation.
+pub(crate) trait WrappedOperation {
+    // Required
+    type Wrapped: Operation;
+    type O;
+    #[cfg(feature = "opentelemetry")]
+    type Otel: crate::otel::OtelWitness<Op = Self>;
+
+    fn wrapped(&self) -> &Self::Wrapped;
+    fn wrapped_mut(&mut self) -> &mut Self::Wrapped;
+
+    fn handle_response<'a>(
+        &'a self,
+        response: Cow<'a, RawCommandResponse>,
+        context: ExecutionContext<'a>,
+    ) -> BoxFuture<'a, Result<Self::O>>;
+
+    // Delegated to wrapped
+    const NAME: &'static CStr = Self::Wrapped::NAME;
+    const ZERO_COPY: bool = Self::Wrapped::ZERO_COPY;
+    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
+        self.wrapped_mut().build(description)
     }
     fn handle_error(&self, error: Error) -> Result<Self::O> {
-        self.handle_error(error)
+        Err(error)
+    }
+    fn extract_at_cluster_time(&self, response: &RawDocument) -> Result<Option<Timestamp>> {
+        self.wrapped().extract_at_cluster_time(response)
     }
     fn selection_criteria(&self) -> Feature<&SelectionCriteria> {
-        self.selection_criteria()
+        self.wrapped().selection_criteria()
     }
     fn read_concern(&self) -> Feature<&ReadConcern> {
-        self.read_concern()
+        self.wrapped().read_concern()
     }
     fn write_concern(&self) -> Feature<&WriteConcern> {
-        self.write_concern()
+        self.wrapped().write_concern()
     }
     fn supports_sessions(&self) -> bool {
-        self.supports_sessions()
+        self.wrapped().supports_sessions()
     }
     fn retryability(&self, options: &ClientOptions) -> Retryability {
-        self.retryability(options)
+        self.wrapped().retryability(options)
     }
     fn is_backpressure_retryable(&self, options: &ClientOptions) -> bool {
-        self.is_backpressure_retryable(options)
+        self.wrapped().is_backpressure_retryable(options)
     }
     fn update_for_retry(&mut self, retry: Option<&Retry>) {
-        self.update_for_retry(retry)
+        self.wrapped_mut().update_for_retry(retry);
     }
     fn override_criteria(&self) -> OverrideCriteriaFn {
-        self.override_criteria()
+        self.wrapped().override_criteria()
     }
     fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
-        self.pinned_connection()
+        self.wrapped().pinned_connection()
     }
     fn name(&self) -> &CStr {
-        self.name()
+        self.wrapped().name()
     }
     fn target(&self) -> OperationTarget {
-        self.target()
+        self.wrapped().target()
     }
-    #[cfg(feature = "opentelemetry")]
-    type Otel = <Self as OperationWithDefaults>::Otel;
 }
+
+pub(crate) struct Wrapped;
+
+operation_dispatch! { WrappedOperation, Wrapped, handle_response }
 
 fn should_redact_body(body: &RawDocumentBuf) -> bool {
     if let Some(Ok((command_name, _))) = body.into_iter().next() {

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -25,7 +25,7 @@ pub(crate) mod run_cursor_command;
 mod search_index;
 mod update;
 
-use std::{borrow::Cow, fmt::Debug, ops::Deref};
+use std::{borrow::Cow, fmt::Debug};
 
 use bson::{RawBsonRef, RawDocument, RawDocumentBuf, Timestamp};
 use futures_util::FutureExt;
@@ -42,16 +42,7 @@ use crate::{
         RawCommandResponse,
         StreamDescription,
     },
-    error::{
-        CommandError,
-        Error,
-        ErrorKind,
-        IndexedWriteError,
-        InsertManyError,
-        Result,
-        WriteConcernError,
-        WriteFailure,
-    },
+    error::{CommandError, Error, ErrorKind, Result},
     options::{ClientOptions, ReadConcern, WriteConcern},
     selection_criteria::SelectionCriteria,
     BoxFuture,
@@ -687,95 +678,6 @@ pub(crate) fn append_options_to_raw_document<T: Serialize>(
         extend_raw_document_buf(doc, options_raw_doc)?;
     }
     Ok(())
-}
-
-#[derive(Deserialize, Debug)]
-pub(crate) struct SingleWriteBody {
-    n: u64,
-}
-
-/// Body of a write response that could possibly have a write concern error but not write errors.
-#[derive(Debug, Deserialize, Default, Clone)]
-pub(crate) struct WriteConcernOnlyBody {
-    #[serde(rename = "writeConcernError")]
-    write_concern_error: Option<WriteConcernError>,
-
-    #[serde(rename = "errorLabels")]
-    labels: Option<Vec<String>>,
-}
-
-impl WriteConcernOnlyBody {
-    fn validate(&self) -> Result<()> {
-        match self.write_concern_error {
-            Some(ref wc_error) => Err(Error::new(
-                ErrorKind::Write(WriteFailure::WriteConcernError(wc_error.clone())),
-                self.labels.clone(),
-            )),
-            None => Ok(()),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct WriteResponseBody<T = SingleWriteBody> {
-    body: T,
-    write_errors: Option<Vec<IndexedWriteError>>,
-    write_concern_error: Option<WriteConcernError>,
-    labels: Option<Vec<String>>,
-}
-
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for WriteResponseBody<T> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use crate::bson_compat::Utf8Lossy;
-        #[derive(Deserialize)]
-        struct Helper<T> {
-            #[serde(flatten)]
-            body: T,
-            #[serde(rename = "writeErrors")]
-            write_errors: Option<Utf8Lossy<Vec<IndexedWriteError>>>,
-            #[serde(rename = "writeConcernError")]
-            write_concern_error: Option<Utf8Lossy<WriteConcernError>>,
-            #[serde(rename = "errorLabels")]
-            labels: Option<Vec<String>>,
-        }
-        let helper = Helper::deserialize(deserializer)?;
-        Ok(Self {
-            body: helper.body,
-            write_errors: helper.write_errors.map(|l| l.0),
-            write_concern_error: helper.write_concern_error.map(|l| l.0),
-            labels: helper.labels,
-        })
-    }
-}
-
-impl<T> WriteResponseBody<T> {
-    fn validate(&self) -> Result<()> {
-        if self.write_errors.is_none() && self.write_concern_error.is_none() {
-            return Ok(());
-        };
-
-        let failure = InsertManyError {
-            write_errors: self.write_errors.clone(),
-            write_concern_error: self.write_concern_error.clone(),
-            inserted_ids: Default::default(),
-        };
-
-        Err(Error::new(
-            ErrorKind::InsertMany(failure),
-            self.labels.clone(),
-        ))
-    }
-}
-
-impl<T> Deref for WriteResponseBody<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.body
-    }
 }
 
 fn cursor_get_at_cluster_time(response: &RawDocument) -> Result<Option<Timestamp>> {

--- a/driver/src/operation/abort_transaction.rs
+++ b/driver/src/operation/abort_transaction.rs
@@ -4,12 +4,12 @@ use crate::{
     client::{session::TransactionPin, Retry},
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::Retryability,
+    operation::{Base, OperationImpl, Retryability},
     options::{ClientOptions, SelectionCriteria, WriteConcern},
     Client,
 };
 
-use super::{ExecutionContext, OperationWithDefaults, WriteConcernOnlyBody};
+use super::{BaseOperation, ExecutionContext, WriteConcernOnlyBody};
 
 pub(crate) struct AbortTransaction {
     write_concern: Option<WriteConcern>,
@@ -31,7 +31,7 @@ impl AbortTransaction {
     }
 }
 
-impl OperationWithDefaults for AbortTransaction {
+impl BaseOperation for AbortTransaction {
     type O = ();
 
     const NAME: &'static CStr = cstr!("abortTransaction");
@@ -87,6 +87,10 @@ impl OperationWithDefaults for AbortTransaction {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for AbortTransaction {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/abort_transaction.rs
+++ b/driver/src/operation/abort_transaction.rs
@@ -9,7 +9,7 @@ use crate::{
     Client,
 };
 
-use super::{BaseOperation, ExecutionContext, WriteConcernOnlyBody};
+use super::{BaseOperation, ExecutionContext};
 
 pub(crate) struct AbortTransaction {
     write_concern: Option<WriteConcern>,
@@ -49,8 +49,7 @@ impl BaseOperation for AbortTransaction {
         response: &RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.validate_single_write()
     }
 
     fn selection_criteria(&self) -> super::Feature<&SelectionCriteria> {

--- a/driver/src/operation/aggregate.rs
+++ b/driver/src/operation/aggregate.rs
@@ -7,16 +7,11 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::common::CursorSpecification,
     error::Result,
-    operation::{append_options, OperationTarget, Retryability},
+    operation::{append_options, Base, OperationImpl, OperationTarget, Retryability},
     options::{AggregateOptions, ClientOptions, ReadPreference, SelectionCriteria, WriteConcern},
 };
 
-use super::{
-    ExecutionContext,
-    OperationWithDefaults,
-    WriteConcernOnlyBody,
-    SERVER_4_4_0_WIRE_VERSION,
-};
+use super::{BaseOperation, ExecutionContext, WriteConcernOnlyBody, SERVER_4_4_0_WIRE_VERSION};
 
 #[derive(Debug)]
 pub(crate) struct Aggregate {
@@ -51,7 +46,7 @@ impl Aggregate {
 
 // IMPORTANT: If new method implementations are added here, make sure `ChangeStreamAggregate` has
 // the equivalent delegations.
-impl OperationWithDefaults for Aggregate {
+impl BaseOperation for Aggregate {
     type O = CursorSpecification;
 
     const NAME: &'static CStr = cstr!("aggregate");
@@ -175,6 +170,10 @@ impl OperationWithDefaults for Aggregate {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Aggregate {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/aggregate.rs
+++ b/driver/src/operation/aggregate.rs
@@ -11,7 +11,7 @@ use crate::{
     options::{AggregateOptions, ClientOptions, ReadPreference, SelectionCriteria, WriteConcern},
 };
 
-use super::{BaseOperation, ExecutionContext, WriteConcernOnlyBody, SERVER_4_4_0_WIRE_VERSION};
+use super::{BaseOperation, ExecutionContext, SERVER_4_4_0_WIRE_VERSION};
 
 #[derive(Debug)]
 pub(crate) struct Aggregate {
@@ -84,8 +84,7 @@ impl BaseOperation for Aggregate {
         context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
         if self.is_out_or_merge {
-            let wc_error_info = response.body::<WriteConcernOnlyBody>()?;
-            wc_error_info.validate()?;
+            response.validate_single_write()?;
         };
 
         let description = context.connection.stream_description()?;

--- a/driver/src/operation/aggregate/change_stream.rs
+++ b/driver/src/operation/aggregate/change_stream.rs
@@ -4,12 +4,18 @@ use crate::{
         common::{ChangeStreamData, WatchArgs},
         event::ResumeToken,
     },
-    client::Retry,
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::common::CursorSpecification,
     error::Result,
-    operation::{append_options, ExecutionContext, Operation, Retryability},
-    options::{ChangeStreamOptions, ClientOptions, SelectionCriteria, WriteConcern},
+    operation::{
+        append_options,
+        ExecutionContext,
+        Operation,
+        OperationImpl,
+        Wrapped,
+        WrappedOperation,
+    },
+    options::ChangeStreamOptions,
 };
 
 use super::Aggregate;
@@ -43,12 +49,18 @@ impl ChangeStreamAggregate {
     }
 }
 
-impl Operation for ChangeStreamAggregate {
+impl WrappedOperation for ChangeStreamAggregate {
+    type Wrapped = Aggregate;
     type O = (CursorSpecification, ChangeStreamData);
-
-    const NAME: &'static crate::bson_compat::CStr = Aggregate::NAME;
-
     const ZERO_COPY: bool = true;
+
+    fn wrapped(&self) -> &Self::Wrapped {
+        &self.inner
+    }
+
+    fn wrapped_mut(&mut self) -> &mut Self::Wrapped {
+        &mut self.inner
+    }
 
     fn build(&mut self, description: &StreamDescription) -> Result<Command> {
         if let Some(data) = &mut self.resume_data {
@@ -80,13 +92,6 @@ impl Operation for ChangeStreamAggregate {
         self.inner.build(description)
     }
 
-    fn extract_at_cluster_time(
-        &self,
-        response: &crate::bson::RawDocument,
-    ) -> Result<Option<crate::bson::Timestamp>> {
-        self.inner.extract_at_cluster_time(response)
-    }
-
     fn handle_response<'a>(
         &'a self,
         response: std::borrow::Cow<'a, RawCommandResponse>,
@@ -105,7 +110,7 @@ impl Operation for ChangeStreamAggregate {
                 effective_criteria: context.effective_criteria,
             };
             let spec = {
-                use crate::operation::OperationWithDefaults;
+                use crate::operation::BaseOperation;
                 self.inner.handle_response_cow(response, inner_context)?
             };
 
@@ -133,56 +138,12 @@ impl Operation for ChangeStreamAggregate {
         .boxed()
     }
 
-    fn selection_criteria(&self) -> crate::operation::Feature<&SelectionCriteria> {
-        self.inner.selection_criteria()
-    }
-
-    fn write_concern(&self) -> crate::operation::Feature<&WriteConcern> {
-        self.inner.write_concern()
-    }
-
-    fn retryability(&self, options: &ClientOptions) -> Retryability {
-        self.inner.retryability(options)
-    }
-
-    fn is_backpressure_retryable(&self, options: &ClientOptions) -> bool {
-        self.inner.is_backpressure_retryable(options)
-    }
-
-    fn target(&self) -> crate::operation::OperationTarget {
-        self.inner.target()
-    }
-
-    fn handle_error(&self, error: crate::error::Error) -> Result<Self::O> {
-        Err(error)
-    }
-
-    fn read_concern(&self) -> crate::operation::Feature<&crate::options::ReadConcern> {
-        self.inner.read_concern()
-    }
-
-    fn supports_sessions(&self) -> bool {
-        self.inner.supports_sessions()
-    }
-
-    fn update_for_retry(&mut self, retry: Option<&Retry>) {
-        self.inner.update_for_retry(retry);
-    }
-
-    fn override_criteria(&self) -> crate::operation::OverrideCriteriaFn {
-        self.inner.override_criteria()
-    }
-
-    fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
-        self.inner.pinned_connection()
-    }
-
-    fn name(&self) -> &crate::bson_compat::CStr {
-        self.inner.name()
-    }
-
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for ChangeStreamAggregate {
+    type Kind = Wrapped;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/bulk_write.rs
+++ b/driver/src/operation/bulk_write.rs
@@ -16,8 +16,10 @@ use crate::{
     error::{BulkWriteError, Error, ErrorKind, Result},
     operation::{
         run_command::RunCommand,
+        Base,
+        BaseOperation,
         GetMore,
-        OperationWithDefaults,
+        OperationImpl,
         MAX_ENCRYPTED_WRITE_SIZE,
     },
     options::{BulkWriteOptions, ClientOptions, OperationType, WriteModel},
@@ -341,7 +343,7 @@ where
     }
 }
 
-impl<R> OperationWithDefaults for BulkWrite<'_, R>
+impl<R> BaseOperation for BulkWrite<'_, R>
 where
     R: BulkWriteResult,
 {
@@ -526,6 +528,10 @@ where
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl<R: BulkWriteResult> OperationImpl for BulkWrite<'_, R> {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/bulk_write.rs
+++ b/driver/src/operation/bulk_write.rs
@@ -11,7 +11,7 @@ use crate::{
     bson_util::{self, RawDocumentCollection},
     checked::Checked,
     client::session::TransactionState,
-    cmap::{Command, RawCommandResponse, StreamDescription},
+    cmap::{conn::WriteErrorBody, Command, RawCommandResponse, StreamDescription},
     cursor::{common::CursorSpecification, NewCursor},
     error::{BulkWriteError, Error, ErrorKind, Result},
     operation::{
@@ -31,13 +31,7 @@ use crate::{
     SessionCursor,
 };
 
-use super::{
-    ExecutionContext,
-    Retryability,
-    WriteResponseBody,
-    OP_MSG_OVERHEAD_BYTES,
-    SERVER_8_0_0_WIRE_VERSION,
-};
+use super::{ExecutionContext, Retryability, OP_MSG_OVERHEAD_BYTES, SERVER_8_0_0_WIRE_VERSION};
 
 use server_responses::*;
 
@@ -405,22 +399,23 @@ where
         mut context: ExecutionContext<'b>,
     ) -> BoxFuture<'b, Result<Self::O>> {
         async move {
-            let response: WriteResponseBody<SummaryInfo> = raw_response.body()?;
-            let n_errors: usize = Checked::new(response.body.n_errors).try_into()?;
+            let write_error: WriteErrorBody = raw_response.body()?;
+            let summary_info: SummaryInfo = raw_response.body()?;
+            let n_errors: usize = Checked::new(summary_info.n_errors).try_into()?;
 
             let mut error: BulkWriteError = Default::default();
             let mut result: R = Default::default();
 
             result.populate_summary_info(
-                response.body.n_inserted,
-                response.body.n_matched,
-                response.body.n_modified,
-                response.body.n_upserted,
-                response.body.n_deleted,
+                summary_info.n_inserted,
+                summary_info.n_matched,
+                summary_info.n_modified,
+                summary_info.n_upserted,
+                summary_info.n_deleted,
             );
 
-            if let Some(write_concern_error) = response.write_concern_error {
-                error.write_concern_errors.push(write_concern_error);
+            if let Some(write_concern_error) = write_error.write_concern_error {
+                error.write_concern_errors.push(write_concern_error.0);
             }
 
             let specification = CursorSpecification::new(
@@ -495,7 +490,7 @@ where
                     error.partial_result = Some(result.into_partial_result());
                 }
 
-                let error = Error::new(ErrorKind::BulkWrite(error), response.labels)
+                let error = Error::new(ErrorKind::BulkWrite(error), write_error.labels)
                     .with_source(iteration_result.err());
                 Err(error)
             }

--- a/driver/src/operation/commit_transaction.rs
+++ b/driver/src/operation/commit_transaction.rs
@@ -6,7 +6,7 @@ use crate::{
     client::Retry,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options_to_raw_document, OperationWithDefaults, Retryability},
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl, Retryability},
     options::{Acknowledgment, ClientOptions, TransactionOptions, WriteConcern},
     Client,
 };
@@ -27,7 +27,7 @@ impl CommitTransaction {
     }
 }
 
-impl OperationWithDefaults for CommitTransaction {
+impl BaseOperation for CommitTransaction {
     type O = ();
 
     const NAME: &'static CStr = cstr!("commitTransaction");
@@ -94,6 +94,10 @@ impl OperationWithDefaults for CommitTransaction {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for CommitTransaction {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/commit_transaction.rs
+++ b/driver/src/operation/commit_transaction.rs
@@ -11,7 +11,7 @@ use crate::{
     Client,
 };
 
-use super::{ExecutionContext, WriteConcernOnlyBody};
+use super::ExecutionContext;
 
 pub(crate) struct CommitTransaction {
     options: Option<TransactionOptions>,
@@ -47,8 +47,7 @@ impl BaseOperation for CommitTransaction {
         response: &RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.validate_single_write()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/count.rs
+++ b/driver/src/operation/count.rs
@@ -1,5 +1,6 @@
 use crate::{
     bson::rawdoc,
+    operation::{Base, OperationImpl},
     options::{ClientOptions, SelectionCriteria},
     Collection,
 };
@@ -11,7 +12,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::options::EstimatedDocumentCountOptions,
     error::{Error, Result},
-    operation::{OperationWithDefaults, Retryability},
+    operation::{BaseOperation, Retryability},
 };
 
 use super::{append_options_to_raw_document, ExecutionContext};
@@ -30,7 +31,7 @@ impl Count {
     }
 }
 
-impl OperationWithDefaults for Count {
+impl BaseOperation for Count {
     type O = u64;
 
     const NAME: &'static CStr = cstr!("count");
@@ -86,6 +87,10 @@ impl OperationWithDefaults for Count {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Count {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/count_documents.rs
+++ b/driver/src/operation/count_documents.rs
@@ -3,12 +3,11 @@ use std::convert::TryInto;
 use serde::Deserialize;
 
 use crate::{
-    bson::{doc, Document, RawDocument},
-    client::Retry,
-    cmap::{Command, RawCommandResponse, StreamDescription},
+    bson::{doc, Document},
+    cmap::RawCommandResponse,
     error::{Error, ErrorKind, Result},
-    operation::{aggregate::Aggregate, Operation},
-    options::{AggregateOptions, ClientOptions, CountOptions, SelectionCriteria},
+    operation::{aggregate::Aggregate, OperationImpl, Wrapped, WrappedOperation},
+    options::{AggregateOptions, ClientOptions, CountOptions},
 };
 
 use super::{ExecutionContext, Retryability, SingleCursorResult};
@@ -73,22 +72,17 @@ impl CountDocuments {
     }
 }
 
-impl Operation for CountDocuments {
+impl WrappedOperation for CountDocuments {
+    type Wrapped = Aggregate;
     type O = u64;
-
-    const NAME: &'static crate::bson_compat::CStr = Aggregate::NAME;
-
     const ZERO_COPY: bool = false;
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
-        self.aggregate.build(description)
+    fn wrapped(&self) -> &Self::Wrapped {
+        &self.aggregate
     }
 
-    fn extract_at_cluster_time(
-        &self,
-        response: &RawDocument,
-    ) -> Result<Option<crate::bson::Timestamp>> {
-        self.aggregate.extract_at_cluster_time(response)
+    fn wrapped_mut(&mut self) -> &mut Self::Wrapped {
+        &mut self.aggregate
     }
 
     fn handle_response<'a>(
@@ -104,10 +98,6 @@ impl Operation for CountDocuments {
         .boxed()
     }
 
-    fn selection_criteria(&self) -> super::Feature<&SelectionCriteria> {
-        self.aggregate.selection_criteria()
-    }
-
     fn retryability(&self, options: &ClientOptions) -> Retryability {
         Retryability::read(options)
     }
@@ -116,44 +106,12 @@ impl Operation for CountDocuments {
         options.retry_reads != Some(false)
     }
 
-    fn target(&self) -> super::OperationTarget {
-        self.aggregate.target()
-    }
-
-    fn read_concern(&self) -> super::Feature<&crate::options::ReadConcern> {
-        self.aggregate.read_concern()
-    }
-
-    fn handle_error(&self, error: Error) -> Result<Self::O> {
-        Err(error)
-    }
-
-    fn write_concern(&self) -> super::Feature<&crate::options::WriteConcern> {
-        self.aggregate.write_concern()
-    }
-
-    fn supports_sessions(&self) -> bool {
-        self.aggregate.supports_sessions()
-    }
-
-    fn update_for_retry(&mut self, retry: Option<&Retry>) {
-        self.aggregate.update_for_retry(retry);
-    }
-
-    fn override_criteria(&self) -> super::OverrideCriteriaFn {
-        self.aggregate.override_criteria()
-    }
-
-    fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
-        self.aggregate.pinned_connection()
-    }
-
-    fn name(&self) -> &crate::bson_compat::CStr {
-        self.aggregate.name()
-    }
-
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for CountDocuments {
+    type Kind = Wrapped;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/create.rs
+++ b/driver/src/operation/create.rs
@@ -5,7 +5,13 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options_to_raw_document, OperationWithDefaults, WriteConcernOnlyBody},
+    operation::{
+        append_options_to_raw_document,
+        Base,
+        BaseOperation,
+        OperationImpl,
+        WriteConcernOnlyBody,
+    },
     options::{CreateCollectionOptions, WriteConcern},
 };
 
@@ -26,7 +32,7 @@ impl Create {
     }
 }
 
-impl OperationWithDefaults for Create {
+impl BaseOperation for Create {
     type O = ();
 
     const NAME: &'static CStr = cstr!("create");
@@ -63,6 +69,10 @@ impl OperationWithDefaults for Create {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Create {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/create.rs
+++ b/driver/src/operation/create.rs
@@ -5,13 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::{CreateCollectionOptions, WriteConcern},
 };
 
@@ -52,8 +46,7 @@ impl BaseOperation for Create {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.validate_single_write()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/create_indexes.rs
+++ b/driver/src/operation/create_indexes.rs
@@ -7,7 +7,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{ErrorKind, Result},
     index::IndexModel,
-    operation::{append_options_to_raw_document, OperationWithDefaults},
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::{CreateIndexOptions, WriteConcern},
     results::CreateIndexesResult,
 };
@@ -35,7 +35,7 @@ impl CreateIndexes {
     }
 }
 
-impl OperationWithDefaults for CreateIndexes {
+impl BaseOperation for CreateIndexes {
     type O = CreateIndexesResult;
     const NAME: &'static CStr = cstr!("createIndexes");
 
@@ -95,6 +95,10 @@ impl OperationWithDefaults for CreateIndexes {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for CreateIndexes {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/create_indexes.rs
+++ b/driver/src/operation/create_indexes.rs
@@ -12,7 +12,7 @@ use crate::{
     results::CreateIndexesResult,
 };
 
-use super::{ExecutionContext, WriteConcernOnlyBody};
+use super::ExecutionContext;
 
 #[derive(Debug)]
 pub(crate) struct CreateIndexes {
@@ -72,8 +72,7 @@ impl BaseOperation for CreateIndexes {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()?;
+        response.validate_single_write()?;
         let index_names = self.indexes.iter().filter_map(|i| i.get_name()).collect();
         Ok(CreateIndexesResult { index_names })
     }

--- a/driver/src/operation/delete.rs
+++ b/driver/src/operation/delete.rs
@@ -4,7 +4,14 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     collation::Collation,
     error::{convert_insert_many_error, Result},
-    operation::{append_options, OperationWithDefaults, Retryability, WriteResponseBody},
+    operation::{
+        append_options,
+        Base,
+        BaseOperation,
+        OperationImpl,
+        Retryability,
+        WriteResponseBody,
+    },
     options::{ClientOptions, DeleteOptions, Hint, WriteConcern},
     results::DeleteResult,
     Collection,
@@ -40,7 +47,7 @@ impl Delete {
     }
 }
 
-impl OperationWithDefaults for Delete {
+impl BaseOperation for Delete {
     type O = DeleteResult;
 
     const NAME: &'static CStr = cstr!("delete");
@@ -111,6 +118,10 @@ impl OperationWithDefaults for Delete {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Delete {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/delete.rs
+++ b/driver/src/operation/delete.rs
@@ -3,15 +3,8 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     collation::Collation,
-    error::{convert_insert_many_error, Result},
-    operation::{
-        append_options,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        Retryability,
-        WriteResponseBody,
-    },
+    error::Result,
+    operation::{append_options, Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, DeleteOptions, Hint, WriteConcern},
     results::DeleteResult,
     Collection,
@@ -85,11 +78,9 @@ impl BaseOperation for Delete {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody = response.body()?;
-        response.validate().map_err(convert_insert_many_error)?;
-
+        response.validate_single_write()?;
         Ok(DeleteResult {
-            deleted_count: response.n,
+            deleted_count: response.extract_n()?,
         })
     }
 

--- a/driver/src/operation/distinct.rs
+++ b/driver/src/operation/distinct.rs
@@ -6,7 +6,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::options::DistinctOptions,
     error::Result,
-    operation::{OperationWithDefaults, Retryability},
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, SelectionCriteria},
     Collection,
 };
@@ -36,7 +36,7 @@ impl Distinct {
     }
 }
 
-impl OperationWithDefaults for Distinct {
+impl BaseOperation for Distinct {
     type O = Vec<Bson>;
 
     const NAME: &'static CStr = cstr!("distinct");
@@ -95,6 +95,10 @@ impl OperationWithDefaults for Distinct {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Distinct {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/drop_collection.rs
+++ b/driver/src/operation/drop_collection.rs
@@ -5,7 +5,13 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
-    operation::{append_options_to_raw_document, OperationWithDefaults, WriteConcernOnlyBody},
+    operation::{
+        append_options_to_raw_document,
+        Base,
+        BaseOperation,
+        OperationImpl,
+        WriteConcernOnlyBody,
+    },
     options::{DropCollectionOptions, WriteConcern},
 };
 
@@ -26,7 +32,7 @@ impl DropCollection {
     }
 }
 
-impl OperationWithDefaults for DropCollection {
+impl BaseOperation for DropCollection {
     type O = ();
 
     const NAME: &'static CStr = cstr!("drop");
@@ -71,6 +77,10 @@ impl OperationWithDefaults for DropCollection {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for DropCollection {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/drop_collection.rs
+++ b/driver/src/operation/drop_collection.rs
@@ -5,13 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
-    operation::{
-        append_options_to_raw_document,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::{DropCollectionOptions, WriteConcern},
 };
 
@@ -52,8 +46,7 @@ impl BaseOperation for DropCollection {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.validate_single_write()
     }
 
     fn handle_error(&self, error: Error) -> Result<Self::O> {

--- a/driver/src/operation/drop_database.rs
+++ b/driver/src/operation/drop_database.rs
@@ -5,7 +5,13 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::DropDatabaseOptions,
     error::Result,
-    operation::{append_options_to_raw_document, OperationWithDefaults, WriteConcernOnlyBody},
+    operation::{
+        append_options_to_raw_document,
+        Base,
+        BaseOperation,
+        OperationImpl,
+        WriteConcernOnlyBody,
+    },
     options::WriteConcern,
 };
 
@@ -23,7 +29,7 @@ impl DropDatabase {
     }
 }
 
-impl OperationWithDefaults for DropDatabase {
+impl BaseOperation for DropDatabase {
     type O = ();
 
     const NAME: &'static CStr = cstr!("dropDatabase");
@@ -60,6 +66,10 @@ impl OperationWithDefaults for DropDatabase {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for DropDatabase {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/drop_database.rs
+++ b/driver/src/operation/drop_database.rs
@@ -5,13 +5,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::DropDatabaseOptions,
     error::Result,
-    operation::{
-        append_options_to_raw_document,
-        Base,
-        BaseOperation,
-        OperationImpl,
-        WriteConcernOnlyBody,
-    },
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::WriteConcern,
 };
 
@@ -49,8 +43,7 @@ impl BaseOperation for DropDatabase {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteConcernOnlyBody = response.body()?;
-        response.validate()
+        response.validate_single_write()
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/drop_indexes.rs
+++ b/driver/src/operation/drop_indexes.rs
@@ -5,7 +5,7 @@ use crate::{
     bson_compat::{cstr, CStr},
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::Result,
-    operation::{append_options_to_raw_document, OperationWithDefaults},
+    operation::{append_options_to_raw_document, Base, BaseOperation, OperationImpl},
     options::{DropIndexOptions, WriteConcern},
 };
 
@@ -31,7 +31,7 @@ impl DropIndexes {
     }
 }
 
-impl OperationWithDefaults for DropIndexes {
+impl BaseOperation for DropIndexes {
     type O = ();
     const NAME: &'static CStr = cstr!("dropIndexes");
 
@@ -71,6 +71,10 @@ impl OperationWithDefaults for DropIndexes {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for DropIndexes {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/find.rs
+++ b/driver/src/operation/find.rs
@@ -4,7 +4,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::common::CursorSpecification,
     error::{Error, Result},
-    operation::{OperationWithDefaults, Retryability, SERVER_4_4_0_WIRE_VERSION},
+    operation::{Base, BaseOperation, OperationImpl, Retryability, SERVER_4_4_0_WIRE_VERSION},
     options::{ClientOptions, CursorType, FindOptions, SelectionCriteria},
     Collection,
 };
@@ -32,7 +32,7 @@ impl Find {
     }
 }
 
-impl OperationWithDefaults for Find {
+impl BaseOperation for Find {
     type O = CursorSpecification;
     const NAME: &'static CStr = cstr!("find");
     const ZERO_COPY: bool = true;
@@ -135,6 +135,10 @@ impl OperationWithDefaults for Find {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Find {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/find_and_modify.rs
+++ b/driver/src/operation/find_and_modify.rs
@@ -15,7 +15,9 @@ use crate::{
     operation::{
         append_options_to_raw_document,
         find_and_modify::options::Modification,
-        OperationWithDefaults,
+        Base,
+        BaseOperation,
+        OperationImpl,
         Retryability,
     },
     options::{ClientOptions, WriteConcern},
@@ -55,7 +57,7 @@ impl<T: DeserializeOwned> FindAndModify<T> {
     }
 }
 
-impl<T: DeserializeOwned> OperationWithDefaults for FindAndModify<T> {
+impl<T: DeserializeOwned> BaseOperation for FindAndModify<T> {
     type O = Option<T>;
     const NAME: &'static CStr = cstr!("findAndModify");
 
@@ -129,6 +131,10 @@ impl<T: DeserializeOwned> OperationWithDefaults for FindAndModify<T> {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl<T: DeserializeOwned> OperationImpl for FindAndModify<T> {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/find_and_modify.rs
+++ b/driver/src/operation/find_and_modify.rs
@@ -11,7 +11,7 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     coll::options::UpdateModifications,
-    error::{ErrorKind, Result},
+    error::{Error, ErrorKind, Result},
     operation::{
         append_options_to_raw_document,
         find_and_modify::options::Modification,
@@ -95,22 +95,20 @@ impl<T: DeserializeOwned> BaseOperation for FindAndModify<T> {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
+        response.validate_single_write()?;
         #[derive(Debug, Deserialize)]
-        pub(crate) struct Response {
+        struct Response {
+            // deserializing directly into Option<T> doesn't report an error if `value` is missing
             value: RawBson,
         }
-        let response: Response = response.body()?;
-
-        match response.value {
-            RawBson::Document(doc) => Ok(Some(deserialize_from_slice(doc.as_bytes())?)),
+        let body = response.body::<Response>()?;
+        match body.value {
+            RawBson::Document(ref doc) => Ok(Some(deserialize_from_slice(doc.as_bytes())?)),
             RawBson::Null => Ok(None),
-            other => Err(ErrorKind::InvalidResponse {
-                message: format!(
-                    "expected document for value field of findAndModify response, but instead got \
-                     {other:?}"
-                ),
-            }
-            .into()),
+            ref other => Err(Error::invalid_response(format!(
+                "expected document for value field of findAndModify response, but instead got \
+                 {other:?}",
+            ))),
         }
     }
 

--- a/driver/src/operation/get_more.rs
+++ b/driver/src/operation/get_more.rs
@@ -7,7 +7,7 @@ use crate::{
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     cursor::common::{CursorInformation, CursorReply},
     error::Result,
-    operation::OperationWithDefaults,
+    operation::{Base, BaseOperation, OperationImpl},
     options::SelectionCriteria,
     results::GetMoreResult,
     Namespace,
@@ -43,7 +43,7 @@ impl<'conn> GetMore<'conn> {
     }
 }
 
-impl OperationWithDefaults for GetMore<'_> {
+impl BaseOperation for GetMore<'_> {
     type O = GetMoreResult;
 
     const NAME: &'static CStr = cstr!("getMore");
@@ -122,6 +122,10 @@ impl OperationWithDefaults for GetMore<'_> {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for GetMore<'_> {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/insert.rs
+++ b/driver/src/operation/insert.rs
@@ -12,7 +12,7 @@ use crate::{
     checked::Checked,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{Error, ErrorKind, InsertManyError, Result},
-    operation::{OperationWithDefaults, Retryability, WriteResponseBody},
+    operation::{Base, BaseOperation, OperationImpl, Retryability, WriteResponseBody},
     options::{ClientOptions, InsertManyOptions, WriteConcern},
     results::InsertManyResult,
     Collection,
@@ -51,7 +51,7 @@ impl<'a> Insert<'a> {
     }
 }
 
-impl OperationWithDefaults for Insert<'_> {
+impl BaseOperation for Insert<'_> {
     type O = InsertManyResult;
 
     const NAME: &'static CStr = cstr!("insert");
@@ -184,6 +184,10 @@ impl OperationWithDefaults for Insert<'_> {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Insert<'_> {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/insert.rs
+++ b/driver/src/operation/insert.rs
@@ -11,8 +11,8 @@ use crate::{
     },
     checked::Checked,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    error::{Error, ErrorKind, InsertManyError, Result},
-    operation::{Base, BaseOperation, OperationImpl, Retryability, WriteResponseBody},
+    error::{ErrorKind, Result},
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, InsertManyOptions, WriteConcern},
     results::InsertManyResult,
     Collection,
@@ -133,41 +133,39 @@ impl BaseOperation for Insert<'_> {
         response: &'b RawCommandResponse,
         _context: ExecutionContext<'b>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody = response.body()?;
-        let response_n = Checked::<usize>::try_from(response.n)?;
+        let n: usize = Checked::new(response.extract_n()?).try_into()?;
+        let inserted_ids = || {
+            self.inserted_ids
+                .iter()
+                .cloned()
+                .enumerate()
+                .take(n)
+                .collect()
+        };
 
-        let mut map = HashMap::new();
-        if self.options.ordered == Some(true) {
-            // in ordered inserts, only the first n were attempted.
-            for (i, id) in self.inserted_ids.iter().enumerate().take(response_n.get()?) {
-                map.insert(i, id.clone());
-            }
-        } else {
-            // for unordered, add all the attempted ids and then remove the ones that have
-            // associated write errors.
-            for (i, id) in self.inserted_ids.iter().enumerate() {
-                map.insert(i, id.clone());
-            }
-
-            if let Some(write_errors) = response.write_errors.as_ref() {
-                for err in write_errors {
-                    map.remove(&err.index);
-                }
+        match response.validate_insert_many() {
+            Ok(()) => Ok(InsertManyResult {
+                inserted_ids: inserted_ids(),
+            }),
+            Err(mut error) => {
+                if let ErrorKind::InsertMany(ref mut insert_many_error) = *error.kind {
+                    let inserted_ids = if self.options.ordered == Some(false) {
+                        let mut all_inserted_ids: HashMap<_, _> =
+                            self.inserted_ids.iter().cloned().enumerate().collect();
+                        if let Some(ref write_errors) = insert_many_error.write_errors {
+                            for write_error in write_errors {
+                                all_inserted_ids.remove(&write_error.index);
+                            }
+                        }
+                        all_inserted_ids
+                    } else {
+                        inserted_ids()
+                    };
+                    insert_many_error.inserted_ids = inserted_ids;
+                };
+                Err(error)
             }
         }
-
-        if response.write_errors.is_some() || response.write_concern_error.is_some() {
-            return Err(Error::new(
-                ErrorKind::InsertMany(InsertManyError {
-                    write_errors: response.write_errors,
-                    write_concern_error: response.write_concern_error,
-                    inserted_ids: map,
-                }),
-                response.labels,
-            ));
-        }
-
-        Ok(InsertManyResult { inserted_ids: map })
     }
 
     fn write_concern(&self) -> super::Feature<&WriteConcern> {

--- a/driver/src/operation/list_collections.rs
+++ b/driver/src/operation/list_collections.rs
@@ -4,7 +4,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::common::CursorSpecification,
     error::Result,
-    operation::{OperationWithDefaults, Retryability},
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, ListCollectionsOptions, ReadPreference, SelectionCriteria},
     Database,
 };
@@ -32,7 +32,7 @@ impl ListCollections {
     }
 }
 
-impl OperationWithDefaults for ListCollections {
+impl BaseOperation for ListCollections {
     type O = CursorSpecification;
 
     const NAME: &'static CStr = cstr!("listCollections");
@@ -89,6 +89,10 @@ impl OperationWithDefaults for ListCollections {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for ListCollections {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/list_databases.rs
+++ b/driver/src/operation/list_databases.rs
@@ -7,7 +7,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     db::options::ListDatabasesOptions,
     error::Result,
-    operation::{OperationWithDefaults, Retryability},
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     selection_criteria::{ReadPreference, SelectionCriteria},
 };
 
@@ -30,7 +30,7 @@ impl ListDatabases {
     }
 }
 
-impl OperationWithDefaults for ListDatabases {
+impl BaseOperation for ListDatabases {
     type O = Vec<RawDocumentBuf>;
 
     const NAME: &'static CStr = cstr!("listDatabases");
@@ -69,6 +69,10 @@ impl OperationWithDefaults for ListDatabases {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for ListDatabases {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/list_indexes.rs
+++ b/driver/src/operation/list_indexes.rs
@@ -5,7 +5,7 @@ use crate::{
     cmap::{Command, RawCommandResponse, StreamDescription},
     cursor::common::CursorSpecification,
     error::Result,
-    operation::OperationWithDefaults,
+    operation::{Base, BaseOperation, OperationImpl},
     options::{ClientOptions, ListIndexesOptions},
     selection_criteria::{ReadPreference, SelectionCriteria},
     Collection,
@@ -24,7 +24,7 @@ impl ListIndexes {
     }
 }
 
-impl OperationWithDefaults for ListIndexes {
+impl BaseOperation for ListIndexes {
     type O = CursorSpecification;
 
     const NAME: &'static CStr = cstr!("listIndexes");
@@ -76,6 +76,10 @@ impl OperationWithDefaults for ListIndexes {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for ListIndexes {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/raw_output.rs
+++ b/driver/src/operation/raw_output.rs
@@ -1,11 +1,9 @@
 use futures_util::FutureExt;
 
 use crate::{
-    bson_compat::CStr,
-    client::Retry,
-    cmap::{Command, RawCommandResponse, StreamDescription},
+    cmap::RawCommandResponse,
     error::Result,
-    options::{ClientOptions, SelectionCriteria},
+    operation::{OperationImpl, Wrapped, WrappedOperation},
     BoxFuture,
 };
 
@@ -16,20 +14,17 @@ use super::{ExecutionContext, Operation};
 #[derive(Clone)]
 pub(crate) struct RawOutput<Op>(pub(crate) Op);
 
-impl<Op: Operation> Operation for RawOutput<Op> {
+impl<Op: Operation + Sync + Send> WrappedOperation for RawOutput<Op> {
+    type Wrapped = Op;
     type O = RawCommandResponse;
-    const NAME: &'static CStr = Op::NAME;
     const ZERO_COPY: bool = true;
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
-        self.0.build(description)
+    fn wrapped(&self) -> &Self::Wrapped {
+        &self.0
     }
 
-    fn extract_at_cluster_time(
-        &self,
-        response: &crate::bson::RawDocument,
-    ) -> Result<Option<crate::bson::Timestamp>> {
-        self.0.extract_at_cluster_time(response)
+    fn wrapped_mut(&mut self) -> &mut Self::Wrapped {
+        &mut self.0
     }
 
     fn handle_response<'a>(
@@ -40,60 +35,16 @@ impl<Op: Operation> Operation for RawOutput<Op> {
         async move { Ok(response.into_owned()) }.boxed()
     }
 
-    fn handle_error(&self, error: crate::error::Error) -> Result<Self::O> {
-        Err(error)
-    }
-
-    fn selection_criteria(&self) -> super::Feature<&SelectionCriteria> {
-        self.0.selection_criteria()
-    }
-
-    fn read_concern(&self) -> super::Feature<&crate::options::ReadConcern> {
-        self.0.read_concern()
-    }
-
-    fn write_concern(&self) -> super::Feature<&crate::options::WriteConcern> {
-        self.0.write_concern()
-    }
-
-    fn supports_sessions(&self) -> bool {
-        self.0.supports_sessions()
-    }
-
-    fn retryability(&self, options: &ClientOptions) -> super::Retryability {
-        self.0.retryability(options)
-    }
-
-    fn is_backpressure_retryable(&self, options: &ClientOptions) -> bool {
-        self.0.is_backpressure_retryable(options)
-    }
-
-    fn update_for_retry(&mut self, retry: Option<&Retry>) {
-        self.0.update_for_retry(retry)
-    }
-
-    fn override_criteria(&self) -> super::OverrideCriteriaFn {
-        self.0.override_criteria()
-    }
-
-    fn pinned_connection(&self) -> Option<&crate::cmap::conn::PinnedConnectionHandle> {
-        self.0.pinned_connection()
-    }
-
-    fn name(&self) -> &CStr {
-        self.0.name()
-    }
-
-    fn target(&self) -> super::OperationTarget {
-        self.0.target()
-    }
-
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
 }
 
+impl<Op> OperationImpl for RawOutput<Op> {
+    type Kind = Wrapped;
+}
+
 #[cfg(feature = "opentelemetry")]
-impl<Op: Operation> crate::otel::OtelInfo for RawOutput<Op> {
+impl<Op: Operation + Sync + Send> crate::otel::OtelInfo for RawOutput<Op> {
     fn log_name(&self) -> &str {
         self.0.otel().log_name()
     }

--- a/driver/src/operation/run_command.rs
+++ b/driver/src/operation/run_command.rs
@@ -6,12 +6,13 @@ use crate::{
     client::SESSIONS_UNSUPPORTED_COMMANDS,
     cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
     error::{Error, Result},
+    operation::{Base, OperationImpl},
     options::ClientOptions,
     selection_criteria::SelectionCriteria,
     Database,
 };
 
-use super::{ExecutionContext, OperationWithDefaults};
+use super::{BaseOperation, ExecutionContext};
 
 #[derive(Debug, Clone)]
 pub(crate) struct RunCommand<'conn> {
@@ -45,7 +46,7 @@ impl<'conn> RunCommand<'conn> {
     }
 }
 
-impl OperationWithDefaults for RunCommand<'_> {
+impl BaseOperation for RunCommand<'_> {
     type O = Document;
 
     // Since we can't actually specify a string statically here, we just put a descriptive string
@@ -116,6 +117,10 @@ impl OperationWithDefaults for RunCommand<'_> {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for RunCommand<'_> {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/run_cursor_command.rs
+++ b/driver/src/operation/run_cursor_command.rs
@@ -2,13 +2,18 @@ use futures_util::FutureExt;
 
 use crate::{
     bson_compat::{cstr, CStr},
-    client::Retry,
-    cmap::{conn::PinnedConnectionHandle, Command, RawCommandResponse, StreamDescription},
-    concern::WriteConcern,
+    cmap::RawCommandResponse,
     cursor::common::CursorSpecification,
-    error::{Error, Result},
-    operation::{run_command::RunCommand, Operation, SERVER_4_4_0_WIRE_VERSION},
-    options::{ClientOptions, RunCursorCommandOptions, SelectionCriteria},
+    error::Result,
+    operation::{
+        run_command::RunCommand,
+        Operation,
+        OperationImpl,
+        Wrapped,
+        WrappedOperation,
+        SERVER_4_4_0_WIRE_VERSION,
+    },
+    options::RunCursorCommandOptions,
     BoxFuture,
 };
 
@@ -32,70 +37,18 @@ impl<'conn> RunCursorCommand<'conn> {
     }
 }
 
-impl Operation for RunCursorCommand<'_> {
+impl<'conn> WrappedOperation for RunCursorCommand<'conn> {
+    type Wrapped = RunCommand<'conn>;
     type O = CursorSpecification;
-
     const NAME: &'static CStr = cstr!("run_cursor_command");
-
     const ZERO_COPY: bool = true;
 
-    fn build(&mut self, description: &StreamDescription) -> Result<Command> {
-        self.run_command.build(description)
+    fn wrapped(&self) -> &Self::Wrapped {
+        &self.run_command
     }
 
-    fn extract_at_cluster_time(
-        &self,
-        response: &crate::bson::RawDocument,
-    ) -> Result<Option<crate::bson::Timestamp>> {
-        self.run_command.extract_at_cluster_time(response)
-    }
-
-    fn handle_error(&self, error: Error) -> Result<Self::O> {
-        Err(error)
-    }
-
-    fn selection_criteria(&self) -> super::Feature<&SelectionCriteria> {
-        self.run_command.selection_criteria()
-    }
-
-    fn read_concern(&self) -> super::Feature<&crate::options::ReadConcern> {
-        self.run_command.read_concern()
-    }
-
-    fn write_concern(&self) -> super::Feature<&WriteConcern> {
-        self.run_command.write_concern()
-    }
-
-    fn supports_sessions(&self) -> bool {
-        self.run_command.supports_sessions()
-    }
-
-    fn retryability(&self, options: &ClientOptions) -> crate::operation::Retryability {
-        self.run_command.retryability(options)
-    }
-
-    fn is_backpressure_retryable(&self, options: &ClientOptions) -> bool {
-        self.run_command.is_backpressure_retryable(options)
-    }
-
-    fn update_for_retry(&mut self, retry: Option<&Retry>) {
-        self.run_command.update_for_retry(retry)
-    }
-
-    fn override_criteria(&self) -> super::OverrideCriteriaFn {
-        self.run_command.override_criteria()
-    }
-
-    fn pinned_connection(&self) -> Option<&PinnedConnectionHandle> {
-        self.run_command.pinned_connection()
-    }
-
-    fn name(&self) -> &CStr {
-        self.run_command.name()
-    }
-
-    fn target(&self) -> super::OperationTarget {
-        self.run_command.target()
+    fn wrapped_mut(&mut self) -> &mut Self::Wrapped {
+        &mut self.run_command
     }
 
     fn handle_response<'a>(
@@ -126,6 +79,10 @@ impl Operation for RunCursorCommand<'_> {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for RunCursorCommand<'_> {
+    type Kind = Wrapped;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/search_index.rs
+++ b/driver/src/operation/search_index.rs
@@ -10,7 +10,7 @@ use crate::{
     SearchIndexModel,
 };
 
-use super::{ExecutionContext, OperationWithDefaults};
+use super::{Base, BaseOperation, ExecutionContext, OperationImpl};
 
 #[derive(Debug)]
 pub(crate) struct CreateSearchIndexes {
@@ -24,7 +24,7 @@ impl CreateSearchIndexes {
     }
 }
 
-impl OperationWithDefaults for CreateSearchIndexes {
+impl BaseOperation for CreateSearchIndexes {
     type O = Vec<String>;
     const NAME: &'static CStr = cstr!("createSearchIndexes");
 
@@ -76,6 +76,10 @@ impl OperationWithDefaults for CreateSearchIndexes {
     type Otel = crate::otel::Witness<Self>;
 }
 
+impl OperationImpl for CreateSearchIndexes {
+    type Kind = Base;
+}
+
 #[cfg(feature = "opentelemetry")]
 impl crate::otel::OtelInfoDefaults for CreateSearchIndexes {}
 
@@ -96,7 +100,7 @@ impl UpdateSearchIndex {
     }
 }
 
-impl OperationWithDefaults for UpdateSearchIndex {
+impl BaseOperation for UpdateSearchIndex {
     type O = ();
     const NAME: &'static CStr = cstr!("updateSearchIndex");
 
@@ -135,6 +139,10 @@ impl OperationWithDefaults for UpdateSearchIndex {
     type Otel = crate::otel::Witness<Self>;
 }
 
+impl OperationImpl for UpdateSearchIndex {
+    type Kind = Base;
+}
+
 #[cfg(feature = "opentelemetry")]
 impl crate::otel::OtelInfoDefaults for UpdateSearchIndex {}
 
@@ -150,7 +158,7 @@ impl DropSearchIndex {
     }
 }
 
-impl OperationWithDefaults for DropSearchIndex {
+impl BaseOperation for DropSearchIndex {
     type O = ();
     const NAME: &'static CStr = cstr!("dropSearchIndex");
 
@@ -190,6 +198,10 @@ impl OperationWithDefaults for DropSearchIndex {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for DropSearchIndex {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/update.rs
+++ b/driver/src/operation/update.rs
@@ -8,7 +8,7 @@ use crate::{
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
     error::{convert_insert_many_error, Result},
-    operation::{OperationWithDefaults, Retryability, WriteResponseBody},
+    operation::{Base, BaseOperation, OperationImpl, Retryability, WriteResponseBody},
     options::{ClientOptions, UpdateModifications, UpdateOptions, WriteConcern},
     results::UpdateResult,
     Collection,
@@ -94,7 +94,7 @@ impl Update {
     }
 }
 
-impl OperationWithDefaults for Update {
+impl BaseOperation for Update {
     type O = UpdateResult;
 
     const NAME: &'static CStr = cstr!("update");
@@ -215,6 +215,10 @@ impl OperationWithDefaults for Update {
 
     #[cfg(feature = "opentelemetry")]
     type Otel = crate::otel::Witness<Self>;
+}
+
+impl OperationImpl for Update {
+    type Kind = Base;
 }
 
 #[cfg(feature = "opentelemetry")]

--- a/driver/src/operation/update.rs
+++ b/driver/src/operation/update.rs
@@ -7,8 +7,8 @@ use crate::{
     bson_compat::{cstr, CStr},
     bson_util,
     cmap::{Command, RawCommandResponse, StreamDescription},
-    error::{convert_insert_many_error, Result},
-    operation::{Base, BaseOperation, OperationImpl, Retryability, WriteResponseBody},
+    error::Result,
+    operation::{Base, BaseOperation, OperationImpl, Retryability},
     options::{ClientOptions, UpdateModifications, UpdateOptions, WriteConcern},
     results::UpdateResult,
     Collection,
@@ -166,8 +166,8 @@ impl BaseOperation for Update {
         response: &'a RawCommandResponse,
         _context: ExecutionContext<'a>,
     ) -> Result<Self::O> {
-        let response: WriteResponseBody<UpdateBody> = response.body()?;
-        response.validate().map_err(convert_insert_many_error)?;
+        response.validate_single_write()?;
+        let response: UpdateBody = response.body()?;
 
         let modified_count = response.n_modified;
         let upserted_id = response
@@ -177,11 +177,7 @@ impl BaseOperation for Update {
             .and_then(|doc| doc.get("_id"))
             .cloned();
 
-        let matched_count = if upserted_id.is_some() {
-            0
-        } else {
-            response.body.n
-        };
+        let matched_count = if upserted_id.is_some() { 0 } else { response.n };
 
         Ok(UpdateResult {
             matched_count,

--- a/driver/src/test/coll.rs
+++ b/driver/src/test/coll.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use crate::{
     bson::{doc, rawdoc, serde_helpers::HumanReadable, Bson, Document, RawDocumentBuf},
     bson_compat::serialize_to_document,
-    error::{ErrorKind, Result, WriteFailure},
+    error::{ErrorKind, Result, WriteFailure, RETRYABLE_WRITE_ERROR},
     options::{
         Acknowledgment,
         CollectionOptions,
@@ -32,6 +32,7 @@ use crate::{
         server_version_lt,
         topology_is_replica_set,
         topology_is_standalone,
+        util::fail_point::{FailPoint, FailPointMode},
         EventClient,
     },
     Client,
@@ -1316,4 +1317,34 @@ async fn aggregate_with_generics() {
     let lens: Vec<B> = cursor.try_collect().await.unwrap();
     let first_len: usize = lens[0].len.try_into().unwrap();
     assert_eq!(first_len, len);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn find_and_modify_write_concern_error() {
+    if server_version_lt(4, 4).await {
+        log_uncaptured(
+            "skipping find_and_modify_write_concern_error due to missing fail command error label \
+             support",
+        );
+        return;
+    }
+
+    let client = Client::for_test().use_single_mongos().await;
+
+    let coll = client
+        .database("db")
+        .collection("find_and_modify_write_concern_error");
+    coll.drop().await.unwrap();
+    coll.insert_one(doc! { "x": 1 }).await.unwrap();
+
+    let fail_point = FailPoint::fail_command(&["findAndModify"], FailPointMode::Times(2))
+        .write_concern_error(doc! { "code": 64 })
+        .error_labels(vec![RETRYABLE_WRITE_ERROR]);
+    let _guard = client.enable_fail_point(fail_point).await.unwrap();
+
+    let error = coll.find_one_and_delete(doc! { "x": 2 }).await.unwrap_err();
+    let ErrorKind::Write(WriteFailure::WriteConcernError(write_concern_error)) = *error.kind else {
+        panic!("expected write concern error, got {error}");
+    };
+    assert_eq!(write_concern_error.code, 64);
 }


### PR DESCRIPTION
da4b098 RUST-2479 Report write concern errors for `findAndModify` (#1768)
8b6d3e4 RUST-2412 Provide an operation wrapper abstraction (#1738)

The latter is needed just so the former patches cleanly.