### PR TITLE
RUST-2133 Allow custom aws credential provider

### DIFF
--- a/.evergreen/cargo-test.sh
+++ b/.evergreen/cargo-test.sh
@@ -21,14 +21,14 @@ cargo_test_options() {
     # Feature flags are set when the archive is built
     FEATURES=""
   fi
-  echo $1 ${CARGO_OPTIONS[@]} "${FEATURES}" -- ${TEST_OPTIONS[@]}
+  echo "$@" ${CARGO_OPTIONS[@]} "${FEATURES}" -- ${TEST_OPTIONS[@]}
 }
 
 cargo_test() {
   LOG_PATH=$(mktemp)
   tail -f ${LOG_PATH} &
   TAIL_PID=$!
-  LOG_UNCAPTURED=${LOG_PATH} RUST_BACKTRACE=1 cargo nextest run --profile ci $(cargo_test_options $1)
+  LOG_UNCAPTURED=${LOG_PATH} RUST_BACKTRACE=1 cargo nextest run --profile ci $(cargo_test_options "$@")
   ((CARGO_RESULT = ${CARGO_RESULT} || $?))
   if [[ -f "results.xml" ]]; then
     mv results.xml previous.xml

--- a/.evergreen/run-csfle-tests.sh
+++ b/.evergreen/run-csfle-tests.sh
@@ -26,13 +26,13 @@ PATH=${PATH}:${DRIVERS_TOOLS}/mongodb/bin
 set -o xtrace
 set +o errexit
 
-TEST_OPTIONS=("--skip" "on_demand_aws::failure")
+TEST_OPTIONS=("--skip" "on_demand_aws::failure" "--skip" "custom_aws_credentials")
 cargo_test test::csfle
 
-# Unset variables for on-demand credential failure tests.
+# Unset variables for credential failure tests.
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
 TEST_OPTIONS=()
-cargo_test on_demand_aws::failure
+cargo_test on_demand_aws::failure custom_aws_credentials
 
 exit ${CARGO_RESULT}

--- a/driver/src/client/auth.rs
+++ b/driver/src/client/auth.rs
@@ -509,6 +509,13 @@ pub struct Credential {
     #[derive_where(skip)]
     #[builder(default)]
     pub oidc_callback: oidc::Callback,
+
+    /// A custom AWS credential provider.
+    #[cfg(feature = "aws-auth")]
+    #[serde(skip)]
+    #[derive_where(skip)]
+    #[builder(default)]
+    pub aws_credential_provider: Option<aws_credential_types::provider::SharedCredentialsProvider>,
 }
 
 impl Credential {

--- a/driver/src/client/auth/aws.rs
+++ b/driver/src/client/auth/aws.rs
@@ -108,19 +108,15 @@ pub(super) const AWS_SESSION_TOKEN: &str = "AWS_SESSION_TOKEN";
 
 // Find credentials using MongoDB URI or AWS SDK
 pub(crate) async fn get_aws_credentials(credential: &Credential) -> Result<Credentials> {
-    if let (Some(access_key), Some(secret_key)) = (&credential.username, &credential.password) {
+    if let Some(provider) = &credential.aws_credential_provider {
+        // If a custom credential provider is given, always use that first
+        provider
+            .provide_credentials()
+            .await
+            .map_err(|e| Error::authentication_error(MECH_NAME, &format!("{e}")))
+    } else if let Some(creds) = get_aws_credentials_from_uri(credential) {
         // Look for credentials in the MongoDB URI
-        Ok(Credentials::new(
-            access_key.clone(),
-            secret_key.clone(),
-            credential
-                .mechanism_properties
-                .as_ref()
-                .and_then(|mp| mp.get_str(AWS_SESSION_TOKEN).ok())
-                .map(str::to_owned),
-            None,
-            "MongoDB URI",
-        ))
+        Ok(creds)
     } else {
         // If credentials are not provided in the URI, use the AWS SDK to load
         let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
@@ -136,6 +132,23 @@ pub(crate) async fn get_aws_credentials(credential: &Credential) -> Result<Crede
             })?;
         Ok(creds)
     }
+}
+
+pub(crate) fn get_aws_credentials_from_uri(credential: &Credential) -> Option<Credentials> {
+    let (Some(access_key), Some(secret_key)) = (&credential.username, &credential.password) else {
+        return None;
+    };
+    Some(Credentials::new(
+        access_key.clone(),
+        secret_key.clone(),
+        credential
+            .mechanism_properties
+            .as_ref()
+            .and_then(|mp| mp.get_str(AWS_SESSION_TOKEN).ok())
+            .map(str::to_owned),
+        None,
+        "MongoDB URI",
+    ))
 }
 
 pub fn compute_aws_sigv4_payload(

--- a/driver/src/client/csfle.rs
+++ b/driver/src/client/csfle.rs
@@ -48,6 +48,8 @@ impl ClientState {
     const MONGOCRYPTD_SERVER_SELECTION_TIMEOUT: Duration = Duration::from_millis(10_000);
 
     pub(super) async fn new(client: &Client, opts: AutoEncryptionOptions) -> Result<Self> {
+        opts.kms_providers
+            .validate_credential_providers(&opts.credential_providers)?;
         let crypt = Self::make_crypt(&opts)?;
         let mongocryptd_opts = Self::make_mongocryptd_opts(&opts, &crypt)?;
         let aux_clients = Self::make_aux_clients(client, &opts)?;
@@ -77,6 +79,7 @@ impl ClientState {
             #[cfg(not(feature = "socks5-proxy"))]
             None,
             opts.kms_connect_callback.clone(),
+            opts.credential_providers.clone(),
         )
         .await?;
 

--- a/driver/src/client/csfle/client_builder.rs
+++ b/driver/src/client/csfle/client_builder.rs
@@ -1,6 +1,12 @@
 use std::time::Duration;
 
-use crate::{bson::Document, error::Result, options::ClientOptions, Client};
+use crate::{
+    bson::Document,
+    client::csfle::options::CredentialProviders,
+    error::Result,
+    options::ClientOptions,
+    Client,
+};
 
 use super::{client_encryption::KmsConnectCallback, options::AutoEncryptionOptions};
 
@@ -112,6 +118,15 @@ impl EncryptedClientBuilder {
     /// [`KmsConnectCallback`] for more details.
     pub fn kms_connect_callback(mut self, callback: impl Into<Option<KmsConnectCallback>>) -> Self {
         self.enc_opts.kms_connect_callback = callback.into();
+        self
+    }
+
+    /// Specify custom credential providers.
+    pub fn credential_providers(
+        mut self,
+        providers: impl Into<Option<CredentialProviders>>,
+    ) -> Self {
+        self.enc_opts.credential_providers = providers.into();
         self
     }
 

--- a/driver/src/client/csfle/client_encryption.rs
+++ b/driver/src/client/csfle/client_encryption.rs
@@ -28,7 +28,7 @@ use crate::{
 
 use super::{options::KmsProviders, state_machine::CryptExecutor};
 
-pub use super::client_builder::EncryptedClientBuilder;
+pub use super::{client_builder::EncryptedClientBuilder, options::CredentialProviders};
 pub use crate::action::csfle::encrypt::{
     EncryptKey,
     PrefixOptions,
@@ -112,6 +112,7 @@ impl ClientEncryption {
             kms_providers: kms_providers.into_iter().collect(),
             key_cache_expiration: None,
             kms_connect_callback: None,
+            credential_providers: None,
         }
     }
 
@@ -223,6 +224,7 @@ pub struct ClientEncryptionBuilder {
     kms_providers: Vec<(KmsProvider, crate::bson::Document, Option<TlsOptions>)>,
     key_cache_expiration: Option<Duration>,
     kms_connect_callback: Option<KmsConnectCallback>,
+    credential_providers: Option<CredentialProviders>,
 }
 
 impl ClientEncryptionBuilder {
@@ -240,9 +242,19 @@ impl ClientEncryptionBuilder {
         self
     }
 
+    /// Specify custom credential providers.
+    pub fn credential_providers(
+        mut self,
+        providers: impl Into<Option<CredentialProviders>>,
+    ) -> Self {
+        self.credential_providers = providers.into();
+        self
+    }
+
     /// Build the [`ClientEncryption`].
     pub fn build(self) -> Result<ClientEncryption> {
         let kms_providers = KmsProviders::new(self.kms_providers)?;
+        kms_providers.validate_credential_providers(&self.credential_providers)?;
 
         let mut crypt_builder = Crypt::builder()
             .kms_providers(&kms_providers.credentials_doc()?)?
@@ -266,6 +278,7 @@ impl ClientEncryptionBuilder {
             self.key_vault_namespace.clone(),
             kms_providers,
             self.kms_connect_callback,
+            self.credential_providers,
         )?;
         let key_vault = self
             .key_vault_client

--- a/driver/src/client/csfle/options.rs
+++ b/driver/src/client/csfle/options.rs
@@ -72,6 +72,8 @@ pub(crate) struct AutoEncryptionOptions {
     pub(crate) key_cache_expiration: Option<Duration>,
     #[serde(skip)]
     pub(crate) kms_connect_callback: Option<KmsConnectCallback>,
+    #[serde(skip)]
+    pub(crate) credential_providers: Option<CredentialProviders>,
 }
 
 fn default_key_vault_namespace() -> Namespace {
@@ -96,6 +98,7 @@ impl AutoEncryptionOptions {
             disable_crypt_shared: None,
             key_cache_expiration: None,
             kms_connect_callback: None,
+            credential_providers: None,
         }
     }
 }
@@ -145,6 +148,32 @@ impl KmsProviders {
 
     pub(crate) fn credentials(&self) -> &HashMap<KmsProvider, Document> {
         &self.credentials
+    }
+
+    pub(crate) fn validate_credential_providers(
+        &self,
+        credential_providers: &Option<CredentialProviders>,
+    ) -> Result<()> {
+        let Some(credential_providers) = credential_providers else {
+            return Ok(());
+        };
+        #[cfg(feature = "aws-auth")]
+        if credential_providers.aws.is_some() {
+            self.validate_on_demand(&KmsProvider::aws())?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "aws-auth")]
+    fn validate_on_demand(&self, provider: &KmsProvider) -> Result<()> {
+        if self.credentials.get(provider).is_none_or(|c| !c.is_empty()) {
+            return Err(Error::invalid_argument(format!(
+                "a custom {} credential provider requires the corresponding KMS provider to be \
+                 configured with an empty credentials document",
+                provider.as_string(),
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -216,3 +245,12 @@ pub(crate) const EO_MONGOCRYPTD_SPAWN_ARGS: ExtraOptionArray =
     ExtraOptionArray("mongocryptdSpawnArgs");
 pub(crate) const EO_CRYPT_SHARED_LIB_PATH: ExtraOptionStr = ExtraOptionStr("cryptSharedLibPath");
 pub(crate) const EO_CRYPT_SHARED_REQUIRED: ExtraOptionBool = ExtraOptionBool("cryptSharedRequired");
+
+/// Custom credential providers.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct CredentialProviders {
+    /// Credential provider for MONGODB-AWS.
+    #[cfg(feature = "aws-auth")]
+    pub aws: Option<aws_credential_types::provider::SharedCredentialsProvider>,
+}

--- a/driver/src/client/csfle/options.rs
+++ b/driver/src/client/csfle/options.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use crate::bson::Array;
 use mongocrypt::ctx::KmsProvider;
 use serde::Deserialize;
+use typed_builder::TypedBuilder;
 
 use crate::{
     bson::{Bson, Document},
@@ -247,7 +248,7 @@ pub(crate) const EO_CRYPT_SHARED_LIB_PATH: ExtraOptionStr = ExtraOptionStr("cryp
 pub(crate) const EO_CRYPT_SHARED_REQUIRED: ExtraOptionBool = ExtraOptionBool("cryptSharedRequired");
 
 /// Custom credential providers.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, TypedBuilder)]
 #[non_exhaustive]
 pub struct CredentialProviders {
     /// Credential provider for MONGODB-AWS.

--- a/driver/src/client/csfle/state_machine.rs
+++ b/driver/src/client/csfle/state_machine.rs
@@ -15,7 +15,7 @@ use tokio::{
 
 use crate::{
     bson::{rawdoc, Document, RawDocument, RawDocumentBuf},
-    client::{options::ServerAddress, WeakClient},
+    client::{csfle::options::CredentialProviders, options::ServerAddress, WeakClient},
     error::{Error, Result},
     operation::{raw_output::RawOutput, run_command::RunCommand},
     options::{ReadConcern, Socks5Proxy},
@@ -42,6 +42,7 @@ pub(crate) struct CryptExecutor {
     azure: azure::ExecutorState,
     proxy: Option<Socks5Proxy>,
     kms_connect_callback: Option<KmsConnectCallback>,
+    credential_providers: Option<CredentialProviders>,
 }
 
 impl CryptExecutor {
@@ -50,6 +51,7 @@ impl CryptExecutor {
         key_vault_namespace: Namespace,
         kms_providers: KmsProviders,
         kms_connect_callback: Option<KmsConnectCallback>,
+        credential_providers: Option<CredentialProviders>,
     ) -> Result<Self> {
         // TODO RUST-1492: Replace num_cpus with std::thread::available_parallelism.
         let crypto_threads = rayon::ThreadPoolBuilder::new()
@@ -68,6 +70,7 @@ impl CryptExecutor {
             azure: azure::ExecutorState::new()?,
             proxy: None,
             kms_connect_callback,
+            credential_providers,
         })
     }
 
@@ -81,6 +84,7 @@ impl CryptExecutor {
         metadata_client: Option<WeakClient>,
         proxy: Option<Socks5Proxy>,
         kms_connect_callback: Option<KmsConnectCallback>,
+        credential_providers: Option<CredentialProviders>,
     ) -> Result<Self> {
         let mongocryptd = match mongocryptd_opts {
             Some(opts) => Some(Mongocryptd::new(opts).await?),
@@ -91,6 +95,7 @@ impl CryptExecutor {
             key_vault_namespace,
             kms_providers,
             kms_connect_callback,
+            credential_providers,
         )?;
         exec.mongocryptd = mongocryptd;
         exec.mongocryptd_client = mongocryptd_client;
@@ -306,8 +311,16 @@ impl CryptExecutor {
                                         Credential,
                                     };
 
-                                    let aws_creds =
-                                        get_aws_credentials(&Credential::default()).await?;
+                                    let mut credential = Credential::default();
+                                    if let Some(custom) = self
+                                        .credential_providers
+                                        .as_ref()
+                                        .and_then(|p| p.aws.as_ref())
+                                    {
+                                        credential.aws_credential_provider = Some(custom.clone());
+                                    }
+
+                                    let aws_creds = get_aws_credentials(&credential).await?;
 
                                     let mut creds = rawdoc! {
                                         "accessKeyId": aws_creds.access_key_id().to_string(),

--- a/driver/src/test/auth/aws.rs
+++ b/driver/src/test/auth/aws.rs
@@ -1,5 +1,12 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use aws_config::BehaviorVersion;
+use aws_credential_types::provider::{ProvideCredentials, SharedCredentialsProvider};
+
 use crate::{
     bson::{doc, Document},
+    options::{aws::get_aws_credentials_from_uri, Credential},
+    test::get_client_options,
     Client,
 };
 
@@ -9,4 +16,49 @@ async fn auth_aws() {
     let coll = client.database("aws").collection::<Document>("somecoll");
 
     coll.find_one(doc! {}).await.unwrap();
+}
+
+static CUSTOM_CALLED: AtomicBool = AtomicBool::new(false);
+
+#[tokio::test]
+async fn auth_aws_custom() {
+    let mut options = get_client_options().await.clone();
+    let credential = options.credential.get_or_insert(Credential::default());
+    let tracking = TrackingCredentialProvider::new(credential).await;
+    credential.aws_credential_provider = Some(SharedCredentialsProvider::new(tracking));
+    let client = Client::for_test().options(options).await;
+
+    let coll = client.database("aws").collection::<Document>("somecoll");
+    coll.find_one(doc! {}).await.unwrap();
+
+    assert!(CUSTOM_CALLED.load(Ordering::SeqCst));
+}
+
+#[derive(Debug)]
+struct TrackingCredentialProvider(SharedCredentialsProvider);
+
+impl TrackingCredentialProvider {
+    async fn new(cred: &Credential) -> Self {
+        let inner = if let Some(creds) = get_aws_credentials_from_uri(cred) {
+            SharedCredentialsProvider::new(creds)
+        } else {
+            aws_config::load_defaults(BehaviorVersion::latest())
+                .await
+                .credentials_provider()
+                .unwrap()
+        };
+        Self(inner)
+    }
+}
+
+impl ProvideCredentials for TrackingCredentialProvider {
+    fn provide_credentials<'a>(
+        &'a self,
+    ) -> aws_credential_types::provider::future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        CUSTOM_CALLED.store(true, Ordering::SeqCst);
+        self.0.provide_credentials()
+    }
 }

--- a/driver/src/test/csfle/prose.rs
+++ b/driver/src/test/csfle/prose.rs
@@ -2461,6 +2461,105 @@ mod lookup {
     }
 }
 
+// Prose test 26. Custom AWS Credentials
+mod custom_aws_credentials {
+    use aws_credential_types::{
+        provider::{
+            future::ProvideCredentials as ProvideCredentialsFuture,
+            ProvideCredentials,
+            SharedCredentialsProvider,
+        },
+        Credentials,
+    };
+    use mongocrypt::ctx::KmsProvider;
+
+    use crate::{
+        client::csfle::options::CredentialProviders,
+        test::csfle_skip_local::{FLE_AWS_KEY, FLE_AWS_SECRET},
+    };
+
+    use super::*;
+
+    // Case 1: ClientEncryption with credentialProviders and incorrect kmsProviders
+    #[tokio::test]
+    async fn case_1() {
+        let setup_client = Client::for_test().await;
+        let ce = ClientEncryption::builder(
+            setup_client.into_client(),
+            KV_NAMESPACE.clone(),
+            [AWS_KMS.clone()],
+        )
+        .credential_providers(CredentialProviders {
+            aws: Some(default_aws_provider().await),
+        })
+        .build();
+        assert!(ce.is_err());
+    }
+
+    static PROVIDER_CALLED: AtomicBool = AtomicBool::new(false);
+
+    // Case 2: ClientEncryption with credentialProviders works
+    #[tokio::test]
+    async fn case_2() {
+        let setup_client = Client::for_test().await;
+        let ce = ClientEncryption::builder(
+            setup_client.into_client(),
+            KV_NAMESPACE.clone(),
+            [(KmsProvider::aws(), doc! {}, None)],
+        )
+        .credential_providers(CredentialProviders {
+            aws: Some(SharedCredentialsProvider::new(ValidProvider)),
+        })
+        .build()
+        .unwrap();
+        ce.create_data_key(AWS_MASTER_KEY.clone()).await.unwrap();
+        assert!(PROVIDER_CALLED.load(Ordering::SeqCst));
+    }
+
+    // Case 3: AutoEncryptionOpts with credentialProviders and incorrect kmsProviders
+    #[tokio::test]
+    async fn case_3() {
+        let client = Client::encrypted_builder(
+            get_client_options().await.clone(),
+            KV_NAMESPACE.clone(),
+            [AWS_KMS.clone()],
+        )
+        .unwrap()
+        .credential_providers(CredentialProviders {
+            aws: Some(default_aws_provider().await),
+        })
+        .build()
+        .await;
+        assert!(client.is_err());
+    }
+
+    async fn default_aws_provider() -> SharedCredentialsProvider {
+        aws_config::load_defaults(aws_config::BehaviorVersion::latest())
+            .await
+            .credentials_provider()
+            .unwrap()
+    }
+
+    #[derive(Debug)]
+    struct ValidProvider;
+
+    impl ProvideCredentials for ValidProvider {
+        fn provide_credentials<'a>(&'a self) -> ProvideCredentialsFuture<'a>
+        where
+            Self: 'a,
+        {
+            PROVIDER_CALLED.store(true, Ordering::SeqCst);
+            ProvideCredentialsFuture::ready(Ok(Credentials::new(
+                FLE_AWS_KEY.clone(),
+                FLE_AWS_SECRET.clone(),
+                None,
+                None,
+                "MongoDB URI",
+            )))
+        }
+    }
+}
+
 // FLE 2.0 Documentation Example
 #[tokio::test]
 async fn fle2_example() -> Result<()> {

--- a/driver/src/test/spec/auth.rs
+++ b/driver/src/test/spec/auth.rs
@@ -33,6 +33,7 @@ impl From<TestCredential> for Credential {
                 .and_then(|s| AuthMechanism::from_str(s.as_str()).ok()),
             mechanism_properties: test_credential.mechanism_properties,
             oidc_callback: crate::client::auth::oidc::Callback::new(),
+            aws_credential_provider: None,
         }
     }
 }

--- a/driver/src/test/spec/auth.rs
+++ b/driver/src/test/spec/auth.rs
@@ -33,6 +33,7 @@ impl From<TestCredential> for Credential {
                 .and_then(|s| AuthMechanism::from_str(s.as_str()).ok()),
             mechanism_properties: test_credential.mechanism_properties,
             oidc_callback: crate::client::auth::oidc::Callback::new(),
+            #[cfg(feature = "aws-auth")]
             aws_credential_provider: None,
         }
     }

--- a/driver/src/test/spec/unified_runner/test_runner.rs
+++ b/driver/src/test/spec/unified_runner/test_runner.rs
@@ -530,6 +530,7 @@ impl TestRunner {
                             disable_crypt_shared: None,
                             key_cache_expiration: opts.key_cache_expiration,
                             kms_connect_callback: None,
+                            credential_providers: None,
                         };
                         entity
                             .client()


### PR DESCRIPTION
RUST-2133 / RUST-2249

This adds `aws_credential_provider` to `Credential`; while the spec says it should be in `mechanism_properties` that's just a `Document`, and there's precedent for callbacks in `Credential` in the form of `oidc_callback`.

The new prose test validates both that authentication via the custom provider succeeds and that it's used preferentially over any other mechanism; [passing run](https://spruce.corp.mongodb.com/version/6a955dfc00536f000714381f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).