### PR TITLE
RUST-2491 Fix libmongocrypt unversioned install and failing tests

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -51,16 +51,16 @@ for arg; do
     mkdir ${PROJECT_DIRECTORY}/libmongocrypt
     cd ${PROJECT_DIRECTORY}/libmongocrypt
 
-    #LIBMONGOCRYPT_TAG="1.20.0"
-    #git clone https://github.com/mongodb/libmongocrypt --depth=1 --branch $LIBMONGOCRYPT_TAG
+    LIBMONGOCRYPT_TAG="1.20.3"
+    git clone https://github.com/mongodb/libmongocrypt --depth=1 --branch $LIBMONGOCRYPT_TAG
 
-    mkdir libmongocrypt
-    pushd libmongocrypt
-    git init
-    git remote add origin https://github.com/mongodb/libmongocrypt
-    git fetch origin c2f80a7153da3537fe32916eef8ff1d4cc08bc67 --depth=1
-    git reset --hard FETCH_HEAD
-    popd
+    #mkdir libmongocrypt
+    #pushd libmongocrypt
+    #git init
+    #git remote add origin https://github.com/mongodb/libmongocrypt
+    #git fetch origin c2f80a7153da3537fe32916eef8ff1d4cc08bc67 --depth=1
+    #git reset --hard FETCH_HEAD
+    #popd
 
     ./libmongocrypt/.evergreen/compile.sh
   elif [ $arg == "cargo-lambda" ]; then

--- a/driver/src/db/action/create_collection.rs
+++ b/driver/src/db/action/create_collection.rs
@@ -120,6 +120,7 @@ impl Database {
         }
         for ns in crate::client::csfle::aux_collections(base_ns, enc_fields)? {
             let mut sub_opts = opts.clone();
+            sub_opts.encrypted_fields = None;
             sub_opts.clustered_index = Some(crate::db::options::ClusteredIndex {
                 key: doc! { "_id": 1 },
                 unique: true,

--- a/driver/src/test/csfle.rs
+++ b/driver/src/test/csfle.rs
@@ -396,3 +396,8 @@ pub(crate) fn fill_kms_placeholders(
 
     kms_providers
 }
+
+#[test]
+fn version_is_nonzero() {
+    assert_ne!(mongocrypt::version(), "0.0.0");
+}

--- a/driver/src/test/csfle/prose.rs
+++ b/driver/src/test/csfle/prose.rs
@@ -2824,7 +2824,7 @@ mod text_indexes_explicit_encryption {
                 .substring(
                     SubstringOptions::builder()
                         .max_string_length(10)
-                        .max_query_length(10)
+                        .max_query_length(6)
                         .min_query_length(2)
                         .build(),
                 )
@@ -2968,7 +2968,7 @@ mod text_indexes_explicit_encryption {
             .substring(
                 SubstringOptions::builder()
                     .max_string_length(10)
-                    .max_query_length(10)
+                    .max_query_length(6)
                     .min_query_length(2)
                     .build(),
             )


### PR DESCRIPTION
RUST-2491

There's a tagged release new enough that we can go back to using that.  I left the untagged fetch present but commented out in case it's ever needed again.