### PR TITLE
RUST-2493 Probe for openssl install path on windows

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -173,7 +173,7 @@ buildvariants:
 
   - name: openssl-windows
     display_name: "OpenSSL (Windows)"
-    patchable: false
+    #patchable: false
     run_on:
       - windows-2022-latest-small
     expansions:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -173,7 +173,7 @@ buildvariants:
 
   - name: openssl-windows
     display_name: "OpenSSL (Windows)"
-    #patchable: false
+    patchable: false
     run_on:
       - windows-2022-latest-small
     expansions:

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -28,8 +28,35 @@ if [[ "$OSTYPE" == "cygwin" ]]; then
   export PATH
   echo "updated path on windows PATH=$PATH"
 
-  export OPENSSL_INCLUDE_DIR="C:\\Program Files\\OpenSSL-Win64\\include"
-  export OPENSSL_LIB_DIR="C:\\Program Files\\OpenSSL-Win64\\lib\\VC\\x64\\MD"
+  # Probe for the openssl install path rather than hardcoding one that keeps changing.
+  OPENSSL_ROOT="${OPENSSL_ROOT:-/cygdrive/c/Program Files/OpenSSL-Win64}"
+  if [ ! -d "${OPENSSL_ROOT}" ]; then
+    echo "OpenSSL install not found at ${OPENSSL_ROOT}" >&2
+    exit 1
+  fi
+  openssl_lib_dir=""
+  while IFS= read -r candidate; do
+    case "${candidate}" in
+      *static*|*MT*|*MTd*|*MDd*) continue ;;
+    esac
+    [ -f "${candidate}/libcrypto.lib" ] || continue
+    # Prefer an explicit MD directory if one exists (matching the Rust toolschain)
+    if [ -z "${openssl_lib_dir}" ] || [ "${candidate}" != "${candidate%MD}" ]; then
+      openssl_lib_dir="${candidate}"
+    fi
+  done < <(find "${OPENSSL_ROOT}" -name 'libssl.lib' -printf '%h\n' | sort)
+  openssl_header=$(find "${OPENSSL_ROOT}" -path '*/openssl/ssl.h' | head -n 1)
+  openssl_include_dir=$(dirname "$(dirname "${openssl_header}")")
+  if [ -z "${openssl_lib_dir}" ] || [ -z "${openssl_header}" ]; then
+    echo "Could not locate OpenSSL libraries/headers under ${OPENSSL_ROOT}:" >&2
+    find "${OPENSSL_ROOT}" \( -name 'libssl.lib' -o -name 'ssl.h' \) >&2
+    exit 1
+  fi
+  OPENSSL_LIB_DIR=$(cygpath --windows "${openssl_lib_dir}")
+  export OPENSSL_LIB_DIR
+  OPENSSL_INCLUDE_DIR=$(cygpath --windows "${openssl_include_dir}")
+  export OPENSSL_INCLUDE_DIR
+  echo "OPENSSL_LIB_DIR=${OPENSSL_LIB_DIR} OPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR}"
 else
   # Turn off tracing for the very-spammy nvm script.
   set +o xtrace

--- a/.evergreen/env.sh
+++ b/.evergreen/env.sh
@@ -37,6 +37,7 @@ if [[ "$OSTYPE" == "cygwin" ]]; then
   openssl_lib_dir=""
   while IFS= read -r candidate; do
     case "${candidate}" in
+      # skip build variants that are definitely Rust-toolchain incompatible
       *static*|*MT*|*MTd*|*MDd*) continue ;;
     esac
     [ -f "${candidate}/libcrypto.lib" ] || continue
@@ -52,6 +53,7 @@ if [[ "$OSTYPE" == "cygwin" ]]; then
     find "${OPENSSL_ROOT}" \( -name 'libssl.lib' -o -name 'ssl.h' \) >&2
     exit 1
   fi
+  
   OPENSSL_LIB_DIR=$(cygpath --windows "${openssl_lib_dir}")
   export OPENSSL_LIB_DIR
   OPENSSL_INCLUDE_DIR=$(cygpath --windows "${openssl_include_dir}")


### PR DESCRIPTION
RUST-2493

The path keeps changing (see https://github.com/mongodb/mongo-rust-driver/pull/1207), so this adds probing logic to hopefully be a bit more robust.  [Passing run](https://spruce.corp.mongodb.com/version/6a9980225a163000079ae448/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).