### PR TITLE
minor: sanity checks

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -64,6 +64,15 @@ buildvariants:
       - name: compile-on-latest
       - name: compile-on-msrv
 
+  - name: sanity
+    display_name: "Sanity"
+    run_on:
+      - rhel8-latest-small
+    expansions:
+      LIBMONGOCRYPT: true
+    tasks:
+      - name: .sanity
+
   - name: lint
     display_name: "Lint"
     run_on:
@@ -72,13 +81,6 @@ buildvariants:
       LIBMONGOCRYPT: true
     tasks:
       - name: .lint
-
-  - name: cargo-deny
-    display_name: "Cargo Deny"
-    run_on:
-      - rhel8-latest-small
-    tasks:
-      - name: check-cargo-deny
 
   - name: rhel-8
     display_name: "RHEL 8"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,7 +67,7 @@ buildvariants:
   - name: sanity
     display_name: "Sanity"
     run_on:
-      - rhel8-latest-small
+      - ubuntu2404-small
     expansions:
       LIBMONGOCRYPT: true
     tasks:

--- a/.evergreen/configs/checks.yml
+++ b/.evergreen/configs/checks.yml
@@ -10,7 +10,54 @@ tasks:
           # Our minimum supported Rust version. This should be updated whenever the MSRV is bumped.
           RUST_VERSION: 1.88.0
 
+  - name: check-semgrep
+    tags: [sanity]
+    commands:
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - PROJECT_DIRECTORY
+            - MONGOCRYPT_LIB_DIR
+          binary: bash
+          args:
+            - .evergreen/check-semgrep.sh
+
+  - name: check-rustdoc
+    tags: [sanity]
+    commands:
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env:
+            - PROJECT_DIRECTORY
+            - MONGOCRYPT_LIB_DIR
+            - LD_LIBRARY_PATH
+          binary: bash
+          args: [.evergreen/check-rustdoc.sh]
+
+  - name: test-rustdoc
+    tags: [sanity]
+    commands:
+      - func: "install libmongocrypt"
+      - command: subprocess.exec
+        type: test
+        params:
+          working_dir: src
+          include_expansions_in_env:
+            - DRIVERS_TOOLS
+            - PROJECT_DIRECTORY
+            - MONGOCRYPT_LIB_DIR
+            - LD_LIBRARY_PATH
+          binary: bash
+          args:
+            - .evergreen/run-rustdoc-tests.sh
+
   - name: check-cargo-deny
+    tags: [lint]
     commands:
       - command: subprocess.exec
         type: test
@@ -41,52 +88,6 @@ tasks:
           include_expansions_in_env: [PROJECT_DIRECTORY]
           binary: bash
           script: [.evergreen/check-clippy.sh]
-
-  - name: check-semgrep
-    tags: [lint]
-    commands:
-      - command: subprocess.exec
-        type: test
-        params:
-          working_dir: src
-          include_expansions_in_env:
-            - DRIVERS_TOOLS
-            - PROJECT_DIRECTORY
-            - MONGOCRYPT_LIB_DIR
-          binary: bash
-          args:
-            - .evergreen/check-semgrep.sh
-
-  - name: check-rustdoc
-    tags: [lint]
-    commands:
-      - command: subprocess.exec
-        type: test
-        params:
-          working_dir: src
-          include_expansions_in_env:
-            - PROJECT_DIRECTORY
-            - MONGOCRYPT_LIB_DIR
-            - LD_LIBRARY_PATH
-          binary: bash
-          args: [.evergreen/check-rustdoc.sh]
-
-  - name: test-rustdoc
-    tags: [lint]
-    commands:
-      - func: "install libmongocrypt"
-      - command: subprocess.exec
-        type: test
-        params:
-          working_dir: src
-          include_expansions_in_env:
-            - DRIVERS_TOOLS
-            - PROJECT_DIRECTORY
-            - MONGOCRYPT_LIB_DIR
-            - LD_LIBRARY_PATH
-          binary: bash
-          args:
-            - .evergreen/run-rustdoc-tests.sh
 
 functions:
   "compile only":


### PR DESCRIPTION
This splits out a subset of our current `lint` checks into a new `sanity` tag; the idea is to have the sanity checks be the ones required for a submit rather than the whole lint set.

Motivating incident: a recent update changed comment line flowing in rustfmt, causing a blocking failure.  With that kind of external change possible, we shouldn't gate our processes on it.