### PR TITLE
RUST-2492 Check for inherited unacknowledged write concerns

### DIFF
--- a/driver/src/client/executor.rs
+++ b/driver/src/client/executor.rs
@@ -345,19 +345,18 @@ impl Client {
             }
         }
 
-        if let Feature::Set(wc) = op.write_concern() {
-            // TODO RUST-9: remove this validation
-            if !wc.is_acknowledged() {
+        let op_target = op.target();
+
+        if let Some(write_concern) = op.write_concern().as_option(&op_target) {
+            if !write_concern.is_acknowledged() {
                 return Err(ErrorKind::InvalidArgument {
                     message: "Unacknowledged write concerns are not supported".to_string(),
                 }
                 .into());
             }
-
-            wc.validate()?;
+            write_concern.validate()?;
         }
 
-        let op_target = op.target();
         let selection_criteria = match op.selection_criteria() {
             Feature::Set(s) => Some(s),
             Feature::NotSupported => None,
@@ -490,11 +489,7 @@ impl Client {
                 return Err(ErrorKind::SessionsNotSupported.into());
             }
 
-            if connection.supports_sessions()
-                && !session.is_set()
-                && op.supports_sessions()
-                && op.write_concern().is_acknowledged()
-            {
+            if connection.supports_sessions() && !session.is_set() && op.supports_sessions() {
                 session.set_implicit(ClientSession::new(self.clone(), None, true).await);
             }
 
@@ -786,9 +781,7 @@ impl Client {
         );
 
         match session {
-            Some(ref mut session)
-                if op.supports_sessions() && op.write_concern().is_acknowledged() =>
-            {
+            Some(ref mut session) if op.supports_sessions() => {
                 cmd.set_session(session);
                 if let Some(txn_number) = txn_number {
                     cmd.set_txn_number(txn_number);
@@ -866,15 +859,6 @@ impl Client {
             Some(ref session) if !op.supports_sessions() && !session.is_implicit() => {
                 return Err(ErrorKind::InvalidArgument {
                     message: format!("{} does not support sessions", cmd.name),
-                }
-                .into());
-            }
-            Some(ref session)
-                if !op.write_concern().is_acknowledged() && !session.is_implicit() =>
-            {
-                return Err(ErrorKind::InvalidArgument {
-                    message: "Cannot use ClientSessions with unacknowledged write concern"
-                        .to_string(),
                 }
                 .into());
             }
@@ -1193,15 +1177,6 @@ impl Error {
             {
                 session.unpin();
             }
-        }
-    }
-}
-
-impl Feature<&crate::options::WriteConcern> {
-    fn is_acknowledged(&self) -> bool {
-        match self {
-            Feature::Set(wc) => wc.is_acknowledged(),
-            _ => true,
         }
     }
 }

--- a/driver/src/client/executor.rs
+++ b/driver/src/client/executor.rs
@@ -347,7 +347,12 @@ impl Client {
 
         let op_target = op.target();
 
-        if let Some(write_concern) = op.write_concern().as_option(&op_target) {
+        let write_concern = match op.write_concern() {
+            Feature::Set(write_concern) => Some(write_concern),
+            Feature::Inherit if !session.in_transaction() => op_target.write_concern(),
+            _ => None,
+        };
+        if let Some(write_concern) = write_concern {
             if !write_concern.is_acknowledged() {
                 return Err(ErrorKind::InvalidArgument {
                     message: "Unacknowledged write concerns are not supported".to_string(),

--- a/driver/src/cmap/conn/command.rs
+++ b/driver/src/cmap/conn/command.rs
@@ -18,7 +18,7 @@ use crate::{
         WriteFailure,
     },
     hello::{HelloCommandResponse, HelloReply},
-    operation::{CommandErrorBody, CommandResponse, Feature, Operation},
+    operation::{CommandErrorBody, CommandResponse, Operation},
     options::{ReadConcernInternal, ReadConcernLevel, ServerAddress, WriteConcern},
     selection_criteria::ReadPreference,
     ClientSession,
@@ -102,19 +102,8 @@ impl Command {
 
     pub(crate) fn from_operation<Op: Operation>(op: &Op, body: RawDocumentBuf) -> Self {
         let target = op.target();
-        let read_concern = match op.read_concern() {
-            Feature::Set(v) => Some(v),
-            Feature::NotSupported => None,
-            Feature::Inherit => target.read_concern(),
-        }
-        .cloned()
-        .map(ReadConcernInternal::from);
-        let write_concern = match op.write_concern() {
-            Feature::Set(v) => Some(v),
-            Feature::NotSupported => None,
-            Feature::Inherit => target.write_concern(),
-        }
-        .cloned();
+        let read_concern = op.read_concern().as_internal_option(&target);
+        let write_concern = op.write_concern().as_option(&target).cloned();
         Self {
             name: crate::bson_compat::cstr_to_str(op.name()).to_owned(),
             target_db: target.db_name().to_owned(),

--- a/driver/src/cmap/conn/command.rs
+++ b/driver/src/cmap/conn/command.rs
@@ -18,7 +18,7 @@ use crate::{
         WriteFailure,
     },
     hello::{HelloCommandResponse, HelloReply},
-    operation::{CommandErrorBody, CommandResponse, Operation},
+    operation::{CommandErrorBody, CommandResponse, Feature, Operation},
     options::{ReadConcernInternal, ReadConcernLevel, ServerAddress, WriteConcern},
     selection_criteria::ReadPreference,
     ClientSession,
@@ -102,8 +102,19 @@ impl Command {
 
     pub(crate) fn from_operation<Op: Operation>(op: &Op, body: RawDocumentBuf) -> Self {
         let target = op.target();
-        let read_concern = op.read_concern().as_internal_option(&target);
-        let write_concern = op.write_concern().as_option(&target).cloned();
+        let read_concern = match op.read_concern() {
+            Feature::Set(v) => Some(v),
+            Feature::NotSupported => None,
+            Feature::Inherit => target.read_concern(),
+        }
+        .cloned()
+        .map(ReadConcernInternal::from);
+        let write_concern = match op.write_concern() {
+            Feature::Set(v) => Some(v),
+            Feature::NotSupported => None,
+            Feature::Inherit => target.write_concern(),
+        }
+        .cloned();
         Self {
             name: crate::bson_compat::cstr_to_str(op.name()).to_owned(),
             target_db: target.db_name().to_owned(),

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -43,7 +43,7 @@ use crate::{
         StreamDescription,
     },
     error::{CommandError, Error, ErrorKind, Result},
-    options::{ClientOptions, ReadConcern, ReadConcernInternal, WriteConcern},
+    options::{ClientOptions, ReadConcern, WriteConcern},
     selection_criteria::SelectionCriteria,
     BoxFuture,
     ClientSession,
@@ -217,30 +217,6 @@ impl<T> Feature<T> {
         match self {
             Self::NotSupported => false,
             _ => true,
-        }
-    }
-}
-
-impl Feature<&ReadConcern> {
-    pub(crate) fn as_internal_option<'a>(
-        self,
-        target: &OperationTarget,
-    ) -> Option<ReadConcernInternal> {
-        match self {
-            Self::Set(read_concern) => Some(read_concern.clone()),
-            Self::Inherit => target.read_concern().cloned(),
-            Self::NotSupported => None,
-        }
-        .map(ReadConcernInternal::from)
-    }
-}
-
-impl Feature<&WriteConcern> {
-    pub(crate) fn as_option<'a>(&'a self, target: &'a OperationTarget) -> Option<&'a WriteConcern> {
-        match self {
-            Self::Set(write_concern) => Some(write_concern),
-            Self::Inherit => target.write_concern(),
-            Self::NotSupported => None,
         }
     }
 }

--- a/driver/src/operation.rs
+++ b/driver/src/operation.rs
@@ -43,7 +43,7 @@ use crate::{
         StreamDescription,
     },
     error::{CommandError, Error, ErrorKind, Result},
-    options::{ClientOptions, ReadConcern, WriteConcern},
+    options::{ClientOptions, ReadConcern, ReadConcernInternal, WriteConcern},
     selection_criteria::SelectionCriteria,
     BoxFuture,
     ClientSession,
@@ -154,8 +154,7 @@ pub(crate) trait Operation {
     /// The read concern to use for this operation, if any.
     fn read_concern(&self) -> Feature<&ReadConcern>;
 
-    /// The write concern to use for this operation, if any.  If this is implemented,
-    /// `set_write_concern` MUST also be.
+    /// The write concern to use for this operation, if any.
     fn write_concern(&self) -> Feature<&WriteConcern>;
 
     /// Whether this operation supports sessions or not.
@@ -218,6 +217,30 @@ impl<T> Feature<T> {
         match self {
             Self::NotSupported => false,
             _ => true,
+        }
+    }
+}
+
+impl Feature<&ReadConcern> {
+    pub(crate) fn as_internal_option<'a>(
+        self,
+        target: &OperationTarget,
+    ) -> Option<ReadConcernInternal> {
+        match self {
+            Self::Set(read_concern) => Some(read_concern.clone()),
+            Self::Inherit => target.read_concern().cloned(),
+            Self::NotSupported => None,
+        }
+        .map(ReadConcernInternal::from)
+    }
+}
+
+impl Feature<&WriteConcern> {
+    pub(crate) fn as_option<'a>(&'a self, target: &'a OperationTarget) -> Option<&'a WriteConcern> {
+        match self {
+            Self::Set(write_concern) => Some(write_concern),
+            Self::Inherit => target.write_concern(),
+            Self::NotSupported => None,
         }
     }
 }

--- a/driver/src/test/db.rs
+++ b/driver/src/test/db.rs
@@ -1,6 +1,12 @@
 use std::cmp::Ord;
 
-use crate::{bson::RawDocumentBuf, bson_compat::cstr, error::ErrorKind, test::server_version_gte};
+use crate::{
+    bson::RawDocumentBuf,
+    bson_compat::cstr,
+    error::ErrorKind,
+    options::{DatabaseOptions, WriteConcern},
+    test::server_version_gte,
+};
 use futures::{stream::TryStreamExt, StreamExt};
 use serde::Deserialize;
 
@@ -512,4 +518,21 @@ async fn null_byte_in_db_name() {
         let error = client.bulk_write(vec![write_model]).await.unwrap_err();
         assert!(error.is_server_error());
     }
+}
+
+#[tokio::test]
+async fn inherited_unacknowledged_write_concern_is_rejected() {
+    let client = Client::for_test().await;
+    let db = client.database_with_options(
+        "inherited_unacknowledged_write_concern_is_rejected",
+        DatabaseOptions::builder()
+            .write_concern(WriteConcern::nodes(0))
+            .build(),
+    );
+    let error = db
+        .collection("inherited_unacknowledged_write_concern_is_rejected")
+        .insert_one(doc! { "x": 1 })
+        .await
+        .unwrap_err();
+    assert!(error.is_invalid_argument());
 }


### PR DESCRIPTION
Checks for an inherited unacknowledged write concern at the beginning of command execution. I also removed a few spots that check for an unacknowledged write concern that would need a similar fix. They're unreachable code with the existing validation, but in the _very_ unlikely case that we decide to support unacknowledged writes in the future, we can add them back in.